### PR TITLE
Fix null reference in Calamari for newly minted services

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.WindowsService_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.WindowsService_BeforePostDeploy.ps1
@@ -97,6 +97,8 @@ if (!$service)
 	if ($LastExitCode -ne 0) {
 		throw "sc.exe create failed with exit code: $LastExitCode"
 	}
+
+	$service = Get-Service $serviceName -ErrorAction SilentlyContinue
 }
 else
 {
@@ -152,6 +154,7 @@ else
 {
 	Write-Host "Starting the $serviceName service"
 	Start-Service $ServiceName
+
 	$service.WaitForStatus('Running', '00:00:30')
 	If ($service.Status -ne 'Running') 
 	{


### PR DESCRIPTION
Checking for service start had a null reference when the service was newly created for the first time

Fixes OctopusDeploy/Issues#1923

Tested newly minted service and existing service