### PR TITLE
Enhance the IIS Step

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Helpers\CalamariResult.cs" />
     <Compile Include="Helpers\CaptureCommandOutput.cs" />
     <Compile Include="Helpers\TarGzBuilder.cs" />
+    <Compile Include="Helpers\TemporaryDirectory.cs" />
     <Compile Include="Helpers\TestEnvironment.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VariableDictionaryExtensions.cs" />

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageToIISFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageToIISFixture.cs
@@ -255,23 +255,26 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             var webSitePhysicalPath = Path.Combine(Path.GetTempPath(), uniqueValue);
             Directory.CreateDirectory(webSitePhysicalPath);
+            using (new TemporaryDirectory(webSitePhysicalPath))
+            {
+                iis.CreateWebSiteOrVirtualDirectory(uniqueValue, null, webSitePhysicalPath, 1087);
 
-            iis.CreateWebSiteOrVirtualDirectory(uniqueValue, null, webSitePhysicalPath, 1087);
+                Variables["Octopus.Action.IISWebSite.DeploymentType"] = "virtualDirectory";
+                Variables["Octopus.Action.IISWebSite.VirtualDirectory.CreateOrUpdate"] = "True";
 
-            Variables["Octopus.Action.IISWebSite.DeploymentType"] = "virtualDirectory";
-            Variables["Octopus.Action.IISWebSite.VirtualDirectory.CreateOrUpdate"] = "True";
+                Variables["Octopus.Action.IISWebSite.VirtualDirectory.WebSiteName"] = uniqueValue;
+                Variables["Octopus.Action.IISWebSite.VirtualDirectory.VirtualPath"] = ToFirstLevelPath(uniqueValue);
 
-            Variables["Octopus.Action.IISWebSite.VirtualDirectory.WebSiteName"] = uniqueValue;
-            Variables["Octopus.Action.IISWebSite.VirtualDirectory.VirtualPath"] = ToFirstLevelPath(uniqueValue);
+                Variables["Octopus.Action.Package.CustomInstallationDirectory"] = Path.Combine(webSitePhysicalPath,
+                    uniqueValue);
+                Variables["Octopus.Action.Package.CustomInstallationDirectoryShouldBePurgedBeforeDeployment"] = "True";
 
-            Variables["Octopus.Action.Package.CustomInstallationDirectory"] = Path.Combine(webSitePhysicalPath, uniqueValue);
-            Variables["Octopus.Action.Package.CustomInstallationDirectoryShouldBePurgedBeforeDeployment"] = "True";
+                Variables[SpecialVariables.Package.EnabledFeatures] = "Octopus.Features.IISWebSite";
 
-            Variables[SpecialVariables.Package.EnabledFeatures] = "Octopus.Features.IISWebSite";
+                var result = DeployPackage(packageV1.FilePath);
 
-            var result = DeployPackage(packageV1.FilePath);
-
-            result.AssertSuccess();
+                result.AssertSuccess();
+            }
         }
 
         private string ToFirstLevelPath(string value)

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageToIISFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageToIISFixture.cs
@@ -184,7 +184,7 @@ namespace Calamari.Tests.Fixtures.Deployment
             var result = DeployPackage(packageV1.FilePath);
 
             result.AssertFailure();
-            result.AssertErrorOutput($"Site \"{uniqueValue}\" does not exist.", true);
+            result.AssertErrorOutput($"The Web Site \"{uniqueValue}\" does not exist", true);
         }
 
         [Test]

--- a/source/Calamari.Tests/Helpers/TemporaryDirectory.cs
+++ b/source/Calamari.Tests/Helpers/TemporaryDirectory.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Calamari.Integration.FileSystem;
+
+namespace Calamari.Tests.Helpers
+{
+    public class TemporaryDirectory : IDisposable
+    {
+        private readonly string directoryPath;
+        readonly ICalamariFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+
+        public TemporaryDirectory(string directoryPath)
+        {
+            this.directoryPath = directoryPath;
+        }
+
+        public void Dispose()
+        {
+            fileSystem.DeleteDirectory(directoryPath, FailureOptions.IgnoreFailure);
+        }
+    }
+}

