### PR TITLE
Check to make sure custom package deployment script types are compatible with the OS

### DIFF
--- a/source/Calamari.Azure/Integration/AzurePowerShellScriptEngine.cs
+++ b/source/Calamari.Azure/Integration/AzurePowerShellScriptEngine.cs
@@ -7,9 +7,9 @@ namespace Calamari.Azure.Integration
 {
     public class AzurePowerShellScriptEngine : IScriptEngine
     {
-        public string[] GetSupportedExtensions()
+        public ScriptType[] GetSupportedTypes()
         {
-            return new[] { ScriptType.Powershell.FileExtension() };
+            return new[] { ScriptType.Powershell };
         }
 
         public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -109,7 +109,7 @@ namespace Calamari.Tests.Fixtures.Bash
                 .Argument("script", GetFixtureResouce("Scripts", "print-encoded-variable.sh")));
 
 
-            output.AssertErrorOutput("Script type `sh` unsupported on this platform");
+            output.AssertErrorOutput("Bash scripts are not supported on this platform");
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Conventions/FeatureScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/FeatureScriptConventionFixture.cs
@@ -32,7 +32,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             scriptEngine = Substitute.For<IScriptEngine>();
             commandLineRunner = Substitute.For<ICommandLineRunner>();
 
-            scriptEngine.GetSupportedExtensions().Returns(new string[] {"ps1"});
+            scriptEngine.GetSupportedTypes().Returns(new[] { ScriptType.Powershell });
 
             variables = new CalamariVariableDictionary();
             variables.Set(SpecialVariables.Package.EnabledFeatures, "Octopus.Features.blah");

--- a/source/Calamari.Tests/Fixtures/Conventions/PackagedScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/PackagedScriptConventionFixture.cs
@@ -34,7 +34,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             commandResult = new CommandResult("PowerShell.exe foo bar", 0, null);
             scriptEngine = Substitute.For<IScriptEngine>();
             scriptEngine.Execute(Arg.Any<Script>(), Arg.Any<CalamariVariableDictionary>(), Arg.Any<ICommandLineRunner>()).Returns(c => commandResult);
-            scriptEngine.GetSupportedExtensions().Returns(new[] {"csx", "ps1"});
+            scriptEngine.GetSupportedTypes().Returns(new[] {ScriptType.ScriptCS, ScriptType.Powershell});
             runner = Substitute.For<ICommandLineRunner>();
             deployment = new RunningDeployment(TestEnvironment.ConstructRootedPath("Packages"), new CalamariVariableDictionary());
         }

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -221,11 +221,11 @@ namespace Calamari.Tests.Fixtures.Deployment
 
             if (CalamariEnvironment.IsRunningOnNix || CalamariEnvironment.IsRunningOnMac)
             {
-                Variables.Set(ConfiguredScriptConvention.GetScriptName(DeploymentStages.Deploy, "sh"), "echo 'The wheels on the bus go round...'");
+                Variables.Set(ConfiguredScriptConvention.GetScriptName(DeploymentStages.Deploy, ScriptType.Bash), "echo 'The wheels on the bus go round...'");
             }
             else
             {
-                Variables.Set(ConfiguredScriptConvention.GetScriptName(DeploymentStages.Deploy, "ps1"), "Write-Host 'The wheels on the bus go round...'");
+                Variables.Set(ConfiguredScriptConvention.GetScriptName(DeploymentStages.Deploy, ScriptType.Powershell), "Write-Host 'The wheels on the bus go round...'");
             }
 
             var result = DeployPackage();

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -481,7 +481,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "Hello.ps1")));
 
-            output.AssertErrorOutput("Script type `ps1` unsupported on this platform");
+            output.AssertErrorOutput("Powershell scripts are not supported on this platform");
         }
     }
 }

--- a/source/Calamari/Deployment/Conventions/FeatureScriptConvention.cs
+++ b/source/Calamari/Deployment/Conventions/FeatureScriptConvention.cs
@@ -126,8 +126,8 @@ namespace Calamari.Deployment.Conventions
         /// </summary>
         private IEnumerable<string> GetScriptNames(string feature)
         {
-            return scriptEngine.GetSupportedExtensions() 
-                .Select(extension => GetScriptName(feature, deploymentStage, extension ));
+            return scriptEngine.GetSupportedTypes() 
+                .Select(type => GetScriptName(feature, deploymentStage, type.FileExtension()));
         }
 
     }

