### PR TITLE
Allow caller to customize package download retries

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
@@ -213,7 +213,7 @@ namespace Calamari.Azure.Deployment.Conventions
         /// <summary>
         /// For azure operations, try again after 1s then 2s, 4s etc...
         /// </summary>
-        static readonly RetryInterval RetryIntervalForAzureOperations = new RetryInterval(1000, 30000, 2);
+        static readonly LimitedExponentialRetryInterval RetryIntervalForAzureOperations = new LimitedExponentialRetryInterval(1000, 30000, 2);
 
         static RetryTracker GetRetryTracker()
         {

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/RetryFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/RetryFixture.cs
@@ -11,7 +11,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         public void ShouldThrowOnceRetriesExceeded()
         {
             const int retries = 100;
-            var subject = new RetryTracker(100, null, new RetryInterval(100, 200, 2));
+            var subject = new RetryTracker(100, null, new LimitedExponentialRetryInterval(100, 200, 2));
             Exception caught = null;
             var retried = 0;
 

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -235,13 +235,13 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         {
             using (var acmeWeb = CreateSamplePackage())
             {
-                var invalidFileShareUri = Path.Combine(acmeWeb.DirectoryPath, "InvalidPath");
+                var invalidFileShareUri = new Uri(Path.Combine(acmeWeb.DirectoryPath, "InvalidPath"));
 
-                var result = DownloadPackage(FileShare.PackageId, FileShare.Version, FileShare.Id, invalidFileShareUri);
+                var result = DownloadPackage(FileShare.PackageId, FileShare.Version, FileShare.Id, invalidFileShareUri.ToString());
                 result.AssertFailure();
 
-                result.AssertOutput("Downloading NuGet package {0} {1} from feed: '{2}'", FileShare.PackageId, FileShare.Version, new Uri(invalidFileShareUri));
-                result.AssertErrorOutput("Unable to download package: Path does not exist: '{0}'", new Uri(invalidFileShareUri));
+                result.AssertOutput("Downloading NuGet package {0} {1} from feed: '{2}'", FileShare.PackageId, FileShare.Version, invalidFileShareUri);
+                result.AssertErrorOutput("Failed to download package Acme.Web 1.0.0.0 from feed: '{0}'", invalidFileShareUri);
                 result.AssertErrorOutput("Failed to download package {0} {1} from feed: '{2}'", FileShare.PackageId, FileShare.Version, invalidFileShareUri);
             }
         }
@@ -339,14 +339,18 @@ namespace Calamari.Tests.Fixtures.PackageDownload
             string feedUri,
             string feedUsername = "",
             string feedPassword = "",
-            bool forcePackageDownload = false)
+            bool forcePackageDownload = false,
+            int attempts = 5,
+            int attemptBackoffSeconds = 0)
         {
             var calamari = Calamari()
                 .Action("download-package")
                 .Argument("packageId", packageId)
                 .Argument("packageVersion", packageVersion)
                 .Argument("feedId", feedId)
-                .Argument("feedUri", feedUri);
+                .Argument("feedUri", feedUri)
+                .Argument("attempts", attempts.ToString())
+                .Argument("attemptBackoffSeconds", attemptBackoffSeconds.ToString());
 
             if (!String.IsNullOrWhiteSpace(feedUsername))
                 calamari.Argument("feedUsername", feedUsername);

--- a/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -27,7 +27,7 @@ namespace Calamari.Integration.FileSystem
         /// <summary>
         /// For file operations, try again after 100ms and again every 200ms after that
         /// </summary>
-        static readonly RetryInterval RetryIntervalForFileOperations = new RetryInterval(100, 200, 2);
+        static readonly LimitedExponentialRetryInterval RetryIntervalForFileOperations = new LimitedExponentialRetryInterval(100, 200, 2);
 
         /// <summary>
         /// For file operations, retry constantly up to one minute

--- a/source/Calamari/Integration/Packages/NuGet/NuGetPackageDownloader.cs
+++ b/source/Calamari/Integration/Packages/NuGet/NuGetPackageDownloader.cs
@@ -51,7 +51,7 @@ namespace Calamari.Integration.Packages.NuGet
                     }
                     else
                     {
-                        var helpfulFailure = $"The package {packageId} version {version} could not be downloaded from the external feed '{feedUri}' after making {maxDownloadAttempts} attempts over a total of {Math.Floor(retry.TotalElapsed.TotalSeconds)}s. Make sure the package is pushed to the external feed and try the deployment again. If this is part of an automated deployment, make sure all packages are pushed to the external feed before starting the deployment. If the packages are pushed, perhaps the external feed hasn't finished updating its index and you need to give the external feed more time to update its index before starting the deployment. If you are getting a package verification error, try switching to a Windows File Share package repository to see if that helps.";
+                        var helpfulFailure = $"The package {packageId} version {version} could not be downloaded from the external feed '{feedUri}' after making {maxDownloadAttempts} attempts over a total of {Math.Floor(retry.TotalElapsed.TotalSeconds)}s. Make sure the package is pushed to the external feed and try the deployment again. For a detailed troubleshooting guide go to http://g.octopushq.com/TroubleshootMissingPackages";
                         helpfulFailure += $"{Environment.NewLine}{ex}";
 
                         throw new Exception(helpfulFailure, ex);

--- a/source/Calamari/Integration/Retry/LimitedExponentialRetryInterval.cs
+++ b/source/Calamari/Integration/Retry/LimitedExponentialRetryInterval.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Calamari.Integration.Retry
+{
+    /// <summary>
+    /// Implements exponential backoff timing for retry trackers
+    /// </summary>
+    /// <remarks>
+    /// e.g. For network operations, try again after 100ms, then double interval up to 5 seconds
+    /// new LimitedExponentialRetryInterval(100, 5000, 2);
+    ///</remarks>
+    public class LimitedExponentialRetryInterval : RetryInterval
+    {
+        readonly int retryInterval;
+        readonly int maxInterval;
+        readonly double multiplier;
+
+        public LimitedExponentialRetryInterval(int retryInterval, int maxInterval, double multiplier)
+        {
+            this.retryInterval = retryInterval;
+            this.maxInterval = maxInterval;
+            this.multiplier = multiplier;
+        }
+
+        public override int GetInterval(int retryCount)
+        {
+            double delayTime = retryInterval * Math.Pow(multiplier, retryCount);
+            if (delayTime > maxInterval) return maxInterval;
+            return (int)delayTime;
+        }
+    }
+}

--- a/source/Calamari/Integration/Retry/LinearRetryInterval.cs
+++ b/source/Calamari/Integration/Retry/LinearRetryInterval.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Calamari.Integration.Retry
+{
+    /// <summary>
+    /// Implements a linear backoff interval as retryCount * retryInterval
+    /// </summary>
+    public class LinearRetryInterval : RetryInterval
+    {
+        private readonly TimeSpan retryInterval;
+
+        public LinearRetryInterval(TimeSpan retryInterval)
+        {
+            this.retryInterval = retryInterval;
+        }
+
+        public override int GetInterval(int retryCount)
+        {
+            return (int)retryInterval.TotalMilliseconds * retryCount;
+        }
+    }
+}

--- a/source/Calamari/Integration/Retry/RetryInterval.cs
+++ b/source/Calamari/Integration/Retry/RetryInterval.cs
@@ -1,32 +1,7 @@
-﻿using System;
-
-namespace Calamari.Integration.Retry
+﻿namespace Calamari.Integration.Retry
 {
-    /// <summary>
-    /// Implements linear or exponential backoff timing for retry trackers
-    /// </summary>
-    /// <remarks>
-    /// e.g. For network operations, try again after 100ms, then double interval up to 5 seconds
-    /// new RetryInterval(100, 5000, 2);
-    ///</remarks>
-    public class RetryInterval
+    public abstract class RetryInterval
     {
-        readonly int retryInterval;
-        readonly int maxInterval;
-        readonly double multiplier;
-
-        public RetryInterval(int retryInterval, int maxInterval, double multiplier)
-        {
-            this.retryInterval = retryInterval;
-            this.maxInterval = maxInterval;
-            this.multiplier = multiplier;
-        }
-
-        public int GetInterval(int retryCount)
-        {
-            double delayTime = retryInterval * Math.Pow(multiplier, retryCount);
-            if (delayTime > maxInterval) return maxInterval;
-            return (int)delayTime;
-        }
+        public abstract int GetInterval(int retryCount);
     }
 }

--- a/source/Calamari/Integration/Retry/RetryTracker.cs
+++ b/source/Calamari/Integration/Retry/RetryTracker.cs
@@ -35,6 +35,8 @@ namespace Calamari.Integration.Retry
 
         public int CurrentTry { get { return currentTry; } }
 
+        public TimeSpan TotalElapsed => stopWatch.Value.Elapsed;
+
         public RetryTracker(int? maxRetries, TimeSpan? timeLimit, RetryInterval retryInterval, bool throwOnFailure = true)
         {
             this.maxRetries = maxRetries;

--- a/source/Calamari/Integration/Retry/RetryTracker.cs
+++ b/source/Calamari/Integration/Retry/RetryTracker.cs
@@ -40,7 +40,7 @@ namespace Calamari.Integration.Retry
         public RetryTracker(int? maxRetries, TimeSpan? timeLimit, RetryInterval retryInterval, bool throwOnFailure = true)
         {
             this.maxRetries = maxRetries;
-            if (maxRetries.HasValue && maxRetries.Value < 1) throw new ArgumentException("maxretries must be 1 or more if set");
+            if (maxRetries.HasValue && maxRetries.Value < 0) throw new ArgumentException("maxretries must be 0 or more if set");
             this.timeLimit = timeLimit;
             this.retryInterval = retryInterval;
             ThrowOnFailure = throwOnFailure;


### PR DESCRIPTION
See related OctopusDeploy PR: https://github.com/OctopusDeploy/OctopusDeploy/pull/704

The main driver for this is to allow the caller to increase total time we wait for external packages to become available where external feeds may take a long time to update their package index. It also lets us speed up the tests considerably!

In testing this I found and fixed quite a few other issues:

1. The loops were implemented differently and weren't actually retrying the right amount of times, nor with the right delays.
2. Spent time getting the log messages sorted out nicely so they balance legibility with detail.
3. Added more helpful "how to avoid this situation in the future" to put downward pressure on support.
4. It would be easy from here to add configuration to the Feed itself in Octopus Deploy for retry behaviour.

Related to https://github.com/OctopusDeploy/Issues/issues/3006