### PR TITLE
Reverting Azure Powershell version upgrade. 

### DIFF
--- a/source/.nuget/packages.config
+++ b/source/.nuget/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NuGet.CommandLine" version="2.8.3" />
-  <package id="Octopus.Dependencies.AzureCmdlets" version="0.8.4" />
+  <package id="Octopus.Dependencies.AzureCmdlets" version="2.1.0" />
   <package id="Octopus.Dependencies.ScriptCS" version="3.0.1" />
 </packages>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -340,7 +340,7 @@
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(SolutionDir)..\tools\Octodiff\Octodiff.exe" "$(TargetDir)" /y
 xcopy "$(SolutionDir)packages\NuGet.CommandLine.2.8.3\tools\Nuget.exe" "$(TargetDir)NuGet\"  /y
-xcopy "$(SolutionDir)packages\Octopus.Dependencies.AzureCmdlets.0.8.4\PowerShell" "$(TargetDir)AzurePowershell\" /y /i /s</PostBuildEvent>
+xcopy "$(SolutionDir)packages\Octopus.Dependencies.AzureCmdlets.2.1.0\runtime" "$(TargetDir)AzurePowershell\" /y /i</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/source/Calamari/Integration/Azure/AzurePowershellContext.cs
+++ b/source/Calamari/Integration/Azure/AzurePowershellContext.cs
@@ -20,7 +20,7 @@ namespace Calamari.Integration.Azure
         const string certificateFileName = "azure_certificate.pfx";
         const int passwordSizeBytes = 20;
 
-        static readonly string azurePowershellModulePath = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "AzurePowershell", "ServiceManagement\\Azure\\Azure.psd1"); 
+        static readonly string azurePowershellModulePath = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "AzurePowershell", "Azure.psd1"); 
 
         public AzurePowershellContext()
         {

--- a/source/Package/Windows/Calamari.nuspec
+++ b/source/Package/Windows/Calamari.nuspec
@@ -13,6 +13,6 @@
   <files>
     <file src="..\Calamari\bin\**\*.*" target="" exclude="*.vshost*;**\*.xml" />
     <file src="..\packages\Octopus.Dependencies.ScriptCS.3.0.1\runtime\**\*.*" target="ScriptCS" exclude="**\*.xml" />
-    <file src="..\packages\Octopus.Dependencies.AzureCmdlets.0.8.4\PowerShell\**\*.*" target="AzurePowershell" exclude="**\*.xml" />
+    <file src="..\packages\Octopus.Dependencies.AzureCmdlets.2.1.0\runtime\**\*.*" target="AzurePowershell" exclude="**\*.xml" />
   </files>
 </package>


### PR DESCRIPTION
Azure Powershell modules had been upgraded to 0.8.4, but this was causing problems with `Set-AzureSubscription` cmdlet.