### PR TITLE
Log the informational version at startup.

### DIFF
--- a/source/Calamari.Azure/Program.cs
+++ b/source/Calamari.Azure/Program.cs
@@ -6,7 +6,7 @@ namespace Calamari.Azure
 {
     class Program : Calamari.Program
     {
-        public Program()
+        public Program() : base("Calamari.Azure", typeof(Azure.Program).Assembly.GetInformationalVersion())
         {
             ScriptEngineRegistry.Instance.ScriptEngines[ScriptType.Powershell] = new AzurePowerShellScriptEngine();            
         }

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -192,6 +192,7 @@
     <Compile Include="Integration\Scripting\CombinedScriptEngine.cs" />
     <Compile Include="Integration\Scripting\ScriptEngineRegistry.cs" />
     <Compile Include="Integration\Scripting\ScriptType.cs" />
+    <Compile Include="Util\AssemblyExtensions.cs" />
     <Compile Include="Util\HashCalculator.cs" />
     <Compile Include="Util\AesEncryption.cs" />
     <Compile Include="Util\Uniquifier.cs" />

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -7,14 +7,25 @@ namespace Calamari
 {
     public class Program
     {
+        readonly string displayName;
+        readonly string informationalVersion;
+
+        public Program(string displayName, string informationalVersion)
+        {
+            this.displayName = displayName;
+            this.informationalVersion = informationalVersion;
+        }
+
         static int Main(string[] args)
         {
-            var program = new Program();
+            var program = new Program("Calamari", typeof(Program).Assembly.GetInformationalVersion());
             return program.Execute(args);
         }
 
         protected int Execute(string[] args)
         {
+            Log.Verbose($"Octopus Deploy: {displayName} version {informationalVersion}");
+
             ProxyInitializer.InitializeDefaultProxy();
             RegisterCommandAssemblies();
 

--- a/source/Calamari/Util/AssemblyExtensions.cs
+++ b/source/Calamari/Util/AssemblyExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+
+// ReSharper disable once CheckNamespace
+namespace Calamari
+{
+    public static class AssemblyExtensions
+    {
+        public static string FullLocalPath(this Assembly assembly)
+        {
+            var codeBase = assembly.CodeBase;
+            var uri = new UriBuilder(codeBase);
+            var root = Uri.UnescapeDataString(uri.Path);
+            root = root.Replace("/", "\\");
+            return root;
+        }
+
+        public static string GetInformationalVersion(this Assembly assembly)
+        {
+            var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.FullLocalPath());
+            return fileVersionInfo.ProductVersion;
+        }
+    }
+}


### PR DESCRIPTION
This will enable us to persist/view the version of Calamari being used to run any Task.

Sample output
```
Task ID:        ServerTasks-44
Task status:    Success
Task queued:    Wednesday, 28 October 2015 1:27 PM
Task started:   Wednesday, 28 October 2015 1:27 PM
Task duration:  11 seconds
Server version: 3.1.6-logversioninfo.1+33.Branch.logversioninfo.Sha.b1c61a58f3a55b553c6a7b8224e15ea92f601a2a

                    | == Success: Script run from management console ==
13:27:01   Info     |   Script run from management console
                    | 
                    |   == Success: Run script on: DWebApp01 ==
13:27:03   Info     |     This server does not have version 1.0.20151028.132655 of the Calamari package. It will be pushed automatically.
13:27:06   Info     |     C:\OctopusDev\master\Tentacle\DWebApp01\Calamari\1.0.20151028.132655\Success.txt
13:27:06   Verbose  |     Octopus Deploy: Tentacle version 3.1.6-logversioninfo0001 (3.1.6-logversioninfo.1+33.Branch.logversioninfo.Sha.b1c61a58f3a55b553c6a7b8224e15ea92f601a2a)
13:27:06   Verbose  |     Package: C:\OctopusDev\master\Tentacle\DWebApp01\Work\20151028032704-9\Calamari.1.0.20151028.132655.nupkg
13:27:06   Verbose  |     Destination: C:\OctopusDev\master\Tentacle\DWebApp01\Calamari\1.0.20151028.132655
13:27:09   Verbose  |     90 files extracted
13:27:09   Verbose  |     Octopus Deploy: Calamari version 1.0.0.0
13:27:11   Info     |     Hello world!
13:27:11   Info     |     Exit code: 0

```

Connects to OctopusDeploy/Issues#2028