### PR TITLE
Using local AzureProfile.json file for Azure deployments

### DIFF
--- a/source/Calamari.Azure/Integration/AzurePowershellContext.cs
+++ b/source/Calamari.Azure/Integration/AzurePowershellContext.cs
@@ -43,6 +43,7 @@ namespace Calamari.Azure.Integration
             SetOutputVariable(SpecialVariables.Action.Azure.Output.SubscriptionId, variables.Get(SpecialVariables.Action.Azure.SubscriptionId), variables);
             SetOutputVariable(SpecialVariables.Action.Azure.Output.SubscriptionName, variables.Get(SpecialVariables.Account.Name), variables);
 
+            using (new TemporaryFile(Path.Combine(workingDirectory, "AzureProfile.json")))
             using (new TemporaryFile(CreateAzureCertificate(workingDirectory, variables)))
             using (var contextScriptFile = new TemporaryFile(CreateContextScriptFile(workingDirectory)))
             {

--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -27,10 +27,7 @@ Write-Verbose "Loading the management certificate"
 Add-Type -AssemblyName "System"
 $certificate = new-object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList @($OctopusAzureCertificateFileName, $OctopusAzureCertificatePassword, ([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags] "PersistKeySet", "Exportable"))
 $azureProfile = New-AzureProfile -SubscriptionId $OctopusAzureSubscriptionId -Certificate $certificate
-
-if (!(Test-Path ".\AzureProfile.json" -ErrorAction SilentlyContinue)) {
-	$azureProfile.Save(".\AzureProfile.json")
-}
+$azureProfile.Save(".\AzureProfile.json")
 
 Select-AzureProfile -Profile $azureProfile | Out-Null
 

--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -19,9 +19,6 @@ Write-Verbose "  Subscription name:     $OctopusAzureSubscriptionName"
 Write-Verbose "Importing Windows Azure modules"
 
 Import-Module $OctopusAzureModulePath
-function Get-OctopusAzureCertificate {
-	return $certificate
-}
 
 Write-Verbose "Loading the management certificate"
 Add-Type -AssemblyName "System"

--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -19,13 +19,22 @@ Write-Verbose "  Subscription name:     $OctopusAzureSubscriptionName"
 Write-Verbose "Importing Windows Azure modules"
 
 Import-Module $OctopusAzureModulePath
+function Get-OctopusAzureCertificate {
+	return $certificate
+}
+
+Write-Verbose "Loading the management certificate"
+Add-Type -AssemblyName "System"
+$certificate = new-object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList @($OctopusAzureCertificateFileName, $OctopusAzureCertificatePassword, ([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags] "PersistKeySet", "Exportable"))
+$azureProfile = New-AzureProfile -SubscriptionId $OctopusAzureSubscriptionId -Certificate $certificate
+
+if (!(Test-Path ".\AzureProfile.json" -ErrorAction SilentlyContinue)) {
+	$azureProfile.Save(".\AzureProfile.json")
+}
+
+Select-AzureProfile -Profile $azureProfile | Out-Null
 
 if (!(Get-AzureSubscription -SubscriptionName $OctopusAzureSubscriptionName -ErrorAction SilentlyContinue)) {
-	Write-Verbose "Loading the management certificate"
-
-	Add-Type -AssemblyName "System"
-	$certificate = new-object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList @($OctopusAzureCertificateFileName, $OctopusAzureCertificatePassword, ([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags] "PersistKeySet", "Exportable"))
-
 	Write-Verbose "Setting up the Azure subscription"
 
 	Set-AzureSubscription -SubscriptionName $OctopusAzureSubscriptionName -SubscriptionId $OctopusAzureSubscriptionId -Certificate $certificate

--- a/source/Calamari.Azure/Scripts/DeployAzureCloudService.ps1
+++ b/source/Calamari.Azure/Scripts/DeployAzureCloudService.ps1
@@ -26,7 +26,7 @@
 
 function CreateOrUpdate() 
 {
-	Set-AzureSubscription -SubscriptionId $OctopusAzureSubscriptionId -CurrentStorageAccount $OctopusAzureStorageAccountName
+	Set-AzureSubscription -SubscriptionName $OctopusAzureSubscriptionName -CurrentStorageAccount $OctopusAzureStorageAccountName
 
     $deployment = Get-AzureDeployment -ServiceName $OctopusAzureServiceName -Slot $OctopusAzureSlot -ErrorVariable a -ErrorAction silentlycontinue
  

--- a/source/Calamari.Azure/Scripts/DeployAzureCloudService.ps1
+++ b/source/Calamari.Azure/Scripts/DeployAzureCloudService.ps1
@@ -26,9 +26,6 @@
 
 function CreateOrUpdate() 
 {
-	$azureProfile = New-AzureProfile -Path ".\AzureProfile.json"
-	Select-AzureProfile -Profile $azureProfile | Out-Null
-
 	Set-AzureSubscription -SubscriptionId $OctopusAzureSubscriptionId -CurrentStorageAccount $OctopusAzureStorageAccountName
 
     $deployment = Get-AzureDeployment -ServiceName $OctopusAzureServiceName -Slot $OctopusAzureSlot -ErrorVariable a -ErrorAction silentlycontinue

--- a/source/Calamari.Azure/Scripts/DeployAzureCloudService.ps1
+++ b/source/Calamari.Azure/Scripts/DeployAzureCloudService.ps1
@@ -26,7 +26,10 @@
 
 function CreateOrUpdate() 
 {
-	Set-AzureSubscription -SubscriptionName $OctopusAzureSubscriptionName -CurrentStorageAccount $OctopusAzureStorageAccountName 
+	$azureProfile = New-AzureProfile -Path ".\AzureProfile.json"
+	Select-AzureProfile -Profile $azureProfile | Out-Null
+
+	Set-AzureSubscription -SubscriptionId $OctopusAzureSubscriptionId -CurrentStorageAccount $OctopusAzureStorageAccountName
 
     $deployment = Get-AzureDeployment -ServiceName $OctopusAzureServiceName -Slot $OctopusAzureSlot -ErrorVariable a -ErrorAction silentlycontinue
  


### PR DESCRIPTION
Create and use a local AzureProfile.json file to prevent locking issues on the global AzureProfile.json file when deploying multiple Azure steps in parallel, or using a cached certificate that is wrong.

Fixes OctopusDeploy/Issues#2054 **(hopefully, have been unable to replicate the issue reported, so can't confirm changes have fixed it)**
Fixes OctopusDeploy/Issues#2076