### PR TITLE
Check if already using the right app pool before trying to set it.

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -254,8 +254,11 @@ Execute-WithRetry {
 }
 
 $cmd = { 
-	Write-Output "Assigning website to application pool..."
-	Set-ItemProperty $sitePath -name applicationPool -value $ApplicationPoolName
+	$pool = Get-ItemProperty $sitePath -name applicationPool
+	if ($ApplicationPoolName -ne $pool) {
+		Write-Output "Assigning website to application pool..."
+		Set-ItemProperty $sitePath -name applicationPool -value $ApplicationPoolName
+	}
 }
 Execute-WithRetry -Command $cmd
 


### PR DESCRIPTION
This should allow calamari to run using an account with less permissions when changes are not needed.

As per forum thread http://help.octopusdeploy.com/discussions/problems/41960-using-octopus-in-an-environment-with-cutdown-security-permissions