### PR TITLE
When writing configured-scripts for package-steps to disk, add UTF8 BOM.

### DIFF
--- a/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Text;
 using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
 using Calamari.Integration.FileSystem;
@@ -6,7 +7,6 @@ using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;
 using NSubstitute;
 using NUnit.Framework;
-using Octostache;
 
 namespace Calamari.Tests.Fixtures.Conventions
 {
@@ -48,7 +48,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             scriptEngine.Execute(scriptPath, variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
 
-            fileSystem.Received().OverwriteFile(scriptPath, scriptBody);
+            fileSystem.Received().OverwriteFile(scriptPath, scriptBody, Encoding.UTF8);
             scriptEngine.Received().Execute(scriptPath, variables, commandLineRunner);
         }
 

--- a/source/Calamari/Deployment/Conventions/ConfiguredScriptConvention.cs
+++ b/source/Calamari/Deployment/Conventions/ConfiguredScriptConvention.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
+using System.Text;
 using Calamari.Commands.Support;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Processes;
@@ -43,7 +44,7 @@ namespace Calamari.Deployment.Conventions
 
                 var scriptFile = Path.Combine(deployment.CurrentDirectory, scriptName);
 
-                fileSystem.OverwriteFile(scriptFile, scriptBody);
+                fileSystem.OverwriteFile(scriptFile, scriptBody, Encoding.UTF8);
 
                 // Execute the script
                 Log.VerboseFormat("Executing '{0}'", scriptFile);


### PR DESCRIPTION
Closes OctopusDeploy/Issues#2396