### PR TITLE
Bring back support for config transform files in a subfolder

### DIFF
--- a/source/Calamari/Deployment/Conventions/ConfigurationTransformsConvention.cs
+++ b/source/Calamari/Deployment/Conventions/ConfigurationTransformsConvention.cs
@@ -102,9 +102,16 @@ namespace Calamari.Deployment.Conventions
             // The reason we use fileSystem.EnumerateFiles here is to get the actual file-names from the physical file-system.
             // This prevents any issues with mis-matched casing in transform specifications.
             return fileSystem.EnumerateFiles(Path.GetDirectoryName(sourceFile),
-               Path.GetFileName(DetermineTransformFileName(sourceFile, transformation, true)),
-               Path.GetFileName(DetermineTransformFileName(sourceFile, transformation, false))
-              );
+               GetRelativePathToTransformFile(sourceFile, DetermineTransformFileName(sourceFile, transformation, true)),
+               GetRelativePathToTransformFile(sourceFile, DetermineTransformFileName(sourceFile, transformation, false))
+            );
+        }
+
+        private static string GetRelativePathToTransformFile(string sourceFile, string transformFile)
+        {
+            return transformFile
+                .Replace(Path.GetDirectoryName(sourceFile) ?? string.Empty, "")
+                .TrimStart('\\');
         }
 
         private static string DetermineTransformFileName(string sourceFile, XmlConfigTransformDefinition transformation, bool defaultExtension)


### PR DESCRIPTION
Add back support for config transforms like `config\foo.bar.config => bar.config`

Wildcard config transforms like `config\*.bar.config => bar.config` is not supported.

Fixes OctopusDeploy/Issues#2032