--- a/source/Calamari/Integration/Scripting/Bash/BashScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/Bash/BashScriptEngine.cs
@@ -6,9 +6,9 @@ namespace Calamari.Integration.Scripting.Bash
 {
     public class BashScriptEngine : IScriptEngine
     {
-        public string[] GetSupportedExtensions()
+        public ScriptType[] GetSupportedTypes()
         {
-            return new[] {ScriptType.Bash.FileExtension()};
+            return new[] {ScriptType.Bash};
         }
 
         public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)

--- a/source/Calamari/Integration/Scripting/FSharp/FSharpEngine.cs
+++ b/source/Calamari/Integration/Scripting/FSharp/FSharpEngine.cs
@@ -6,9 +6,9 @@ namespace Calamari.Integration.Scripting.FSharp
 {
     public class FSharpEngine : IScriptEngine
     {
-        public string[] GetSupportedExtensions()
+        public ScriptType[] GetSupportedTypes()
         {
-            return new[] {ScriptType.FSharp.FileExtension()};
+            return new[] {ScriptType.FSharp};
         }
 
         public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)

--- a/source/Calamari/Integration/Scripting/IScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/IScriptEngine.cs
@@ -4,7 +4,7 @@ namespace Calamari.Integration.Scripting
 {
     public interface IScriptEngine  
     {
-        string[] GetSupportedExtensions();
+        ScriptType[] GetSupportedTypes();
         CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner);
     }
 }

--- a/source/Calamari/Integration/Scripting/PackagedScriptRunner.cs
+++ b/source/Calamari/Integration/Scripting/PackagedScriptRunner.cs
@@ -50,7 +50,7 @@ namespace Calamari.Integration.Scripting
 
         IEnumerable<string> FindScripts(RunningDeployment deployment)
         {
-            var supportedScriptExtensions = scriptEngine.GetSupportedExtensions();
+            var supportedScriptExtensions = scriptEngine.GetSupportedTypes();
             var searchPatterns = supportedScriptExtensions.Select(e => "*." + e).ToArray();
             return
                 from file in fileSystem.EnumerateFiles(deployment.CurrentDirectory, searchPatterns)

--- a/source/Calamari/Integration/Scripting/PackagedScriptRunner.cs
+++ b/source/Calamari/Integration/Scripting/PackagedScriptRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Calamari.Commands.Support;
@@ -51,7 +52,7 @@ namespace Calamari.Integration.Scripting
         IEnumerable<string> FindScripts(RunningDeployment deployment)
         {
             var supportedScriptExtensions = scriptEngine.GetSupportedTypes();
-            var searchPatterns = supportedScriptExtensions.Select(e => "*." + e).ToArray();
+            var searchPatterns = supportedScriptExtensions.Select(e => "*." + e.FileExtension()).ToArray();
             return
                 from file in fileSystem.EnumerateFiles(deployment.CurrentDirectory, searchPatterns)
                 let nameWithoutExtension = Path.GetFileNameWithoutExtension(file)

--- a/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
@@ -6,9 +6,9 @@ namespace Calamari.Integration.Scripting.ScriptCS
 {
     public class ScriptCSScriptEngine : IScriptEngine
     {
-        public string[] GetSupportedExtensions()
+        public ScriptType[] GetSupportedTypes()
         {
-            return new[] {ScriptType.ScriptCS.FileExtension()};
+            return new[] {ScriptType.ScriptCS};
         }
 
         public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
@@ -6,9 +6,9 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
 {
     public class PowerShellScriptEngine : IScriptEngine
     {
-        public string[] GetSupportedExtensions()
+        public ScriptType[] GetSupportedTypes()
         {
-            return new[] {ScriptType.Powershell.FileExtension()};
+            return new[] {ScriptType.Powershell};
         }
 
         public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner)


### PR DESCRIPTION
… and throw an error if it not supported. Refactored how Engines declare the scripts they support.

Resolves https://github.com/OctopusDeploy/Issues/issues/2905