### PR TITLE
Fixed issue with bin path escaping

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.WindowsService_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.WindowsService_BeforePostDeploy.ps1
@@ -43,7 +43,7 @@ if (!$serviceName)
 if ($arguments) 
 {
 	$arguments = $arguments.Replace("`"", "\`"")
-	$binPath = ("\`"" + $fullPath + "\`" " + $arguments) # An extra set of escaped quotes added around the exe	
+	$binPath = "$fullPath $arguments" # An extra set of escaped quotes added around the exe	
 }
 else
 {


### PR DESCRIPTION
The "\" escape character was causing services to fail deployment in WMF 5+ with error similar to:
12:13:59   Info     |       The <My Service Name> service does not exist. It will be created.
12:13:59   Info     |       sc.exe create "<My Service Name>" binPath= \\"<My Service Full Path>\\" depend= "/" start= "auto" obj= "<Domain>\<Username>" password= "************"
12:13:59   Info     |       DESCRIPTION:
12:13:59   Info     |       Creates a service entry in the registry and Service Database.
12:13:59   Info     |       USAGE:
12:13:59   Info     |       sc <server> create [service name] [binPath= ] <option1> <option2>...
12:13:59   Info     |       OPTIONS:
12:13:59   Info     |       NOTE: The option name includes the equal sign.
12:13:59   Info     |       A space is required between the equal sign and the value.
12:13:59   Info     |       type= <own|share|interact|kernel|filesys|rec|userown|usershare>
12:13:59   Info     |       (default = own)
12:13:59   Info     |       start= <boot|system|auto|demand|disabled|delayed-auto>
12:13:59   Info     |       (default = demand)
12:13:59   Info     |       error= <normal|severe|critical|ignore>
12:13:59   Info     |       (default = normal)
12:13:59   Info     |       binPath= <BinaryPathName to the .exe file>
12:13:59   Info     |       group= <LoadOrderGroup>
12:13:59   Info     |       tag= <yes|no>
12:13:59   Info     |       depend= <Dependencies(separated by / (forward slash))>
12:13:59   Info     |       obj= <AccountName|ObjectName>
12:13:59   Info     |       (default = LocalSystem)
12:13:59   Info     |       DisplayName= <display name>
12:13:59   Info     |       password= <password>
12:13:59   Error    |       sc.exe create failed with exit code: 1639
12:13:59   Error    |       At <Folder Path>\Octopus.Features.WindowsService_BeforePostDeploy.ps1:98 char:3
12:13:59   Error    |       +         throw "sc.exe create failed with exit code: $LastExitCode"
12:13:59   Error    |       +         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
12:13:59   Error    |       + CategoryInfo          : OperationStopped: (sc.exe create f...exit code:
12:13:59   Error    |       1639:String) [], RuntimeException
12:13:59   Error    |       + FullyQualifiedErrorId : sc.exe create failed with exit code: 1639