--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -177,10 +177,11 @@ function Assert-ParentSegmentsExist($sitePath, $virtualPathSegments) {
 
 function Assert-WebsiteExists($SitePath, $SiteName)
 {
+	Write-Verbose "Looking for the parent Site `"$SiteName`" at `"$SitePath`"..."
 	$site = Get-Item $SitePath -ErrorAction SilentlyContinue
 	if (!$site) 
 	{ 
-		throw "Site `"$SiteName`" does not exist." 
+		throw "The Web Site `"$SiteName`" does not exist in IIS and this step cannot create the Web Site because the necessary details are not available. Add a step which makes sure the parent Web Site exists before this step attempts to add a child to it." 
 	}
 }
 
@@ -203,14 +204,12 @@ if ($deployAsVirtualDirectory)
 	$physicalPath = Determine-Path $OctopusParameters["Octopus.Action.IISWebSite.VirtualDirectory.PhysicalPath"]
 	$virtualPath = $OctopusParameters["Octopus.Action.IISWebSite.VirtualDirectory.VirtualPath"]
 
-	Write-Host "Creating Virtual Directory $virtualPath ..."
+	Write-Host "Making sure a Virtual Directory `"$virtualPath`" is configured as a child of `"$webSiteName`" at `"$physicalPath`"..."
     
     pushd IIS:\
 
 	$sitePath = "IIS:\Sites\$webSiteName"
 
-	Write-Verbose "Searching for $webSiteName Web Site."
-	
 	Assert-WebsiteExists -SitePath $sitePath -SiteName $webSiteName
 
 	[array]$virtualPathSegments =  Convert-ToPathSegments -VirtualPath $virtualPath
@@ -244,7 +243,7 @@ if ($deployAsWebApplication)
 	$physicalPath = Determine-Path $OctopusParameters["Octopus.Action.IISWebSite.WebApplication.PhysicalPath"]
 	$virtualPath = $OctopusParameters["Octopus.Action.IISWebSite.WebApplication.VirtualPath"]
 
-	Write-Host "Creating Web Application $virtualPath ..."
+	Write-Host "Making sure a Web Application `"$virtualPath`" is configured as a child of `"$webSiteName`" at `"$physicalPath`"..."
     
     pushd IIS:\
 
@@ -256,8 +255,6 @@ if ($deployAsWebApplication)
 
 	$sitePath = ("IIS:\Sites\" + $webSiteName)
 
-	Write-Verbose "Searching for $webSiteName Web Site."
-	
 	Assert-WebsiteExists -SitePath $sitePath -SiteName $webSiteName
 
 	[array]$virtualPathSegments =  Convert-ToPathSegments -VirtualPath $virtualPath
@@ -307,7 +304,7 @@ if ($deployAsWebSite)
 	$applicationPoolPassword = $OctopusParameters["Octopus.Action.IISWebSite.ApplicationPoolPassword"]
 	$applicationPoolFrameworkVersion = $OctopusParameters["Octopus.Action.IISWebSite.ApplicationPoolFrameworkVersion"]
 
-	Write-Host "Creating Website $webSiteName"
+	Write-Host "Making sure a Website `"$webSiteName`" is configured in IIS..."
 
 	#Assess SNI support (IIS 8 or greater)
 	$iis = get-itemproperty HKLM:\SOFTWARE\Microsoft\InetStp\  | select setupstring 


### PR DESCRIPTION
Relates to OctopusDeploy/Issues#2840
Relates to OctopusDeploy/Issues#2839
Relates to OctopusDeploy/Issues#2846

- [x] Make the use of WebSite clearer - create or assert

The Web Site configuration of this step will create the Site if missing, but the Virtual Directory and Web Application configurations expect the parent site to already exist.

![image](https://cloud.githubusercontent.com/assets/1627582/19503890/06530b8c-95fa-11e6-8cea-de844096b7b0.png)


- [x] Provide better collision detection, conversion, and messaging

This code detects misconfigured and duplicate items at the same path in IIS and will try to convert an existing directory to either a Virtual Directory or Web Application. If something goes wrong we now try to provide all the information required to fix the problem.

![image](https://cloud.githubusercontent.com/assets/1627582/19578053/4c874b86-975d-11e6-8937-394271500dd9.png)

![image](https://cloud.githubusercontent.com/assets/1627582/19578083/73a6bfbc-975d-11e6-9ac6-8fe59477d31c.png)

