### PR TITLE
Added support to override azure cloud service deployment label.

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/DeployAzureCloudServicePackageConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/DeployAzureCloudServicePackageConvention.cs
@@ -33,7 +33,10 @@ namespace Calamari.Azure.Deployment.Conventions
             Log.SetOutputVariable("OctopusAzureStorageAccountName", deployment.Variables.Get(SpecialVariables.Action.Azure.StorageAccountName), deployment.Variables);
             Log.SetOutputVariable("OctopusAzureSlot", deployment.Variables.Get(SpecialVariables.Action.Azure.Slot), deployment.Variables);
             Log.SetOutputVariable("OctopusAzurePackageUri", deployment.Variables.Get(SpecialVariables.Action.Azure.UploadedPackageUri), deployment.Variables);
-            Log.SetOutputVariable("OctopusAzureDeploymentLabel", deployment.Variables.Get(SpecialVariables.Action.Name) + " v" + deployment.Variables.Get(SpecialVariables.Release.Number), deployment.Variables);
+
+            var deploymentLabel = deployment.Variables.Get(SpecialVariables.Action.Azure.DeploymentLabel, defaultValue: deployment.Variables.Get(SpecialVariables.Action.Name) + " v" + deployment.Variables.Get(SpecialVariables.Release.Number));
+            Log.SetOutputVariable("OctopusAzureDeploymentLabel", deploymentLabel, deployment.Variables);
+
             Log.SetOutputVariable("OctopusAzureSwapIfPossible", deployment.Variables.Get(SpecialVariables.Action.Azure.SwapIfPossible, defaultValue: false.ToString()), deployment.Variables);
             Log.SetOutputVariable("OctopusAzureUseCurrentInstanceCount", deployment.Variables.Get(SpecialVariables.Action.Azure.UseCurrentInstanceCount), deployment.Variables);
 

--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -165,6 +165,7 @@
                 public static readonly string CloudServicePackageExtractionDisabled = "Octopus.Action.Azure.CloudServicePackageExtractionDisabled";
                 public static readonly string LogExtractedCspkg = "Octopus.Action.Azure.LogExtractedCspkg";
                 public static readonly string CloudServiceConfigurationFileRelativePath = "Octopus.Action.Azure.CloudServiceConfigurationFileRelativePath";
+                public static readonly string DeploymentLabel = "Octopus.Action.Azure.DeploymentLabel";
 
                 public static readonly string ResourceGroupName = "Octopus.Action.Azure.ResourceGroupName";
                 public static readonly string ResourceGroupDeploymentName = "Octopus.Action.Azure.ResourceGroupDeploymentName";


### PR DESCRIPTION
Tested by performing the following.

Default: 

![2016-08-30_10-12-13](https://cloud.githubusercontent.com/assets/216245/18071910/b972fdce-6e9c-11e6-89d0-f114c527e98f.png)
![2016-08-29_21-35-10](https://cloud.githubusercontent.com/assets/216245/18071912/bf24bb0e-6e9c-11e6-8237-8022166b612d.png)

Setting override variable.
![2016-08-30_10-12-22](https://cloud.githubusercontent.com/assets/216245/18071931/e29c3922-6e9c-11e6-8c11-f654a3d8e4b2.png)
![2016-08-30_10-19-55](https://cloud.githubusercontent.com/assets/216245/18071932/e736314a-6e9c-11e6-9c90-f6c95e2135bc.png)

Resolves OctopusDeploy/Issues#2677

Note: Will update http://docs.octopus.com/display/OD/System+variables once this is merged.