### PR TITLE
Fixed Azure Web App deploy to work with non-global Azure regions

### DIFF
--- a/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
+++ b/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
@@ -20,8 +20,8 @@ namespace Calamari.Azure.Integration.Websites.Publishing
         {
             var token = ServicePrincipal.GetAuthorizationToken(tenantId, applicationId, password, serviceManagementEndPoint, activeDirectoryEndPoint);
 
-            using (var resourcesClient = new ResourceManagementClient(new TokenCloudCredentials(subscriptionId, token)))
-            using (var webSiteClient = new WebSiteManagementClient(new TokenCredentials(token)) { SubscriptionId = subscriptionId})
+            using (var resourcesClient = new ResourceManagementClient(new TokenCloudCredentials(subscriptionId, token), new Uri(serviceManagementEndPoint)))
+            using (var webSiteClient = new WebSiteManagementClient(new Uri(serviceManagementEndPoint), new TokenCredentials(token)) { SubscriptionId = subscriptionId})
             {
                 // We may need to search all ResourceGroups, if one isn't specified.  New Step template will always provide the Resource Group, it is currently treated as optional here
                 // for backward compatibility.


### PR DESCRIPTION
I am working with Azure Germany, which requires specific API endpoints in order to deploy web apps. So far, Calamari did not fully respect the endpoints specified as variables. Therefore, I am passing the endpoint to the resource and website management clients.