### PR TITLE
PurgeDirectory can now also check if a directory should be excluded.

### DIFF
--- a/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -342,8 +342,8 @@ namespace Calamari.Integration.FileSystem
 
                 if (include != null)
                 {
-                    var info = new FileInfoAdapter(new FileInfo(file));
-                    if (!include(info))
+                    var includeInfo = new FileInfoAdapter(new FileInfo(file));
+                    if (!include(includeInfo))
                     {
                         continue;
                     }
@@ -357,6 +357,16 @@ namespace Calamari.Integration.FileSystem
                 cancel.ThrowIfCancellationRequested();
 
                 var info = new DirectoryInfo(directory);
+
+                if (include != null)
+                {
+                    var includeInfo = new FileInfoAdapter(info);
+                    if (!include(includeInfo))
+                    {
+                        continue;
+                    }
+                }
+
                 if ((info.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
                 {
                     Directory.Delete(directory);

--- a/source/Calamari/Integration/FileSystem/FileInfoAdapter.cs
+++ b/source/Calamari/Integration/FileSystem/FileInfoAdapter.cs
@@ -5,9 +5,9 @@ namespace Calamari.Integration.FileSystem
 {
     public class FileInfoAdapter : IFileInfo
     {
-        readonly FileInfo info;
+        readonly FileSystemInfo info;
 
-        public FileInfoAdapter(FileInfo info)
+        public FileInfoAdapter(FileSystemInfo info)
         {
             this.info = info;
         }
@@ -16,5 +16,6 @@ namespace Calamari.Integration.FileSystem
         public string Extension { get { return info.Extension; } }
         public DateTime LastAccessTimeUtc { get { return info.LastAccessTimeUtc; } }
         public DateTime LastWriteTimeUtc { get { return info.LastWriteTimeUtc; } }
+        public bool IsDirectory { get { return info.Attributes.HasFlag(FileAttributes.Directory); } }
     }
 }

--- a/source/Calamari/Integration/FileSystem/IFileInfo.cs
+++ b/source/Calamari/Integration/FileSystem/IFileInfo.cs
@@ -8,5 +8,6 @@ namespace Calamari.Integration.FileSystem
         string Extension { get; }
         DateTime LastAccessTimeUtc { get; }
         DateTime LastWriteTimeUtc { get; }
+        bool IsDirectory { get; }
     }
 }


### PR DESCRIPTION
This patch changes the `FileInfoAdapter` to use `FileSystemInfo` instead of `FileInfo` so it can also be used with directories. I also think the name of `FileInfoAdapter` and `IFileInfo` should also be changed to `FileSystemInfoAdapter` and `IFileSystemInfo` but I did not include that in this pull request because you might not be happy with this breaking change. I can add another commit to rename those classes if you are okay with me renaming them. The `PurgeDirectory` method from `CalamariPhysicalFileSystem` has also been changed to check if the directory should be included or excluded.

The reason that I made these changes is because I would like to add an extra option to `CopyPackageToCustomInstallationDirectoryConvention` that would make it possible to exclude a set of files or directories when the `customInstallationDirectory` is purged. I already made a proof of concept for this but I would also like to know if you would be open to adding such a feature to the interface. I can send another pull request if you would be okay with me adding this option to Calamari.
