### PR TITLE
Allow semaphore access to everyone

### DIFF
--- a/source/Calamari/Integration/Processes/SystemSemaphore.cs
+++ b/source/Calamari/Integration/Processes/SystemSemaphore.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Threading;
 
 namespace Calamari.Integration.Processes
@@ -30,7 +31,8 @@ namespace Calamari.Integration.Processes
         static Semaphore CreateGlobalSemaphoreAccessibleToEveryone(string name)
         {
             var semaphoreSecurity = new SemaphoreSecurity();
-            var rule = new SemaphoreAccessRule("Everyone", SemaphoreRights.FullControl, AccessControlType.Allow);
+            var everyone = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+            var rule = new SemaphoreAccessRule(everyone, SemaphoreRights.FullControl, AccessControlType.Allow);
 
             semaphoreSecurity.AddAccessRule(rule);
             bool createdNew;


### PR DESCRIPTION
Semaphore permissions are for current user (or admin).  When Calamari is run as different users and both users try to acquire the same semaphore an exception is thrown because one will not have permissions to access the semaphore.

This adds semaphore control to "Everyone".

Relates to OctopusDeploy/Issues#2485