### PR TITLE
Octopus.Action.Azure.PackageExtractionPath variable

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -152,7 +152,7 @@
     <Compile Include="Fixtures\Conventions\ContributeEnvironmentVariablesFixture.cs" />
     <Compile Include="Fixtures\Conventions\CopyPackageToCustomInstallationDirectoryConventionFixture.cs" />
     <Compile Include="Fixtures\Conventions\PackagedScriptConventionFixture.cs" />
-    <Compile Include="Fixtures\Conventions\ExtractPackageConventionFixture.cs" />
+    <Compile Include="Fixtures\Conventions\ExtractPackageToApplicationDirectoryConventionFixture.cs" />
     <Compile Include="Fixtures\Conventions\FeatureScriptConventionFixture.cs" />
     <Compile Include="Fixtures\Conventions\LegacyIisWebSiteConventionFixture.cs" />
     <Compile Include="Fixtures\Conventions\RunningDeploymentFixture.cs" />

--- a/source/Calamari.Tests/Fixtures/Conventions/ExtractPackageToApplicationDirectoryConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ExtractPackageToApplicationDirectoryConventionFixture.cs
@@ -12,11 +12,11 @@ using Octostache;
 namespace Calamari.Tests.Fixtures.Conventions
 {
     [TestFixture]
-    public class ExtractPackageConventionFixture
+    public class ExtractPackageToApplicationDirectoryConventionFixture
     {
         IPackageExtractor extractor;
         VariableDictionary variables;
-        ExtractPackageConvention convention;
+        ExtractPackageToApplicationDirectoryConvention convention;
         ICalamariFileSystem fileSystem;
         static readonly string PackageLocation = TestEnvironment.ConstructRootedPath("Package.nupkg");
 
@@ -30,7 +30,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             fileSystem.RemoveInvalidFileNameChars(Arg.Any<string>()).Returns(c => c.Arg<string>().Replace("!", ""));
 
             variables = new VariableDictionary();
-            convention = new ExtractPackageConvention(extractor, fileSystem, new SystemSemaphore());
+            convention = new ExtractPackageToApplicationDirectoryConvention(extractor, fileSystem, new SystemSemaphore());
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/Deployment/Azure/DeployAzureCloudServiceSansPackageExtractionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Azure/DeployAzureCloudServiceSansPackageExtractionFixture.cs
@@ -13,6 +13,8 @@ namespace Calamari.Tests.Fixtures.Deployment.Azure
     public class DeployAzureCloudServiceSansPackageExtractionFixture : CalamariFixture
     {
         CalamariResult result;
+        ICalamariFileSystem fileSystem;
+        string stagingDirectory;
 
         [TestFixtureSetUp]
         public void Deploy()
@@ -35,6 +37,10 @@ namespace Calamari.Tests.Fixtures.Deployment.Azure
             // Disable cspkg extraction
             variables.Set(SpecialVariables.Action.Azure.CloudServicePackageExtractionDisabled, true.ToString());
 
+            fileSystem = new WindowsPhysicalFileSystem();
+            stagingDirectory = Path.GetTempPath(); 
+            variables.Set(SpecialVariables.Action.Azure.PackageExtractionPath, stagingDirectory);
+
             variables.Save(variablesFile);
 
             result = Invoke(
@@ -42,6 +48,12 @@ namespace Calamari.Tests.Fixtures.Deployment.Azure
                     .Action("deploy-azure-cloud-service")
                     .Argument("package", nugetPackageFile)
                     .Argument("variables", variablesFile));       
+        }
+
+        [TestFixtureTearDown]
+        public void CleanUp()
+        {
+           fileSystem.DeleteDirectory(stagingDirectory, DeletionOptions.TryThreeTimesIgnoreFailure); 
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/Deployment/Azure/DeployAzureWebFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Azure/DeployAzureWebFixture.cs
@@ -16,6 +16,7 @@ namespace Calamari.Tests.Fixtures.Deployment.Azure
     public class DeployAzureWebFixture : CalamariFixture
     {
         ICalamariFileSystem fileSystem;
+        string stagingDirectory;
         VariableDictionary variables;
         CalamariResult result;
 
@@ -38,8 +39,16 @@ namespace Calamari.Tests.Fixtures.Deployment.Azure
             variables.Set(SpecialVariables.Package.SubstituteInFilesTargets, "web.config");
 
             fileSystem = new WindowsPhysicalFileSystem();
+            stagingDirectory = Path.GetTempPath(); 
+            variables.Set(SpecialVariables.Action.Azure.PackageExtractionPath, stagingDirectory);
 
             result = DeployPackage("Acme.Web");
+        }
+
+        [TestFixtureTearDown]
+        public void CleanUp()
+        {
+           fileSystem.DeleteDirectory(stagingDirectory, DeletionOptions.TryThreeTimesIgnoreFailure); 
         }
 
         [Test]
@@ -47,13 +56,6 @@ namespace Calamari.Tests.Fixtures.Deployment.Azure
         {
             result.AssertZero();
 
-        }
-
-        [Test]
-        public void ShouldRemoveStagingDirectory()
-        {
-            Assert.False(
-                fileSystem.DirectoryExists(result.CapturedOutput.OutputVariables[SpecialVariables.Package.Output.InstallationDirectoryPath]));
         }
 
         [Test]

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Deployment\Conventions\EnsureCloudServicePackageIsCtpFormatConvention.cs" />
     <Compile Include="Deployment\Conventions\ExtractAzureCloudServicePackageConvention.cs" />
     <Compile Include="Deployment\Conventions\ExtractPackageConvention.cs" />
+    <Compile Include="Deployment\Conventions\ExtractPackageToStagingDirectoryConvention.cs" />
     <Compile Include="Deployment\Conventions\FindCloudServicePackageConvention.cs" />
     <Compile Include="Deployment\Conventions\LogVariablesConvention.cs" />
     <Compile Include="Deployment\Conventions\FeatureScriptConvention.cs" />
@@ -203,6 +204,7 @@
     <Compile Include="Deployment\DeploymentStages.cs" />
     <Compile Include="Deployment\DeploymentWorkingDirectory.cs" />
     <Compile Include="Deployment\Conventions\PackagedScriptConvention.cs" />
+    <Compile Include="Deployment\Conventions\ExtractPackageToApplicationDirectoryConvention.cs" />
     <Compile Include="Deployment\Conventions\IConvention.cs" />
     <Compile Include="Deployment\Conventions\IInstallConvention.cs" />
     <Compile Include="Deployment\Conventions\IRollbackConvention.cs" />

--- a/source/Calamari/Commands/DeployAzureCloudServiceCommand.cs
+++ b/source/Calamari/Commands/DeployAzureCloudServiceCommand.cs
@@ -64,7 +64,7 @@ namespace Calamari.Commands
             {
                 new ContributeEnvironmentVariablesConvention(),
                 new LogVariablesConvention(),
-                new ExtractPackageConvention(new LightweightPackageExtractor(), fileSystem, new SystemSemaphore()),
+                new ExtractPackageToStagingDirectoryConvention(new LightweightPackageExtractor(), fileSystem),
                 new FindCloudServicePackageConvention(fileSystem),
                 new EnsureCloudServicePackageIsCtpFormatConvention(fileSystem),
                 new ExtractAzureCloudServicePackageConvention(fileSystem),

--- a/source/Calamari/Commands/DeployAzureWebCommand.cs
+++ b/source/Calamari/Commands/DeployAzureWebCommand.cs
@@ -60,7 +60,7 @@ namespace Calamari.Commands
             {
                 new ContributeEnvironmentVariablesConvention(),
                 new LogVariablesConvention(),
-                new ExtractPackageConvention(new LightweightPackageExtractor(), fileSystem, new SystemSemaphore()),
+                new ExtractPackageToStagingDirectoryConvention(new LightweightPackageExtractor(), fileSystem),
                 new ConfiguredScriptConvention(DeploymentStages.PreDeploy, scriptEngine, fileSystem, commandLineRunner),
                 new PackagedScriptConvention(DeploymentStages.PreDeploy, fileSystem, scriptEngine, commandLineRunner),
                 new SubstituteInFilesConvention(fileSystem, substituter),

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -65,7 +65,7 @@ namespace Calamari.Commands
                 new ContributePreviousInstallationConvention(journal),
                 new LogVariablesConvention(),
                 new AlreadyInstalledConvention(journal),
-                new ExtractPackageConvention(new LightweightPackageExtractor(), fileSystem, semaphore),
+                new ExtractPackageToApplicationDirectoryConvention(new LightweightPackageExtractor(), fileSystem, semaphore),
                 new FeatureScriptConvention(DeploymentStages.BeforePreDeploy, fileSystem, embeddedResources, scriptCapability, commandLineRunner),
                 new ConfiguredScriptConvention(DeploymentStages.PreDeploy, scriptCapability, fileSystem, commandLineRunner),
                 new PackagedScriptConvention(DeploymentStages.PreDeploy, fileSystem, scriptCapability, commandLineRunner),

--- a/source/Calamari/Deployment/Conventions/ExtractPackageConvention.cs
+++ b/source/Calamari/Deployment/Conventions/ExtractPackageConvention.cs
@@ -1,23 +1,17 @@
-﻿using System;
-using System.IO;
-using Calamari.Integration.FileSystem;
+﻿using Calamari.Integration.FileSystem;
 using Calamari.Integration.Packages;
-using Calamari.Integration.Processes;
-using Octostache;
 
 namespace Calamari.Deployment.Conventions
 {
-    public class ExtractPackageConvention : IInstallConvention
+    public abstract class ExtractPackageConvention : IInstallConvention
     {
         readonly IPackageExtractor extractor;
-        readonly ICalamariFileSystem fileSystem;
-        readonly ISemaphore semaphore;
+        protected readonly ICalamariFileSystem fileSystem;
 
-        public ExtractPackageConvention(IPackageExtractor extractor, ICalamariFileSystem fileSystem, ISemaphore semaphore) 
+        protected ExtractPackageConvention(IPackageExtractor extractor, ICalamariFileSystem fileSystem)
         {
             this.extractor = extractor;
             this.fileSystem = fileSystem;
-            this.semaphore = semaphore;
         }
 
         public void Install(RunningDeployment deployment)
@@ -37,76 +31,7 @@ namespace Calamari.Deployment.Conventions
             Log.SetOutputVariable(SpecialVariables.Package.Output.InstallationDirectoryPath, targetPath, deployment.Variables);
         }
 
+        protected abstract string GetTargetPath(RunningDeployment deployment, PackageMetadata metadata);
 
-        string GetTargetPath(RunningDeployment deployment, PackageMetadata metadata)
-        {
-            var root = GetInitialExtractionDirectory(deployment.Variables);
-            return EnsureTargetPathIsEmpty(Path.Combine(root, metadata.Id, metadata.Version));
-        }
-
-        string GetInitialExtractionDirectory(VariableDictionary variables)
-        {
-            var root = GetApplicationDirectoryPath(variables);
-            root = AppendEnvironmentNameIfProvided(variables, root);
-            fileSystem.EnsureDirectoryExists(root);
-            fileSystem.EnsureDiskHasEnoughFreeSpace(root);
-
-            return root;
-        }
-
-        string GetApplicationDirectoryPath (VariableDictionary variables)
-        {
-            const string windowsRoot = "env:SystemDrive";
-            const string linuxRoot = "env:HOME";
-
-            var root = variables.Get(SpecialVariables.Tentacle.Agent.ApplicationDirectoryPath);
-            if (root != null)
-                return root;
-
-            root = variables.Get(windowsRoot);
-            if (root == null)
-            {
-                root = variables.Get(linuxRoot);
-                if (root == null)
-                {
-                    throw new Exception(string.Format("Unable to determine the ApplicationRootDirectory. Please provide the {0} variable", SpecialVariables.Tentacle.Agent.ApplicationDirectoryPath));
-                }
-            }
-            return string.Format("{0}{1}Applications", root, Path.DirectorySeparatorChar);
-        }
-
-        string AppendEnvironmentNameIfProvided(VariableDictionary variables, string root)
-        {
-            var environment = variables.Get(SpecialVariables.Environment.Name);
-            if (!string.IsNullOrWhiteSpace(environment))
-            {
-                environment = fileSystem.RemoveInvalidFileNameChars(environment);
-                root = Path.Combine(root, environment);
-            }
-
-            return root;
-        }
-
-        // When a package has been installed once, Octopus gives users the ability to 'force' a redeployment of the package. 
-        // This is often useful for example if a deployment partially completes and the installation is in an invalid state 
-        // (e.g., corrupt files are left on disk, or the package is only half extracted). We *can't* just uninstall the package 
-        // or overwrite the files, since they might be locked by IIS or another process. So instead we create a new unique 
-        // directory. 
-        string EnsureTargetPathIsEmpty(string desiredTargetPath)
-        {
-            var target = desiredTargetPath;
-
-            using (semaphore.Acquire("Octopus.Calamari.ExtractionDirectory", "Another process is finding an extraction directory, please wait..."))
-            {
-                for (var i = 1; fileSystem.DirectoryExists(target) || fileSystem.FileExists(target); i++)
-                {
-                    target = desiredTargetPath + "_" + i;
-                }
-
-                fileSystem.EnsureDirectoryExists(target);
-            }
-
-            return target;
-        }
     }
 }

--- a/source/Calamari/Deployment/Conventions/ExtractPackageToApplicationDirectoryConvention.cs
+++ b/source/Calamari/Deployment/Conventions/ExtractPackageToApplicationDirectoryConvention.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using Calamari.Integration.FileSystem;
+using Calamari.Integration.Packages;
+using Calamari.Integration.Processes;
+using Octostache;
+
+namespace Calamari.Deployment.Conventions
+{
+    public class ExtractPackageToApplicationDirectoryConvention : ExtractPackageConvention 
+    {
+        readonly ISemaphore semaphore;
+
+        public ExtractPackageToApplicationDirectoryConvention(IPackageExtractor extractor, ICalamariFileSystem fileSystem, ISemaphore semaphore) : base(extractor, fileSystem)
+        {
+            this.semaphore = semaphore;
+        }
+
+        protected override string GetTargetPath(RunningDeployment deployment, PackageMetadata metadata)
+        {
+            var root = GetInitialExtractionDirectory(deployment.Variables);
+            return EnsureTargetPathIsEmpty(Path.Combine(root, metadata.Id, metadata.Version));
+        }
+
+        private string GetInitialExtractionDirectory(VariableDictionary variables)
+        {
+            var root = GetApplicationDirectoryPath(variables);
+            root = AppendEnvironmentNameIfProvided(variables, root);
+            fileSystem.EnsureDirectoryExists(root);
+            fileSystem.EnsureDiskHasEnoughFreeSpace(root);
+
+            return root;
+        }
+
+        string GetApplicationDirectoryPath (VariableDictionary variables)
+        {
+            const string windowsRoot = "env:SystemDrive";
+            const string linuxRoot = "env:HOME";
+
+            var root = variables.Get(SpecialVariables.Tentacle.Agent.ApplicationDirectoryPath);
+            if (root != null)
+                return root;
+
+            root = variables.Get(windowsRoot);
+            if (root == null)
+            {
+                root = variables.Get(linuxRoot);
+                if (root == null)
+                {
+                    throw new Exception(string.Format("Unable to determine the ApplicationRootDirectory. Please provide the {0} variable", SpecialVariables.Tentacle.Agent.ApplicationDirectoryPath));
+                }
+            }
+            return string.Format("{0}{1}Applications", root, Path.DirectorySeparatorChar);
+        }
+
+        string AppendEnvironmentNameIfProvided(VariableDictionary variables, string root)
+        {
+            var environment = variables.Get(SpecialVariables.Environment.Name);
+            if (!string.IsNullOrWhiteSpace(environment))
+            {
+                environment = fileSystem.RemoveInvalidFileNameChars(environment);
+                root = Path.Combine(root, environment);
+            }
+
+            return root;
+        }
+
+        // When a package has been installed once, Octopus gives users the ability to 'force' a redeployment of the package. 
+        // This is often useful for example if a deployment partially completes and the installation is in an invalid state 
+        // (e.g., corrupt files are left on disk, or the package is only half extracted). We *can't* just uninstall the package 
+        // or overwrite the files, since they might be locked by IIS or another process. So instead we create a new unique 
+        // directory. 
+        string EnsureTargetPathIsEmpty(string desiredTargetPath)
+        {
+            var target = desiredTargetPath;
+
+            using (semaphore.Acquire("Octopus.Calamari.ExtractionDirectory", "Another process is finding an extraction directory, please wait..."))
+            {
+                for (var i = 1; fileSystem.DirectoryExists(target) || fileSystem.FileExists(target); i++)
+                {
+                    target = desiredTargetPath + "_" + i;
+                }
+
+                fileSystem.EnsureDirectoryExists(target);
+            }
+
+            return target;
+        }
+
+    }
+}

--- a/source/Calamari/Deployment/Conventions/ExtractPackageToStagingDirectoryConvention.cs
+++ b/source/Calamari/Deployment/Conventions/ExtractPackageToStagingDirectoryConvention.cs
@@ -12,7 +12,13 @@ namespace Calamari.Deployment.Conventions
 
         protected override string GetTargetPath(RunningDeployment deployment, PackageMetadata metadata)
         {
-            return deployment.Variables[SpecialVariables.Action.Azure.PackageExtractionPath];
+            var packageExtractionPathVariable = deployment.Variables[SpecialVariables.Action.Azure.PackageExtractionPath];
+
+            // The PackageExtractionPath variable will always be provided by the OD server, but just in case Calamari is run
+            // stand-alone, we will fall-back to a temporary path
+            return !string.IsNullOrWhiteSpace(packageExtractionPathVariable)
+                ? packageExtractionPathVariable
+                : fileSystem.CreateTemporaryDirectory();
         }
     }
 }

--- a/source/Calamari/Deployment/Conventions/ExtractPackageToStagingDirectoryConvention.cs
+++ b/source/Calamari/Deployment/Conventions/ExtractPackageToStagingDirectoryConvention.cs
@@ -1,0 +1,18 @@
+﻿using Calamari.Integration.FileSystem;
+using Calamari.Integration.Packages;
+
+namespace Calamari.Deployment.Conventions
+{
+    public class ExtractPackageToStagingDirectoryConvention : ExtractPackageConvention
+    {
+        public ExtractPackageToStagingDirectoryConvention(IPackageExtractor extractor, ICalamariFileSystem fileSystem) 
+            : base(extractor, fileSystem)
+        {
+        }
+
+        protected override string GetTargetPath(RunningDeployment deployment, PackageMetadata metadata)
+        {
+            return deployment.Variables[SpecialVariables.Action.Azure.PackageExtractionPath];
+        }
+    }
+}

--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -120,6 +120,8 @@ namespace Calamari.Deployment
 
             public static class Azure
             {
+                public static readonly string PackageExtractionPath = "Octopus.Action.Azure.PackageExtractionPath";
+
                 public static readonly string SubscriptionId = "Octopus.Action.Azure.SubscriptionId";
                 public static readonly string CertificateBytes = "Octopus.Action.Azure.CertificateBytes";
                 public static readonly string CertificateThumbprint = "Octopus.Action.Azure.CertificateThumbprint";


### PR DESCRIPTION
Further discussion re: https://github.com/OctopusDeploy/Issues/issues/1643 resulted in a change of approach.

A new variable was created (Octopus.Action.Azure.PackageExtractionPath). This is used by the Calamari Azure commands.

This reverts commit c2f89f90565ad4b101962ec09e21a2ca85466bc8, reversing
changes made to e0977877d402f1e2e45f6b888534824e8672b23b.

This has a corresponding PR in the OctopusDeploy repo.