### PR TITLE
Include full stack trace in StdErr logging from Calamari

### DIFF
--- a/source/Calamari/Commands/Support/ConsoleFormatter.cs
+++ b/source/Calamari/Commands/Support/ConsoleFormatter.cs
@@ -34,8 +34,7 @@ namespace Calamari.Commands.Support
                 return 43;
             }
 
-            Log.Error(ex.Message);
-            Log.Info(ex.ToString());
+            Log.Error(ex.ToString());
             return 100;
         }
     }


### PR DESCRIPTION
By logging the exception stacktrace to StdOut but not StdErr we are not getting it in customer reports like http://community.octopusdeploy.com/t/error-object-reference-not-set-to-an-instance-of-an-object-on-nuget-deployment-to-iis/418

This change gets the full stacktrace from exceptions that happen in Calamari

[Fixes OctopusDeploy/Issues/issues/1731]