### PR TITLE
New convention for appSettings.json generation

### DIFF
--- a/source/Calamari.Azure/Commands/DeployAzureCloudServiceCommand.cs
+++ b/source/Calamari.Azure/Commands/DeployAzureCloudServiceCommand.cs
@@ -5,6 +5,7 @@ using Calamari.Azure.Integration;
 using Calamari.Commands.Support;
 using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
+using Calamari.Integration.AppSettingsJson;
 using Calamari.Integration.Certificates;
 using Calamari.Integration.ConfigurationTransforms;
 using Calamari.Integration.ConfigurationVariables;
@@ -61,6 +62,7 @@ namespace Calamari.Azure.Commands
             var substituter = new FileSubstituter(fileSystem);
             var configurationTransformer = new ConfigurationTransformer(variables.GetFlag(SpecialVariables.Package.IgnoreConfigTransformationErrors), variables.GetFlag(SpecialVariables.Package.SuppressConfigTransformationLogging));
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
+            var generator = new AppSettingsJsonGenerator();
 
             var conventions = new List<IConvention>
             {
@@ -77,6 +79,7 @@ namespace Calamari.Azure.Commands
                 new SubstituteInFilesConvention(fileSystem, substituter),
                 new ConfigurationTransformsConvention(fileSystem, configurationTransformer),
                 new ConfigurationVariablesConvention(fileSystem, replacer),
+                new AppSettingsJsonConvention(generator),
                 new PackagedScriptConvention(DeploymentStages.Deploy, fileSystem, scriptEngine, commandLineRunner),
                 new ConfiguredScriptConvention(DeploymentStages.Deploy, scriptEngine, fileSystem, commandLineRunner),
                 new RePackageCloudServiceConvention(fileSystem),

--- a/source/Calamari.Azure/Commands/DeployAzureWebCommand.cs
+++ b/source/Calamari.Azure/Commands/DeployAzureWebCommand.cs
@@ -4,6 +4,7 @@ using Calamari.Azure.Deployment.Conventions;
 using Calamari.Commands.Support;
 using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
+using Calamari.Integration.AppSettingsJson;
 using Calamari.Integration.ConfigurationTransforms;
 using Calamari.Integration.ConfigurationVariables;
 using Calamari.Integration.FileSystem;
@@ -50,6 +51,7 @@ namespace Calamari.Azure.Commands
 
             var fileSystem = new WindowsPhysicalFileSystem();
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
+            var generator = new AppSettingsJsonGenerator();
             var scriptEngine = new CombinedScriptEngine();
             var substituter = new FileSubstituter(fileSystem);
             var commandLineRunner = new CommandLineRunner(new SplitCommandOutput(new ConsoleCommandOutput(), new ServiceMessageCommandOutput(variables)));
@@ -68,6 +70,7 @@ namespace Calamari.Azure.Commands
                 new SubstituteInFilesConvention(fileSystem, substituter),
                 new ConfigurationTransformsConvention(fileSystem, configurationTransformer),
                 new ConfigurationVariablesConvention(fileSystem, replacer),
+                new AppSettingsJsonConvention(generator),
                 new PackagedScriptConvention(DeploymentStages.Deploy, fileSystem, scriptEngine, commandLineRunner),
                 new ConfiguredScriptConvention(DeploymentStages.Deploy, scriptEngine, fileSystem, commandLineRunner),
                 new AzureWebAppConvention(variables),

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -188,6 +188,9 @@
     <None Include="Fixtures\AppSettingsJson\Samples\appsettings.ignore-octopus.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Fixtures\AppSettingsJson\Samples\appsettings.ambiguous.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Fixtures\AppSettingsJson\Samples\appsettings.simple.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -185,6 +185,9 @@
     <None Include="Fixtures\AppSettingsJson\Samples\appsettings.existing-initial.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Fixtures\AppSettingsJson\Samples\appsettings.ignore-octopus.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Fixtures\AppSettingsJson\Samples\appsettings.simple.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -132,6 +132,8 @@
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
     <Compile Include="Fixtures\ApplyDelta\ApplyDeltaFixture.cs" />
+    <Compile Include="Fixtures\AppSettingsJson\AppSettingsJsonFixture.cs" />
+    <Compile Include="Fixtures\Conventions\AppSettingsJsonConventionFixture.cs" />
     <Compile Include="Fixtures\SetUpFixture.cs" />
     <Compile Include="Fixtures\ConfigurationTransforms\ConfigurationTransformsFixture.cs" />
     <Compile Include="Fixtures\ConfigurationVariables\ConfigurationVariablesFixture.cs" />
@@ -177,6 +179,15 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="Fixtures\AppSettingsJson\Samples\appsettings.existing-expected.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Fixtures\AppSettingsJson\Samples\appsettings.existing-initial.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Fixtures\AppSettingsJson\Samples\appsettings.simple.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Fixtures\Bash\Scripts\create-artifact.sh">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/source/Calamari.Tests/Fixtures/AppSettingsJson/AppSettingsJsonFixture.cs
+++ b/source/Calamari.Tests/Fixtures/AppSettingsJson/AppSettingsJsonFixture.cs
@@ -36,6 +36,19 @@ namespace Calamari.Tests.Fixtures.AppSettingsJson
         }
 
         [Test]
