### PR TITLE
Upgrade Octopus.Dependencies.AzureBinaries

### DIFF
--- a/source/Calamari.Azure/project.json
+++ b/source/Calamari.Azure/project.json
@@ -26,7 +26,7 @@
     "Microsoft.WindowsAzure.Management.Storage": "3.2.2",
     "Microsoft.WindowsAzure.Management.WebSites": "4.0.0",
     "Newtonsoft.Json": "7.0.1",
-    "Octopus.Dependencies.AzureBinaries": "2.6.0",
+    "Octopus.Dependencies.AzureBinaries": "2.6.1",
     "Octopus.Dependencies.AzureCmdlets": "1.6.0",
     "Octostache": "2.0.7",
     "Sprache": "2.1.0",

--- a/source/Calamari.Azure/project.json
+++ b/source/Calamari.Azure/project.json
@@ -26,7 +26,7 @@
     "Microsoft.WindowsAzure.Management.Storage": "3.2.2",
     "Microsoft.WindowsAzure.Management.WebSites": "4.0.0",
     "Newtonsoft.Json": "7.0.1",
-    "Octopus.Dependencies.AzureBinaries": "2.6.1",
+    "Octopus.Dependencies.AzureBinaries": "2.9.0",
     "Octopus.Dependencies.AzureCmdlets": "1.6.0",
     "Octostache": "2.0.7",
     "Sprache": "2.1.0",


### PR DESCRIPTION
We've updated the Azure binaries to the binaries released in `Azure SDK v2.9` hoping this can resolve the `Cannot access closed stream` error some of our customers are seeing when deploying their Cloud Services.

Relates to OctopusDeploy/Issues#2750