### PR TITLE
Fix variable substitution under nix when target entries contain path

### DIFF
--- a/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -126,19 +126,23 @@ namespace Calamari.Integration.FileSystem
             }
         }
 
-        public IEnumerable<string> EnumerateFiles(string parentDirectoryPath, params string[] searchPatterns)
+        public virtual IEnumerable<string> EnumerateFiles(string parentDirectoryPath, params string[] searchPatterns)
         {
+            var parentDirectoryInfo = new DirectoryInfo(parentDirectoryPath);
+
             return searchPatterns.Length == 0
-                ? Directory.EnumerateFiles(parentDirectoryPath, "*", SearchOption.TopDirectoryOnly)
-                : searchPatterns.SelectMany(pattern => Directory.EnumerateFiles(parentDirectoryPath, pattern, SearchOption.TopDirectoryOnly));
+				? parentDirectoryInfo.GetFiles("*", SearchOption.TopDirectoryOnly).Select(fi => fi.FullName)
+                : searchPatterns.SelectMany(pattern => parentDirectoryInfo.GetFiles(pattern, SearchOption.TopDirectoryOnly).Select(fi => fi.FullName));
         }
 
-        public IEnumerable<string> EnumerateFilesRecursively(string parentDirectoryPath, params string[] searchPatterns)
+        public virtual IEnumerable<string> EnumerateFilesRecursively(string parentDirectoryPath, params string[] searchPatterns)
         {
-            return searchPatterns.Length == 0
-                ? Directory.EnumerateFiles(parentDirectoryPath, "*", SearchOption.AllDirectories)
-                : searchPatterns.SelectMany(pattern => Directory.EnumerateFiles(parentDirectoryPath, pattern, SearchOption.AllDirectories));
-        }
+            var parentDirectoryInfo = new DirectoryInfo(parentDirectoryPath);
+
+			return searchPatterns.Length == 0
+				? parentDirectoryInfo.GetFiles("*", SearchOption.AllDirectories).Select(fi => fi.FullName)
+                : searchPatterns.SelectMany(pattern => parentDirectoryInfo.GetFiles(pattern, SearchOption.AllDirectories).Select(fi => fi.FullName));
+		}
 
         public IEnumerable<string> EnumerateDirectories(string parentDirectoryPath)
         {

--- a/source/Calamari/Integration/FileSystem/NixPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/NixPhysicalFileSystem.cs
@@ -1,22 +1,36 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace Calamari.Integration.FileSystem
 {
-    public class NixCalamariPhysicalFileSystem : CalamariPhysicalFileSystem
-    {
-        protected override bool GetFiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
-        {
-            // This method will not work for UNC paths on windows 
-            // (hence WindowsPhysicalFileSystem) but should be sufficient for Linux mounts
-            var pathRoot = Path.GetPathRoot(directoryPath);
-            foreach (var drive in DriveInfo.GetDrives())
-            {
-                if (!drive.Name.Equals(pathRoot)) continue;
-                totalNumberOfFreeBytes = (ulong)drive.TotalFreeSpace;
-                return true;
-            }
-            totalNumberOfFreeBytes = 0;
-            return false;
-        }
-    }
+	public class NixCalamariPhysicalFileSystem : CalamariPhysicalFileSystem
+	{
+		public override IEnumerable<string> EnumerateFiles(string parentDirectoryPath, params string[] searchPatterns)
+		{
+			searchPatterns = searchPatterns.Select(sp => sp.Replace("\\", "/")).ToArray();
+			return base.EnumerateFiles(parentDirectoryPath, searchPatterns);
+		}
+
+		public override IEnumerable<string> EnumerateFilesRecursively(string parentDirectoryPath, params string[] searchPatterns)
+		{
+			searchPatterns = searchPatterns.Select(sp => sp.Replace("\\", "/")).ToArray();
+			return base.EnumerateFilesRecursively(parentDirectoryPath, searchPatterns);
+		}
+
+		protected override bool GetFiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
+		{
+			// This method will not work for UNC paths on windows (hence WindowsPhysicalFileSystem)
+			// but should be sufficient for Linux mounts
+			var pathRoot = Path.GetPathRoot(directoryPath);
+			foreach (var drive in DriveInfo.GetDrives())
+			{
+				if (!drive.Name.Equals(pathRoot)) continue;
+				totalNumberOfFreeBytes = (ulong)drive.TotalFreeSpace;
+				return true;
+			}
+			totalNumberOfFreeBytes = 0;
+			return false;
+		}
+	}
 }

--- a/source/Calamari/Scripts/Octopus.Features.WindowsService_AfterPreDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.WindowsService_AfterPreDeploy.ps1
@@ -29,7 +29,7 @@ if (!$serviceName)
 	exit -2
 }
 
-$service = Get-Service $ServiceName -ErrorAction SilentlyContinue
+$service = Get-Service $serviceName -ErrorAction SilentlyContinue
 
 if (!$service)
 {
@@ -40,5 +40,14 @@ else
     Write-Host "The $serviceName service already exists; it will be stopped"
     Write-Host "Stopping the $serviceName service"
 
-    Stop-Service $ServiceName -Force
+    Stop-Service $serviceName -Force
+	## Wait up to 30 seconds for the service to stop
+	$service.WaitForStatus('Stopped', '00:00:30')
+
+	If ($service.Status -ne 'Stopped') 
+	{
+		Write-Warning "Service $serviceName did not stop within 30 seconds"
+	} Else {
+		Write-Verbose "Service $serviceName stopped"
+	}
 }


### PR DESCRIPTION
Addresses https://github.com/OctopusDeploy/Issues/issues/1706 by:

1. Allowing Octopus Deploy to standardize variable substitution target entries on Windows path delimiter syntax while still allowing file matching to work on nix deployments.
2. Implementing a work around far a [mono bug](https://bugzilla.xamarin.com/show_bug.cgi?id=31885) which was causing FileNotFoundExceptions for variable substitution target entries which contain path.