### PR TITLE
Fix number of retries for nuget package download

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Fixtures\Deployment\DeployPackageFixture.cs" />
     <Compile Include="Fixtures\Deployment\DeployWebPackageToIISFixture.cs" />
     <Compile Include="Fixtures\Deployment\DeployWindowsServiceFixture.cs" />
+    <Compile Include="Fixtures\Integration\Packages\NuGetPackageDownloaderFixture.cs" />
     <Compile Include="Helpers\InMemoryLog.cs" />
     <Compile Include="Fixtures\FSharp\FSharpFixture.cs" />
     <Compile Include="Helpers\CaptureCommandOutputExtensions.cs" />

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using Calamari.Integration.Packages.NuGet;
+using Calamari.Integration.Retry;
+using NuGet.Versioning;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Integration.Packages
+{
+    [TestFixture]
+    public class NuGetPackageDownloaderFixture
+    {
+        [Test]
+        public void AttemptsOnlyOnceIfSuccessful()
+        {
+            var packageId = "FakePackageId";
+            var version = new NuGetVersion(1, 2, 3);
+            var feedUri = new Uri("http://www.myget.org");
+            var feedCredentials = new CredentialCache();
+            var targetFilePath = "FakeTargetFilePath";
+
+            var calledCount = 0;
+            var downloader = new NuGetPackageDownloader();
+            downloader.DownloadPackage(packageId, version, feedUri, feedCredentials, targetFilePath, (arg1, arg2, arg3, arg4, arg5) =>
+            {
+                calledCount++;
+            });
+
+            Assert.That(calledCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void AttemptsFiveTimesOnError()
+        {
+            var packageId = "FakePackageId";
+            var version = new NuGetVersion(1, 2, 3);
+            var feedUri = new Uri("http://www.myget.org");
+            var feedCredentials = new CredentialCache();
+            var targetFilePath = "FakeTargetFilePath";
+
+            var calledCount = 0;
+            Assert.Throws<Exception>(() =>
+            {
+                //total attempts is initial attempt + 4 retries
+                var retryTracker = new RetryTracker(maxRetries: 4, 
+                                                    timeLimit: null, 
+                                                    retryInterval: new RetryInterval(100, 150, 1));
+                var downloader = new NuGetPackageDownloader(retryTracker);
+                downloader.DownloadPackage(packageId, version, feedUri, feedCredentials, targetFilePath,
+                    (arg1, arg2, arg3, arg4, arg5) =>
+                    {
+                        calledCount++;
+                        throw new ApplicationException("Expected exception from test");
+                    });
+            });
+            Assert.That(calledCount, Is.EqualTo(5));
+        }
+    }
+}

--- a/source/Calamari/Integration/Packages/Download/PackageDownloader.cs
+++ b/source/Calamari/Integration/Packages/Download/PackageDownloader.cs
@@ -121,7 +121,8 @@ namespace Calamari.Integration.Packages.Download
 
             var fullPathToDownloadTo = GetFilePathToDownloadPackageTo(cacheDirectory, packageId, version.ToString());
 
-           NuGetPackageDownloader.DownloadPackage(packageId, version, feedUri, feedCredentials, fullPathToDownloadTo); 
+            var downloader = new NuGetPackageDownloader();
+            downloader.DownloadPackage(packageId, version, feedUri, feedCredentials, fullPathToDownloadTo); 
 
             downloaded = new LocalNuGetPackage(fullPathToDownloadTo);
             downloadedTo = fullPathToDownloadTo; 

--- a/source/Calamari/Integration/Packages/NuGet/NuGetPackageDownloader.cs
+++ b/source/Calamari/Integration/Packages/NuGet/NuGetPackageDownloader.cs
@@ -8,45 +8,42 @@ namespace Calamari.Integration.Packages.NuGet
 {
     internal class NuGetPackageDownloader
     {
-        const int NumberOfTimesToAttemptToDownloadPackage = 5;
+        private RetryTracker retry;
+        internal const int NumberOfTimesToRetryOnFailure = 4;
+        internal const int NumberOfTimesToAttemptToDownloadPackage = NumberOfTimesToRetryOnFailure + 1;
 
-        public static void DownloadPackage(string packageId, NuGetVersion version, Uri feedUri, ICredentials feedCredentials, string targetFilePath)
+        public NuGetPackageDownloader() : this(GetRetryTracker())
         {
-            var retry = GetRetryTracker();
+        }
 
+        public NuGetPackageDownloader(RetryTracker retry)
+        {
+            this.retry = retry;
+        }
+
+        public void DownloadPackage(string packageId, NuGetVersion version, Uri feedUri, ICredentials feedCredentials, string targetFilePath)
+        {
+            DownloadPackage(packageId, version, feedUri, feedCredentials, targetFilePath, DownloadPackageAction);
+        }
+
+        public void DownloadPackage(string packageId, NuGetVersion version, Uri feedUri, ICredentials feedCredentials, string targetFilePath, Action<string, NuGetVersion, Uri, ICredentials, string> action)
+        {
             while (retry.Try())
             {
                 Log.Verbose($"Downloading package (attempt {retry.CurrentTry} of {NumberOfTimesToAttemptToDownloadPackage})");
 
                 try
                 {
-                    // FileSystem feed 
-                    if (feedUri.IsFile)
-                    {
-                        NuGetFileSystemDownloader.DownloadPackage(packageId, version, feedUri, targetFilePath);
-                    }
-
-                    // NuGet V3 feed 
-                    else if (IsHttp(feedUri.ToString()) && feedUri.ToString().EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-                    {
-                        NuGetV3Downloader.DownloadPackage(packageId, version, feedUri, feedCredentials, targetFilePath);
-                    }
-
-                    // V2 feed
-                    else 
-                    {
-                        NuGetV2Downloader.DownloadPackage(packageId, version.ToString(), feedUri, feedCredentials, targetFilePath);
-                    }
-
+                    action(packageId, version, feedUri, feedCredentials, targetFilePath);
                     return;
                 }
                 catch (Exception ex)
                 {
+                    Log.VerboseFormat("Attempt {0} of {1}: Unable to download package: {2}", retry.CurrentTry,
+                        NumberOfTimesToAttemptToDownloadPackage, ex.ToString());
+
                     if (retry.CanRetry())
                     {
-                        Log.VerboseFormat("Attempt {0} of {1}: Unable to download package: {2}", retry.CurrentTry,
-                            NumberOfTimesToAttemptToDownloadPackage, ex.ToString());
-
                         Thread.Sleep(retry.Sleep());
                     }
                     else
@@ -59,7 +56,28 @@ namespace Calamari.Integration.Packages.NuGet
             }
         }
 
-        static bool IsHttp(string uri)
+        private void DownloadPackageAction(string packageId, NuGetVersion version, Uri feedUri, ICredentials feedCredentials, string targetFilePath)
+        {
+            // FileSystem feed 
+            if (feedUri.IsFile)
+            {
+                NuGetFileSystemDownloader.DownloadPackage(packageId, version, feedUri, targetFilePath);
+            }
+
+            // NuGet V3 feed 
+            else if (IsHttp(feedUri.ToString()) && feedUri.ToString().EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            {
+                NuGetV3Downloader.DownloadPackage(packageId, version, feedUri, feedCredentials, targetFilePath);
+            }
+
+            // V2 feed
+            else
+            {
+                NuGetV2Downloader.DownloadPackage(packageId, version.ToString(), feedUri, feedCredentials, targetFilePath);
+            }
+        }
+
+        bool IsHttp(string uri)
         {
             return uri.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
                    uri.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
@@ -67,7 +85,7 @@ namespace Calamari.Integration.Packages.NuGet
 
         static RetryTracker GetRetryTracker()
         {
-            return new RetryTracker(maxRetries: NumberOfTimesToAttemptToDownloadPackage, timeLimit: null, retryInterval: new RetryInterval(1000, 15000, 2));
+            return new RetryTracker(maxRetries: NumberOfTimesToRetryOnFailure, timeLimit: null, retryInterval: new RetryInterval(1000, 15000, 2));
         }
     }
 }


### PR DESCRIPTION
Was mixing up number of attempts and number of retries and showing "attempt 6 of 5".
Fixes OctopusDeploy/Issues#2799.