+        public void ShouldIgnoreOctopusPrefix()
+        {
+            var variables = new VariableDictionary();
+            variables.Set("MyMessage", "Hello world");
+            variables.Set("IThinkOctopusIsGreat", "Yes, I do");
+            variables.Set("OctopusRocks", "This is ignored");
+            variables.Set("Octopus.Rocks", "So is this");
+            
+            var generated = Generate(variables);
+            AssertJsonEquivalent(generated, "appsettings.ignore-octopus.json");
+        }
+
+        [Test]
         public void ShouldKeepExistingValues()
         {
             var variables = new VariableDictionary();

--- a/source/Calamari.Tests/Fixtures/AppSettingsJson/AppSettingsJsonFixture.cs
+++ b/source/Calamari.Tests/Fixtures/AppSettingsJson/AppSettingsJsonFixture.cs
@@ -49,6 +49,20 @@ namespace Calamari.Tests.Fixtures.AppSettingsJson
         }
 
         [Test]
+        public void ShouldWarnAndIgnoreAmbiguousSettings()
+        {
+            var variables = new VariableDictionary();
+            variables.Set("EmailSettings:DefaultRecipients:To", "paul@octopus.com");
+            variables.Set("EmailSettings:DefaultRecipients", "test@test.com");
+
+            var writer = new StringWriter();
+            Log.StdOut = writer;
+            var generated = Generate(variables);
+            AssertJsonEquivalent(generated, "appsettings.ambiguous.json");
+            Assert.That(writer.ToString(), Is.StringContaining("Unable to set value for EmailSettings:DefaultRecipients:To. The property at EmailSettings.DefaultRecipients is a String."));
+        }
+
+        [Test]
         public void ShouldKeepExistingValues()
         {
             var variables = new VariableDictionary();

--- a/source/Calamari.Tests/Fixtures/AppSettingsJson/AppSettingsJsonFixture.cs
+++ b/source/Calamari.Tests/Fixtures/AppSettingsJson/AppSettingsJsonFixture.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.IO;
+using Calamari.Integration.AppSettingsJson;
+using Calamari.Integration.FileSystem;
+using Calamari.Tests.Helpers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Octostache;
+
+namespace Calamari.Tests.Fixtures.AppSettingsJson
+{
+    [TestFixture]
+    public class AppSettingsJsonFixture : CalamariFixture
+    {
+        AppSettingsJsonGenerator appSettings;
+
+        [SetUp]
+        public void SetUp()
+        {
+            appSettings = new AppSettingsJsonGenerator();
+        }
+
+        [Test]
+        public void ShouldGenerateSimpleFile()
+        {
+            var variables = new VariableDictionary();
+            variables.Set("MyMessage", "Hello world");
+            variables.Set("EmailSettings:SmtpHost", "localhost");
+            variables.Set("EmailSettings:SmtpPort", "23");
+            variables.Set("EmailSettings:DefaultRecipients:To", "paul@octopus.com");
+            variables.Set("EmailSettings:DefaultRecipients:Cc", "mike@octopus.com");
+
+            var generated = Generate(variables);
+            AssertJsonEquivalent(generated, "appsettings.simple.json");
+        }
+
+        [Test]
+        public void ShouldKeepExistingValues()
+        {
+            var variables = new VariableDictionary();
+            variables.Set("MyMessage", "Hello world!");
+            variables.Set("EmailSettings:SmtpPort", "24");
+            variables.Set("EmailSettings:DefaultRecipients:Cc", "damo@octopus.com");
+
+            var generated = Generate(variables, existingFile: "appsettings.existing-expected.json");
+            AssertJsonEquivalent(generated, "appsettings.existing-expected.json");
+        }
+
+        string Generate(VariableDictionary variables, string existingFile = null)
+        {
+            var temp = Path.GetTempFileName();
+            if (existingFile != null)
+                File.Copy(GetFixtureResouce("Samples", existingFile), temp, true);
+
+            using (new TemporaryFile(temp))
+            {
+                appSettings.Generate(temp, variables);
+                return File.ReadAllText(temp);
+            }
+        }
+
+        void AssertJsonEquivalent(string generated, string sampleFile)
+        {
+            var expected = File.ReadAllText(GetFixtureResouce("Samples", sampleFile));
+
+            var generatedJson = JToken.Parse(generated);
+            var expectedJson = JToken.Parse(expected);
+
+            if (!JToken.DeepEquals(generatedJson, expectedJson))
+            {
+                Console.WriteLine("Expected:");
+                Console.WriteLine(expectedJson.ToString(Formatting.Indented));
+
+                Console.WriteLine("Generated:");
+                Console.WriteLine(generatedJson.ToString(Formatting.Indented));
+
+                Assert.Fail("Generated JSON did not match expected JSON");                
+            }
+        } 
+    }
+}

--- a/source/Calamari.Tests/Fixtures/AppSettingsJson/Samples/appsettings.ambiguous.json
+++ b/source/Calamari.Tests/Fixtures/AppSettingsJson/Samples/appsettings.ambiguous.json
@@ -1,0 +1,5 @@
+﻿{
+	"EmailSettings": {
+		"DefaultRecipients": "test@test.com"
+	}
+}

--- a/source/Calamari.Tests/Fixtures/AppSettingsJson/Samples/appsettings.existing-expected.json
+++ b/source/Calamari.Tests/Fixtures/AppSettingsJson/Samples/appsettings.existing-expected.json
@@ -1,0 +1,11 @@
+﻿{
+	"MyMessage": "Hello world!",
+	"EmailSettings": {
+		"SmtpPort": "24",
+		"SmtpHost": "localhost",
+		"DefaultRecipients": {
+			"To": "paul@octopus.com",
+			"Cc": "damo@octopus.com"
+		}
+	}
+}

--- a/source/Calamari.Tests/Fixtures/AppSettingsJson/Samples/appsettings.existing-initial.json
+++ b/source/Calamari.Tests/Fixtures/AppSettingsJson/Samples/appsettings.existing-initial.json
@@ -1,0 +1,11 @@
+﻿{
+	"MyMessage": "Hello world",
+	"EmailSettings": {
+		"SmtpPort": "23",
+		"SmtpHost": "localhost",
+		"DefaultRecipients": {
+			"To": "paul@octopus.com",
+			"Cc": "mike@octopus.com"
+		}
+	}
+}

--- a/source/Calamari.Tests/Fixtures/AppSettingsJson/Samples/appsettings.ignore-octopus.json
+++ b/source/Calamari.Tests/Fixtures/AppSettingsJson/Samples/appsettings.ignore-octopus.json
@@ -1,0 +1,4 @@
+﻿{
+	"MyMessage": "Hello world",
+	"IThinkOctopusIsGreat": "Yes, I do"
+}

--- a/source/Calamari.Tests/Fixtures/AppSettingsJson/Samples/appsettings.simple.json
+++ b/source/Calamari.Tests/Fixtures/AppSettingsJson/Samples/appsettings.simple.json
@@ -1,0 +1,11 @@
+﻿{
+	"MyMessage": "Hello world",
+	"EmailSettings": {
+		"SmtpPort": "23",
+		"SmtpHost": "localhost",
+		"DefaultRecipients": {
+			"To": "paul@octopus.com",
+			"Cc": "mike@octopus.com"
+		}
+	}
+}

--- a/source/Calamari.Tests/Fixtures/Conventions/AppSettingsJsonConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/AppSettingsJsonConventionFixture.cs
@@ -1,0 +1,41 @@
+﻿using Calamari.Deployment;
+using Calamari.Deployment.Conventions;
+using Calamari.Integration.AppSettingsJson;
+using Calamari.Integration.Processes;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Conventions
+{
+    [TestFixture]
+    public class AppSettingsJsonConventionFixture
+    {
+        RunningDeployment deployment;
+        IAppSettingsJsonGenerator generator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            deployment = new RunningDeployment("C:\\Packages", new CalamariVariableDictionary());
+            generator = Substitute.For<IAppSettingsJsonGenerator>();
+        }
+
+        [Test]
+        public void ShouldNotRunIfVariableNotSet()
+        {
+            var convention = new AppSettingsJsonConvention(generator);
+            convention.Install(deployment);
+            generator.DidNotReceiveWithAnyArgs().Generate(null, null);
+        }
+
+        [Test]
+        public void ShouldFindAndCallDeployScripts()
+        {
+            deployment.Variables.Set(SpecialVariables.Package.GenerateAppSettingsJson, "true");
+            deployment.Variables.Set(SpecialVariables.Package.AppSettingsJsonPath, "appsettings.environment.json");
+            var convention = new AppSettingsJsonConvention(generator);
+            convention.Install(deployment);
+            generator.Received().Generate("appsettings.environment.json", deployment.Variables);
+        }
+    }
+}

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Commands\Support\OptionValueType.cs" />
     <Compile Include="Deployment\Conventions\AlreadyInstalledConvention.cs" />
     <Compile Include="Deployment\Conventions\ConfigurationTransformsConvention.cs" />
