### PR TITLE
Add ability to pass parameters to scripts executed by Calamari

### DIFF
--- a/source/Calamari.Azure.Tests/Deployment/Azure/DeployAzureCloudServiceFixture.cs
+++ b/source/Calamari.Azure.Tests/Deployment/Azure/DeployAzureCloudServiceFixture.cs
@@ -63,7 +63,7 @@ namespace Calamari.Azure.Tests.Deployment.Azure
         [Test]
         public void ShouldReturnZero()
         {
-           result.AssertZero(); 
+           result.AssertSuccess(); 
         }
 
         [Test]

--- a/source/Calamari.Azure.Tests/Deployment/Azure/DeployAzureCloudServiceSansPackageExtractionFixture.cs
+++ b/source/Calamari.Azure.Tests/Deployment/Azure/DeployAzureCloudServiceSansPackageExtractionFixture.cs
@@ -60,7 +60,7 @@ namespace Calamari.Azure.Tests.Deployment.Azure
         [Test]
         public void ShouldReturnZero()
         {
-           result.AssertZero(); 
+           result.AssertSuccess(); 
         }
     }
 }

--- a/source/Calamari.Azure.Tests/Deployment/Azure/DeployAzureWebFixture.cs
+++ b/source/Calamari.Azure.Tests/Deployment/Azure/DeployAzureWebFixture.cs
@@ -51,7 +51,7 @@ namespace Calamari.Azure.Tests.Deployment.Azure
         [Test]
         public void ShouldDeployPackage()
         {
-            result.AssertZero();
+            result.AssertSuccess();
 
         }
 

--- a/source/Calamari.Azure.Tests/PowerShell/AzurePowerShellContextFixture.cs
+++ b/source/Calamari.Azure.Tests/PowerShell/AzurePowerShellContextFixture.cs
@@ -28,10 +28,10 @@ namespace Calamari.Azure.Tests.PowerShell
                 var expectedCertFile = Path.Combine(variablesFile.DirectoryPath, "azure_certificate.pfx");
 
                 scriptEngine
-                    .When(engine => engine.Execute(Arg.Any<string>(), variables, commandLineRunner))
+                    .When(engine => engine.Execute(new Script(Arg.Any<string>()), variables, commandLineRunner))
                     .Do(callInfo => Assert.True(File.Exists(expectedCertFile)));
 
-                powershellContext.ExecuteScript(scriptEngine, variablesFile.FilePath, variables, commandLineRunner);
+                powershellContext.ExecuteScript(scriptEngine, new Script(variablesFile.FilePath), variables, commandLineRunner);
 
                 Assert.False(File.Exists(expectedCertFile));
             }

--- a/source/Calamari.Azure.Tests/PowerShell/AzurePowershellFixture.cs
+++ b/source/Calamari.Azure.Tests/PowerShell/AzurePowershellFixture.cs
@@ -29,7 +29,7 @@ namespace Calamari.Azure.Tests.PowerShell
                 .Argument("script", GetFixtureResouce("AzureSubscription.ps1"))
                 .Argument("variables", variablesFile));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("Current subscription ID: " + OctopusTestAzureSubscription.AzureSubscriptionId);
         }
     }

--- a/source/Calamari.Azure/Deployment/Conventions/DeployAzureCloudServicePackageConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/DeployAzureCloudServicePackageConvention.cs
@@ -46,7 +46,7 @@ namespace Calamari.Azure.Deployment.Conventions
                fileSystem.OverwriteFile(scriptFile, embeddedResources.GetEmbeddedResourceText("Calamari.Azure.Scripts.DeployAzureCloudService.ps1")); 
             }
 
-            var result = scriptEngine.Execute(scriptFile, deployment.Variables, commandLineRunner);
+            var result = scriptEngine.Execute(new Script(scriptFile), deployment.Variables, commandLineRunner);
 
             fileSystem.DeleteFile(scriptFile, FailureOptions.IgnoreFailure);
 

--- a/source/Calamari.Azure/Deployment/Conventions/SwapAzureDeploymentConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/SwapAzureDeploymentConvention.cs
@@ -44,7 +44,7 @@ namespace Calamari.Azure.Deployment.Conventions
                 fileSystem.OverwriteFile(scriptFile, embeddedResources.GetEmbeddedResourceText("Calamari.Azure.Scripts.SwapAzureCloudServiceDeployment.ps1"));
             }
 
-            var result = scriptEngine.Execute(scriptFile, deployment.Variables, commandLineRunner);
+            var result = scriptEngine.Execute(new Script(scriptFile), deployment.Variables, commandLineRunner);
 
             fileSystem.DeleteDirectory(tempDirectory, FailureOptions.IgnoreFailure);
 

--- a/source/Calamari.Azure/Integration/AzurePowerShellScriptEngine.cs
+++ b/source/Calamari.Azure/Integration/AzurePowerShellScriptEngine.cs
@@ -12,7 +12,7 @@ namespace Calamari.Azure.Integration
             return new[] { ScriptType.Powershell.FileExtension() };
         }
 
-        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
+        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner, string scriptParameters = null)
         {
             var powerShellEngine = new PowerShellScriptEngine();
             if (variables.Get(SpecialVariables.Account.AccountType).StartsWith("Azure"))
@@ -20,7 +20,7 @@ namespace Calamari.Azure.Integration
                 return new AzurePowerShellContext().ExecuteScript(powerShellEngine, scriptFile, variables, commandLineRunner);
             }
 
-            return powerShellEngine.Execute(scriptFile, variables, commandLineRunner);
+            return powerShellEngine.Execute(scriptFile, variables, commandLineRunner, scriptParameters);
         }
     }
 }

--- a/source/Calamari.Azure/Integration/AzurePowerShellScriptEngine.cs
+++ b/source/Calamari.Azure/Integration/AzurePowerShellScriptEngine.cs
@@ -12,15 +12,15 @@ namespace Calamari.Azure.Integration
             return new[] { ScriptType.Powershell.FileExtension() };
         }
 
-        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner, string scriptParameters = null)
+        public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
         {
             var powerShellEngine = new PowerShellScriptEngine();
             if (variables.Get(SpecialVariables.Account.AccountType).StartsWith("Azure"))
             {
-                return new AzurePowerShellContext().ExecuteScript(powerShellEngine, scriptFile, variables, commandLineRunner);
+                return new AzurePowerShellContext().ExecuteScript(powerShellEngine, script, variables, commandLineRunner);
             }
 
-            return powerShellEngine.Execute(scriptFile, variables, commandLineRunner, scriptParameters);
+            return powerShellEngine.Execute(script, variables, commandLineRunner);
         }
     }
 }

--- a/source/Calamari.Azure/Integration/AzurePowershellContext.cs
+++ b/source/Calamari.Azure/Integration/AzurePowershellContext.cs
@@ -30,10 +30,10 @@ namespace Calamari.Azure.Integration
             this.embeddedResources = new CallingAssemblyEmbeddedResources();
         }
 
-        public CommandResult ExecuteScript(IScriptEngine scriptEngine, string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
+        public CommandResult ExecuteScript(IScriptEngine scriptEngine, Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
         {
-            var workingDirectory = Path.GetDirectoryName(scriptFile);
-            variables.Set("OctopusAzureTargetScript", scriptFile);
+            var workingDirectory = Path.GetDirectoryName(script.File);
+            variables.Set("OctopusAzureTargetScript", script.File);
 
             SetAzureModuleLoadingMethod(variables);
 
@@ -49,14 +49,14 @@ namespace Calamari.Azure.Integration
                     SetOutputVariable("OctopusAzureADTenantId", variables.Get(SpecialVariables.Action.Azure.TenantId), variables);
                     SetOutputVariable("OctopusAzureADClientId", variables.Get(SpecialVariables.Action.Azure.ClientId), variables);
                     variables.Set("OctopusAzureADPassword", variables.Get(SpecialVariables.Action.Azure.Password));
-                    return scriptEngine.Execute(contextScriptFile.FilePath, variables, commandLineRunner);
+                    return scriptEngine.Execute(new Script(contextScriptFile.FilePath), variables, commandLineRunner);
                 }
 
                 //otherwise use management certificate
                 SetOutputVariable("OctopusUseServicePrincipal", false.ToString(), variables);
                 using (new TemporaryFile(CreateAzureCertificate(workingDirectory, variables)))
                 {
-                    return scriptEngine.Execute(contextScriptFile.FilePath, variables, commandLineRunner);
+                    return scriptEngine.Execute(new Script(contextScriptFile.FilePath), variables, commandLineRunner);
                 }
             }
         }

