### PR TITLE
fix url for myget

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,7 +4,7 @@
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
   <packageSources>
-    <add key="Octopus Dependencies" value="hhttps://octopus.myget.org/F/octopus-dependencies/" />
+    <add key="Octopus Dependencies" value="https://octopus.myget.org/F/octopus-dependencies/" />
     <add key="NuGet.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
There were 2 'h' in 'https...'

Steps to reproduce error:
- Clear nuget cache -> nuget.exe locals -clear all
- Clear repo's packages and bin
- Build solution
- - nuget restore should fail on unable to find certain packages.