### PR TITLE
Calamari now supports creating artifacts on Mac OS X SSH Targets. Fixes OctopusDeploy/Issues#1800

### DIFF
--- a/source/Calamari/Integration/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari/Integration/Scripting/Bash/Bootstrap.sh
@@ -97,7 +97,7 @@ function new_octopusartifact
 
 	pth=$1
 	ofn=$2
-	len=$(stat -c%s $1 )
+	len=$(wc -c < $1 )
 
 
 	if [ -z "$ofn" ]


### PR DESCRIPTION
Updated bootstrapper script to be more generic and support Mac OS X.

Fixes OctopusDeploy/Issues#1800