--- a/source/Calamari.Azure/Integration/AzurePowershellContext.cs
+++ b/source/Calamari.Azure/Integration/AzurePowershellContext.cs
@@ -34,6 +34,7 @@ namespace Calamari.Azure.Integration
         {
             var workingDirectory = Path.GetDirectoryName(script.File);
             variables.Set("OctopusAzureTargetScript", script.File);
+            variables.Set("OctopusAzureTargetScriptParameters", script.Parameters);
 
             SetAzureModuleLoadingMethod(variables);
 

--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -8,6 +8,7 @@
 ##   $OctopusUseBundledAzureModules = "true"
 ##   $OctopusAzureModulePath = "....\Calamari\AzurePowershell\Azure.psd1"
 ##   $OctopusAzureTargetScript = "..."
+##   $OctopusAzureTargetScriptParameters = "..."
 ##   $UseServicePrincipal = "false"
 ##   $OctopusAzureSubscriptionId = "..."
 ##   $OctopusAzureStorageAccountName = "..."
@@ -79,10 +80,10 @@ If ([System.Convert]::ToBoolean($OctopusUseServicePrincipal)) {
 	Select-AzureProfile -Profile $azureProfile | Out-Null
 } 
 
-Write-Verbose "Invoking target script $OctopusAzureTargetScript"
+Write-Verbose "Invoking target script $OctopusAzureTargetScript with $OctopusAzureTargetScriptParameters parameters"
 
 try {
-	. $OctopusAzureTargetScript
+	Invoke-Expression ". $OctopusAzureTargetScript $OctopusAzureTargetScriptParameters"
 } catch {
 	# Warn if FIPS 140 compliance required when using Service Management SDK
 	if ([System.Security.Cryptography.CryptoConfig]::AllowOnlyFipsAlgorithms -and ![System.Convert]::ToBoolean($OctopusUseServicePrincipal)) {

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -203,6 +203,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="Fixtures\Bash\Scripts\parameters.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Fixtures\Deployment\Packages\Acme.Service\Acme.Service.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -438,6 +441,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Fixtures\ScriptCS\Scripts\CreateArtifact.csx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Fixtures\ScriptCS\Scripts\Parameters.csx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Fixtures\ScriptCS\Scripts\PrintEncodedVariable.csx">

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -401,6 +401,9 @@
     <None Include="Fixtures\PowerShell\Packages\PackagedScript.1.0.0.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Fixtures\PowerShell\Scripts\Parameters.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Fixtures\PowerShell\Scripts\WarningForMissingArtifact.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/source/Calamari.Tests/Fixtures/ApplyDelta/ApplyDeltaFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ApplyDelta/ApplyDeltaFixture.cs
@@ -63,7 +63,7 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
                     .PositionalArgument(basisFile.FilePath)
                     .PositionalArgument(signatureFile.FilePath));
                 
-                signatureResult.AssertZero();
+                signatureResult.AssertSuccess();
                 Assert.That(File.Exists(signatureFile.FilePath));
 
                 using (var newFile = new TemporaryFile(PackageBuilder.BuildSamplePackage("Acme.Web", "1.0.0.1", true)))
@@ -75,11 +75,11 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
                         .PositionalArgument(newFile.FilePath)
                         .PositionalArgument(deltaFile.FilePath));
 
-                    deltaResult.AssertZero();
+                    deltaResult.AssertSuccess();
                     Assert.That(File.Exists(deltaFile.FilePath));
 
                     var patchResult = ApplyDelta(basisFile.FilePath, basisFile.Hash, deltaFile.FilePath, NewFileName);
-                    patchResult.AssertZero();
+                    patchResult.AssertSuccess();
                     patchResult.AssertOutput("Applying delta to {0} with hash {1} and storing as {2}", basisFile.FilePath,
                         basisFile.Hash, Path.Combine(DownloadPath, NewFileName));
                     patchResult.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name);

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -40,7 +40,7 @@ namespace Calamari.Tests.Fixtures.Bash
             var output = Invoke(Calamari()
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "parameters.sh"))
-                .Argument("scriptParameters", "-- \"Para meter0\" 'Para meter1'"));
+                .Argument("scriptParameters", "\"Para meter0\" 'Para meter1'"));
 
             output.AssertSuccess();
             output.AssertOutput("Parameters Para meter0Para meter1'");

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -17,7 +17,7 @@ namespace Calamari.Tests.Fixtures.Bash
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "print-encoded-variable.sh")));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("##octopus[setVariable name='U3VwZXI=' value='TWFyaW8gQnJvcw==']");
         }
 
@@ -29,8 +29,21 @@ namespace Calamari.Tests.Fixtures.Bash
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "create-artifact.sh")));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("##octopus[createArtifact path='Li9zdWJkaXIvYW5vdGhlcmRpci9teWZpbGU=' name='bXlmaWxl' length='MA==']");
+        }
+
+        [Test]
+        [Category(TestEnvironment.CompatibleOS.Nix)]
+        public void ShouldConsumeParametersWithQuotes()
+        {
+            var output = Invoke(Calamari()
+                .Action("run-script")
+                .Argument("script", GetFixtureResouce("Scripts", "parameters.sh"))
+                .Argument("scriptParameters", "-- \"Para meter0\" 'Para meter1'"));
+
+            output.AssertSuccess();
+            output.AssertOutput("Parameters Para meter0Para meter1'");
         }
 
         [Test]
@@ -53,7 +66,7 @@ namespace Calamari.Tests.Fixtures.Bash
                     .Argument("script", GetFixtureResouce("Scripts", "hello.sh"))
                     .Argument("variables", variablesFile));
 
-                output.AssertZero();
+                output.AssertSuccess();
                 output.AssertOutput("Hello Paul");
             }
         }

--- a/source/Calamari.Tests/Fixtures/Bash/Scripts/parameters.sh
+++ b/source/Calamari.Tests/Fixtures/Bash/Scripts/parameters.sh
@@ -1,0 +1,2 @@
+﻿#!/bin/bash
+echo "Parameters $1$2"

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
@@ -6,6 +6,7 @@ using Calamari.Integration.FileSystem;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;
 using NSubstitute;
+using NSubstitute.Core.Arguments;
 using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures.Conventions
@@ -46,11 +47,11 @@ namespace Calamari.Tests.Fixtures.Conventions
             variables.Set(scriptName, scriptBody);
 
             var convention = CreateConvention(stage);