+    <Compile Include="Deployment\Conventions\AppSettingsJsonConvention.cs" />
     <Compile Include="Deployment\Conventions\ConfigurationVariablesConvention.cs" />
     <Compile Include="Deployment\Conventions\ContributeEnvironmentVariablesConvention.cs" />
     <Compile Include="Deployment\ConventionProcessor.cs" />
@@ -169,6 +170,8 @@
     <Compile Include="Deployment\Conventions\LogVariablesConvention.cs" />
     <Compile Include="Deployment\Conventions\FeatureScriptConvention.cs" />
     <Compile Include="Deployment\Conventions\ConfiguredScriptConvention.cs" />
+    <Compile Include="Integration\AppSettingsJson\AppSettingsJsonGenerator.cs" />
+    <Compile Include="Integration\AppSettingsJson\IAppSettingsJsonGenerator.cs" />
     <Compile Include="Integration\Scripting\PackagedScriptRunner.cs" />
     <Compile Include="Deployment\Conventions\RollbackScriptConvention.cs" />
     <Compile Include="Deployment\DeploymentStages.cs" />

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -6,6 +6,7 @@ using Calamari.Commands.Support;
 using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
 using Calamari.Deployment.Journal;
+using Calamari.Integration.AppSettingsJson;
 using Calamari.Integration.ConfigurationTransforms;
 using Calamari.Integration.ConfigurationVariables;
 using Calamari.Integration.EmbeddedResources;
