### PR TITLE
Allow setting physical path when deploying to Azure Web App 

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
@@ -47,12 +47,21 @@ namespace Calamari.Azure.Deployment.Conventions
 
             var changeSummary = DeploymentManager
                 .CreateObject("contentPath", deployment.CurrentDirectory)
-                .SyncTo("contentPath", publishProfile.MSDeploySite, DeploymentOptions(publishProfile), 
+                .SyncTo("contentPath", BuildPath(publishProfile.MSDeploySite, variables), DeploymentOptions(publishProfile), 
                 DeploymentSyncOptions(variables)
                 );
 
             Log.Info("Successfully deployed to Azure. {0} objects added. {1} objects updated. {2} objects deleted.",
                 changeSummary.ObjectsAdded, changeSummary.ObjectsUpdated, changeSummary.ObjectsDeleted);
+        }
+
+        private static string BuildPath(string site, VariableDictionary variables)
+        {
+            var relativePath = (variables.Get(SpecialVariables.Action.Azure.PhysicalPath) ?? "").TrimStart('\\');
+
+            return relativePath != ""
+                ? site + "\\" + relativePath
+                : site;
         }
 
         private static DeploymentBaseOptions DeploymentOptions(

--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -126,6 +126,7 @@
                 public static readonly string WebAppName = "Octopus.Action.Azure.WebAppName";
                 public static readonly string RemoveAdditionalFiles = "Octopus.Action.Azure.RemoveAdditionalFiles";
                 public static readonly string PreserveAppData = "Octopus.Action.Azure.PreserveAppData";
+                public static readonly string PhysicalPath = "Octopus.Action.Azure.PhysicalPath";
 
                 public static readonly string CloudServiceName = "Octopus.Action.Azure.CloudServiceName";
                 public static readonly string Slot = "Octopus.Action.Azure.Slot";


### PR DESCRIPTION
Added `Octopus.Action.Azure.PhysicalPath` variable, which is the physical path, relative to the site root.

Connects to OctopusDeploy/Issues#1914