-            scriptEngine.Execute(script, variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(Arg.Any<Script>(), variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
 
             fileSystem.Received().OverwriteFile(scriptPath, scriptBody, Encoding.UTF8);
-            scriptEngine.Received().Execute(script, variables, commandLineRunner);
+            scriptEngine.Received().Execute(Arg.Is<Script>(s => s.File == scriptPath), variables, commandLineRunner);
         }
 
         [Test]
@@ -63,7 +64,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             variables.Set(scriptName, "blah blah");
 
             var convention = CreateConvention(stage);
-            scriptEngine.Execute(script, variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(Arg.Any<Script>(), variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
 
             fileSystem.Received().DeleteFile(scriptPath, Arg.Any<FailureOptions>());
@@ -76,11 +77,10 @@ namespace Calamari.Tests.Fixtures.Conventions
             const string stage = DeploymentStages.PostDeploy;
             var scriptName = ConfiguredScriptConvention.GetScriptName(stage, "ps1");
             var scriptPath = Path.Combine(stagingDirectory, scriptName);
-            var script = new Script(scriptPath);
             variables.Set(scriptName, "blah blah");
 
             var convention = CreateConvention(stage);
-            scriptEngine.Execute(script, variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(Arg.Any<Script>(), variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
 
             fileSystem.DidNotReceive().DeleteFile(scriptPath, Arg.Any<FailureOptions>());

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
@@ -42,14 +42,15 @@ namespace Calamari.Tests.Fixtures.Conventions
             const string scriptBody = "lorem ipsum blah blah blah";
             var scriptName = ConfiguredScriptConvention.GetScriptName(stage, "ps1");
             var scriptPath = Path.Combine(stagingDirectory, scriptName);
+            var script = new Script(scriptPath);
             variables.Set(scriptName, scriptBody);
 
             var convention = CreateConvention(stage);
-            scriptEngine.Execute(scriptPath, variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(script, variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
 
             fileSystem.Received().OverwriteFile(scriptPath, scriptBody, Encoding.UTF8);
-            scriptEngine.Received().Execute(scriptPath, variables, commandLineRunner);
+            scriptEngine.Received().Execute(script, variables, commandLineRunner);
         }
 
         [Test]
@@ -58,10 +59,11 @@ namespace Calamari.Tests.Fixtures.Conventions
             const string stage = DeploymentStages.PostDeploy;
             var scriptName = ConfiguredScriptConvention.GetScriptName(stage, "ps1");
             var scriptPath = Path.Combine(stagingDirectory, scriptName);
+            var script = new Script(scriptPath);
             variables.Set(scriptName, "blah blah");
 
             var convention = CreateConvention(stage);
-            scriptEngine.Execute(scriptPath, variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(script, variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
 
             fileSystem.Received().DeleteFile(scriptPath, Arg.Any<FailureOptions>());
@@ -74,10 +76,11 @@ namespace Calamari.Tests.Fixtures.Conventions
             const string stage = DeploymentStages.PostDeploy;
             var scriptName = ConfiguredScriptConvention.GetScriptName(stage, "ps1");
             var scriptPath = Path.Combine(stagingDirectory, scriptName);
+            var script = new Script(scriptPath);
             variables.Set(scriptName, "blah blah");
 
             var convention = CreateConvention(stage);
-            scriptEngine.Execute(scriptPath, variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(script, variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
 
             fileSystem.DidNotReceive().DeleteFile(scriptPath, Arg.Any<FailureOptions>());

--- a/source/Calamari.Tests/Fixtures/Conventions/FeatureScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/FeatureScriptConventionFixture.cs
@@ -52,8 +52,8 @@ namespace Calamari.Tests.Fixtures.Conventions
 
             foreach (var feature in features)
             {
-                var script = new Script(Path.Combine(stagingDirectory, FeatureScriptConvention.GetScriptName(feature, suffix, "ps1")));
-                scriptEngine.Received().Execute(script, variables, commandLineRunner);
+                var scriptPath = Path.Combine(stagingDirectory, FeatureScriptConvention.GetScriptName(feature, suffix, "ps1"));
+                scriptEngine.Received().Execute(Arg.Is<Script>(s => s.File == scriptPath), variables, commandLineRunner);
             }
         }
 
@@ -69,7 +69,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             fileSystem.FileExists(scriptPath).Returns(false);
 
             var convention = CreateConvention(deployStage);
-            scriptEngine.Execute(new Script(scriptPath), variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(Arg.Is<Script>(s => s.File == scriptPath), variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
 
             fileSystem.Received().OverwriteFile(scriptPath, scriptContents );
@@ -87,7 +87,7 @@ namespace Calamari.Tests.Fixtures.Conventions
 
             var convention = CreateConvention(deployStage);
 
-            scriptEngine.Execute(new Script(scriptPath), variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(Arg.Is<Script>(s => s.File == scriptPath), variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
 
             fileSystem.DidNotReceive().OverwriteFile(scriptPath, Arg.Any<string>() );
@@ -103,7 +103,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             Arrange(new List<string>{ feature }, deployStage);
             var convention = CreateConvention(deployStage);
 
-            scriptEngine.Execute(new Script(scriptPath), variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(Arg.Is<Script>(s => s.File == scriptPath), variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
             fileSystem.Received().DeleteFile(scriptPath, Arg.Any<FailureOptions>());
         }
@@ -121,7 +121,8 @@ namespace Calamari.Tests.Fixtures.Conventions
                 embeddedResources.GetEmbeddedResourceText(embeddedResourceName).Returns(scriptContents);
                 embeddedResourceNames.Add(embeddedResourceName);
                 var scriptPath = Path.Combine(stagingDirectory, scriptName);
-                scriptEngine.Execute(new Script(scriptPath), variables, commandLineRunner).Returns(new CommandResult("", 0));
+                scriptEngine.Execute(Arg.Is<Script>(s => s.File == scriptPath), variables, commandLineRunner)
+                            .Returns(new CommandResult("", 0));
             }
 
             embeddedResources.GetEmbeddedResourceNames().Returns(embeddedResourceNames.ToArray());

--- a/source/Calamari.Tests/Fixtures/Conventions/FeatureScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/FeatureScriptConventionFixture.cs
@@ -52,7 +52,8 @@ namespace Calamari.Tests.Fixtures.Conventions
 
             foreach (var feature in features)
             {
-                scriptEngine.Received().Execute(Path.Combine(stagingDirectory, FeatureScriptConvention.GetScriptName(feature, suffix, "ps1")), variables, commandLineRunner);
+                var script = new Script(Path.Combine(stagingDirectory, FeatureScriptConvention.GetScriptName(feature, suffix, "ps1")));
+                scriptEngine.Received().Execute(script, variables, commandLineRunner);
             }
         }
 
@@ -68,7 +69,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             fileSystem.FileExists(scriptPath).Returns(false);
 
             var convention = CreateConvention(deployStage);
-            scriptEngine.Execute(scriptPath, variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(new Script(scriptPath), variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
 
             fileSystem.Received().OverwriteFile(scriptPath, scriptContents );
@@ -86,7 +87,7 @@ namespace Calamari.Tests.Fixtures.Conventions
 
             var convention = CreateConvention(deployStage);
 
-            scriptEngine.Execute(scriptPath, variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(new Script(scriptPath), variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
 
             fileSystem.DidNotReceive().OverwriteFile(scriptPath, Arg.Any<string>() );
@@ -102,7 +103,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             Arrange(new List<string>{ feature }, deployStage);
             var convention = CreateConvention(deployStage);
 
-            scriptEngine.Execute(scriptPath, variables, commandLineRunner).Returns(new CommandResult("", 0));
+            scriptEngine.Execute(new Script(scriptPath), variables, commandLineRunner).Returns(new CommandResult("", 0));
             convention.Install(deployment);
             fileSystem.Received().DeleteFile(scriptPath, Arg.Any<FailureOptions>());
         }
@@ -120,7 +121,7 @@ namespace Calamari.Tests.Fixtures.Conventions
                 embeddedResources.GetEmbeddedResourceText(embeddedResourceName).Returns(scriptContents);
                 embeddedResourceNames.Add(embeddedResourceName);
                 var scriptPath = Path.Combine(stagingDirectory, scriptName);
-                scriptEngine.Execute(scriptPath, variables, commandLineRunner).Returns(new CommandResult("", 0));
+                scriptEngine.Execute(new Script(scriptPath), variables, commandLineRunner).Returns(new CommandResult("", 0));
             }
 
             embeddedResources.GetEmbeddedResourceNames().Returns(embeddedResourceNames.ToArray());

--- a/source/Calamari.Tests/Fixtures/Conventions/PackagedScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/PackagedScriptConventionFixture.cs
@@ -33,7 +33,7 @@ namespace Calamari.Tests.Fixtures.Conventions
 
             commandResult = new CommandResult("PowerShell.exe foo bar", 0, null);
             scriptEngine = Substitute.For<IScriptEngine>();
-            scriptEngine.Execute(Arg.Any<string>(), Arg.Any<CalamariVariableDictionary>(), Arg.Any<ICommandLineRunner>()).Returns(c => commandResult);
+            scriptEngine.Execute(new Script(Arg.Any<string>()), Arg.Any<CalamariVariableDictionary>(), Arg.Any<ICommandLineRunner>()).Returns(c => commandResult);
             scriptEngine.GetSupportedExtensions().Returns(new[] {"csx", "ps1"});
             runner = Substitute.For<ICommandLineRunner>();
             deployment = new RunningDeployment(TestEnvironment.ConstructRootedPath("Packages"), new CalamariVariableDictionary());
@@ -44,8 +44,8 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             var convention = CreateConvention("Deploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.ps1"), deployment.Variables, runner);
-            scriptEngine.Received().Execute(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.csx"), deployment.Variables, runner);
+            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.ps1")), deployment.Variables, runner);
+            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.csx")), deployment.Variables, runner);
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             var convention = CreateConvention("PreDeploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1"), deployment.Variables, runner);
+            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1")), deployment.Variables, runner);
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             var convention = CreateConvention("PreDeploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1"), deployment.Variables, runner);
+            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1")), deployment.Variables, runner);
             fileSystem.Received().DeleteFile(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1"), Arg.Any<FailureOptions>());
         }
 
@@ -71,7 +71,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             deployment.Variables.Set(SpecialVariables.DeleteScriptsOnCleanup, false.ToString());
             var convention = CreateConvention("PreDeploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1"), deployment.Variables, runner);
+            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1")), deployment.Variables, runner);
             fileSystem.DidNotReceive().DeleteFile(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1"), Arg.Any<FailureOptions>());
         }
 
@@ -81,8 +81,8 @@ namespace Calamari.Tests.Fixtures.Conventions
             deployment.Variables.Set(SpecialVariables.DeleteScriptsOnCleanup, false.ToString());
             var convention = CreateConvention("Deploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.ps1"), deployment.Variables, runner);
-            scriptEngine.Received().Execute(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.csx"), deployment.Variables, runner);
+            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.ps1")), deployment.Variables, runner);
+            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.csx")), deployment.Variables, runner);
             fileSystem.DidNotReceive().DeleteFile(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.ps1"), Arg.Any<FailureOptions>());
             fileSystem.DidNotReceive().DeleteFile(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.csx"), Arg.Any<FailureOptions>());
         }
@@ -93,7 +93,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             deployment.Variables.Set(SpecialVariables.DeleteScriptsOnCleanup, false.ToString());
             var convention = CreateConvention("PostDeploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(TestEnvironment.ConstructRootedPath("App", "MyApp", "PostDeploy.ps1"), deployment.Variables, runner);
+            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "PostDeploy.ps1")), deployment.Variables, runner);
             fileSystem.DidNotReceive().DeleteFile(TestEnvironment.ConstructRootedPath("App", "MyApp", "PostDeploy.ps1"), Arg.Any<FailureOptions>());
         }
 

--- a/source/Calamari.Tests/Fixtures/Conventions/PackagedScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/PackagedScriptConventionFixture.cs
@@ -33,7 +33,7 @@ namespace Calamari.Tests.Fixtures.Conventions
 
             commandResult = new CommandResult("PowerShell.exe foo bar", 0, null);
             scriptEngine = Substitute.For<IScriptEngine>();
-            scriptEngine.Execute(new Script(Arg.Any<string>()), Arg.Any<CalamariVariableDictionary>(), Arg.Any<ICommandLineRunner>()).Returns(c => commandResult);
+            scriptEngine.Execute(Arg.Any<Script>(), Arg.Any<CalamariVariableDictionary>(), Arg.Any<ICommandLineRunner>()).Returns(c => commandResult);
             scriptEngine.GetSupportedExtensions().Returns(new[] {"csx", "ps1"});
             runner = Substitute.For<ICommandLineRunner>();
             deployment = new RunningDeployment(TestEnvironment.ConstructRootedPath("Packages"), new CalamariVariableDictionary());
@@ -44,8 +44,8 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             var convention = CreateConvention("Deploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.ps1")), deployment.Variables, runner);
-            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.csx")), deployment.Variables, runner);
+            scriptEngine.Received().Execute(Arg.Is<Script>(s => s.File == TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.ps1")), deployment.Variables, runner);
+            scriptEngine.Received().Execute(Arg.Is<Script>(s => s.File == TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.csx")), deployment.Variables, runner);
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             var convention = CreateConvention("PreDeploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1")), deployment.Variables, runner);
+            scriptEngine.Received().Execute(Arg.Is<Script>(s => s.File == TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1")), deployment.Variables, runner);
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             var convention = CreateConvention("PreDeploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1")), deployment.Variables, runner);
+            scriptEngine.Received().Execute(Arg.Is<Script>(s => s.File == TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1")), deployment.Variables, runner);
             fileSystem.Received().DeleteFile(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1"), Arg.Any<FailureOptions>());
         }
 
@@ -71,7 +71,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             deployment.Variables.Set(SpecialVariables.DeleteScriptsOnCleanup, false.ToString());
             var convention = CreateConvention("PreDeploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1")), deployment.Variables, runner);
+            scriptEngine.Received().Execute(Arg.Is<Script>(s => s.File == TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1")), deployment.Variables, runner);
             fileSystem.DidNotReceive().DeleteFile(TestEnvironment.ConstructRootedPath("App", "MyApp", "PreDeploy.ps1"), Arg.Any<FailureOptions>());
         }
 
@@ -81,8 +81,8 @@ namespace Calamari.Tests.Fixtures.Conventions
             deployment.Variables.Set(SpecialVariables.DeleteScriptsOnCleanup, false.ToString());
             var convention = CreateConvention("Deploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.ps1")), deployment.Variables, runner);
-            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.csx")), deployment.Variables, runner);
+            scriptEngine.Received().Execute(Arg.Is<Script>(s => s.File == TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.ps1")), deployment.Variables, runner);
+            scriptEngine.Received().Execute(Arg.Is<Script>(s => s.File == TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.csx")), deployment.Variables, runner);
             fileSystem.DidNotReceive().DeleteFile(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.ps1"), Arg.Any<FailureOptions>());
             fileSystem.DidNotReceive().DeleteFile(TestEnvironment.ConstructRootedPath("App", "MyApp", "Deploy.csx"), Arg.Any<FailureOptions>());
         }
@@ -93,7 +93,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             deployment.Variables.Set(SpecialVariables.DeleteScriptsOnCleanup, false.ToString());
             var convention = CreateConvention("PostDeploy");
             convention.Install(deployment);
-            scriptEngine.Received().Execute(new Script(TestEnvironment.ConstructRootedPath("App", "MyApp", "PostDeploy.ps1")), deployment.Variables, runner);
+            scriptEngine.Received().Execute(Arg.Is<Script>(s => s.File == TestEnvironment.ConstructRootedPath("App", "MyApp", "PostDeploy.ps1")), deployment.Variables, runner);
             fileSystem.DidNotReceive().DeleteFile(TestEnvironment.ConstructRootedPath("App", "MyApp", "PostDeploy.ps1"), Arg.Any<FailureOptions>());
         }
 

--- a/source/Calamari.Tests/Fixtures/Deployment/CleanFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/CleanFixture.cs
@@ -64,7 +64,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             result = Clean("retentionPolicySet1", 3, null);
 
-            result.AssertZero();
+            result.AssertSuccess();
 
             Assert.False(fileSystem.DirectoryExists(Path.Combine(stagingDirectory, "Acme.1.0.0")));
             Assert.False(fileSystem.FileExists(Path.Combine(packagesDirectory, "Acme.1.0.0.nupkg")));
@@ -75,7 +75,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             result = Clean("retentionPolicySet1", null, 1);
 
-            result.AssertZero();
+            result.AssertSuccess();
 
             Assert.False(fileSystem.DirectoryExists(Path.Combine(stagingDirectory, "Acme.1.0.0")));
             Assert.False(fileSystem.FileExists(Path.Combine(packagesDirectory, "Acme.1.0.0.nupkg")));

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -47,7 +47,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         public void ShouldDeployPackage()
         {
             var result = DeployPackage();
-            result.AssertZero();
+            result.AssertSuccess();
 
             result.AssertOutput("Extracting package to: " + Path.Combine(StagingDirectory, "Acme.Web", "1.0.0"));
 
@@ -59,7 +59,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         public void ShouldSetExtractionVariable()
         {
             var result = DeployPackage();
-            result.AssertZero();
+            result.AssertSuccess();
             result.AssertOutputVariable(SpecialVariables.Package.Output.InstallationDirectoryPath, Is.EqualTo(Path.Combine(StagingDirectory, "Acme.Web", "1.0.0")));
         }
 
@@ -68,7 +68,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             Variables[SpecialVariables.Package.CustomInstallationDirectory] = CustomDirectory;
             var result = DeployPackage();
-            result.AssertZero();
+            result.AssertSuccess();
             result.AssertOutput("Copying package contents to");
             result.AssertOutputVariable(SpecialVariables.Package.Output.InstallationDirectoryPath, Is.EqualTo(CustomDirectory));
         }
@@ -252,11 +252,11 @@ namespace Calamari.Tests.Fixtures.Deployment
             Variables.Set(SpecialVariables.Package.NuGetPackageVersion, "1.0.0");
 
             var result = DeployPackage(deploymentType);
-            result.AssertZero();
+            result.AssertSuccess();
             result.AssertOutput("The package has been installed to");
 
             result = DeployPackage(deploymentType);
-            result.AssertZero();
+            result.AssertSuccess();
             result.AssertOutput("The package has already been installed on this machine");
         }
 
@@ -269,11 +269,11 @@ namespace Calamari.Tests.Fixtures.Deployment
             Variables.Set(SpecialVariables.Package.NuGetPackageVersion, "1.0.0");
 
             var result = DeployPackage(DeploymentType.Tar);
-            result.AssertZero();
+            result.AssertSuccess();
             result.AssertOutput("The package has been installed to");
 
             result = DeployPackage(DeploymentType.Nupkg);
-            result.AssertZero();
+            result.AssertSuccess();
             result.AssertOutput("The package has already been installed on this machine");
         }
 
@@ -300,7 +300,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                             .Argument("variables", variablesFile.FilePath));
                     }
 
-                    result.AssertZero();
+                    result.AssertSuccess();
                     var extracted = result.GetOutputForLineContaining("Extracting package to: ");
                     result.AssertOutput("Extracted 12 files");
 

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWindowsServiceFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWindowsServiceFixture.cs
@@ -104,7 +104,7 @@ namespace Calamari.Tests.Fixtures.Deployment
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, "1.0.0")))
             {
                 var result = DeployPackage(file.FilePath);
-                result.AssertZero();
+                result.AssertSuccess();
 
                 result.AssertOutput("Extracting package to: " + Path.Combine(StagingDirectory, ServiceName, "1.0.0"));
 

--- a/source/Calamari.Tests/Fixtures/FindPackage/FindPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/FindPackage/FindPackageFixture.cs
@@ -60,7 +60,7 @@ namespace Calamari.Tests.Fixtures.FindPackage
             {
                 var result = FindPackages(packageId, packageVersion, acmeWeb.Hash);
 
-                result.AssertZero();
+                result.AssertSuccess();
                 result.AssertOutput("Package {0} version {1} hash {2} has not been uploaded.", packageId, packageVersion, acmeWeb.Hash);
                 result.AssertOutput("Finding earlier packages that have been uploaded to this Tentacle");
                 result.AssertOutput("No earlier packages for {0} has been uploaded", packageId);
@@ -80,7 +80,7 @@ namespace Calamari.Tests.Fixtures.FindPackage
                 {
                     var result = FindPackages(packageId, newpackageVersion, newAcmeWeb.Hash);
 
-                    result.AssertZero();
+                    result.AssertSuccess();
                     result.AssertOutput("Package {0} version {1} hash {2} has not been uploaded.", packageId, newpackageVersion,
                         newAcmeWeb.Hash);
                     result.AssertOutput("Finding earlier packages that have been uploaded to this Tentacle");
@@ -117,7 +117,7 @@ namespace Calamari.Tests.Fixtures.FindPackage
                 {
                     var result = FindPackages(packageId, newpackageVersion, newAcmeWeb.Hash);
 
-                    result.AssertZero();
+                    result.AssertSuccess();
                     result.AssertOutput("Package {0} version {1} hash {2} has not been uploaded.", packageId, newpackageVersion,
                         newAcmeWeb.Hash);
                     result.AssertOutput("Finding earlier packages that have been uploaded to this Tentacle");
@@ -147,7 +147,7 @@ namespace Calamari.Tests.Fixtures.FindPackage
 
                 var result = FindPackages(packageId, packageVersion, acmeWeb.Hash);
 
-                result.AssertZero();
+                result.AssertSuccess();
                 result.AssertServiceMessage(
                     ServiceMessageNames.CalamariFoundPackage.Name,
                     Is.True,

--- a/source/Calamari.Tests/Fixtures/HelpFixture.cs
+++ b/source/Calamari.Tests/Fixtures/HelpFixture.cs
@@ -27,7 +27,7 @@ namespace Calamari.Tests.Fixtures
         public void HelpShouldPrintHelp()
         {
             var output = Invoke(Calamari().Action("help"));
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("Usage: Calamari");
         }
 
@@ -35,7 +35,7 @@ namespace Calamari.Tests.Fixtures
         public void HelpOnCommandShouldPrintHelp()
         {
             var output = Invoke(Calamari().Action("help").Argument("run-script"));
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("Usage: Calamari run-script");
         }
 
@@ -43,7 +43,7 @@ namespace Calamari.Tests.Fixtures
         public void QuestionMarkShouldPrintHelp()
         {
             var output = Invoke(Calamari().Action("-?"));
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("Usage: Calamari");
         }
     }

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
@@ -60,7 +60,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
         {
             var capture = new CaptureCommandOutput();
             var runner = new CommandLineRunner(capture);
-            var result = psse.Execute(scriptName, variables, runner);
+            var result = psse.Execute(new Script(scriptName), variables, runner);
             return new CalamariResult(result.ExitCode, capture);
         }
     }

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -54,7 +54,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         {
             var result = DownloadPackage(PublicFeed.PackageId, PublicFeed.Version, PublicFeed.Id, PublicFeedUri);
 
-            result.AssertZero();
+            result.AssertSuccess();
 
             result.AssertOutput("Downloading NuGet package {0} {1} from feed: '{2}'", PublicFeed.PackageId, PublicFeed.Version, PublicFeedUri);
             result.AssertOutput("Downloaded package will be stored in: '{0}'", PublicFeed.DownloadFolder);
@@ -68,11 +68,11 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [Test]
         public void ShouldUsePackageFromCache()
         {
-            DownloadPackage(AuthFeed.PackageId, PublicFeed.Version, PublicFeed.Id, PublicFeedUri).AssertZero();
+            DownloadPackage(AuthFeed.PackageId, PublicFeed.Version, PublicFeed.Id, PublicFeedUri).AssertSuccess();
 
             var result = DownloadPackage(PublicFeed.PackageId, PublicFeed.Version, PublicFeed.Id, PublicFeedUri);
 
-            result.AssertZero();
+            result.AssertSuccess();
 
             result.AssertOutput("Checking package cache for package {0} {1}", PublicFeed.PackageId, PublicFeed.Version);
             result.AssertOutput("Package was found in cache. No need to download. Using file: '{0}", PublicFeed.File);
@@ -84,11 +84,11 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [Test]
         public void ShouldByPassCacheAndDownloadPackage()
         {
-            DownloadPackage(AuthFeed.PackageId, PublicFeed.Version, PublicFeed.Id, PublicFeedUri).AssertZero();
+            DownloadPackage(AuthFeed.PackageId, PublicFeed.Version, PublicFeed.Id, PublicFeedUri).AssertSuccess();
 
             var result = DownloadPackage(PublicFeed.PackageId, PublicFeed.Version, PublicFeed.Id, PublicFeedUri, forcePackageDownload: true);
 
-            result.AssertZero();
+            result.AssertSuccess();
 
             result.AssertOutput("Downloading NuGet package {0} {1} from feed: '{2}'", PublicFeed.PackageId, PublicFeed.Version, PublicFeedUri);
             result.AssertOutput("Downloaded package will be stored in: '{0}'", PublicFeed.DownloadFolder);
@@ -105,7 +105,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         {
             var result = DownloadPackage(AuthFeed.PackageId, AuthFeed.Version, AuthFeed.Id, AuthFeedUri, FeedUsername, FeedPassword);
 
-            result.AssertZero();
+            result.AssertSuccess();
 
             result.AssertOutput("Downloading NuGet package {0} {1} from feed: '{2}'", AuthFeed.PackageId, AuthFeed.Version, AuthFeedUri);
             result.AssertOutput("Downloaded package will be stored in: '{0}'", AuthFeed.DownloadFolder);
@@ -121,11 +121,11 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         public void PrivateNuGetFeedShouldUsePackageFromCache()
         {
             DownloadPackage(AuthFeed.PackageId, AuthFeed.Version, AuthFeed.Id, AuthFeedUri, FeedUsername, FeedPassword)
-                .AssertZero();
+                .AssertSuccess();
 
             var result = DownloadPackage(AuthFeed.PackageId, AuthFeed.Version, AuthFeed.Id, AuthFeedUri, FeedUsername, FeedPassword);
 
-            result.AssertZero();
+            result.AssertSuccess();
 
             result.AssertOutput("Checking package cache for package {0} {1}", AuthFeed.PackageId, AuthFeed.Version);
             result.AssertOutput("Package was found in cache. No need to download. Using file: '{0}", AuthFeed.File);
@@ -138,11 +138,11 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [AuthenticatedTest(FeedUriEnvironmentVariable, FeedUsernameEnvironmentVariable, FeedPasswordEnvironmentVariable)]
         public void PrivateNuGetFeedShouldByPassCacheAndDownloadPackage()
         {
-            DownloadPackage(AuthFeed.PackageId, AuthFeed.Version, AuthFeed.Id, AuthFeedUri, FeedUsername, FeedPassword).AssertZero();
+            DownloadPackage(AuthFeed.PackageId, AuthFeed.Version, AuthFeed.Id, AuthFeedUri, FeedUsername, FeedPassword).AssertSuccess();
 
             var result = DownloadPackage(AuthFeed.PackageId, AuthFeed.Version, AuthFeed.Id, AuthFeedUri, FeedUsername, FeedPassword, true);
 
-            result.AssertZero();
+            result.AssertSuccess();
 
             result.AssertOutput("Downloading NuGet package {0} {1} from feed: '{2}'", AuthFeed.PackageId, AuthFeed.Version, AuthFeedUri);
             result.AssertOutput("Downloaded package will be stored in: '{0}'", AuthFeed.DownloadFolder);
@@ -173,7 +173,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
             {
                 var result = DownloadPackage(FileShare.PackageId, FileShare.Version, FileShare.Id, acmeWeb.DirectoryPath);
 
-                result.AssertZero();
+                result.AssertSuccess();
 
                 result.AssertOutput("Downloading NuGet package {0} {1} from feed: '{2}'", FileShare.PackageId, FileShare.Version, new Uri(acmeWeb.DirectoryPath));
                 result.AssertOutput("Downloaded package will be stored in: '{0}'", FileShare.DownloadFolder);
@@ -190,10 +190,10 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         {
             using (var acmeWeb = CreateSamplePackage())
             {
-                DownloadPackage(FileShare.PackageId, FileShare.Version, FileShare.Id, acmeWeb.DirectoryPath).AssertZero();
+                DownloadPackage(FileShare.PackageId, FileShare.Version, FileShare.Id, acmeWeb.DirectoryPath).AssertSuccess();
 
                 var result = DownloadPackage(FileShare.PackageId, FileShare.Version, FileShare.Id, acmeWeb.DirectoryPath);
-                result.AssertZero();
+                result.AssertSuccess();
 
                 result.AssertOutput("Checking package cache for package {0} {1}", FileShare.PackageId, FileShare.Version);
                 result.AssertOutput("Package was found in cache. No need to download. Using file: '{0}", FileShare.File);
@@ -209,12 +209,12 @@ namespace Calamari.Tests.Fixtures.PackageDownload
             using (var acmeWeb = CreateSamplePackage())
             {
                 DownloadPackage(FileShare.PackageId, FileShare.Version, FileShare.Id, acmeWeb.DirectoryPath)
-                    .AssertZero();
+                    .AssertSuccess();
 
                 var result = DownloadPackage(FileShare.PackageId, FileShare.Version, FileShare.Id, acmeWeb.DirectoryPath,
                     forcePackageDownload: true);
 
-                result.AssertZero();
+                result.AssertSuccess();
 
                 result.AssertOutput("Downloading NuGet package {0} {1} from feed: '{2}'", FileShare.PackageId, FileShare.Version, new Uri(acmeWeb.DirectoryPath));
                 result.AssertOutput("Downloaded package will be stored in: '{0}'", FileShare.DownloadFolder);

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -36,7 +36,9 @@ namespace Calamari.Tests.Fixtures.PackageDownload
                 Directory.CreateDirectory(TentacleHome);
 
             Directory.SetCurrentDirectory(TentacleHome);
+   
             Environment.SetEnvironmentVariable("TentacleHome", TentacleHome);
+            Console.WriteLine("TentacleHome is set to: " + TentacleHome);
         }
 
         [TearDown]

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -51,6 +51,19 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Windows)]
+        public void ShouldConsumeParametersWithQuotes()
+        {
+            var output = Invoke(Calamari()
+                .Action("run-script")
+                .Argument("script", GetFixtureResouce("Scripts", "Parameters.ps1"))
+                .Argument("scriptParameters", "-Parameter0 \"Para meter0\" -Parameter1 'Para meter1'"));
+
+            output.AssertSuccess();
+            output.AssertOutput("Parameters Para meter0Para meter1");
+        }
+
+        [Test]
+        [Category(TestEnvironment.CompatibleOS.Windows)]
         public void ShouldCaptureAllOutput()
         {
             var output = Invoke(Calamari()

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -31,7 +31,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                     .Argument("script", GetFixtureResouce("Scripts", "Hello.ps1"))
                     .Argument("variables", variablesFile));
 
-                output.AssertZero();
+                output.AssertSuccess();
                 output.AssertOutput(expectedLogMessage);
                 output.AssertOutput("Hello!");
             }
@@ -45,7 +45,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "Hello.ps1")));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("Hello!");
         }
 
@@ -73,7 +73,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "CanCreateArtifact.ps1")));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("##octopus[createArtifact path='QzpcUGF0aFxGaWxlLnR4dA==' name='RmlsZS50eHQ=' length='MA==']");
             //output.ApproveOutput();
         }
@@ -86,7 +86,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "WarningForMissingArtifact.ps1")));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput(@"There is no file at 'C:\NonExistantPath\NonExistantFile.txt' right now. Writing the service message just in case the file is available when the artifacts are collected at a later point in time.");
             output.AssertOutput("##octopus[createArtifact path='QzpcTm9uRXhpc3RhbnRQYXRoXE5vbkV4aXN0YW50RmlsZS50eHQ=' name='Tm9uRXhpc3RhbnRGaWxlLnR4dA==' length='MA==']");
             //output.ApproveOutput();
@@ -100,7 +100,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "CanDotSource.ps1")));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("Hello!");
         }
 
