### PR TITLE
Allow existing files to be preserved when deploying Azure Web App

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -126,6 +126,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.IO">

--- a/source/Calamari/Deployment/Conventions/AzureWebAppConvention.cs
+++ b/source/Calamari/Deployment/Conventions/AzureWebAppConvention.cs
@@ -73,8 +73,8 @@ namespace Calamari.Deployment.Conventions
 
             if (variables.GetFlag(SpecialVariables.Action.Azure.PreserveAppData, false))
             {
-               syncOptions.Rules.Add(new DeploymentSkipRule("SkipAddDataFiles", "Delete", "filePath", "\\\\App_Data\\\\.*", null)); 
-               syncOptions.Rules.Add(new DeploymentSkipRule("SkipAddDataDir", "Delete", "dirPath", "\\\\App_Data(\\\\.*|$)", null)); 
+               syncOptions.Rules.Add(new DeploymentSkipRule("SkipDeleteDataFiles", "Delete", "filePath", "\\\\App_Data\\\\.*", null)); 
+               syncOptions.Rules.Add(new DeploymentSkipRule("SkipDeleteDataDir", "Delete", "dirPath", "\\\\App_Data(\\\\.*|$)", null)); 
             }
 
             return syncOptions;

--- a/source/Calamari/Deployment/Conventions/AzureWebAppConvention.cs
+++ b/source/Calamari/Deployment/Conventions/AzureWebAppConvention.cs
@@ -36,7 +36,8 @@ namespace Calamari.Deployment.Conventions
             var changeSummary = DeploymentManager
                 .CreateObject("contentPath", deployment.CurrentDirectory)
                 .SyncTo("contentPath", publishProfile.MSDeploySite, DeploymentOptions(publishProfile), 
-                new DeploymentSyncOptions {WhatIf = false, UseChecksum = true});
+                DeploymentSyncOptions(variables)
+                );
 
             Log.Info("Successfully deployed to Azure. {0} objects added. {1} objects updated. {2} objects deleted.",
                 changeSummary.ObjectsAdded, changeSummary.ObjectsUpdated, changeSummary.ObjectsDeleted);
@@ -59,6 +60,24 @@ namespace Calamari.Deployment.Conventions
             options.Trace += (sender, eventArgs) => LogDeploymentEvent(eventArgs);
 
             return options;
+        }
+
+        private static DeploymentSyncOptions DeploymentSyncOptions(VariableDictionary variables)
+        {
+            var syncOptions = new DeploymentSyncOptions
+            {
+                WhatIf = false,
+                UseChecksum = true,
+                DoNotDelete = !variables.GetFlag(SpecialVariables.Action.Azure.RemoveAdditionalFiles, false)
+            };
+
+            if (variables.GetFlag(SpecialVariables.Action.Azure.PreserveAppData, false))
+            {
+               syncOptions.Rules.Add(new DeploymentSkipRule("SkipAddDataFiles", "Delete", "filePath", "\\\\App_Data\\\\.*", null)); 
+               syncOptions.Rules.Add(new DeploymentSkipRule("SkipAddDataDir", "Delete", "dirPath", "\\\\App_Data(\\\\.*|$)", null)); 
+            }
+
+            return syncOptions;
         }
 
         private static void LogDeploymentEvent(DeploymentTraceEventArgs args)

--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -125,6 +125,8 @@
 
                 public static readonly string WebSpaceName = "Octopus.Action.Azure.WebSpaceName";
                 public static readonly string WebAppName = "Octopus.Action.Azure.WebAppName";
+                public static readonly string RemoveAdditionalFiles = "Octopus.Action.Azure.RemoveAdditionalFiles";
+                public static readonly string PreserveAppData = "Octopus.Action.Azure.PreserveAppData";
 
                 public static readonly string CloudServiceName = "Octopus.Action.Azure.CloudServiceName";
                 public static readonly string Slot = "Octopus.Action.Azure.Slot";


### PR DESCRIPTION
Added `Octopus.Action.Azure.RemoveAdditionalFiles` and `Octopus.Action.Azure.PreserveAppData` variables.
Connects to OctopusDeploy/Issues#1852