### PR TITLE
Detect if IIS Windows Feature is installed

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -13,10 +13,16 @@ $deployAsVirtualDirectory = !(Is-DeploymentTypeDisabled $OctopusParameters["Octo
 
 if (!$deployAsVirtualDirectory -and !$deployAsWebSite -and !$deployAsWebApplication)
 {
-   Write-Host "Skipping IIS deployment. Neither Website nor Virtual Directory nor Web Application deployment type has been enabled." 
-   exit 0
+	Write-Host "Skipping IIS deployment. Neither Website nor Virtual Directory nor Web Application deployment type has been enabled." 
+	exit 0
 }
 
+$iisFeature = Get-WindowsFeature Web-WebServer
+if ($iisFeature -eq $null -or $iisFeature.Installed -eq $false) {
+	Write-Warning "It looks like IIS is not installed on this server and the deployment is likely to fail."
+	Write-Warning "Tip: You can use PowerShell to ensure IIS is installed: 'Install-WindowsFeature Web-WebServer'"
+	Write-Warning "     You are likely to want more IIS features than just the web server. Run 'Get-WindowsFeature *web*' to see all of the features you can install."
+}
 
 try {
 	Add-PSSnapin WebAdministration


### PR DESCRIPTION
This avoids an ugly COM error when IIS is not installed on the server.

`Get-WindowsFeature` and `Install-WindowsFeature` were available since Windows Server 2008 so this should work on all supported platforms.