@@ -114,7 +114,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "CanSetVariable.ps1")), variables);
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("##octopus[setVariable name='VGVzdEE=' value='V29ybGQh']");
             Assert.AreEqual("World!", variables.Get("TestA"));
         }
@@ -195,7 +195,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                    .Argument("script", GetFixtureResouce("Scripts", "PrintVariables.ps1"))
                    .Argument("variables", variablesFile));
 
-                output.AssertZero();
+                output.AssertSuccess();
                 output.AssertOutput("V1= ABC");
                 output.AssertOutput("V2= DEF");
                 output.AssertOutput("V3= GHI");
@@ -221,7 +221,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                    .Argument("script", GetFixtureResouce("Scripts", "UseModule.ps1"))
                    .Argument("variables", variablesFile));
 
-                output.AssertZero();
+                output.AssertSuccess();
                 output.AssertOutput("Hello from module!");
             }
         }
@@ -248,7 +248,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                     .Argument("script", scriptFile)
                     .Argument("variables", variablesFile));
 
-                output.AssertZero();
+                output.AssertSuccess();
                 output.AssertOutput("Hello #{Octopus.Environment.Name}!");
             }
         }
@@ -276,7 +276,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                     .Argument("variables", variablesFile)
                     .Flag("substituteVariables"));
 