@@ -52,6 +53,7 @@ namespace Calamari.Commands
             var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
             var scriptCapability = new CombinedScriptEngine();
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
+            var generator = new AppSettingsJsonGenerator();
             var substituter = new FileSubstituter(fileSystem);
             var configurationTransformer = new ConfigurationTransformer(variables.GetFlag(SpecialVariables.Package.IgnoreConfigTransformationErrors), variables.GetFlag(SpecialVariables.Package.SuppressConfigTransformationLogging));
             var embeddedResources = new CallingAssemblyEmbeddedResources();
@@ -74,6 +76,7 @@ namespace Calamari.Commands
                 new SubstituteInFilesConvention(fileSystem, substituter),
                 new ConfigurationTransformsConvention(fileSystem, configurationTransformer),
                 new ConfigurationVariablesConvention(fileSystem, replacer),
+                new AppSettingsJsonConvention(generator),
                 new CopyPackageToCustomInstallationDirectoryConvention(fileSystem),
                 new FeatureScriptConvention(DeploymentStages.BeforeDeploy, fileSystem, embeddedResources, scriptCapability, commandLineRunner),
                 new PackagedScriptConvention(DeploymentStages.Deploy, fileSystem, scriptCapability, commandLineRunner),

--- a/source/Calamari/Deployment/Conventions/AppSettingsJsonConvention.cs
+++ b/source/Calamari/Deployment/Conventions/AppSettingsJsonConvention.cs
@@ -1,0 +1,30 @@
+﻿using Calamari.Integration.AppSettingsJson;
+using Calamari.Integration.ConfigurationVariables;
+using Calamari.Integration.FileSystem;
+
+namespace Calamari.Deployment.Conventions
+{
+    public class AppSettingsJsonConvention : IInstallConvention
+    {
+        readonly IAppSettingsJsonGenerator appSettings;
+
+        public AppSettingsJsonConvention(IAppSettingsJsonGenerator appSettings)
+        {
+            this.appSettings = appSettings;
+        }
+
+        public void Install(RunningDeployment deployment)
+        {
+            if (deployment.Variables.GetFlag(SpecialVariables.Package.GenerateAppSettingsJson) == false)
+            {
+                return;
+            }
+
+            var path = deployment.Variables.Get(SpecialVariables.Package.AppSettingsJsonPath);
+            if (string.IsNullOrWhiteSpace(path))
+                return;
+
+            appSettings.Generate(path, deployment.Variables);
+        }
+    }
+}

