### PR TITLE
Add mac test category

### DIFF
--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -11,6 +11,7 @@ namespace Calamari.Tests.Fixtures.Bash
     {
         [Test]
         [Category(TestEnvironment.CompatibleOS.Nix)]
+        [Category(TestEnvironment.CompatibleOS.Mac)]
         public void ShouldPrintEncodedVariable()
         {
             var output = Invoke(Calamari()
@@ -23,6 +24,7 @@ namespace Calamari.Tests.Fixtures.Bash
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Nix)]
+        [Category(TestEnvironment.CompatibleOS.Mac)]
         public void ShouldCreateArtifact()
         {
             var output = Invoke(Calamari()
@@ -35,6 +37,7 @@ namespace Calamari.Tests.Fixtures.Bash
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Nix)]
+        [Category(TestEnvironment.CompatibleOS.Mac)]
         public void ShouldConsumeParametersWithQuotes()
         {
             var output = Invoke(Calamari()
@@ -48,6 +51,7 @@ namespace Calamari.Tests.Fixtures.Bash
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Nix)]
+        [Category(TestEnvironment.CompatibleOS.Mac)]
         public void ShouldCallHello()
         {
             var variablesFile = Path.GetTempFileName();
@@ -74,6 +78,7 @@ namespace Calamari.Tests.Fixtures.Bash
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Nix)]
+        [Category(TestEnvironment.CompatibleOS.Mac)]
         public void ShouldCallHelloWithSensitiveVariable()
         {
             var variablesFile = Path.GetTempFileName();

--- a/source/Calamari.Tests/Fixtures/Conventions/ContributeEnvironmentVariablesFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ContributeEnvironmentVariablesFixture.cs
@@ -15,7 +15,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldAddWindowsEnvironmentVariables()
         {
             var variables = AddEnvironmentVariables();
-            WindowsEnvironmentVariableTest(variables);
+            Assert.That(variables.Evaluate("My OS is #{env:OS}"), Is.StringStarting("My OS is Windows"));
         }
 
         [Test]
@@ -23,7 +23,15 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldAddLinuxEnvironmentVariables()
         {
             var variables = AddEnvironmentVariables();
-            LinuxEnvironmentVariableTest(variables);
+            Assert.That(variables.Evaluate("My home starts at #{env:HOME}"), Is.StringStarting("My home starts at /home/"));
+        }
+
+        [Test]
+        [Category(TestEnvironment.CompatibleOS.Mac)]
+        public void ShouldAddMacEnvironmentVariables()
+        {
+            var variables = AddEnvironmentVariables();
+            Assert.That(variables.Evaluate("My home starts at #{env:HOME}"), Is.StringStarting("My home starts at /Users/"));
         }
 
         private VariableDictionary AddEnvironmentVariables()
@@ -36,16 +44,5 @@ namespace Calamari.Tests.Fixtures.Conventions
             Assert.That(variables.GetRaw(SpecialVariables.Tentacle.Agent.InstanceName), Is.EqualTo("#{env:TentacleInstanceName}"));
             return variables;
         }
-
-        private void WindowsEnvironmentVariableTest(VariableDictionary variables)
-        {
-            Assert.That(variables.Evaluate("My OS is #{env:OS}"), Is.StringStarting("My OS is Windows"));
-        }
-
-        private void LinuxEnvironmentVariableTest(VariableDictionary variables)
-        {
-            Assert.That(variables.Evaluate("My home starts at #{env:HOME}"), Is.StringStarting("My home starts at /home"));
-        }
-
     }
 }

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -57,7 +57,8 @@ namespace Calamari.Tests.Fixtures.Deployment
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Nix)]
-        public void ShouldDeployPackageOnNix()
+        [Category(TestEnvironment.CompatibleOS.Mac)]
+        public void ShouldDeployPackageOnMacOrNix()
         {
             var result = DeployPackage();
             result.AssertSuccess();

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
@@ -39,6 +39,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Nix)]
+        [Category(TestEnvironment.CompatibleOS.Mac)]
         public void BashDecryptsSensitiveVariables()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "sh")))

--- a/source/Calamari.Tests/Fixtures/PackageDownload/AuthenticatedTestAttribute.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/AuthenticatedTestAttribute.cs
@@ -19,7 +19,6 @@ namespace Calamari.Tests.Fixtures.PackageDownload
 
         public void BeforeTest(TestDetails testDetails)
         {
-            Console.WriteLine($"Environment.GetEnvironmentVariable(\"{feedUri}\") = \"{Environment.GetEnvironmentVariable(feedUri)}\"");
             if (String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(feedUri)) ||
                 String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(feedUsernameVariable)) ||
                 String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(feedPasswordVariable)))

--- a/source/Calamari.Tests/Fixtures/PackageDownload/AuthenticatedTestAttribute.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/AuthenticatedTestAttribute.cs
@@ -19,6 +19,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
 
         public void BeforeTest(TestDetails testDetails)
         {
+            Console.WriteLine($"Environment.GetEnvironmentVariable(\"{feedUri}\") = \"{Environment.GetEnvironmentVariable(feedUri)}\"");
             if (String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(feedUri)) ||
                 String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(feedUsernameVariable)) ||
                 String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(feedPasswordVariable)))

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -469,7 +469,8 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Nix)]
-        public void ThrowsExceptionOnNix()
+        [Category(TestEnvironment.CompatibleOS.Mac)]
+        public void ThrowsExceptionOnNixOrMac()
         {
             var output = Invoke(Calamari()
                 .Action("run-script")

--- a/source/Calamari.Tests/Helpers/TestEnvironment.cs
+++ b/source/Calamari.Tests/Helpers/TestEnvironment.cs
@@ -23,6 +23,8 @@ namespace Calamari.Tests.Helpers
             public const string Nix = "Nix";
 
             public const string Windows = "Windows";
+
+            public const string Mac = "macOS";
         }
     }
 }


### PR DESCRIPTION
As there are minor differences between linux and mac, and add specific mac versions of the tests that were failing