### PR TITLE
Added option to select the files that should be purged.

### DIFF
--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -92,6 +92,7 @@
             public static readonly string UpdateIisWebsiteName = "Octopus.Action.Package.UpdateIisWebsiteName";
             public static readonly string CustomInstallationDirectory = "Octopus.Action.Package.CustomInstallationDirectory";
             public static readonly string CustomInstallationDirectoryShouldBePurgedBeforeDeployment = "Octopus.Action.Package.CustomInstallationDirectoryShouldBePurgedBeforeDeployment";
+            public static readonly string CustomInstallationDirectoryPurgePaths = "Octopus.Action.Package.CustomInstallationDirectoryPurgePaths";
             public static readonly string AutomaticallyUpdateAppSettingsAndConnectionStrings = "Octopus.Action.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings";
             public static readonly string JsonConfigurationVariablesEnabled = "Octopus.Action.Package.JsonConfigurationVariablesEnabled";
             public static readonly string JsonConfigurationVariablesTargets = "Octopus.Action.Package.JsonConfigurationVariablesTargets";


### PR DESCRIPTION
This patch adds an extra option to select the files that should be purged and is a follow-up of #121 and OctopusDeploy/Issues#2943. But instead of an exclusion list this is an inclusion list. Our situation is that we have a website with a known structure. Extra files are added by an external system and we don't know the files/folders that are added. This means that we need to make sure that those files are left behind. Maybe it should be an option if the list is an exclude or include list though. I could add an extra setting to the special variables to set that.