### PR TITLE
Add FIPS warning when a script fails.

### DIFF
--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -81,4 +81,13 @@ If ([System.Convert]::ToBoolean($OctopusUseServicePrincipal)) {
 
 Write-Verbose "Invoking target script $OctopusAzureTargetScript"
 
-. $OctopusAzureTargetScript 
+try {
+	. $OctopusAzureTargetScript
+} catch {
+	# Warn if FIPS 140 compliance required when using Service Management SDK
+	if ([System.Security.Cryptography.CryptoConfig]::AllowOnlyFipsAlgorithms -and ![System.Convert]::ToBoolean($OctopusUseServicePrincipal)) {
+		Write-Warning "The Azure Service Management SDK is not FIPS 140 compliant. http://g.octopushq.com/FIPS"
+	}
+	
+	throw
+}


### PR DESCRIPTION
Connects to OctopusDeploy/Issues#2376

Warning only shows when:
1. FIPS compliance required
2. Using Azure Service Management API (management certificate)
3. The PowerShell script actually fails to run
g.octopushq.com/FIPS

![image](https://cloud.githubusercontent.com/assets/1627582/13306107/7b378454-dbac-11e5-9057-2d6e25a71bd0.png)
