### PR TITLE
Use Join-Path instead of Path.Combine to make it compatible with PowerShell 2

### DIFF
--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -20,9 +20,9 @@
 
 if ([System.Convert]::ToBoolean($OctopusUseBundledAzureModules)) {
 	# Add bundled Azure modules to PSModulePath
-	$StorageModulePath = ([IO.Path]::Combine("$OctopusAzureModulePath", "Storage"))
-	$ServiceManagementModulePath = ([IO.Path]::Combine("$OctopusAzureModulePath", "ServiceManagement"))
-	$ResourceManagerModulePath = [IO.Path]::Combine("$OctopusAzureModulePath", "ResourceManager", "AzureResourceManager")
+	$StorageModulePath = Join-Path "$OctopusAzureModulePath" -ChildPath "Storage"
+	$ServiceManagementModulePath = Join-Path "$OctopusAzureModulePath" -ChildPath "ServiceManagement"
+	$ResourceManagerModulePath = Join-Path "$OctopusAzureModulePath" -ChildPath "ResourceManager" | Join-Path -ChildPath "AzureResourceManager"
 	Write-Verbose "Adding bundled Azure PowerShell modules to PSModulePath"
 	$env:PSModulePath = $ResourceManagerModulePath + ";" + $ServiceManagementModulePath + ";" + $StorageModulePath + ";" + $env:PSModulePath
 }


### PR DESCRIPTION
This PR fixes the error related to Path.Combine in PowerShell 2 not taking 3 arguments.

The user would still run into an error during deployment though as the Azure PowerShell cmdlets require PowerShell 3 or newer. But the error message will be about the Azure cmdlet we use not being available.

Connected to OctopusDeploy/Issues#2823