-                output.AssertZero();
+                output.AssertSuccess();
                 output.AssertOutput("Substituting variables");
                 output.AssertOutput("Hello Production!");
             }
@@ -301,7 +301,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                     .Argument("variables", variablesFile)
                     .Flag("substituteVariables"));
 
-                output.AssertZero();
+                output.AssertSuccess();
                 output.AssertOutput("Extracting package");
                 output.AssertOutput("Substituting variables");
                 output.AssertOutput("OctopusParameter: Production");
@@ -318,7 +318,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "Ping.ps1")));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("Pinging ");
         }
 
@@ -330,7 +330,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts\\Path With '", "PathWithSingleQuote.ps1")));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("Hello from a path containing a '");
         }
 
@@ -342,7 +342,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts\\Path With $", "PathWithDollar.ps1")));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("Hello from a path containing a $");
         }
 

--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/Parameters.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/Parameters.ps1
@@ -1,0 +1,3 @@
+﻿param([string]$Parameter0, [string]$Parameter1) 
+
+Write-Host "Parameters $Parameter0$Parameter1"

--- a/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
@@ -16,7 +16,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "PrintEncodedVariable.csx")));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("##octopus[setVariable name='RG9ua2V5' value='S29uZw==']");
         }
 
@@ -27,7 +27,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "CreateArtifact.csx")));
 
