### PR TITLE
Script working directory

### DIFF
--- a/source/Calamari/Integration/Processes/CommandLineInvocation.cs
+++ b/source/Calamari/Integration/Processes/CommandLineInvocation.cs
@@ -1,14 +1,23 @@
+using System;
+
 namespace Calamari.Integration.Processes
 {
     public class CommandLineInvocation
     {
         readonly string executable;
         readonly string arguments;
+        readonly string workingDirectory; 
 
         public CommandLineInvocation(string executable, string arguments)
         {
             this.executable = executable;
             this.arguments = arguments;
+        }
+
+        public CommandLineInvocation(string executable, string arguments, string workingDirectory) 
+            : this(executable, arguments)
+        {
+            this.workingDirectory = workingDirectory;
         }
 
         public string Executable
@@ -19,6 +28,15 @@ namespace Calamari.Integration.Processes
         public string Arguments
         {
             get { return arguments; }
+        }
+
+        /// <summary>
+        /// The initial working-directory for the invocation.
+        /// Defaults to Environment.CurrentDirectory
+        /// </summary>
+        public string WorkingDirectory
+        {
+            get { return workingDirectory ?? Environment.CurrentDirectory;}
         }
 
         public override string ToString()

--- a/source/Calamari/Integration/Processes/CommandLineRunner.cs
+++ b/source/Calamari/Integration/Processes/CommandLineRunner.cs
@@ -18,7 +18,7 @@ namespace Calamari.Integration.Processes
                 var exitCode = SilentProcessRunner.ExecuteCommand(
                     invocation.Executable, 
                     invocation.Arguments,
-                    Environment.CurrentDirectory,
+                    invocation.WorkingDirectory,
                     commandOutput.WriteInfo,
                     commandOutput.WriteError);
 

--- a/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
@@ -17,7 +17,7 @@ namespace Calamari.Integration.Scripting.ScriptCS
             using (new TemporaryFile(configurationFile))
             using (new TemporaryFile(boostrapFile))
             {
-                return commandLineRunner.Execute(new CommandLineInvocation(ScriptCSBootstrapper.FindScriptCSExecutable(), ScriptCSBootstrapper.FormatCommandArguments(boostrapFile)));
+                return commandLineRunner.Execute(new CommandLineInvocation(ScriptCSBootstrapper.FindScriptCSExecutable(), ScriptCSBootstrapper.FormatCommandArguments(boostrapFile), workingDirectory));
             }
         }
     }

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
@@ -1,4 +1,5 @@
-﻿using Calamari.Integration.FileSystem;
+﻿using System.IO;
+using Calamari.Integration.FileSystem;
 using Calamari.Integration.Processes;
 using Octostache;
 
@@ -8,15 +9,18 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
     {
         public CommandResult Execute(string scriptFile, VariableDictionary variables, ICommandLineRunner commandLineRunner)
         {
+            var workingDirectory = Path.GetDirectoryName(scriptFile);
+
             var executable = PowerShellBootstrapper.PathToPowerShellExecutable();
             var boostrapFile = PowerShellBootstrapper.PrepareBootstrapFile(scriptFile, variables);
             var arguments = PowerShellBootstrapper.FormatCommandArguments(boostrapFile);
 
             using (new TemporaryFile(boostrapFile))
             {
-                var invocation = new CommandLineInvocation(executable, arguments);
+                var invocation = new CommandLineInvocation(executable, arguments, workingDirectory);
                 return commandLineRunner.Execute(invocation);
             }
         }
+
     }
 }


### PR DESCRIPTION
Allow a working-directory to be set for a CommandLineInvocation instance.
Use the directory the script is located in as the working directory for
the PS and CS script engines.
Are there any scenarios where we wouldn't want the directory the script was located in to be the working directory?
