### PR TITLE
Fix issue with wildcards in the middle of transform filename

### DIFF
--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/Approved/TransformFileLocatorFixture.When_TransformIsWildcardFileNameOnlyWithWildCardInMiddleOfFileName_And_TargetIsFileNameOnly_ItSucceeds.approved.txt
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/Approved/TransformFileLocatorFixture.When_TransformIsWildcardFileNameOnlyWithWildCardInMiddleOfFileName_And_TargetIsFileNameOnly_ItSucceeds.approved.txt
@@ -1,0 +1,8 @@
+﻿Wildcard transform with wildcard in the middle of the filename to a single target where both are in the same directory
+Given a package which has the structure:
+Acme.Core.1.0.0.nupkg
+├─MyApp.connstrings.octopus.config
+├─MyApp.nlog_octopus.config
+└─MyApp.WinSvc.exe.config
+Then the transform MyApp.*.octopus.config => MyApp.WinSvc.exe.config will:
+ - Apply the transform MyApp.connstrings.octopus.config to file MyApp.WinSvc.exe.config

--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/Approved/TransformFileLocatorFixture.When_TransformIsWildcardFileNameOnly_And_TargetIsWildcardFileNameOnlyWithWildCardInMiddleOfFilename_ItFails.approved.txt
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/Approved/TransformFileLocatorFixture.When_TransformIsWildcardFileNameOnly_And_TargetIsWildcardFileNameOnlyWithWildCardInMiddleOfFilename_ItFails.approved.txt
@@ -1,0 +1,6 @@
+﻿Not supported: Using wildcard in the middle of target filename
+Given a package which has the structure:
+Acme.Core.1.0.0.nupkg
+├─web.config
+└─web.mytransform.config
+Then the transform *.mytransform.config => w*.config will do nothing.

--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/ConfigurationTransformTestCaseBuilder.cs
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/ConfigurationTransformTestCaseBuilder.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using Assent;
 using Assent.Namers;
 using Calamari.Integration.ConfigurationTransforms;
@@ -83,7 +84,13 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
         private bool FilesMatch(CallInfo callInfo, string file)
         {
             var filePatterns = callInfo.ArgAt<string[]>(1);
-            return filePatterns.Any(z => file.EndsWith(z.TrimStart('*')));
+            return filePatterns.Any(pattern =>
+            {
+                //bit of a naive regex, but it works enough for our tests
+                //"foo.*.config" becomes "foo\..*\.config"
+                var regex = new Regex(pattern.Replace(".", @"\.").Replace("*", ".*"));
+                return regex.IsMatch(file);
+            });
         }
 
         private string GetRelativePath(CallInfo callInfo, CalamariPhysicalFileSystem realFileSystem)

--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/TransformFileLocatorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/TransformFileLocatorFixture.cs
@@ -340,6 +340,19 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
         }
 
         [Test]
+        public void When_TransformIsWildcardFileNameOnly_And_TargetIsWildcardFileNameOnlyWithWildCardInMiddleOfFilename_ItFails()
+        {
+            ConfigurationTransformTestCaseBuilder
+                .ForTheScenario("Not supported: Using wildcard in the middle of target filename")
+                .Given.FileExists(@"c:\temp\web.config")
+                .And.FileExists(@"c:\temp\web.mytransform.config")
+                .When.UsingTransform(@"*.mytransform.config => w*.config")
+                .Then.SourceFile(@"c:\temp\web.config")
+                .Should.FailToBeTransformed()
+                .Verify(this);
+        }
+
+        [Test]
         public void When_TransformIsWildcardFileNameOnly_And_TargetIsWildcardFileNameOnly_ItSucceeds()
         {
             ConfigurationTransformTestCaseBuilder

--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/TransformFileLocatorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/TransformFileLocatorFixture.cs
@@ -326,6 +326,20 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
         }
 
         [Test]
+        public void When_TransformIsWildcardFileNameOnlyWithWildCardInMiddleOfFileName_And_TargetIsFileNameOnly_ItSucceeds()
+        {
+            ConfigurationTransformTestCaseBuilder
+                .ForTheScenario("Wildcard transform with wildcard in the middle of the filename to a single target where both are in the same directory")
+                .Given.FileExists(@"c:\temp\MyApp.connstrings.octopus.config")
+                .And.FileExists(@"c:\temp\MyApp.nlog_octopus.config")
+                .And.FileExists(@"c:\temp\MyApp.WinSvc.exe.config")
+                .When.UsingTransform(@"MyApp.*.octopus.config => MyApp.WinSvc.exe.config")
+                .Then.SourceFile(@"c:\temp\MyApp.WinSvc.exe.config")
+                .Should.BeTransFormedBy(@"c:\temp\MyApp.connstrings.octopus.config")
+                .Verify(this);
+        }
+
+        [Test]
         public void When_TransformIsWildcardFileNameOnly_And_TargetIsWildcardFileNameOnly_ItSucceeds()
         {
             ConfigurationTransformTestCaseBuilder

--- a/source/Calamari/Integration/ConfigurationTransforms/TransformFileLocator.cs
+++ b/source/Calamari/Integration/ConfigurationTransforms/TransformFileLocator.cs
@@ -25,22 +25,13 @@ namespace Calamari.Integration.ConfigurationTransforms
             var transformFileName = DetermineTransformFileName(sourceFile, transformation, false);
 
             string fullTransformDirectoryPath;
-            string fullTransformFilePath;
             if (Path.IsPathRooted(transformFileName))
             {
-                if (transformation.IsTransformWildcard)
-                    fullTransformFilePath = transformFileName;
-                else
-                    fullTransformFilePath = Path.GetFullPath(transformFileName);
-                fullTransformDirectoryPath = Path.GetFullPath(GetDirectoryName(fullTransformFilePath));
+                fullTransformDirectoryPath = Path.GetFullPath(GetDirectoryName(transformFileName));
             }
             else
             {
                 var relativeTransformPath = fileSystem.GetRelativePath(sourceFile, transformFileName);
-                if (transformation.IsTransformWildcard)
-                    fullTransformFilePath = relativeTransformPath;
-                else
-                    fullTransformFilePath = Path.GetFullPath(relativeTransformPath);
                 fullTransformDirectoryPath = Path.GetFullPath(Path.Combine(GetDirectoryName(sourceFile), GetDirectoryName(relativeTransformPath)));
             }
             


### PR DESCRIPTION
Was working fine when wildcard was at the start (`*.mytransform.config`) but not in the middle (`MyApp.*.mytransform.config`).

Fixes OctopusDeploy/Issues#2970