### PR TITLE
When a file operation succeeds there should be no retry

### DIFF
--- a/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -66,6 +66,7 @@ namespace Calamari.Integration.FileSystem
                             File.SetAttributes(path, FileAttributes.Normal);
                         }
                         File.Delete(path);
+                        return;
                     }
                 }
                 catch
@@ -77,7 +78,6 @@ namespace Calamari.Integration.FileSystem
                         {
                             throw;
                         }
-
                         break;
                     }
                     Thread.Sleep(options.SleepBetweenAttemptsMilliseconds);
@@ -107,6 +107,7 @@ namespace Calamari.Integration.FileSystem
                         dir.Attributes = dir.Attributes & ~FileAttributes.ReadOnly;
                         dir.Delete(true);
                     }
+                    return;
                 }
                 catch
                 {
@@ -369,6 +370,7 @@ namespace Calamari.Integration.FileSystem
                 try
                 {
                     File.Copy(sourceFile, targetFile, true);
+                    return;
                 }
                 catch
                 {


### PR DESCRIPTION
Current loop logic retries even when the operation succeeds. So instead of copying a file once it copies it multiple times; instead of deleting a file once it tries a second time (which then fails) etc.

Fixes OctopusDeploy/Issues#1860