-            output.AssertZero();
+            output.AssertSuccess();
             output.AssertOutput("##octopus[createArtifact");
             output.AssertOutput("name='bXlGaWxlLnR4dA==' length='MTAw']");
         }
@@ -52,9 +52,33 @@ namespace Calamari.Tests.Fixtures.ScriptCS
                     .Argument("script", GetFixtureResouce("Scripts", "Hello.csx"))
                     .Argument("variables", variablesFile));
 
-                output.AssertZero();
+                output.AssertSuccess();
                 output.AssertOutput("Hello Paul");
             }
+        }
+
+        [Test, RequiresDotNet45]
+        public void ShouldConsumeParametersWithQuotes()
+        {
+            var output = Invoke(Calamari()
+                .Action("run-script")
+                .Argument("script", GetFixtureResouce("Scripts", "Parameters.csx"))
+                .Argument("scriptParameters", "-- \"Para meter0\" 'Parameter1'"));                ;
+
+            output.AssertSuccess();
+            output.AssertOutput("Parameters Para meter0'Parameter1'");
+        }
+
+        [Test, RequiresDotNet45]
+        public void ShouldConsumeParametersWithoutParametersPrefix()
+        {
+            var output = Invoke(Calamari()
+                .Action("run-script")
+                .Argument("script", GetFixtureResouce("Scripts", "Parameters.csx"))
+                .Argument("scriptParameters", "Parameter0 Parameter1")); ;
+
+            output.AssertSuccess();
+            output.AssertOutput("Parameters Parameter0Parameter1");
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/ScriptCS/Scripts/Parameters.csx
+++ b/source/Calamari.Tests/Fixtures/ScriptCS/Scripts/Parameters.csx
@@ -1,0 +1,3 @@
+﻿using System;
+
+Console.WriteLine("Parameters " + Env.ScriptArgs[0] + Env.ScriptArgs[1]);

--- a/source/Calamari.Tests/Helpers/CalamariResult.cs
+++ b/source/Calamari.Tests/Helpers/CalamariResult.cs
@@ -28,7 +28,7 @@ namespace Calamari.Tests.Helpers
 
         public CaptureCommandOutput CapturedOutput { get { return captured; } }
 
-        public void AssertZero()
+        public void AssertSuccess()
         {
             var capturedErrors = string.Join(Environment.NewLine, captured.Errors);
             Assert.That(ExitCode, Is.EqualTo(0), string.Format("Expected command to return exit code 0{0}{0}Output:{0}{1}", Environment.NewLine, capturedErrors));

--- a/source/Calamari.Tests/Helpers/TestEnvironment.cs
+++ b/source/Calamari.Tests/Helpers/TestEnvironment.cs
@@ -3,7 +3,7 @@ using Calamari.Integration.Processes;
 
 namespace Calamari.Tests.Helpers
 {
-    public static class TestEnvironment
+    public static class TestEnvironment 
     {
         public static readonly string AssemblyLocalPath = typeof(TestEnvironment).Assembly.FullLocalPath();
         public static readonly string CurrentWorkingDirectory = Path.GetDirectoryName(AssemblyLocalPath);

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Integration\Packages\TarGzipPackageExtractor.cs" />
     <Compile Include="Integration\Packages\TarPackageExtractor.cs" />
     <Compile Include="Integration\Packages\ZipPackageExtractor.cs" />
+    <Compile Include="Integration\Scripting\InvalidScriptException.cs" />
     <Compile Include="Integration\Scripting\PackagedScriptRunner.cs" />
     <Compile Include="Deployment\Conventions\RollbackScriptConvention.cs" />
     <Compile Include="Deployment\DeploymentStages.cs" />
@@ -216,6 +217,7 @@
     <Compile Include="Integration\Scripting\FileExtensionAttribute.cs" />
     <Compile Include="Integration\Scripting\IScriptEngine.cs" />
     <Compile Include="Integration\Scripting\CombinedScriptEngine.cs" />
+    <Compile Include="Integration\Scripting\Script.cs" />
     <Compile Include="Integration\Scripting\ScriptEngineRegistry.cs" />
     <Compile Include="Integration\Scripting\ScriptType.cs" />
     <Compile Include="Util\AssemblyExtensions.cs" />

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -21,12 +21,14 @@ namespace Calamari.Commands
         private string sensitiveVariablesPassword;
         private string packageFile;
         private bool substituteVariables;
+        private string scriptParameters;
 
         public RunScriptCommand()
         {
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
             Options.Add("package=", "Path to the package to extract that contains the package.", v => packageFile = Path.GetFullPath(v));
             Options.Add("script=", "Path to the script to execute. If --package is used, it can be a script inside the package.", v => scriptFile = Path.GetFullPath(v));
+            Options.Add("scriptParameters=", "Parameters to pass to the script.", v => scriptParameters = v);
             Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
             Options.Add("substituteVariables", "Perform variable substitution on the script body before executing it.", v => substituteVariables = true);
@@ -79,7 +81,7 @@ namespace Calamari.Commands
             var scriptEngine = new CombinedScriptEngine();
             var runner = new CommandLineRunner(
                 new SplitCommandOutput(new ConsoleCommandOutput(), new ServiceMessageCommandOutput(variables)));
-            var result = scriptEngine.Execute(validatedScriptFilePath, variables, runner);
+            var result = scriptEngine.Execute(validatedScriptFilePath, variables, runner, scriptParameters);
             return result.ExitCode;
         }
 

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -81,7 +81,7 @@ namespace Calamari.Commands
             var scriptEngine = new CombinedScriptEngine();
             var runner = new CommandLineRunner(
                 new SplitCommandOutput(new ConsoleCommandOutput(), new ServiceMessageCommandOutput(variables)));
-            var result = scriptEngine.Execute(validatedScriptFilePath, variables, runner, scriptParameters);
+            var result = scriptEngine.Execute(new Script(validatedScriptFilePath, scriptParameters), variables, runner);
             return result.ExitCode;
         }
 

--- a/source/Calamari/Deployment/Conventions/ConfiguredScriptConvention.cs
+++ b/source/Calamari/Deployment/Conventions/ConfiguredScriptConvention.cs
@@ -48,7 +48,7 @@ namespace Calamari.Deployment.Conventions
 
                 // Execute the script
                 Log.VerboseFormat("Executing '{0}'", scriptFile);
-                var result = scriptEngine.Execute(scriptFile, deployment.Variables, commandLineRunner);
+                var result = scriptEngine.Execute(new Script(scriptFile), deployment.Variables, commandLineRunner);
 
                 if (result.ExitCode != 0)
                 {

--- a/source/Calamari/Deployment/Conventions/FeatureScriptConvention.cs
+++ b/source/Calamari/Deployment/Conventions/FeatureScriptConvention.cs
@@ -63,7 +63,7 @@ namespace Calamari.Deployment.Conventions
 
                 // Execute the script
                 Log.VerboseFormat("Executing '{0}'", scriptFile);
-                var result = scriptEngine.Execute(scriptFile, deployment.Variables, commandLineRunner);
+                var result = scriptEngine.Execute(new Script(scriptFile), deployment.Variables, commandLineRunner);
 
                 // And then delete it
                 Log.VerboseFormat("Deleting '{0}'", scriptFile);

--- a/source/Calamari/Integration/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari/Integration/Scripting/Bash/BashScriptBootstrapper.cs
@@ -93,8 +93,7 @@ namespace Calamari.Integration.Scripting.Bash
         }
 
         public static string PrepareBootstrapFile(string scriptFilePath, string configurationFile, string workingDirectory)
-        {
-            
+        {            
             var bootstrapFile = Path.Combine(workingDirectory, "Bootstrap." + Guid.NewGuid().ToString().Substring(10) + "." + Path.GetFileName(scriptFilePath));
 
             using (var writer = new StreamWriter(bootstrapFile, false, Encoding.ASCII))

--- a/source/Calamari/Integration/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari/Integration/Scripting/Bash/BashScriptBootstrapper.cs
@@ -36,7 +36,6 @@ namespace Calamari.Integration.Scripting.Bash
             var builder = new StringBuilder(BootstrapScriptTemplate);
             builder.Replace("#### VariableDeclarations ####", string.Join(Environment.NewLine, GetVariableSwitchConditions(variables)));
 
-
             using (var writer = new StreamWriter(configurationFile, false, Encoding.ASCII))
             {
                 writer.Write(builder.Replace(WindowsNewLine, Environment.NewLine));
@@ -92,21 +91,21 @@ namespace Calamari.Integration.Scripting.Bash
             File.WriteAllText(scriptFilePath, text);
         }
 
-        public static string PrepareBootstrapFile(string scriptFilePath, string configurationFile, string workingDirectory)
+        public static string PrepareBootstrapFile(Script script, string configurationFile, string workingDirectory)
         {            
-            var bootstrapFile = Path.Combine(workingDirectory, "Bootstrap." + Guid.NewGuid().ToString().Substring(10) + "." + Path.GetFileName(scriptFilePath));
+            var bootstrapFile = Path.Combine(workingDirectory, "Bootstrap." + Guid.NewGuid().ToString().Substring(10) + "." + Path.GetFileName(script.File));
 
             using (var writer = new StreamWriter(bootstrapFile, false, Encoding.ASCII))
             {
                 writer.NewLine = Environment.NewLine;
                 writer.WriteLine("#!/bin/bash");
                 writer.WriteLine("source \"" + configurationFile.Replace("\\", "\\\\") + "\"");
-                writer.WriteLine("source \"" + scriptFilePath.Replace("\\", "\\\\") + "\"");
+                writer.WriteLine("source \"" + script.File.Replace("\\", "\\\\") + "\" " + script.Parameters);
                 writer.Flush();
             }
 
             File.SetAttributes(bootstrapFile, FileAttributes.Hidden);
-            EnsureValidUnixFile(scriptFilePath);
+            EnsureValidUnixFile(script.File);
             return bootstrapFile;
         }
     }

--- a/source/Calamari/Integration/Scripting/Bash/BashScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/Bash/BashScriptEngine.cs
@@ -12,7 +12,7 @@ namespace Calamari.Integration.Scripting.Bash
         }
 
         public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables,
-            ICommandLineRunner commandLineRunner)
+            ICommandLineRunner commandLineRunner, string scriptParameters = null)
         {
 
             var workingDirectory = Path.GetDirectoryName(scriptFile);

--- a/source/Calamari/Integration/Scripting/Bash/BashScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/Bash/BashScriptEngine.cs
@@ -11,13 +11,11 @@ namespace Calamari.Integration.Scripting.Bash
             return new[] {ScriptType.Bash.FileExtension()};
         }
 
-        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables,
-            ICommandLineRunner commandLineRunner, string scriptParameters = null)
+        public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
         {
-
-            var workingDirectory = Path.GetDirectoryName(scriptFile);
+            var workingDirectory = Path.GetDirectoryName(script.File);
             var configurationFile = BashScriptBootstrapper.PrepareConfigurationFile(workingDirectory, variables);
-            var boostrapFile = BashScriptBootstrapper.PrepareBootstrapFile(scriptFile, configurationFile, workingDirectory);
+            var boostrapFile = BashScriptBootstrapper.PrepareBootstrapFile(script.File, configurationFile, workingDirectory);
 
             using (new TemporaryFile(configurationFile))
             using (new TemporaryFile(boostrapFile))

--- a/source/Calamari/Integration/Scripting/Bash/BashScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/Bash/BashScriptEngine.cs
@@ -15,7 +15,7 @@ namespace Calamari.Integration.Scripting.Bash
         {
             var workingDirectory = Path.GetDirectoryName(script.File);
             var configurationFile = BashScriptBootstrapper.PrepareConfigurationFile(workingDirectory, variables);
-            var boostrapFile = BashScriptBootstrapper.PrepareBootstrapFile(script.File, configurationFile, workingDirectory);
+            var boostrapFile = BashScriptBootstrapper.PrepareBootstrapFile(script, configurationFile, workingDirectory);
 
             using (new TemporaryFile(configurationFile))
             using (new TemporaryFile(boostrapFile))

--- a/source/Calamari/Integration/Scripting/CombinedScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/CombinedScriptEngine.cs
@@ -14,10 +14,10 @@ namespace Calamari.Integration.Scripting
                 : new[] {ScriptType.ScriptCS.FileExtension(), ScriptType.Powershell.FileExtension()};
         }
 
-        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
+        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner, string scriptParameters = null)
         {
             var scriptType = ValidateScriptType(scriptFile);
-            return ScriptEngineRegistry.Instance.ScriptEngines[scriptType].Execute(scriptFile, variables, commandLineRunner);
+            return ScriptEngineRegistry.Instance.ScriptEngines[scriptType].Execute(scriptFile, variables, commandLineRunner, scriptParameters);
         }
 
         private ScriptType ValidateScriptType(string scriptFile)

