### PR TITLE
Add two new special variables to allow for skipping the free disk space check and to specify a custom free space threshold

### DIFF
--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -51,6 +51,10 @@ namespace Calamari.Commands
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
             var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+
+            fileSystem.FreeDiskSpaceOverrideInMegaBytes = variables.GetInt32(SpecialVariables.FreeDiskSpaceOverrideInMegaBytes);
+            fileSystem.SkipFreeDiskSpaceCheck = variables.GetFlag(SpecialVariables.SkipFreeDiskSpaceCheck);
+
             var scriptCapability = new CombinedScriptEngine();
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
             var generator = new AppSettingsJsonGenerator();

--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -41,6 +41,9 @@
         public static readonly string RetentionPolicyDaysToKeep = "OctopusRetentionPolicyDaysToKeep";
         public static readonly string PrintEvaluatedVariables = "OctopusPrintEvaluatedVariables";
 
+        public static readonly string SkipFreeDiskSpaceCheck = "OctopusSkipFreeDiskSpaceCheck";
+        public static readonly string FreeDiskSpaceOverrideInMegaBytes = "OctopusFreeDiskSpaceOverrideInMegaBytes";
+
         public static readonly string DeleteScriptsOnCleanup = "OctopusDeleteScriptsOnCleanup";
 
         public static class Tentacle

--- a/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
+using Calamari.Deployment;
+using Microsoft.Web.Administration;
 
 namespace Calamari.Integration.FileSystem
 {
@@ -453,25 +455,44 @@ namespace Calamari.Integration.FileSystem
             }
         }
 
+        public bool SkipFreeDiskSpaceCheck { get; set; }
+        public int? FreeDiskSpaceOverrideInMegaBytes { get; set; }
+
         public void EnsureDiskHasEnoughFreeSpace(string directoryPath)
         {
-            EnsureDiskHasEnoughFreeSpace(directoryPath, 500 * 1024 * 1024);
+            if (SkipFreeDiskSpaceCheck)
+            {
+                Log.Verbose($"{SpecialVariables.SkipFreeDiskSpaceCheck} is enabled. The check to ensure that the drive containing the directory '{directoryPath}' on machine '{Environment.MachineName}' has enough free space will be skipped.");
+                return;
+            }
+
+            long? freeDiskSpaceOverrideInBytes = null;
+            if (FreeDiskSpaceOverrideInMegaBytes.HasValue)
+            {
+                freeDiskSpaceOverrideInBytes = ((long) FreeDiskSpaceOverrideInMegaBytes*1024*1024);
+                Log.Verbose($"{SpecialVariables.FreeDiskSpaceOverrideInMegaBytes} has been specified. We will check and ensure that the drive containing the directory '{directoryPath}' on machine '{Environment.MachineName}' has {((ulong)freeDiskSpaceOverrideInBytes).ToFileSizeString()} free disk space.");
+            }
+
+            EnsureDiskHasEnoughFreeSpace(directoryPath, freeDiskSpaceOverrideInBytes ?? 500L * 1024 * 1024);
         }
 
         public void EnsureDiskHasEnoughFreeSpace(string directoryPath, long requiredSpaceInBytes)
         {
             ulong totalNumberOfFreeBytes;
 
-            var success = GetFiskFreeSpace(directoryPath, out totalNumberOfFreeBytes);
+            var success = GetDiskFreeSpace(directoryPath, out totalNumberOfFreeBytes);
             if (!success)
                 return;
 
-            // Always make sure at least 500MB are available regardless of what we need 
             var required = requiredSpaceInBytes < 0 ? 0 : (ulong)requiredSpaceInBytes;
-            required = Math.Max(required, 500L * 1024 * 1024);
+            // If a free disk space override value has not been provided, always make sure at least 500MB are available regardless of what we need
+            if(!FreeDiskSpaceOverrideInMegaBytes.HasValue)
+                required = Math.Max(required, 500L * 1024 * 1024);
+
             if (totalNumberOfFreeBytes < required)
             {
-                throw new IOException(string.Format("The drive containing the directory '{0}' on machine '{1}' does not have enough free disk space available for this operation to proceed. The disk only has {2} available; please free up at least {3}.", directoryPath, Environment.MachineName, totalNumberOfFreeBytes.ToFileSizeString(), required.ToFileSizeString()));
+                throw new IOException(
+                    $"The drive containing the directory '{directoryPath}' on machine '{Environment.MachineName}' does not have enough free disk space available for this operation to proceed. The disk only has {totalNumberOfFreeBytes.ToFileSizeString()} available; please free up at least {required.ToFileSizeString()}.");
             }
         }
 
@@ -486,7 +507,7 @@ namespace Calamari.Integration.FileSystem
             return relativeOrAbsoluteFilePath;
         }
 
-        protected abstract bool GetFiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes);
+        protected abstract bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes);
 
         public string GetRelativePath(string fromFile, string toFile)
         {

--- a/source/Calamari/Integration/FileSystem/NixPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/NixPhysicalFileSystem.cs
@@ -6,7 +6,7 @@ namespace Calamari.Integration.FileSystem
 {
     public class NixCalamariPhysicalFileSystem : CalamariPhysicalFileSystem
     {
-        protected override bool GetFiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
+        protected override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
         {
             // This method will not work for UNC paths on windows 
             // (hence WindowsPhysicalFileSystem) but should be sufficient for Linux mounts

--- a/source/Calamari/Integration/FileSystem/WindowsPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/WindowsPhysicalFileSystem.cs
@@ -13,7 +13,7 @@ namespace Calamari.Integration.FileSystem
         [return: MarshalAs(UnmanagedType.Bool)]
         static extern bool GetDiskFreeSpaceEx(string lpDirectoryName, out ulong lpFreeBytesAvailable, out ulong lpTotalNumberOfBytes, out ulong lpTotalNumberOfFreeBytes);
 
-        protected override bool GetFiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
+        protected override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
         {
             ulong freeBytesAvailable;
             ulong totalNumberOfBytes;


### PR DESCRIPTION
 - `OctopusSkipFreeDiskSpaceCheck`: Skip the free disk space check all together
 - `OctopusFreeDiskSpaceOverrideInMegaBytes`: Override the default 500MB free disk space value

No variable specified
![image](https://cloud.githubusercontent.com/assets/1035315/12383198/dd740e70-bdee-11e5-91eb-f6838937f206.png)

`OctopusSkipFreeDiskSpaceCheck` enabled
![image](https://cloud.githubusercontent.com/assets/1035315/12383195/cca46a7c-bdee-11e5-949e-175a54857b08.png)

`OctopusFreeDiskSpaceOverrideInMegaBytes` specified
![image](https://cloud.githubusercontent.com/assets/1035315/12383224/1f8a1502-bdef-11e5-85e7-73ad366ff881.png)

`OctopusFreeDiskSpaceOverrideInMegaBytes` specified but not enough free space
![image](https://cloud.githubusercontent.com/assets/1035315/12383489/7b046560-bdf2-11e5-84a3-a00d83b3de09.png)

- [ ] Update [variables docs](http://docs.octopusdeploy.com/display/OD/System+variables) with the new variables

Connected to OctopusDeploy/Issues#2291