### PR TITLE
Allow the use of F# script (.fsx)

### DIFF
--- a/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_BuildCalamari.xml
+++ b/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_BuildCalamari.xml
@@ -4,7 +4,7 @@
   <description>Build the open source Calamari package</description>
   <settings>
     <options>
-      <option name="artifactRules" value="built-packages/Calamari*.nupkg&#xA;source/Calamari.Tests/bin/**/*=&gt;Binaries.zip&#xA;source/packages/Octopus.Dependencies.ScriptCS.3.0.1/runtime/**/*=&gt;ScriptCS.zip" />
+      <option name="artifactRules" value="built-packages/Calamari*.nupkg&#xA;source/Calamari.Tests/bin/**/*=&gt;Binaries.zip&#xA;source/packages/Octopus.Dependencies.ScriptCS.3.0.1/runtime/**/*=&gt;ScriptCS.zip&#xA;source/packages/FSharp.Compiler.Tools.4.0.0.1/tools/**/*=&gt;FSharp.zip" />
       <option name="checkoutMode" value="ON_AGENT" />
       <option name="showDependenciesChanges" value="true" />
     </options>

--- a/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestRedhat67CentOS.xml
+++ b/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestRedhat67CentOS.xml
@@ -79,7 +79,7 @@ chmod +x Binaries/ScriptCS/*.exe]]></param>
     <artifact-dependencies>
       <dependency sourceBuildTypeId="OctopusDeploy_BuildCalamari" cleanDestination="true">
         <revisionRule name="sameChainOrLastFinished" revision="latest.sameChainOrLastFinished" />
-        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS" />
+        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS&#xD;&#xA;FSharp.zip!**=&gt;Binaries\FSharp" />
       </dependency>
     </artifact-dependencies>
     <dependencies>

--- a/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestUbuntu1202lts.xml
+++ b/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestUbuntu1202lts.xml
@@ -79,7 +79,7 @@ chmod +x Binaries/ScriptCS/*.exe]]></param>
     <artifact-dependencies>
       <dependency sourceBuildTypeId="OctopusDeploy_BuildCalamari" cleanDestination="true">
         <revisionRule name="sameChainOrLastFinished" revision="latest.sameChainOrLastFinished" />
-        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS" />
+        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS&#xD;&#xA;FSharp.zip!**=&gt;Binaries\FSharp" />
       </dependency>
     </artifact-dependencies>
     <dependencies>

--- a/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestUbuntu1404lts.xml
+++ b/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestUbuntu1404lts.xml
@@ -79,7 +79,7 @@ chmod +x Binaries/ScriptCS/*.exe]]></param>
     <artifact-dependencies>
       <dependency sourceBuildTypeId="OctopusDeploy_BuildCalamari" cleanDestination="true">
         <revisionRule name="sameChainOrLastFinished" revision="latest.sameChainOrLastFinished" />
-        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS" />
+        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS&#xD;&#xA;FSharp.zip!**=&gt;Binaries\FSharp" />
       </dependency>
     </artifact-dependencies>
     <dependencies>

--- a/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestWindows2008r1sp2.xml
+++ b/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestWindows2008r1sp2.xml
@@ -50,7 +50,7 @@
     <artifact-dependencies>
       <dependency sourceBuildTypeId="OctopusDeploy_BuildCalamari" cleanDestination="true">
         <revisionRule name="sameChainOrLastFinished" revision="latest.sameChainOrLastFinished" />
-        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS" />
+        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS&#xD;&#xA;FSharp.zip!**=&gt;Binaries\FSharp" />
       </dependency>
     </artifact-dependencies>
     <dependencies>

--- a/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestWindows2008r2.xml
+++ b/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestWindows2008r2.xml
@@ -50,7 +50,7 @@
     <artifact-dependencies>
       <dependency sourceBuildTypeId="OctopusDeploy_BuildCalamari" cleanDestination="true">
         <revisionRule name="sameChainOrLastFinished" revision="latest.sameChainOrLastFinished" />
-        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS" />
+        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS&#xD;&#xA;FSharp.zip!**=&gt;Binaries\FSharp" />
       </dependency>
     </artifact-dependencies>
     <dependencies>

--- a/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestWindows2012.xml
+++ b/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestWindows2012.xml
@@ -50,7 +50,7 @@
     <artifact-dependencies>
       <dependency sourceBuildTypeId="OctopusDeploy_BuildCalamari" cleanDestination="true">
         <revisionRule name="sameChainOrLastFinished" revision="latest.sameChainOrLastFinished" />
-        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS" />
+        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS&#xD;&#xA;FSharp.zip!**=&gt;Binaries\FSharp" />
       </dependency>
     </artifact-dependencies>
     <dependencies>

--- a/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestWindows2012r2.xml
+++ b/.teamcity/OctopusDeploy_Calamari/buildTypes/OctopusDeploy_Calamari_TestWindows2012r2.xml
@@ -50,7 +50,7 @@
     <artifact-dependencies>
       <dependency sourceBuildTypeId="OctopusDeploy_BuildCalamari" cleanDestination="true">
         <revisionRule name="sameChainOrLastFinished" revision="latest.sameChainOrLastFinished" />
-        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS" />
+        <artifact sourcePath="Binaries.zip!**=&gt;Binaries&#xD;&#xA;ScriptCS.zip!**=&gt;Binaries\ScriptCS&#xD;&#xA;FSharp.zip!**=&gt;Binaries\FSharp" />
       </dependency>
     </artifact-dependencies>
     <dependencies>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Fixtures\ApplyDelta\ApplyDeltaFixture.cs" />
     <Compile Include="Fixtures\Deployment\DeployPackageFixture.cs" />
     <Compile Include="Fixtures\Deployment\DeployWindowsServiceFixture.cs" />
+    <Compile Include="Fixtures\FSharp\FSharpFixture.cs" />
     <Compile Include="Helpers\CaptureCommandOutputExtensions.cs" />
     <Compile Include="Helpers\ProxyLog.cs" />
     <Compile Include="Fixtures\JsonVariables\JsonConfigurationVariableReplacerFixture.cs" />
@@ -443,6 +444,18 @@
     <None Include="Fixtures\PowerShell\Scripts\PrintVariables.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="Fixtures\FSharp\Scripts\CreateArtifact.fsx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Fixtures\FSharp\Scripts\Hello.fsx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Fixtures\FSharp\Scripts\Parameters.fsx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Fixtures\FSharp\Scripts\PrintEncodedVariable.fsx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="Fixtures\ScriptCS\Scripts\CreateArtifact.csx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -454,6 +454,12 @@
     <Content Include="Fixtures\FSharp\Scripts\CreateArtifact.fsx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="Fixtures\FSharp\Scripts\HelloDefaultValue.fsx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Fixtures\FSharp\Scripts\HelloDirectValue.fsx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
     <Content Include="Fixtures\FSharp\Scripts\Hello.fsx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Fixtures\Deployment\DeployWindowsServiceFixture.cs" />
     <Compile Include="Fixtures\FSharp\FSharpFixture.cs" />
     <Compile Include="Helpers\CaptureCommandOutputExtensions.cs" />
+    <Compile Include="Fixtures\ScriptCS\RequiresMono4Attribute.cs" />
     <Compile Include="Helpers\ProxyLog.cs" />
     <Compile Include="Fixtures\JsonVariables\JsonConfigurationVariableReplacerFixture.cs" />
     <Compile Include="Fixtures\Conventions\JsonConfigurationVariablesConventionFixture.cs" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -210,6 +210,9 @@
     <None Include="Fixtures\Deployment\Packages\Acme.Service\Acme.Service.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Fixtures\Deployment\Packages\Acme.Web\Deploy.csx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Fixtures\JsonVariables\Samples\appsettings.existing-expected.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -444,6 +447,9 @@
     <None Include="Fixtures\PowerShell\Scripts\PrintVariables.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="Fixtures\Deployment\Packages\Acme.Web\Deploy.fsx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Fixtures\FSharp\Scripts\CreateArtifact.fsx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -211,7 +211,7 @@
     <None Include="Fixtures\Deployment\Packages\Acme.Service\Acme.Service.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="Fixtures\Deployment\Packages\Acme.Web\Deploy.csx">
+    <None Include="Fixtures\Deployment\Packages\Acme.Web\DeployFailed.csx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Fixtures\JsonVariables\Samples\appsettings.existing-expected.json">
@@ -448,7 +448,7 @@
     <None Include="Fixtures\PowerShell\Scripts\PrintVariables.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <Content Include="Fixtures\Deployment\Packages\Acme.Web\Deploy.fsx">
+    <Content Include="Fixtures\Deployment\Packages\Acme.Web\DeployFailed.fsx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Fixtures\FSharp\Scripts\CreateArtifact.fsx">

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -151,7 +151,7 @@
     <Compile Include="Fixtures\Deployment\DeployWindowsServiceFixture.cs" />
     <Compile Include="Fixtures\FSharp\FSharpFixture.cs" />
     <Compile Include="Helpers\CaptureCommandOutputExtensions.cs" />
-    <Compile Include="Fixtures\ScriptCS\RequiresMono4Attribute.cs" />
+    <Compile Include="Fixtures\RequiresMono4Attribute.cs" />
     <Compile Include="Helpers\ProxyLog.cs" />
     <Compile Include="Fixtures\JsonVariables\JsonConfigurationVariableReplacerFixture.cs" />
     <Compile Include="Fixtures\Conventions\JsonConfigurationVariablesConventionFixture.cs" />
@@ -187,7 +187,7 @@
     <Compile Include="Fixtures\PackageDownload\PackageDownloadFixture.cs" />
     <Compile Include="Fixtures\Retention\RetentionPolicyFixture.cs" />
     <Compile Include="Fixtures\Processes\SemaphoreFixture.cs" />
-    <Compile Include="Fixtures\ScriptCS\RequiresDotNet45Attribute.cs" />
+    <Compile Include="Fixtures\RequiresDotNet45Attribute.cs" />
     <Compile Include="Fixtures\Bash\BashFixture.cs" />
     <Compile Include="Fixtures\ScriptCS\ScriptCSFixture.cs" />
     <Compile Include="Fixtures\Integration\Process\CalamariVariableDictionaryFixture.cs" />

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -53,8 +53,6 @@ namespace Calamari.Tests.Fixtures.Deployment
 
             result.AssertOutput("Extracted 14 files");
             result.AssertOutput("Hello from Deploy.ps1");
-            result.AssertOutput("Hello from Deploy.fsx");
-            result.AssertOutput("Hello from Deploy.csx");
         }
 
         [Test]
@@ -65,8 +63,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             result.AssertSuccess();
 
             result.AssertOutput("Hello from Deploy.sh");
-            result.AssertOutput("Hello from Deploy.fsx");
-            result.AssertOutput("Hello from Deploy.csx");
         }
 
         [Test]
@@ -140,6 +136,8 @@ namespace Calamari.Tests.Fixtures.Deployment
             Variables.Set("ShouldFail", "yes");
             var result = DeployPackage();
             result.AssertOutput("I have failed! DeployFailed.ps1");
+            result.AssertOutput("I have failed! DeployFailed.fsx");
+            result.AssertOutput("I have failed! DeployFailed.csx");
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -316,7 +316,7 @@ namespace Calamari.Tests.Fixtures.Deployment
 
                     result.AssertSuccess();
                     var extracted = result.GetOutputForLineContaining("Extracting package to: ");
-                    result.AssertOutput("Extracted 12 files");
+                    result.AssertOutput("Extracted 14 files");
 
                     lock (extractionDirectories)
                     {

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -19,8 +19,7 @@ namespace Calamari.Tests.Fixtures.Deployment
     {
         // Fixture Depedencies
         TemporaryFile nupkgFile;
-        TemporaryFile tarFile;
-     
+        TemporaryFile tarFile;     
 
         [SetUp]
         public override void SetUp()
@@ -44,15 +43,30 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        public void ShouldDeployPackage()
+        [Category(TestEnvironment.CompatibleOS.Windows)]
+        public void ShouldDeployPackageOnWindows()
         {
             var result = DeployPackage();
             result.AssertSuccess();
 
             result.AssertOutput("Extracting package to: " + Path.Combine(StagingDirectory, "Acme.Web", "1.0.0"));
 
-            result.AssertOutput("Extracted 12 files");
-            result.AssertOutput("Bonjour from PreDeploy");
+            result.AssertOutput("Extracted 14 files");
+            result.AssertOutput("Hello from Deploy.ps1");
+            result.AssertOutput("Hello from Deploy.fsx");
+            result.AssertOutput("Hello from Deploy.csx");
+        }
+
+        [Test]
+        [Category(TestEnvironment.CompatibleOS.Nix)]
+        public void ShouldDeployPackageOnNix()
+        {
+            var result = DeployPackage();
+            result.AssertSuccess();
+
+            result.AssertOutput("Hello from Deploy.sh");
+            result.AssertOutput("Hello from Deploy.fsx");
+            result.AssertOutput("Hello from Deploy.csx");
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Deploy.csx
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Deploy.csx
@@ -1,0 +1,1 @@
+﻿System.Console.WriteLine("Hello from Deploy.csx");

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Deploy.csx
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Deploy.csx
@@ -1,1 +1,0 @@
-﻿System.Console.WriteLine("Hello from Deploy.csx");

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Deploy.fsx
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Deploy.fsx
@@ -1,0 +1,1 @@
+﻿printfn "Hello from Deploy.fsx"

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Deploy.fsx
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Deploy.fsx
@@ -1,1 +1,0 @@
-﻿printfn "Hello from Deploy.fsx"

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Deploy.sh
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Deploy.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-echo $(get_octopusvariable "PreDeployGreeting") "from Deploy.sh"
+echo "Hello from Deploy.sh"

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/DeployFailed.csx
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/DeployFailed.csx
@@ -1,0 +1,1 @@
+﻿System.Console.WriteLine("I have failed! DeployFailed.csx");

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/DeployFailed.fsx
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/DeployFailed.fsx
@@ -1,0 +1,1 @@
+﻿printfn "I have failed! DeployFailed.fsx"

--- a/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
+++ b/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
@@ -1,0 +1,73 @@
+﻿using System.IO;
+using Calamari.Integration.FileSystem;
+using Calamari.Tests.Fixtures.ScriptCS;
+using Calamari.Tests.Helpers;
+using NUnit.Framework;
+using Octostache;
+
+namespace Calamari.Tests.Fixtures.FSharp
+{
+    [TestFixture]
+    public class FSharpFixture : CalamariFixture
+    {
+        [Test, RequiresDotNet45]
+        public void ShouldPrintEncodedVariable()
+        {
+            var output = Invoke(Calamari()
+                .Action("run-script")
+                .Argument("script", GetFixtureResouce("Scripts", "PrintEncodedVariable.fsx")));
+
+            output.AssertSuccess();
+            output.AssertOutput("##octopus[setVariable name='RG9ua2V5' value='S29uZw==']");
+        }
+
+        [Test, RequiresDotNet45]
+        public void ShouldCreateArtifact()
+        {
+            var output = Invoke(Calamari()
+                .Action("run-script")
+                .Argument("script", GetFixtureResouce("Scripts", "CreateArtifact.fsx")));
+
+            output.AssertSuccess();
+            output.AssertOutput("##octopus[createArtifact");
+            output.AssertOutput("name='bXlGaWxlLnR4dA==' length='MTAw']");
+        }
+
+        [Test, RequiresDotNet45]
+        public void ShouldCallHello()
+        {
+            var variablesFile = Path.GetTempFileName();
+
+            var variables = new VariableDictionary();
+            variables.Set("Name", "Paul");
+            variables.Set("Variable2", "DEF");
+            variables.Set("Variable3", "GHI");
+            variables.Set("Foo_bar", "Hello");
+            variables.Set("Host", "Never");
+            variables.Save(variablesFile);
+
+            using (new TemporaryFile(variablesFile))
+            {
+                var output = Invoke(Calamari()
+                    .Action("run-script")
+                    .Argument("script", GetFixtureResouce("Scripts", "Hello.fsx"))
+                    .Argument("variables", variablesFile));
+
+                output.AssertSuccess();
+                output.AssertOutput("Hello Paul");
+            }
+        }
+
+        [Test, RequiresDotNet45]
+        public void ShouldConsumeParametersWithQuotes()
+        {
+            var output = Invoke(Calamari()
+                .Action("run-script")
+                .Argument("script", GetFixtureResouce("Scripts", "Parameters.fsx"))
+                .Argument("scriptParameters", "\"Para meter0\" Parameter1")); ;
+
+            output.AssertSuccess();
+            output.AssertOutput("Parameters Para meter0-Parameter1");
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
+++ b/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
@@ -10,7 +10,7 @@ namespace Calamari.Tests.Fixtures.FSharp
     [TestFixture]
     public class FSharpFixture : CalamariFixture
     {
-        [Test, RequiresDotNet45]
+        [Test, RequiresDotNet45, RequiresMono4]
         public void ShouldPrintEncodedVariable()
         {
             var output = Invoke(Calamari()
@@ -21,7 +21,7 @@ namespace Calamari.Tests.Fixtures.FSharp
             output.AssertOutput("##octopus[setVariable name='RG9ua2V5' value='S29uZw==']");
         }
 
-        [Test, RequiresDotNet45]
+        [Test, RequiresDotNet45, RequiresMono4]
         public void ShouldCreateArtifact()
         {
             var output = Invoke(Calamari()
@@ -33,7 +33,7 @@ namespace Calamari.Tests.Fixtures.FSharp
             output.AssertOutput("name='bXlGaWxlLnR4dA==' length='MTAw']");
         }
 
-        [Test, RequiresDotNet45]
+        [Test, RequiresDotNet45, RequiresMono4]
         public void ShouldCallHello()
         {
             var variablesFile = Path.GetTempFileName();
@@ -58,7 +58,7 @@ namespace Calamari.Tests.Fixtures.FSharp
             }
         }
 
-        [Test, RequiresDotNet45]
+        [Test, RequiresDotNet45, RequiresMono4]
         public void ShouldConsumeParametersWithQuotes()
         {
             var output = Invoke(Calamari()

--- a/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
+++ b/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
@@ -58,6 +58,38 @@ namespace Calamari.Tests.Fixtures.FSharp
         }
 
         [Test, RequiresDotNet45, RequiresMono4]
+        public void ShouldCallHelloDirectValue()
+        {
+            var variablesFile = Path.GetTempFileName();
+
+            var variables = new VariableDictionary();
+            variables.Set("Name", "direct value");
+            variables.Save(variablesFile);
+
+            using (new TemporaryFile(variablesFile))
+            {
+                var output = Invoke(Calamari()
+                    .Action("run-script")
+                    .Argument("script", GetFixtureResouce("Scripts", "Hello.fsx"))
+                    .Argument("variables", variablesFile));
+
+                output.AssertSuccess();
+                output.AssertOutput("Hello direct value");
+            }
+        }
+
+        [Test, RequiresDotNet45, RequiresMono4]
+        public void ShouldCallHelloDefaultValue()
+        {
+            var output = Invoke(Calamari()
+                .Action("run-script")
+                .Argument("script", GetFixtureResouce("Scripts", "HelloDefaultvalue.fsx")));
+
+            output.AssertSuccess();
+            output.AssertOutput("Hello default value");
+        }
+
+        [Test, RequiresDotNet45, RequiresMono4]
         public void ShouldConsumeParametersWithQuotes()
         {
             var output = Invoke(Calamari()

--- a/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
+++ b/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using Calamari.Integration.FileSystem;
-using Calamari.Tests.Fixtures.ScriptCS;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
 using Octostache;

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/CreateArtifact.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/CreateArtifact.fsx
@@ -1,0 +1,8 @@
+﻿open System
+open System.IO
+
+//System.IO.Directory.CreateDirectory("Temp");
+//System.IO.File.WriteAllBytes(Path.Combine("Temp","myFile.txt"), new byte[100]);
+
+//Octopus.CreateArtifact(Path.Combine("Temp","myFile.txt"));
+

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/CreateArtifact.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/CreateArtifact.fsx
@@ -1,8 +1,8 @@
 ﻿open System
 open System.IO
 
-//System.IO.Directory.CreateDirectory("Temp");
-//System.IO.File.WriteAllBytes(Path.Combine("Temp","myFile.txt"), new byte[100]);
-
-//Octopus.CreateArtifact(Path.Combine("Temp","myFile.txt"));
-
+let bytes : byte array = Array.zeroCreate 100
+System.IO.Directory.CreateDirectory("Temp")
+System.IO.File.WriteAllBytes(Path.Combine("Temp","myFile.txt"), bytes)
+let path = Path.Combine("Temp","myFile.txt")
+Octopus.CreateArtifact path None

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/CreateArtifact.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/CreateArtifact.fsx
@@ -5,4 +5,5 @@ let bytes : byte array = Array.zeroCreate 100
 System.IO.Directory.CreateDirectory("Temp")
 System.IO.File.WriteAllBytes(Path.Combine("Temp","myFile.txt"), bytes)
 let path = Path.Combine("Temp","myFile.txt")
-Octopus.CreateArtifact path None
+
+Octopus.createArtifact path None

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/Hello.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/Hello.fsx
@@ -1,0 +1,3 @@
+﻿open System
+
+//Console.WriteLine("Hello " + Octopus.Parameters["Name"]);

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/Hello.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/Hello.fsx
@@ -1,2 +1,7 @@
-﻿open System
-printfn "Hello %s" Octopus.Parameters.["Name"]
+﻿let tryFindVariable = Octopus.tryFindVariable Octopus.variables
+let value = 
+    match "Name" |> tryFindVariable with
+        | Some x -> x
+        | None -> "not available"
+
+printfn "Hello %s" value

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/Hello.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/Hello.fsx
@@ -1,3 +1,2 @@
 ﻿open System
-
-//Console.WriteLine("Hello " + Octopus.Parameters["Name"]);
+printfn "Hello %s" Octopus.Parameters.["Name"]

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/Hello.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/Hello.fsx
@@ -1,6 +1,5 @@
-﻿let tryFindVariable = Octopus.tryFindVariable Octopus.variables
-let value = 
-    match "Name" |> tryFindVariable with
+﻿let value = 
+    match "Name" |> Octopus.tryFindVariable with
         | Some x -> x
         | None -> "not available"
 

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/HelloDefaultValue.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/HelloDefaultValue.fsx
@@ -1,0 +1,3 @@
+﻿let findVariableOrDefault = "default value" |> Octopus.findVariableOrDefault
+let value = "84C7692E-AD89-41F5-9987-DA4C555D2813" |> findVariableOrDefault
+printfn "Hello %s" value

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/HelloDirectValue.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/HelloDirectValue.fsx
@@ -1,0 +1,2 @@
+﻿let value = "Name" |> Octopus.findVariable 
+printfn "Hello %s" value

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/Parameters.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/Parameters.fsx
@@ -1,0 +1,3 @@
+﻿open System
+
+printfn "Parameters %s-%s" fsi.CommandLineArgs.[1] fsi.CommandLineArgs.[2]

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/Parameters.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/Parameters.fsx
@@ -1,3 +1,3 @@
 ﻿open System
 
-printfn "Parameters %s-%s" fsi.CommandLineArgs.[1] fsi.CommandLineArgs.[2]
+printfn "Parameters %s-%s" fsi.CommandLineArgs.[1] fsi.CommandLineArgs.[2] 

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/Parameters.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/Parameters.fsx
@@ -1,3 +1,1 @@
-﻿open System
-
-printfn "Parameters %s-%s" fsi.CommandLineArgs.[1] fsi.CommandLineArgs.[2] 
+﻿printfn "Parameters %s-%s" fsi.CommandLineArgs.[1] fsi.CommandLineArgs.[2] 

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/PrintEncodedVariable.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/PrintEncodedVariable.fsx
@@ -1,0 +1,4 @@
+﻿open System
+
+//Octopus.SetVariable("Donkey","Kong");
+

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/PrintEncodedVariable.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/PrintEncodedVariable.fsx
@@ -1,4 +1,2 @@
-﻿open System
-
-Octopus.SetVariable "Donkey" "Kong"
+﻿Octopus.setVariable "Donkey" "Kong"
 

--- a/source/Calamari.Tests/Fixtures/FSharp/Scripts/PrintEncodedVariable.fsx
+++ b/source/Calamari.Tests/Fixtures/FSharp/Scripts/PrintEncodedVariable.fsx
@@ -1,4 +1,4 @@
 ﻿open System
 
-//Octopus.SetVariable("Donkey","Kong");
+Octopus.SetVariable "Donkey" "Kong"
 

--- a/source/Calamari.Tests/Fixtures/RequiresDotNet45Attribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresDotNet45Attribute.cs
@@ -1,7 +1,7 @@
 ﻿using Calamari.Integration.Scripting.ScriptCS;
 using NUnit.Framework;
 
-namespace Calamari.Tests.Fixtures.ScriptCS
+namespace Calamari.Tests.Fixtures
 {
     public class RequiresDotNet45Attribute : TestAttribute, ITestAction
     {

--- a/source/Calamari.Tests/Fixtures/RequiresDotNet45Attribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresDotNet45Attribute.cs
@@ -1,4 +1,5 @@
-﻿using Calamari.Integration.Scripting.ScriptCS;
+﻿using Calamari.Integration.Scripting;
+using Calamari.Integration.Scripting.ScriptCS;
 using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures

--- a/source/Calamari.Tests/Fixtures/RequiresMono4Attribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresMono4Attribute.cs
@@ -2,7 +2,7 @@
 using Calamari.Integration.Scripting.ScriptCS;
 using NUnit.Framework;
 
-namespace Calamari.Tests.Fixtures.ScriptCS
+namespace Calamari.Tests.Fixtures
 {
     public class RequiresMono4Attribute : TestAttribute, ITestAction
     {

--- a/source/Calamari.Tests/Fixtures/RequiresMono4Attribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresMono4Attribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Calamari.Integration.Scripting;
 using Calamari.Integration.Scripting.ScriptCS;
 using NUnit.Framework;
 

--- a/source/Calamari.Tests/Fixtures/ScriptCS/RequiresMono4Attribute.cs
+++ b/source/Calamari.Tests/Fixtures/ScriptCS/RequiresMono4Attribute.cs
@@ -1,15 +1,16 @@
-﻿using Calamari.Integration.Scripting.ScriptCS;
+﻿using System;
+using Calamari.Integration.Scripting.ScriptCS;
 using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures.ScriptCS
 {
-    public class RequiresDotNet45Attribute : TestAttribute, ITestAction
+    public class RequiresMono4Attribute : TestAttribute, ITestAction
     {
         public void BeforeTest(TestDetails testDetails)
         {
-            if (!ScriptingEnvironment.IsNet45OrNewer())
+            if (ScriptingEnvironment.IsRunningOnMono() && (ScriptingEnvironment.GetMonoVersion() < new Version(4,0,0)))
             {
-                Assert.Ignore("Requires .NET 4.5");
+                Assert.Ignore("Requires Mono 4");
             }
         }
 

--- a/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
@@ -9,7 +9,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
     [TestFixture]
     public class ScriptCSFixture : CalamariFixture
     {
-        [Test, RequiresDotNet45]
+        [Test, RequiresDotNet45, RequiresMono4]
         public void ShouldPrintEncodedVariable()
         {
             var output = Invoke(Calamari()
@@ -20,7 +20,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
             output.AssertOutput("##octopus[setVariable name='RG9ua2V5' value='S29uZw==']");
         }
 
-        [Test, RequiresDotNet45]
+        [Test, RequiresDotNet45, RequiresMono4]
         public void ShouldCreateArtifact()
         {
             var output = Invoke(Calamari()
@@ -32,7 +32,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
             output.AssertOutput("name='bXlGaWxlLnR4dA==' length='MTAw']");
         }
 
-        [Test, RequiresDotNet45]
+        [Test, RequiresDotNet45, RequiresMono4]
         public void ShouldCallHello()
         {
             var variablesFile = Path.GetTempFileName();

--- a/source/Calamari.Tests/Helpers/TestEnvironment.cs
+++ b/source/Calamari.Tests/Helpers/TestEnvironment.cs
@@ -24,7 +24,6 @@ namespace Calamari.Tests.Helpers
 
             public const string Windows = "Windows";
         }
-
     }
 }
 

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -218,6 +218,8 @@
     <Compile Include="Integration\Scripting\IScriptEngine.cs" />
     <Compile Include="Integration\Scripting\CombinedScriptEngine.cs" />
     <Compile Include="Integration\Scripting\Script.cs" />
+    <Compile Include="Integration\Scripting\FSharp\FSharpBootstrapper.cs" />
+    <Compile Include="Integration\Scripting\FSharp\FSharpEngine.cs" />
     <Compile Include="Integration\Scripting\ScriptEngineRegistry.cs" />
     <Compile Include="Integration\Scripting\ScriptType.cs" />
     <Compile Include="Util\AssemblyExtensions.cs" />
@@ -301,6 +303,7 @@
     <EmbeddedResource Include="Integration\Scripting\WindowsPowerShell\Bootstrap.ps1" />
     <EmbeddedResource Include="Integration\Scripting\ScriptCS\Bootstrap.csx" />
     <None Include="app.config" />
+    <EmbeddedResource Include="Integration\Scripting\FSharp\Bootstrap.fsx" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -220,6 +220,8 @@
     <Compile Include="Integration\Scripting\Script.cs" />
     <Compile Include="Integration\Scripting\FSharp\FSharpBootstrapper.cs" />
     <Compile Include="Integration\Scripting\FSharp\FSharpEngine.cs" />
+    <Compile Include="Integration\Scripting\ScriptCS\MonoVersionCanNotBeDeterminedException.cs" />
+    <Compile Include="Integration\Scripting\ScriptCS\ScriptingEnvironment.cs" />
     <Compile Include="Integration\Scripting\ScriptEngineRegistry.cs" />
     <Compile Include="Integration\Scripting\ScriptType.cs" />
     <Compile Include="Util\AssemblyExtensions.cs" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -221,7 +221,7 @@
     <Compile Include="Integration\Scripting\FSharp\FSharpBootstrapper.cs" />
     <Compile Include="Integration\Scripting\FSharp\FSharpEngine.cs" />
     <Compile Include="Integration\Scripting\ScriptCS\MonoVersionCanNotBeDeterminedException.cs" />
-    <Compile Include="Integration\Scripting\ScriptCS\ScriptingEnvironment.cs" />
+    <Compile Include="Integration\Scripting\ScriptingEnvironment.cs" />
     <Compile Include="Integration\Scripting\ScriptEngineRegistry.cs" />
     <Compile Include="Integration\Scripting\ScriptType.cs" />
     <Compile Include="Util\AssemblyExtensions.cs" />

--- a/source/Calamari/Integration/Scripting/CombinedScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/CombinedScriptEngine.cs
@@ -10,8 +10,8 @@ namespace Calamari.Integration.Scripting
         public string[] GetSupportedExtensions()
         {
             return CalamariEnvironment.IsRunningOnNix
-                ? new[] {ScriptType.ScriptCS.FileExtension(), ScriptType.Bash.FileExtension()}
-                : new[] {ScriptType.ScriptCS.FileExtension(), ScriptType.Powershell.FileExtension()};
+                ? new[] {ScriptType.ScriptCS.FileExtension(), ScriptType.Bash.FileExtension(), ScriptType.FSharp.FileExtension()}
+                : new[] {ScriptType.ScriptCS.FileExtension(), ScriptType.Powershell.FileExtension(), ScriptType.FSharp.FileExtension()};
         }
 
         public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)

--- a/source/Calamari/Integration/Scripting/FSharp/Bootstrap.fsx
+++ b/source/Calamari/Integration/Scripting/FSharp/Bootstrap.fsx
@@ -1,0 +1,103 @@
+﻿#r "System.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+
+open System
+open System.Collections.Generic
+open System.IO
+open System.Text
+open System.Net
+open System.Security.Cryptography
+
+(*public static class Octopus
+{
+    public static OctopusParametersDictionary Parameters { get; private set; }
+	
+	static Octopus() 
+	{
+		InitializeDefaultProxy();
+	}
+
+	public static void Initialize(string password) {
+		if(Parameters != null) {
+			throw new Exception("Octopus can only be initialized once.");
+		}
+		Parameters = new OctopusParametersDictionary(password);
+	}
+
+	public class OctopusParametersDictionary : System.Collections.Generic.Dictionary<string,string>
+	{
+		private byte[] Key { get;set; }
+
+		public OctopusParametersDictionary(string key) : base(System.StringComparer.OrdinalIgnoreCase)
+		{
+			Key = Convert.FromBase64String(key);
+{{VariableDeclarations}}
+		}
+        
+     	public string DecryptString(string encrypted, string iv)
+        {
+            using (var algorithm = new AesCryptoServiceProvider() {
+                Mode = CipherMode.CBC,
+                Padding = PaddingMode.PKCS7,
+                KeySize = 128,
+                BlockSize = 128 })
+			{
+				algorithm.Key = Key;
+				algorithm.IV =  Convert.FromBase64String(iv);
+				using (var dec = algorithm.CreateDecryptor())
+				using (var ms = new MemoryStream(Convert.FromBase64String(encrypted)))
+				using (var cs = new CryptoStream(ms, dec, CryptoStreamMode.Read))
+				using (var sr = new StreamReader(cs, Encoding.UTF8))
+				{
+					return sr.ReadToEnd();
+				}
+			}
+        }
+	}
+
+	private static string EncodeServiceMessageValue(string value)
+	{
+		var valueBytes = System.Text.Encoding.UTF8.GetBytes(value);
+		return Convert.ToBase64String(valueBytes);
+	}
+
+	public static void SetVariable(string name, string value) 
+	{ 	
+		name = EncodeServiceMessageValue(name);
+		value = EncodeServiceMessageValue(value);
+
+		Parameters[name] = value;
+
+		Console.WriteLine("##octopus[setVariable name='{0}' value='{1}']", name, value);
+	}
+
+	public static void CreateArtifact(string path, string fileName = null) 
+	{
+		if(fileName == null){
+			fileName = System.IO.Path.GetFileName(path); 
+		} 
+
+		fileName = EncodeServiceMessageValue(fileName);	
+
+		var length = System.IO.File.Exists(path) ? new System.IO.FileInfo(path).Length.ToString() : "0";
+		length = EncodeServiceMessageValue(length);
+
+		path = System.IO.Path.GetFullPath(path);
+		path = EncodeServiceMessageValue(path);
+
+
+		Console.WriteLine("##octopus[createArtifact path='{0}' name='{1}' length='{2}']", path, fileName, length);
+	}
+
+	public static void InitializeDefaultProxy() 
+	{
+		var proxyUsername = Environment.GetEnvironmentVariable("TentacleProxyUsername");
+        var proxyPassword = Environment.GetEnvironmentVariable("TentacleProxyPassword");
+
+        WebRequest.DefaultWebProxy.Credentials = string.IsNullOrWhiteSpace(proxyUsername) 
+            ? CredentialCache.DefaultCredentials 
+            : new NetworkCredential(proxyUsername, proxyPassword);
+	}
+}
+
+Octopus.Initialize(Env.ScriptArgs[Env.ScriptArgs.Count - 1]);
+*)

--- a/source/Calamari/Integration/Scripting/FSharp/Bootstrap.fsx
+++ b/source/Calamari/Integration/Scripting/FSharp/Bootstrap.fsx
@@ -1,7 +1,5 @@
 ﻿module Bootstrap
 
-#r "System.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
-
 open System
 open System.Collections.Generic
 open System.IO

--- a/source/Calamari/Integration/Scripting/FSharp/Bootstrap.fsx
+++ b/source/Calamari/Integration/Scripting/FSharp/Bootstrap.fsx
@@ -20,7 +20,7 @@ let tryFindVariable name =
 let findVariable name =
     match name |> tryFindVariable with
     | Some x -> x
-    | None -> raise (System.Collections.Generic.KeyNotFoundException(name + "variable has not been found."))     
+    | None -> raise (System.Collections.Generic.KeyNotFoundException(name + " variable has not been found."))     
 
 let decryptString encrypted iv =
     let key =  fsi.CommandLineArgs.[fsi.CommandLineArgs.Length - 1]

--- a/source/Calamari/Integration/Scripting/FSharp/FSharpBootstrapper.cs
+++ b/source/Calamari/Integration/Scripting/FSharp/FSharpBootstrapper.cs
@@ -51,7 +51,8 @@ namespace Calamari.Integration.Scripting.FSharp
             using (var writer = new StreamWriter(bootstrapFile, false, Encoding.UTF8))
             {
                 writer.WriteLine("#load \"" + configurationFile.Replace("\\", "\\\\") + "\"");
-                writer.WriteLine("open Bootstrap");
+                writer.WriteLine("open Octopus");
+                writer.WriteLine("Octopus.initializeProxy()");
                 writer.WriteLine("#load \"" + scriptFilePath.Replace("\\", "\\\\") + "\"");
                 writer.Flush();
             }

--- a/source/Calamari/Integration/Scripting/FSharp/FSharpBootstrapper.cs
+++ b/source/Calamari/Integration/Scripting/FSharp/FSharpBootstrapper.cs
@@ -20,7 +20,7 @@ namespace Calamari.Integration.Scripting.FSharp
 
         public static string FindExecutable()
         {
-            if (!IsNet45OrNewer())
+            if (!ScriptingEnvironment.IsNet45OrNewer())
                 throw new CommandException("FSharp scripts require requires .NET framework 4.5");
 
             var myPath = typeof(FSharpEngine).Assembly.Location;
@@ -42,12 +42,6 @@ namespace Calamari.Integration.Scripting.FSharp
             var commandArguments = new StringBuilder();
             commandArguments.AppendFormat("\"{0}\" {1} \"{2}\"", bootstrapFile, scriptParameters, encryptionKey);
             return commandArguments.ToString();
-        }
-
-        static bool IsNet45OrNewer()
-        {
-            // Class "ReflectionContext" exists from .NET 4.5 onwards.
-            return Type.GetType("System.Reflection.ReflectionContext", false) != null;
         }
 
         public static string PrepareBootstrapFile(string scriptFilePath, string configurationFile, string workingDirectory)

--- a/source/Calamari/Integration/Scripting/FSharp/FSharpBootstrapper.cs
+++ b/source/Calamari/Integration/Scripting/FSharp/FSharpBootstrapper.cs
@@ -57,6 +57,7 @@ namespace Calamari.Integration.Scripting.FSharp
             using (var writer = new StreamWriter(bootstrapFile, false, Encoding.UTF8))
             {
                 writer.WriteLine("#load \"" + configurationFile.Replace("\\", "\\\\") + "\"");
+                writer.WriteLine("open Bootstrap");
                 writer.WriteLine("#load \"" + scriptFilePath.Replace("\\", "\\\\") + "\"");
                 writer.Flush();
             }
@@ -90,7 +91,7 @@ namespace Calamari.Integration.Scripting.FSharp
                 var variableValue = variables.IsSensitive(variable)
                     ? EncryptVariable(variables.Get(variable))
                     : EncodeValue(variables.Get(variable));
-                builder.Append("\t\t\tthis[").Append(EncodeValue(variable)).Append("] = ").Append(variableValue).AppendLine(";");
+                builder.AppendFormat("({0}, {1});", EncodeValue(variable), variableValue);
             }
             return builder.ToString();
         }

--- a/source/Calamari/Integration/Scripting/FSharp/FSharpEngine.cs
+++ b/source/Calamari/Integration/Scripting/FSharp/FSharpEngine.cs
@@ -2,23 +2,23 @@
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Processes;
 
-namespace Calamari.Integration.Scripting.ScriptCS
+namespace Calamari.Integration.Scripting.FSharp
 {
-    public class ScriptCSScriptEngine : IScriptEngine
+    public class FSharpEngine : IScriptEngine
     {
         public string[] GetSupportedExtensions()
         {
-            return new[] {ScriptType.ScriptCS.FileExtension()};
+            return new[] {ScriptType.FSharp.FileExtension()};
         }
 
         public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)
         {
             var workingDirectory = Path.GetDirectoryName(script.File);
 
-            var executable = ScriptCSBootstrapper.FindExecutable();
-            var configurationFile = ScriptCSBootstrapper.PrepareConfigurationFile(workingDirectory, variables);
-            var boostrapFile = ScriptCSBootstrapper.PrepareBootstrapFile(script.File, configurationFile, workingDirectory);
-            var arguments = ScriptCSBootstrapper.FormatCommandArguments(boostrapFile, script.Parameters);
+            var executable = FSharpBootstrapper.FindExecutable();
+            var configurationFile = FSharpBootstrapper.PrepareConfigurationFile(workingDirectory, variables);
+            var boostrapFile = FSharpBootstrapper.PrepareBootstrapFile(script.File, configurationFile, workingDirectory);
+            var arguments = FSharpBootstrapper.FormatCommandArguments(boostrapFile, script.Parameters);
 
             using (new TemporaryFile(configurationFile))
             using (new TemporaryFile(boostrapFile))

--- a/source/Calamari/Integration/Scripting/ScriptCS/MonoVersionCanNotBeDeterminedException.cs
+++ b/source/Calamari/Integration/Scripting/ScriptCS/MonoVersionCanNotBeDeterminedException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Calamari.Integration.Scripting.ScriptCS
+{
+    public class MonoVersionCanNotBeDeterminedException : Exception
+    {
+        public MonoVersionCanNotBeDeterminedException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSBootstrapper.cs
+++ b/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSBootstrapper.cs
@@ -20,7 +20,7 @@ namespace Calamari.Integration.Scripting.ScriptCS
 
         public static string FindExecutable()
         {
-            if (!IsNet45OrNewer())
+            if (!ScriptingEnvironment.IsNet45OrNewer())
                 throw new CommandException("ScriptCS scripts require the Roslyn CTP, which requires .NET framework 4.5");
 
             var myPath = typeof(ScriptCSScriptEngine).Assembly.Location;
@@ -52,12 +52,6 @@ namespace Calamari.Integration.Scripting.ScriptCS
             return scriptParameters.Trim()
                                    .TrimStart('-')
                                    .Trim();
-        }
-
-        static bool IsNet45OrNewer()
-        {
-            // Class "ReflectionContext" exists from .NET 4.5 onwards.
-            return Type.GetType("System.Reflection.ReflectionContext", false) != null;
         }
 
         public static string PrepareBootstrapFile(string scriptFilePath, string configurationFile, string workingDirectory)

--- a/source/Calamari/Integration/Scripting/ScriptCS/ScriptingEnvironment.cs
+++ b/source/Calamari/Integration/Scripting/ScriptCS/ScriptingEnvironment.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Calamari.Integration.Scripting.ScriptCS
+{
+    public class ScriptingEnvironment
+    {
+        public static bool IsNet45OrNewer()
+        {
+            // Class "ReflectionContext" exists from .NET 4.5 onwards.
+            return Type.GetType("System.Reflection.ReflectionContext", false) != null;
+        }
+
+        public static bool IsRunningOnMono()
+        {
+            var monoRuntime = Type.GetType("Mono.Runtime");
+            return monoRuntime != null;
+        }
+
+        public static Version GetMonoVersion()
+        {
+            // A bit hacky, but this is what Mono community seems to be using: 
+            // http://stackoverflow.com/questions/8413922/programmatically-determining-mono-runtime-version
+
+            var monoRuntime = Type.GetType("Mono.Runtime");
+            if (monoRuntime == null) throw new MonoVersionCanNotBeDeterminedException("It looks like the code is not running on Mono.");
+
+            var dispalayNameMethod = monoRuntime.GetMethod("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static);
+            if (dispalayNameMethod == null) throw new MonoVersionCanNotBeDeterminedException("Mono.Runtime.GetDisplayName can not be found.");
+            
+            var displayName = dispalayNameMethod.Invoke(null, null).ToString();
+            var match = Regex.Match(displayName, @"^\d+\.\d+.\d+");
+            if (match == null || !match.Success || string.IsNullOrEmpty(match.Value))
+                throw new MonoVersionCanNotBeDeterminedException($"Display name does not seem to include version number. Retrieved value: {displayName}.");
+
+            return Version.Parse(match.Value);           
+        }
+    }
+}

--- a/source/Calamari/Integration/Scripting/ScriptEngineRegistry.cs
+++ b/source/Calamari/Integration/Scripting/ScriptEngineRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Calamari.Integration.Scripting.Bash;
+using Calamari.Integration.Scripting.FSharp;
 using Calamari.Integration.Scripting.ScriptCS;
 using Calamari.Integration.Scripting.WindowsPowerShell;
 
@@ -11,7 +12,8 @@ namespace Calamari.Integration.Scripting
         {
             {ScriptType.Powershell, new PowerShellScriptEngine() },
             {ScriptType.ScriptCS, new ScriptCSScriptEngine() },
-            {ScriptType.Bash, new BashScriptEngine() }
+            {ScriptType.Bash, new BashScriptEngine()},
+            {ScriptType.FSharp, new FSharpEngine()}
         }; 
 
         public static readonly ScriptEngineRegistry Instance = new ScriptEngineRegistry();

--- a/source/Calamari/Integration/Scripting/ScriptType.cs
+++ b/source/Calamari/Integration/Scripting/ScriptType.cs
@@ -12,7 +12,10 @@ namespace Calamari.Integration.Scripting
         ScriptCS,
 
         [FileExtension("sh")]
-        Bash
+        Bash,
+
+        [FileExtension("fsx")]
+        FSharp
     }
 
     public static class ScriptTypeExtensions

--- a/source/Calamari/Integration/Scripting/ScriptingEnvironment.cs
+++ b/source/Calamari/Integration/Scripting/ScriptingEnvironment.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Calamari.Integration.Scripting.ScriptCS;
 
-namespace Calamari.Integration.Scripting.ScriptCS
+namespace Calamari.Integration.Scripting
 {
     public class ScriptingEnvironment
     {

--- a/source/Calamari/packages.config
+++ b/source/Calamari/packages.config
@@ -20,4 +20,5 @@
   <package id="sharpcompress" version="0.11.6" targetFramework="net40" />
   <package id="Sprache" version="2.0.0.45" targetFramework="net4" />
   <package id="System.Spatial" version="5.6.2" targetFramework="net4" />
+  <package id="FSharp.Compiler.Tools" version="4.0.0.1"/>
 </packages>

--- a/source/Package/Windows/Calamari.nuspec
+++ b/source/Package/Windows/Calamari.nuspec
@@ -13,5 +13,6 @@
   <files>
     <file src="..\Calamari\bin\**\*.*" target="" exclude="*.vshost*;**\*.xml" />
     <file src="..\packages\Octopus.Dependencies.ScriptCS.3.0.1\runtime\**\*.*" target="ScriptCS" exclude="**\*.xml" />
+    <file src="..\packages\FSharp.Compiler.Tools.4.0.0.1\tools\**\*.*" target="FSharp" exclude="**\*.xml" />
   </files>
 </package>


### PR DESCRIPTION
Replaces #105 so code can be released as part of 3.4
Connects to OctopusDeploy/Issues/issues/2549

- [x] Quick PoC
- [x] Test Pre,PostDeploy etc
- [x] Review style with a F# expert
- [x] Use more F# idioms
- [x] Update Output Variables docs http://docs.octopusdeploy.com/display/OD/Output+variables
- [x] Update Artifact docs http://docs.octopusdeploy.com/display/OD/Artifacts
- [x] Update custom scripts http://docs.octopusdeploy.com/display/OD/Custom+scripts
- [x] Docs .NET 4.5 nad Mono 4