--- a/source/Calamari/Integration/Scripting/CombinedScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/CombinedScriptEngine.cs
@@ -14,15 +14,15 @@ namespace Calamari.Integration.Scripting
                 : new[] {ScriptType.ScriptCS.FileExtension(), ScriptType.Powershell.FileExtension()};
         }
 
-        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner, string scriptParameters = null)
+        public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
         {
-            var scriptType = ValidateScriptType(scriptFile);
-            return ScriptEngineRegistry.Instance.ScriptEngines[scriptType].Execute(scriptFile, variables, commandLineRunner, scriptParameters);
+            var scriptType = ValidateScriptType(script);
+            return ScriptEngineRegistry.Instance.ScriptEngines[scriptType].Execute(script, variables, commandLineRunner);
         }
 
-        private ScriptType ValidateScriptType(string scriptFile)
+        private ScriptType ValidateScriptType(Script script)
         {
-            var scriptExtension = Path.GetExtension(scriptFile).TrimStart('.');
+            var scriptExtension = Path.GetExtension(script.File).TrimStart('.');
             if (!GetSupportedExtensions().Any(ext => ext.Equals(scriptExtension, StringComparison.InvariantCultureIgnoreCase)))
             {
                 throw new InvalidOperationException(string.Format("Script type `{0}` unsupported on this platform.", scriptExtension));

--- a/source/Calamari/Integration/Scripting/IScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/IScriptEngine.cs
@@ -5,6 +5,6 @@ namespace Calamari.Integration.Scripting
     public interface IScriptEngine  
     {
         string[] GetSupportedExtensions();
-        CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner);
+        CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner, string scriptParameters = null);
     }
 }

--- a/source/Calamari/Integration/Scripting/IScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/IScriptEngine.cs
@@ -5,6 +5,6 @@ namespace Calamari.Integration.Scripting
     public interface IScriptEngine  
     {
         string[] GetSupportedExtensions();
-        CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner, string scriptParameters = null);
+        CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner);
     }
 }

--- a/source/Calamari/Integration/Scripting/InvalidScriptException.cs
+++ b/source/Calamari/Integration/Scripting/InvalidScriptException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Calamari.Integration.Scripting
+{
+    public class InvalidScriptException : Exception
+    {
+        public InvalidScriptException(string message) : base(message)
+        {            
+        }
+    }
+}

