### PR TITLE
Decreased Azure deployment retry count to 3 but removed the time limit.

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
@@ -205,8 +205,8 @@ namespace Calamari.Azure.Deployment.Conventions
 
         static RetryTracker GetRetryTracker()
         {
-            return new RetryTracker(maxRetries: 5,
-                timeLimit: TimeSpan.FromMinutes(1),
+            return new RetryTracker(maxRetries: 3,
+                timeLimit: TimeSpan.MaxValue,
                 retryInterval: RetryIntervalForAzureOperations);
         }
     }


### PR DESCRIPTION
Fixes OctopusDeploy/Issues#2580

Previously no retry would be performed if more than one minute had elapsed. This change may triple the time before failing Azure deployments finally finish.