### PR TITLE
Choose Azure Cloud Service Configuration (CSCFG) file after Package Extraction

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Fixtures\Conventions\AlreadyInstalledConventionFixture.cs" />
     <Compile Include="Fixtures\Conventions\ConfigurationTransformConventionFixture.cs" />
     <Compile Include="Fixtures\Conventions\ConfigurationVariablesConventionFixture.cs" />
+    <Compile Include="Fixtures\Conventions\ChooseAzureCloudServiceConfigurationFileConventionFixture.cs" />
     <Compile Include="Fixtures\Conventions\ConfigureAzureCloudServiceConventionFixture.cs" />
     <Compile Include="Fixtures\Conventions\ConfiguredScriptConventionFixture.cs" />
     <Compile Include="Fixtures\Conventions\ContributePreviousInstallationConventionFixture.cs" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -327,10 +327,6 @@
     </Content>
     <Content Include="Fixtures\Deployment\Packages\Acme.Web\assets\styles.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Fixtures\Deployment\Packages\Acme.Web\assets\styles.css">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>

--- a/source/Calamari.Tests/Fixtures/Conventions/ChooseAzureCloudServiceConfigurationFileConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ChooseAzureCloudServiceConfigurationFileConventionFixture.cs
@@ -1,0 +1,81 @@
+﻿using System.IO;
+using Calamari.Deployment;
+using Calamari.Deployment.Conventions;
+using Calamari.Integration.FileSystem;
+using Calamari.Tests.Helpers;
+using NSubstitute;
+using NUnit.Framework;
+using Octostache;
+
+namespace Calamari.Tests.Fixtures.Conventions
+{
+    [TestFixture]
+    [Category(TestEnvironment.CompatableOS.Windows)]
+    public class ChooseAzureCloudServiceConfigurationFileConventionFixture
+    {
+        ICalamariFileSystem fileSystem;
+        RunningDeployment deployment;
+        VariableDictionary variables;
+        ChooseCloudServiceConfigurationFileConvention convention;
+        const string StagingDirectory = "C:\\Applications\\Foo";
+
+        [SetUp]
+        public void SetUp()
+        {
+            fileSystem = Substitute.For<ICalamariFileSystem>();
+            variables = new VariableDictionary();
+            variables.Set(SpecialVariables.OriginalPackageDirectoryPath, StagingDirectory);
+            deployment = new RunningDeployment(StagingDirectory, variables);
+
+            convention = new ChooseCloudServiceConfigurationFileConvention(fileSystem);
+        }
+
+        [Test]
+        [TestCase("MyCustomCloud.cscfg")]
+        [TestCase("CloudService\\MyCustomCloud.cscfg")]
+        [TestCase("\\CloudService\\MyCustomCloud.cscfg")]
+        [TestCase(".\\CloudService\\MyCustomCloud.cscfg")]
+        public void ShouldUseUserSpecifiedConfigurationFile(string customRelativePath)
+        {
+            variables.Set(SpecialVariables.Action.Azure.CloudServiceConfigurationFileRelativePath, customRelativePath);
+            var expectedAbsolutePath = Path.Combine(StagingDirectory, customRelativePath);
+            fileSystem.FileExists(expectedAbsolutePath).Returns(true);
+
+            convention.Install(deployment);
+
+            Assert.That(GetResolvedPathFromVariables(), Is.EqualTo(expectedAbsolutePath));
+        }
+
+        [Test]
+        [TestCase("Production")]
+        [TestCase("Staging")]
+        [TestCase("SomeOtherEnvironment")]
+        [TestCase("What if my environment has spaces")]
+        public void IfNoUserSpecifiedConfigThenShouldUseEnvironmentConfigurationFile(string environment)
+        {
+            variables.Set(SpecialVariables.Environment.Name, environment);
+            var expectedAbsolutePath = Path.Combine(StagingDirectory, string.Format("ServiceConfiguration.{0}.cscfg", environment));
+            fileSystem.FileExists(expectedAbsolutePath).Returns(true);
+
+            convention.Install(deployment);
+
+            Assert.That(GetResolvedPathFromVariables(), Is.EqualTo(expectedAbsolutePath));
+        }
+
+        [Test]
+        public void IfNoUserSpecifiedOrEnvironmentFileThenShouldUseDefault()
+        {
+            var expectedAbsolutePath = Path.Combine(StagingDirectory, "ServiceConfiguration.Cloud.cscfg");
+            fileSystem.FileExists(expectedAbsolutePath).Returns(true);
+
+            convention.Install(deployment);
+
+            Assert.That(GetResolvedPathFromVariables(), Is.EqualTo(expectedAbsolutePath));
+        }
+
+        string GetResolvedPathFromVariables()
+        {
+            return deployment.Variables.Get(SpecialVariables.Action.Azure.Output.ConfigurationFile);
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Deployment/Azure/OctopusTestAzureSubscription.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Azure/OctopusTestAzureSubscription.cs
@@ -15,7 +15,9 @@ namespace Calamari.Tests.Fixtures.Deployment.Azure
         {
             // Ignore the test if the certificate is not installed on the machine
             if (GetCertificate() == null)
-                Assert.Ignore("Azure tests can only run if the expected certificate is present in the Certificate Store");
+                Assert.Ignore(
+                    "Cannot run Azure Integration Tests without an Azure Management Certificate that we can use for delegated access to the Azure Subscription. Was looking for a Certificate with the Thumbprint {0} authorized to Subscription {1}. If you work for Octopus Deploy ask one of your team mates for the test Certificate.",
+                    CertificateThumbprint, AzureSubscriptionId);
         }
 
         public static void PopulateVariables(VariableDictionary variables)

--- a/source/Calamari.sln.DotSettings
+++ b/source/Calamari.sln.DotSettings
@@ -5,5 +5,6 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_PRIVATE_MODIFIER/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -183,6 +183,7 @@
     <Compile Include="Commands\Support\OptionValueType.cs" />
     <Compile Include="Deployment\Conventions\AlreadyInstalledConvention.cs" />
     <Compile Include="Deployment\Conventions\AzureWebAppConvention.cs" />
+    <Compile Include="Deployment\Conventions\ChooseCloudServiceConfigurationFileConvention.cs" />
     <Compile Include="Deployment\Conventions\ConfigurationTransformsConvention.cs" />
     <Compile Include="Deployment\Conventions\ConfigurationVariablesConvention.cs" />
     <Compile Include="Deployment\Conventions\ConfigureAzureCloudServiceConvention.cs" />

--- a/source/Calamari/Commands/DeployAzureCloudServiceCommand.cs
+++ b/source/Calamari/Commands/DeployAzureCloudServiceCommand.cs
@@ -68,6 +68,7 @@ namespace Calamari.Commands
                 new FindCloudServicePackageConvention(fileSystem),
                 new EnsureCloudServicePackageIsCtpFormatConvention(fileSystem),
                 new ExtractAzureCloudServicePackageConvention(fileSystem),
+                new ChooseCloudServiceConfigurationFileConvention(fileSystem),
                 new ConfiguredScriptConvention(DeploymentStages.PreDeploy, scriptEngine, fileSystem, commandLineRunner),
                 new PackagedScriptConvention(DeploymentStages.PreDeploy, fileSystem, scriptEngine, commandLineRunner),
                 new ConfigureAzureCloudServiceConvention(fileSystem, cloudCredentialsFactory, cloudServiceConfigurationRetriever),

--- a/source/Calamari/Deployment/Conventions/ChooseCloudServiceConfigurationFileConvention.cs
+++ b/source/Calamari/Deployment/Conventions/ChooseCloudServiceConfigurationFileConvention.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using Calamari.Commands.Support;
+using Calamari.Integration.FileSystem;
+
+namespace Calamari.Deployment.Conventions
+{
+    public class ChooseCloudServiceConfigurationFileConvention : IInstallConvention
+    {
+        static readonly string FallbackFileName = "ServiceConfiguration.Cloud.cscfg"; // Default from Visual Studio
+        static readonly string EnvironmentFallbackFileName = "ServiceConfiguration.{0}.cscfg";
+        readonly ICalamariFileSystem fileSystem;
+
+        public ChooseCloudServiceConfigurationFileConvention(ICalamariFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
+        public void Install(RunningDeployment deployment)
+        {
+            var configurationFile = ChooseWhichConfigurationFileToUse(deployment);
+            Log.SetOutputVariable(SpecialVariables.Action.Azure.Output.ConfigurationFile,
+                configurationFile, deployment.Variables);
+        }
+
+        string ChooseWhichConfigurationFileToUse(RunningDeployment deployment)
+        {
+            var configurationFilePath = GetFirstExistingFile(deployment,
+                deployment.Variables.Get(SpecialVariables.Action.Azure.CloudServiceConfigurationFileRelativePath),
+                BuildEnvironmentSpecificFallbackFileName(deployment),
+                FallbackFileName);
+
+            return configurationFilePath;
+        }
+
+        string GetFirstExistingFile(RunningDeployment deployment, params string[] fileNames)
+        {
+            foreach (var name in fileNames)
+            {
+                if (string.IsNullOrWhiteSpace(name))
+                    continue;
+
+                var path = Path.Combine(deployment.CurrentDirectory, name);
+                if (fileSystem.FileExists(path))
+                {
+                    Log.Verbose("Found Azure Cloud Service Configuration file: " + path);
+                    return path;
+                }
+
+                Log.Verbose("Azure Cloud Service Configuration file (*.cscfg) not found: " + path);
+            }
+
+            throw new CommandException(
+                "Could not find an Azure Cloud Service Configuration file (*.cscfg) in the package.");
+        }
+
+        static string BuildEnvironmentSpecificFallbackFileName(RunningDeployment deployment)
+        {
+            return string.Format(EnvironmentFallbackFileName,
+                deployment.Variables.Get(SpecialVariables.Environment.Name));
+        }
+    }
+}

--- a/source/Calamari/Deployment/Conventions/DeployAzureCloudServicePackageConvention.cs
+++ b/source/Calamari/Deployment/Conventions/DeployAzureCloudServicePackageConvention.cs
@@ -25,7 +25,7 @@ namespace Calamari.Deployment.Conventions
 
         public void Install(RunningDeployment deployment)
         {
-            Log.Info("Config file: " + deployment.Variables.Get(ConfigureAzureCloudServiceConvention.ConfigurationFileVariable));
+            Log.Info("Config file: " + deployment.Variables.Get(SpecialVariables.Action.Azure.Output.ConfigurationFile));
 
             Log.SetOutputVariable("OctopusAzureServiceName", deployment.Variables.Get(SpecialVariables.Action.Azure.CloudServiceName), deployment.Variables);
             Log.SetOutputVariable("OctopusAzureStorageAccountName", deployment.Variables.Get(SpecialVariables.Action.Azure.StorageAccountName), deployment.Variables);

--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Calamari.Deployment
+﻿namespace Calamari.Deployment
 {
     public static class SpecialVariables
     {
@@ -141,7 +139,9 @@ namespace Calamari.Deployment
 
                 public static readonly string CloudServicePackageExtractionDisabled = "OctopusCloudServicePackageExtractionDisabled";
 
-                public static readonly string LogExtractedCspkg = "Octopus.Action.Azure.LogExtractedCspkg"; 
+                public static readonly string LogExtractedCspkg = "Octopus.Action.Azure.LogExtractedCspkg";
+
+                public static readonly string CloudServiceConfigurationFileRelativePath = "Octopus.Action.Azure.CloudServiceConfigurationFileRelativePath";
 
                 public static class Output
                 {
@@ -151,6 +151,7 @@ namespace Calamari.Deployment
                     public static readonly string SubscriptionId = "OctopusAzureSubscriptionId";
                     public static readonly string SubscriptionName = "OctopusAzureSubscriptionName";
                     public static readonly string ModulePath = "OctopusAzureModulePath";
+                    public static readonly string ConfigurationFile = "OctopusAzureConfigurationFile";
                 }
             }
         }

--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -118,8 +118,6 @@
 
             public static class Azure
             {
-                public static readonly string PackageExtractionPath = "Octopus.Action.Azure.PackageExtractionPath";
-
                 public static readonly string SubscriptionId = "Octopus.Action.Azure.SubscriptionId";
                 public static readonly string CertificateBytes = "Octopus.Action.Azure.CertificateBytes";
                 public static readonly string CertificateThumbprint = "Octopus.Action.Azure.CertificateThumbprint";
@@ -132,15 +130,11 @@
                 public static readonly string SwapIfPossible = "Octopus.Action.Azure.SwapIfPossible";
                 public static readonly string StorageAccountName = "Octopus.Action.Azure.StorageAccountName";
                 public static readonly string UseCurrentInstanceCount = "Octopus.Action.Azure.UseCurrentInstanceCount";
-
                 public static readonly string UploadedPackageUri = "Octopus.Action.Azure.UploadedPackageUri";
-
                 public static readonly string CloudServicePackagePath = "Octopus.Action.Azure.CloudServicePackagePath";
-
-                public static readonly string CloudServicePackageExtractionDisabled = "OctopusCloudServicePackageExtractionDisabled";
-
+                public static readonly string PackageExtractionPath = "Octopus.Action.Azure.PackageExtractionPath";
+                public static readonly string CloudServicePackageExtractionDisabled = "Octopus.Action.Azure.CloudServicePackageExtractionDisabled";
                 public static readonly string LogExtractedCspkg = "Octopus.Action.Azure.LogExtractedCspkg";
-
                 public static readonly string CloudServiceConfigurationFileRelativePath = "Octopus.Action.Azure.CloudServiceConfigurationFileRelativePath";
 
                 public static class Output


### PR DESCRIPTION
Fixes OctopusDeploy/Issues#1640
Fixes OctopusDeploy/Issues#1250
Connects to https://github.com/OctopusDeploy/OctopusDeploy/pull/240

Breaking the step of choosing which CSCFG file to use as a source makes sense as its own step/convention. To select a custom CSCFG file, provide the path relative to the package extraction folder in the `Octopus.Action.Azure.CloudServiceConfigurationFileRelativePath` special variable.