### PR TITLE
Unescape zip entry before using it

### DIFF
--- a/source/Calamari/Integration/Packages/NuGet/NupkgExtractor.cs
+++ b/source/Calamari/Integration/Packages/NuGet/NupkgExtractor.cs
@@ -37,10 +37,12 @@ namespace Calamari.Integration.Packages.NuGet
             {
                 while (reader.MoveToNextEntry())
                 {
-                    if (IsExcludedPath(reader.Entry.Key))
+                    var unescapedKey = UnescapePath(reader.Entry.Key);
+
+                    if (IsExcludedPath(unescapedKey))
                         continue;
 
-                    var targetDirectory = Path.Combine(directory, UnescapePath(Path.GetDirectoryName(reader.Entry.Key)));
+                    var targetDirectory = Path.Combine(directory, Path.GetDirectoryName(unescapedKey));
 
                     if (!Directory.Exists(targetDirectory))
                     {
@@ -50,7 +52,7 @@ namespace Calamari.Integration.Packages.NuGet
                     if (reader.Entry.IsDirectory || !IsPackageFile(reader.Entry.Key))
                         continue;
 
-                    var targetFile = Path.Combine(targetDirectory, UnescapePath(Path.GetFileName(reader.Entry.Key)));
+                    var targetFile = Path.Combine(targetDirectory, Path.GetFileName(unescapedKey));
                     reader.WriteEntryToFile(targetFile, ExtractOptions.Overwrite);
 
                     SetFileLastModifiedTime(reader.Entry, targetFile);
@@ -58,7 +60,7 @@ namespace Calamari.Integration.Packages.NuGet
                     filesExtracted++;
 
                     if (!suppressNestedScriptWarning)
-                        GenericPackageExtractor.WarnIfScriptInSubFolder(reader.Entry.Key);
+                        GenericPackageExtractor.WarnIfScriptInSubFolder(unescapedKey);
                 }
 
                 return filesExtracted;


### PR DESCRIPTION
When extracting files with unicode characters in their name we were attempting to extract the escaped file name (such as 21113.%D0%9A%D0%BB%D0%B0%D1%81%D1%81%D0%B8%D1%84%D0%B8%D0%BA%D0%B0%D1%82%D0%BE%D1%80%20%D0%B2%D0%B8%D0%B4%D0%BE%D0%B2%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%BE%D0%B2%2C%20%D1%83%D0%B4%D0%BE%D1%81%D1%82%D0%BE%D0%B2%D0%B5%D1%80%D1%8F%D1%8E%D1%89%).  This PR escapes the file name before using it.

Relates to OctopusDeploy/Issues#2687