--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -79,6 +79,8 @@
             public static readonly string CustomInstallationDirectory = "Octopus.Action.Package.CustomInstallationDirectory";
             public static readonly string CustomInstallationDirectoryShouldBePurgedBeforeDeployment = "Octopus.Action.Package.CustomInstallationDirectoryShouldBePurgedBeforeDeployment";
             public static readonly string AutomaticallyUpdateAppSettingsAndConnectionStrings = "Octopus.Action.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings";
+            public static readonly string GenerateAppSettingsJson = "Octopus.Action.Package.GenerateAppSettingsJson";
+            public static readonly string AppSettingsJsonPath = "Octopus.Action.Package.AppSettingsJsonPath";
             public static readonly string AutomaticallyRunConfigurationTransformationFiles = "Octopus.Action.Package.AutomaticallyRunConfigurationTransformationFiles";
             public static readonly string IgnoreConfigTransformationErrors = "Octopus.Action.Package.IgnoreConfigTransformationErrors";
             public static readonly string SuppressConfigTransformationLogging = "Octopus.Action.Package.SuppressConfigTransformationLogging";

--- a/source/Calamari/Integration/AppSettingsJson/AppSettingsJsonGenerator.cs
+++ b/source/Calamari/Integration/AppSettingsJson/AppSettingsJsonGenerator.cs
@@ -9,7 +9,7 @@ namespace Calamari.Integration.AppSettingsJson
     public class AppSettingsJsonGenerator : IAppSettingsJsonGenerator
     {
         const string KeyDelimiter = ":";
-
+        
         public void Generate(string appSettingsFilePath, VariableDictionary variables)
         {
             var root = LoadJson(appSettingsFilePath);
@@ -19,6 +19,9 @@ namespace Calamari.Integration.AppSettingsJson
 
             foreach (var name in names)
             {
+                if (name.StartsWith("Octopus", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
                 SetValueRecursive(root, name, variables.Get(name));
             }
 

--- a/source/Calamari/Integration/AppSettingsJson/AppSettingsJsonGenerator.cs
+++ b/source/Calamari/Integration/AppSettingsJson/AppSettingsJsonGenerator.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Octostache;
+
+namespace Calamari.Integration.AppSettingsJson
+{
+    public class AppSettingsJsonGenerator : IAppSettingsJsonGenerator
+    {
+        const string KeyDelimiter = ":";
+
+        public void Generate(string appSettingsFilePath, VariableDictionary variables)
+        {
+            var root = LoadJson(appSettingsFilePath);
+
+            var names = variables.GetNames();
+            names.Sort(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var name in names)
+            {
+                SetValueRecursive(root, name, variables.Get(name));
+            }
+
+            SaveJson(appSettingsFilePath, root);
+        }
+
+        static JObject LoadJson(string appSettingsFilePath)
+        {
+            if (!File.Exists(appSettingsFilePath))
+                return new JObject();
+
+            if (new FileInfo(appSettingsFilePath).Length == 0)
+                return new JObject();
+
+            using (var reader = new StreamReader(appSettingsFilePath))
+            using (var json = new JsonTextReader(reader))
+            {
+                return JObject.Load(json);
+            }
+        }
+
+        static void SetValueRecursive(JObject currentObject, string name, string value)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return;
+
+            var firstKey = name.IndexOf(KeyDelimiter, StringComparison.OrdinalIgnoreCase);
+            if (firstKey > 0)
+            {
+                var key = name.Substring(0, firstKey);
+                var remainder = name.Substring(firstKey + 1).Trim(':');
+
+                var property = GetOrCreateProperty(currentObject, key);
+
+                SetValueRecursive((JObject)property, remainder, value);
+            }
+            else
+            {
+                currentObject[name] = value;
+            }
+        }
+
+        static JToken GetOrCreateProperty(JObject currentObject, string key)
+        {
+            JToken currentToken;
+            if (currentObject.TryGetValue(key, StringComparison.InvariantCultureIgnoreCase, out currentToken))
+            {
+                if (currentToken is JObject == false)
+                {
+                    // This can happen if, for example, we have something like:
+                    //  Foo = "Hello"
+                    //  Foo:Bar = "World"
+                    // In this case, what would Foo be set to - the string or the object? We go with the first value, the string. Since the keys are sorted first we get the shortest value
+                    return currentToken;
+                }
+            }
+            else
+            {
+                currentObject[key] = currentToken = new JObject();
+            }
+            return currentToken;
+        }
+
+        static void SaveJson(string appSettingsFilePath, JObject root)
+        {
+            using (var writer = new StreamWriter(appSettingsFilePath))
+            using (var json = new JsonTextWriter(writer))
+            {
+                json.Formatting = Formatting.Indented;
+                root.WriteTo(json);
+            }
+        }
+    }
+}

--- a/source/Calamari/Integration/AppSettingsJson/IAppSettingsJsonGenerator.cs
+++ b/source/Calamari/Integration/AppSettingsJson/IAppSettingsJsonGenerator.cs
@@ -1,0 +1,9 @@
+﻿using Octostache;
+
+namespace Calamari.Integration.AppSettingsJson
+{
+    public interface IAppSettingsJsonGenerator
+    {
+        void Generate(string appSettingsFilePath, VariableDictionary variables);
+    }
+}

--- a/source/Calamari/Log.cs
+++ b/source/Calamari/Log.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.CodeDom.Compiler;
 using System.Globalization;
+using System.IO;
 using System.Text;
 using Calamari.Integration.Processes;
 using Octostache;
@@ -10,15 +11,16 @@ namespace Calamari
     public class Log
     {
         static string stdOutMode;
-        static readonly IndentedTextWriter StdOut;
-        static readonly IndentedTextWriter StdErr;
         static readonly object Sync = new object();
 
         static Log()
         {
-            StdOut = new IndentedTextWriter(Console.Out, "  ");
-            StdErr = new IndentedTextWriter(Console.Error, "  ");
+            StdOut = Console.Out;
+            StdErr = Console.Error;
         }
+
+        public static TextWriter StdOut { get; set; }
+        public static TextWriter StdErr { get; set; }
 
         static void SetMode(string mode)
         {
@@ -43,12 +45,9 @@ namespace Calamari
 
         public static void SetOutputVariable(string name, string value, VariableDictionary variables)
         {
-            Info(String.Format("##octopus[setVariable name=\"{0}\" value=\"{1}\"]",
-                ConvertServiceMessageValue(name),
-                ConvertServiceMessageValue(value)));
+            Info($"##octopus[setVariable name=\"{ConvertServiceMessageValue(name)}\" value=\"{ConvertServiceMessageValue(value)}\"]");
 
-            if (variables != null)
-                variables.SetOutputVariable(name, value);
+            variables?.SetOutputVariable(name, value);
         }
 
         static string ConvertServiceMessageValue(string value)
@@ -58,7 +57,7 @@ namespace Calamari
 
         public static void VerboseFormat(string messageFormat, params object[] args)
         {
-            Verbose(String.Format(messageFormat, args));
+            Verbose(string.Format(messageFormat, args));
         }
 
         public static void Info(string message)
@@ -101,7 +100,7 @@ namespace Calamari
 
         public static void ErrorFormat(string messageFormat, params object[] args)
         {
-            Error(String.Format(messageFormat, args));
+            Error(string.Format(messageFormat, args));
         }
 
         public static class ServiceMessages


### PR DESCRIPTION
To support ASP.NET 5 we will have a new convention to generate AppSettings.json files. Here's what the UI in Octopus will look like:

![screen shot 2015-11-23 at 3 48 50 pm](https://cloud.githubusercontent.com/assets/47085/11338226/ab4fc76c-923e-11e5-859a-205080b434e9.png)
