### PR TITLE
Add two new special variables to allow for skipping the free disk space check and to specify a custom free space threshold

### DIFF
--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -51,6 +51,10 @@ namespace Calamari.Commands
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
             var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+
+            fileSystem.FreeDiskSpaceOverrideInMegaBytes = variables.GetInt32(SpecialVariables.FreeDiskSpaceOverrideInMegaBytes);
+            fileSystem.SkipFreeDiskSpaceCheck = variables.GetFlag(SpecialVariables.SkipFreeDiskSpaceCheck);
+
             var scriptCapability = new CombinedScriptEngine();
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
             var generator = new AppSettingsJsonGenerator();

--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -41,6 +41,9 @@
         public static readonly string RetentionPolicyDaysToKeep = "OctopusRetentionPolicyDaysToKeep";
         public static readonly string PrintEvaluatedVariables = "OctopusPrintEvaluatedVariables";
 
+        public static readonly string SkipFreeDiskSpaceCheck = "OctopusSkipFreeDiskSpaceCheck";
+        public static readonly string FreeDiskSpaceOverrideInMegaBytes = "OctopusFreeDiskSpaceOverrideInMegaBytes";
+
         public static readonly string DeleteScriptsOnCleanup = "OctopusDeleteScriptsOnCleanup";
 
         public static class Tentacle

--- a/source/Calamari/Integration/FileSystem/NixPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/NixPhysicalFileSystem.cs
@@ -6,7 +6,7 @@ namespace Calamari.Integration.FileSystem
 {
     public class NixCalamariPhysicalFileSystem : CalamariPhysicalFileSystem
     {
-        protected override bool GetFiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
+        protected override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
         {
             // This method will not work for UNC paths on windows 
             // (hence WindowsPhysicalFileSystem) but should be sufficient for Linux mounts

--- a/source/Calamari/Integration/FileSystem/WindowsPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/WindowsPhysicalFileSystem.cs
@@ -13,7 +13,7 @@ namespace Calamari.Integration.FileSystem
         [return: MarshalAs(UnmanagedType.Bool)]
         static extern bool GetDiskFreeSpaceEx(string lpDirectoryName, out ulong lpFreeBytesAvailable, out ulong lpTotalNumberOfBytes, out ulong lpTotalNumberOfFreeBytes);
 
-        protected override bool GetFiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
+        protected override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
         {
             ulong freeBytesAvailable;
             ulong totalNumberOfBytes;


### PR DESCRIPTION
 - `OctopusSkipFreeDiskSpaceCheck`: Skip the free disk space check all together
 - `OctopusFreeDiskSpaceOverrideInMegaBytes`: Override the default 500MB free disk space value

No variable specified
![image](https://cloud.githubusercontent.com/assets/1035315/12383198/dd740e70-bdee-11e5-91eb-f6838937f206.png)

`OctopusSkipFreeDiskSpaceCheck` enabled
![image](https://cloud.githubusercontent.com/assets/1035315/12383195/cca46a7c-bdee-11e5-949e-175a54857b08.png)

`OctopusFreeDiskSpaceOverrideInMegaBytes` specified
![image](https://cloud.githubusercontent.com/assets/1035315/12383224/1f8a1502-bdef-11e5-85e7-73ad366ff881.png)

Connected to OctopusDeploy/Issues#2291