### PR TITLE
Add variable to use the Release Number in the blob storage path instead of the nuget package version

### DIFF
--- a/source/Calamari.Azure.Tests/Conventions/UploadAzureCloudServicePackageConventionFixture.cs
+++ b/source/Calamari.Azure.Tests/Conventions/UploadAzureCloudServicePackageConventionFixture.cs
@@ -73,5 +73,32 @@ namespace Calamari.Azure.Tests.Conventions
 
             Assert.AreEqual(uploadedUri.ToString(), variables.Get(SpecialVariables.Action.Azure.UploadedPackageUri));
         }
+
+        [Test]
+        public void ShouldUploadPackageWithReleaseNumber()
+        {
+            const string packageFileName = "Acme.cspkg";
+            var packageFilePath = Path.Combine(stagingDirectory, packageFileName);
+            variables.Set(SpecialVariables.Package.NuGetPackageVersion, "1.0.0");
+            variables.Set(SpecialVariables.Action.Azure.CloudServicePackagePath, packageFilePath);
+            variables.Set(SpecialVariables.Action.Azure.UseReleaseNumberAsStoragePackageVersion, "true");
+            variables.Set(SpecialVariables.Release.Number, "1.1.1");
+
+            fileSystem.EnumerateFiles(stagingDirectory, "*.cspkg")
+                .Returns(new[] { packageFilePath });
+            fileSystem.OpenFile(packageFilePath, Arg.Any<FileMode>())
+                .Returns(new MemoryStream(Encoding.UTF8.GetBytes("blah blah blah")));
+
+            var uploadedUri = new Uri("http://azure.com/wherever/my-package.cspkg");
+
+            packageUploader.Upload(
+                Arg.Is<SubscriptionCloudCredentials>(cred => cred.SubscriptionId == azureSubscriptionId),
+                storageAccountName, packageFilePath, Arg.Any<string>())
+            .Returns(uploadedUri);
+
+            convention.Install(deployment);
+
+            Assert.AreEqual(uploadedUri.ToString(), variables.Get(SpecialVariables.Action.Azure.UploadedPackageUri));
+        }
     }
 }

--- a/source/Calamari.Azure/Deployment/Conventions/UploadAzureCloudServicePackageConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/UploadAzureCloudServicePackageConvention.cs
@@ -23,11 +23,15 @@ namespace Calamari.Azure.Deployment.Conventions
 
         public void Install(RunningDeployment deployment)
         {
-            var package = deployment.Variables.Get(SpecialVariables.Action.Azure.CloudServicePackagePath); 
+            var package = deployment.Variables.Get(SpecialVariables.Action.Azure.CloudServicePackagePath);
             Log.Info("Uploading package to Azure blob storage: '{0}'", package);
             var packageHash = Hash(package);
-            var nugetPackageVersion = deployment.Variables.Get(SpecialVariables.Package.NuGetPackageVersion);
-            var uploadedFileName = Path.ChangeExtension(Path.GetFileName(package), "." + nugetPackageVersion + "_" + packageHash + ".cspkg");
+
+            var versionNumber = deployment.Variables.GetFlag(SpecialVariables.Action.Azure.UseReleaseNumberAsStoragePackageVersion)
+                ? deployment.Variables.Get(SpecialVariables.Release.Number)
+                : deployment.Variables.Get(SpecialVariables.Package.NuGetPackageVersion);
+
+            var uploadedFileName = Path.ChangeExtension(Path.GetFileName(package), "." + versionNumber + "_" + packageHash + ".cspkg");
 
             var credentials = credentialsFactory.GetCredentials(
                 deployment.Variables.Get(SpecialVariables.Action.Azure.SubscriptionId),

--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -154,6 +154,7 @@
                 public static readonly string CloudServicePackageExtractionDisabled = "Octopus.Action.Azure.CloudServicePackageExtractionDisabled";
                 public static readonly string LogExtractedCspkg = "Octopus.Action.Azure.LogExtractedCspkg";
                 public static readonly string CloudServiceConfigurationFileRelativePath = "Octopus.Action.Azure.CloudServiceConfigurationFileRelativePath";
+                public static readonly string UseReleaseNumberAsStoragePackageVersion = "Octopus.Action.Azure.UseReleaseNumberAsStoragePackageVersion";
 
                 public static readonly string ResourceGroupName = "Octopus.Action.Azure.ResourceGroupName";
                 public static readonly string ResourceGroupDeploymentName = "Octopus.Action.Azure.ResourceGroupDeploymentName";


### PR DESCRIPTION
Related to http://help.octopusdeploy.com/discussions/questions/7226-is-there-a-way-to-change-override-the-package-name-when-uploading-to-azure-blob-storage
