### PR TITLE
Using CalamariPhysicalFileSystem for PowerShellBootstrapper and TemporaryFile

### DIFF
--- a/source/Calamari/Integration/FileSystem/TemporaryFile.cs
+++ b/source/Calamari/Integration/FileSystem/TemporaryFile.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.IO;
 using System.Security.Cryptography;
-using System.Threading;
 
 namespace Calamari.Integration.FileSystem
 {
     public class TemporaryFile : IDisposable
     {
         private readonly string filePath;
+        readonly ICalamariFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         public TemporaryFile(string filePath)
         {
@@ -48,19 +48,7 @@ namespace Calamari.Integration.FileSystem
         }
         public void Dispose()
         {
-            for (var i = 0; i < 10; i++)
-            {
-                try
-                {
-                    File.Delete(filePath);
-                    if (!File.Exists(filePath))
-                        return;
-                }
-                catch (Exception)
-                {
-                    Thread.Sleep(1000);
-                }
-            }
+            fileSystem.DeleteFile(filePath, FailureOptions.IgnoreFailure);
         }
     }
 }

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Calamari.Deployment;
+using Calamari.Integration.FileSystem;
 using Calamari.Integration.Processes;
 using Calamari.Util;
 using Octostache;
@@ -16,6 +17,7 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
         private static readonly string BootstrapScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
         static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword);
+        static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static PowerShellBootstrapper()
         {
@@ -70,11 +72,7 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
             builder.Replace("{{VariableDeclarations}}", DeclareVariables(variables));
             builder.Replace("{{ScriptModules}}", DeclareScriptModules(variables));
 
-            using (var writer = new StreamWriter(bootstrapFile, false, new UTF8Encoding(true)))
-            {
-                writer.WriteLine(builder.ToString());
-                writer.Flush();
-            }
+            CalamariFileSystem.OverwriteFile(bootstrapFile, builder.ToString(), new UTF8Encoding(true));
 
             File.SetAttributes(bootstrapFile, FileAttributes.Hidden);
             return bootstrapFile;


### PR DESCRIPTION
Made the PowerShellBootstrapper file creation and deletion more robust through use of CalamariPhysicalFileSystem and RetryTracker. This should overcome temporary locks placed on bootstrap PowerShell files by anti-virus applications