### PR TITLE
Throw an error if we can't evaluate the custom directory or it is a relative path

### DIFF
--- a/source/Calamari.Tests/Fixtures/Conventions/CopyPackageToCustomInstallationDirectoryConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/CopyPackageToCustomInstallationDirectoryConventionFixture.cs
@@ -73,6 +73,25 @@ namespace Calamari.Tests.Fixtures.Conventions
             Assert.AreEqual(variables.Get(SpecialVariables.Package.CustomInstallationDirectory), customInstallationDirectory);
         }
 
+        [Test]
+        [ExpectedException(ExpectedMessage = "An error occurred when evaluating the value for the custom install directory. The following tokens were unable to be evaluated: '#{CustomInstalDirectory}'")]
+        public void ShouldFailIfCustomInstallationDirectoryVariableIsNotEvaluated()
+        {
+            variables.Set("CustomInstallDirectory", customInstallationDirectory);
+            variables.Set(SpecialVariables.Package.CustomInstallationDirectory, "#{CustomInstalDirectory}");
+
+            CreateConvention().Install(deployment);
+        }
+
+        [Test]
+        [ExpectedException(ExpectedMessage = "The custom install directory 'relative\\path\\to\\folder' is a relative path, please specify the path as an absolute path or a UNC path.")]
+        public void ShouldFailIfCustomInstallationDirectoryIsRelativePath()
+        {
+            const string relativeInstallDirectory = "relative\\path\\to\\folder";
+            variables.Set(SpecialVariables.Package.CustomInstallationDirectory, relativeInstallDirectory);
+
+            CreateConvention().Install(deployment);
+        }
 
         private CopyPackageToCustomInstallationDirectoryConvention CreateConvention()
         {

--- a/source/Calamari/Deployment/Conventions/CopyPackageToCustomInstallationDirectoryConvention.cs
+++ b/source/Calamari/Deployment/Conventions/CopyPackageToCustomInstallationDirectoryConvention.cs
@@ -1,4 +1,6 @@
-﻿using Calamari.Integration.FileSystem;
+﻿using System.IO;
+using Calamari.Commands.Support;
+using Calamari.Integration.FileSystem;
 
 namespace Calamari.Deployment.Conventions
 {
@@ -13,18 +15,32 @@ namespace Calamari.Deployment.Conventions
 
         public void Install(RunningDeployment deployment)
         {
-            var customInstallationDirectory = deployment.Variables.Get(SpecialVariables.Package.CustomInstallationDirectory);
+            string errorString;
+            var customInstallationDirectory = deployment.Variables.Get(SpecialVariables.Package.CustomInstallationDirectory, out errorString);
             var sourceDirectory = deployment.Variables.Get(SpecialVariables.OriginalPackageDirectoryPath);
 
             if (string.IsNullOrWhiteSpace(customInstallationDirectory))
             {
                 Log.Verbose("The package has been installed to: " + sourceDirectory);
-                Log.VerboseFormat("If you would like the package to be installed to an alternative location, please specify the variable '{0}'", SpecialVariables.Package.CustomInstallationDirectory);
+                Log.VerboseFormat(
+                    "If you would like the package to be installed to an alternative location, please specify the variable '{0}'",
+                    SpecialVariables.Package.CustomInstallationDirectory);
                 // If the variable was not set then we set it, as it makes it simpler for anything to depend on it from this point on
                 deployment.Variables.Set(SpecialVariables.Package.CustomInstallationDirectory,
-                   sourceDirectory);
+                    sourceDirectory);
 
                 return;
+            }
+
+            if (!string.IsNullOrEmpty(errorString))
+            {
+                throw new CommandException(
+                    $"An error occurred when evaluating the value for the custom install directory. {errorString}");
+            }
+            if (!Path.IsPathRooted(customInstallationDirectory))
+            {
+                throw new CommandException(
+                    $"The custom install directory '{customInstallationDirectory}' is a relative path, please specify the path as an absolute path or a UNC path.");
             }
 
             // Purge if requested


### PR DESCRIPTION
Using an incorrect variable:
![image](https://cloud.githubusercontent.com/assets/1035315/18980774/141f4d22-871b-11e6-92bd-acae994bcd9a.png)

Using a relative path:
![image](https://cloud.githubusercontent.com/assets/1035315/18980781/23cfcac6-871b-11e6-9c8e-557034e0a638.png)

Fixes OctopusDeploy/Issues#2763