### PR TITLE
Corrected file-system retry handling and attempt to ensure directory deletion.

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Fixtures\Deployment\DeployPackageFixture.cs" />
     <Compile Include="Fixtures\Deployment\Packages\PackageBuilder.cs" />
     <Compile Include="Fixtures\FileSystem\PackageStoreFixture.cs" />
+    <Compile Include="Fixtures\FileSystem\RetryFixture.cs" />
     <Compile Include="Fixtures\FindPackage\FindPackageFixture.cs" />
     <Compile Include="Fixtures\Iis\IisFixture.cs" />
     <Compile Include="Fixtures\PackageDownload\AuthenticatedTestAttribute.cs" />

--- a/source/Calamari.Tests/Fixtures/FileSystem/RetryFixture.cs
+++ b/source/Calamari.Tests/Fixtures/FileSystem/RetryFixture.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Calamari.Integration.FileSystem;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.FileSystem
+{
+    [TestFixture]
+    public class RetryFixture
+    {
+        [Test]
+        public void ShouldThrowOnceRetriesExceeded()
+        {
+            const int retries = 100;
+            var subject = new RetryTracker(100, null, new RetryInterval(100, 200, 2));
+            Exception caught = null;
+            var retried = 0;
+
+            try
+            {
+                while (subject.Try())
+                {
+                    try
+                    {
+                        throw new Exception("Blah");
+                    }
+                    catch
+                    {
+                        if (subject.CanRetry())
+                        {
+                            //swallow exception
+                            retried++;
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                caught = ex;
+            }
+
+            Assert.NotNull(caught);
+            Assert.AreEqual(retries, retried);
+        }
+    }
+}

--- a/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -166,7 +166,7 @@ namespace Calamari.Integration.FileSystem
                     Log.VerboseFormat("Waiting for directory '{0}' to be deleted", path);
             }
 
-            var message = $"Unable to ensure directory '{path}' was deleted";
+            var message = $"Directory '{path}' still exists, despite requested deletion";
 
             if (failureOptions == FailureOptions.ThrowOnFailure)
                 throw new Exception(message);

--- a/source/Calamari/Integration/FileSystem/RetryTracker.cs
+++ b/source/Calamari/Integration/FileSystem/RetryTracker.cs
@@ -45,8 +45,9 @@ namespace Calamari.Integration.FileSystem
 
         public bool Try()
         {
+            var canRetry = CanRetry();
             currentTry++;
-            return CanRetry();
+            return canRetry;
         }
 
         public int Sleep()


### PR DESCRIPTION
Corrected `CanRetry()` logic.
Implemented `EnsureDirectoryDeleted()` in `CalamariPhysicalFileSystem`.
Connects to OctopusDeploy/Issues#1960