--- a/source/Calamari/Integration/Scripting/PackagedScriptRunner.cs
+++ b/source/Calamari/Integration/Scripting/PackagedScriptRunner.cs
@@ -30,7 +30,7 @@ namespace Calamari.Integration.Scripting
 
             foreach (var script in scripts)
             {
-                var result = scriptEngine.Execute(script, deployment.Variables, commandLineRunner);
+                var result = scriptEngine.Execute(new Script(script), deployment.Variables, commandLineRunner);
                 if (result.ExitCode != 0)
                 {
                     throw new CommandException(string.Format("Script '{0}' returned non-zero exit code: {1}. Deployment terminated.", script, result.ExitCode));

--- a/source/Calamari/Integration/Scripting/Script.cs
+++ b/source/Calamari/Integration/Scripting/Script.cs
@@ -1,0 +1,20 @@
+namespace Calamari.Integration.Scripting
+{
+    public class Script
+    {
+        public string File { get; private set; }
+        public string Parameters { get; private set; }
+
+        public Script(string file) :this (file, null)
+        {
+        }
+
+        public Script(string file, string parameters)
+        {
+            if (string.IsNullOrEmpty(file)) throw new InvalidScriptException("File can not be null or empty.");
+
+            File = file;
+            Parameters = parameters;
+        }
+    }
+}

--- a/source/Calamari/Integration/Scripting/ScriptCS/Bootstrap.csx
+++ b/source/Calamari/Integration/Scripting/ScriptCS/Bootstrap.csx
@@ -99,4 +99,4 @@ public static class Octopus
 	}
 }
 
-Octopus.Initialize(Env.ScriptArgs[0]);
+Octopus.Initialize(Env.ScriptArgs[Env.ScriptArgs.Count - 1]);

--- a/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSBootstrapper.cs
+++ b/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSBootstrapper.cs
@@ -37,12 +37,21 @@ namespace Calamari.Integration.Scripting.ScriptCS
             throw new CommandException(string.Format("ScriptCS.exe was not found at either '{0}' or '{1}'", attemptOne, attemptTwo));
         }
 
-        public static string FormatCommandArguments(string bootstrapFile)
+        public static string FormatCommandArguments(string bootstrapFile, string scriptParameters)
         {
+            scriptParameters = RetriveParameterValues(scriptParameters);
             var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword));
             var commandArguments = new StringBuilder();
-            commandArguments.AppendFormat("-script \"{0}\" -- \"{1}\"", bootstrapFile, encryptionKey);
+            commandArguments.AppendFormat("-script \"{0}\" -- {1} \"{2}\"", bootstrapFile, scriptParameters, encryptionKey);
             return commandArguments.ToString();
+        }
+
+        private static string RetriveParameterValues(string scriptParameters)
+        {
+            if (scriptParameters == null) return null;
+            return scriptParameters.Trim()
+                                   .TrimStart('-')
+                                   .Trim();
         }
 
         static bool IsNet45OrNewer()

--- a/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
@@ -11,7 +11,7 @@ namespace Calamari.Integration.Scripting.ScriptCS
             return new[] {ScriptType.ScriptCS.FileExtension()};
         }
 
-        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
+        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner, string scriptParameters = null)
         {
             var workingDirectory = Path.GetDirectoryName(scriptFile);
 

--- a/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
@@ -11,13 +11,13 @@ namespace Calamari.Integration.Scripting.ScriptCS
             return new[] {ScriptType.ScriptCS.FileExtension()};
         }
 
-        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner, string scriptParameters = null)
+        public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
         {
-            var workingDirectory = Path.GetDirectoryName(scriptFile);
+            var workingDirectory = Path.GetDirectoryName(script.File);
 
             var executable = ScriptCSBootstrapper.FindScriptCSExecutable();
             var configurationFile = ScriptCSBootstrapper.PrepareConfigurationFile(workingDirectory, variables);
-            var boostrapFile = ScriptCSBootstrapper.PrepareBootstrapFile(scriptFile, configurationFile, workingDirectory);
+            var boostrapFile = ScriptCSBootstrapper.PrepareBootstrapFile(script.File, configurationFile, workingDirectory);
             var arguments = ScriptCSBootstrapper.FormatCommandArguments(boostrapFile);
 
             using (new TemporaryFile(configurationFile))

--- a/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
@@ -18,7 +18,7 @@ namespace Calamari.Integration.Scripting.ScriptCS
             var executable = ScriptCSBootstrapper.FindScriptCSExecutable();
             var configurationFile = ScriptCSBootstrapper.PrepareConfigurationFile(workingDirectory, variables);
             var boostrapFile = ScriptCSBootstrapper.PrepareBootstrapFile(script.File, configurationFile, workingDirectory);
-            var arguments = ScriptCSBootstrapper.FormatCommandArguments(boostrapFile);
+            var arguments = ScriptCSBootstrapper.FormatCommandArguments(boostrapFile, script.Parameters);
 
             using (new TemporaryFile(configurationFile))
             using (new TemporaryFile(boostrapFile))

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -147,7 +147,7 @@ Initialize-ProxySettings
 # -----------------------------------------------------------------
 # Invoke target script
 # -----------------------------------------------------------------
-. '{{TargetScriptFile}}'
+. '{{TargetScriptFile}} {{ScriptParameters}}'
 
 # -----------------------------------------------------------------
 # Ensure we exit with whatever exit code the last exe used

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -147,7 +147,7 @@ Initialize-ProxySettings
 # -----------------------------------------------------------------
 # Invoke target script
 # -----------------------------------------------------------------
-. '{{TargetScriptFile}} {{ScriptParameters}}'
+. '{{TargetScriptFile}}' {{ScriptParameters}}
 
 # -----------------------------------------------------------------
 # Ensure we exit with whatever exit code the last exe used

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -64,15 +64,15 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
             return commandArguments.ToString();
         }
 
-        public static string PrepareBootstrapFile(string targetScriptFile, string scriptParameters, CalamariVariableDictionary variables)
+        public static string PrepareBootstrapFile(Script script, CalamariVariableDictionary variables)
         {
-            var parent = Path.GetDirectoryName(Path.GetFullPath(targetScriptFile));
-            var name = Path.GetFileName(targetScriptFile);
+            var parent = Path.GetDirectoryName(Path.GetFullPath(script.File));
+            var name = Path.GetFileName(script.File);
             var bootstrapFile = Path.Combine(parent, "Bootstrap." + name);
 
             var builder = new StringBuilder(BootstrapScriptTemplate);
-            builder.Replace("{{TargetScriptFile}}", targetScriptFile.Replace("'", "''"))
-                    .Replace("{{ScriptParameters}}", scriptParameters)
+            builder.Replace("{{TargetScriptFile}}", script.File.Replace("'", "''"))
+                    .Replace("{{ScriptParameters}}", script.Parameters)
                     .Replace("{{VariableDeclarations}}", DeclareVariables(variables))
                     .Replace("{{ScriptModules}}", DeclareScriptModules(variables));
 

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -64,16 +64,17 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
             return commandArguments.ToString();
         }
 
-        public static string PrepareBootstrapFile(string targetScriptFile, CalamariVariableDictionary variables)
+        public static string PrepareBootstrapFile(string targetScriptFile, string scriptParameters, CalamariVariableDictionary variables)
         {
             var parent = Path.GetDirectoryName(Path.GetFullPath(targetScriptFile));
             var name = Path.GetFileName(targetScriptFile);
             var bootstrapFile = Path.Combine(parent, "Bootstrap." + name);
 
             var builder = new StringBuilder(BootstrapScriptTemplate);
-            builder.Replace("{{TargetScriptFile}}", targetScriptFile.Replace("'", "''"));
-            builder.Replace("{{VariableDeclarations}}", DeclareVariables(variables));
-            builder.Replace("{{ScriptModules}}", DeclareScriptModules(variables));
+            builder.Replace("{{TargetScriptFile}}", targetScriptFile.Replace("'", "''"))
+                    .Replace("{{ScriptParameters}}", scriptParameters)
+                    .Replace("{{VariableDeclarations}}", DeclareVariables(variables))
+                    .Replace("{{ScriptModules}}", DeclareScriptModules(variables));
 
             using (var writer = new StreamWriter(bootstrapFile, false, new UTF8Encoding(true)))
             {

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
@@ -11,12 +11,12 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
             return new[] {ScriptType.Powershell.FileExtension()};
         }
 
-        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
+        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner, string scriptParameters)
         {
             var workingDirectory = Path.GetDirectoryName(scriptFile);
 
             var executable = PowerShellBootstrapper.PathToPowerShellExecutable();
-            var boostrapFile = PowerShellBootstrapper.PrepareBootstrapFile(scriptFile, variables);
+            var boostrapFile = PowerShellBootstrapper.PrepareBootstrapFile(scriptFile, scriptParameters, variables);
             var arguments = PowerShellBootstrapper.FormatCommandArguments(boostrapFile, variables);
 
             using (new TemporaryFile(boostrapFile))

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
@@ -11,12 +11,12 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
             return new[] {ScriptType.Powershell.FileExtension()};
         }
 
-        public CommandResult Execute(string scriptFile, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner, string scriptParameters)
+        public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
         {
-            var workingDirectory = Path.GetDirectoryName(scriptFile);
+            var workingDirectory = Path.GetDirectoryName(script.File);
 
             var executable = PowerShellBootstrapper.PathToPowerShellExecutable();
-            var boostrapFile = PowerShellBootstrapper.PrepareBootstrapFile(scriptFile, scriptParameters, variables);
+            var boostrapFile = PowerShellBootstrapper.PrepareBootstrapFile(script, variables);
             var arguments = PowerShellBootstrapper.FormatCommandArguments(boostrapFile, variables);
 
             using (new TemporaryFile(boostrapFile))


### PR DESCRIPTION
We can now pass parameters to Bash, PowerShell and ScriptCS files. scriptParameters parameter is optional so it is a non-breaking change. Related to OctopusDeploy/Issues#2502