### PR TITLE
Config changes to support long paths in Windows 10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Calamari is the command-line tool invoked by Tentacle during a deployment. It knows how to extract and install NuGet packages, run the build.cmd etc. conventions, modify configuration files, and all the other things that happen during an deployment.
+Calamari is the command-line tool invoked by Tentacle during a deployment. It knows how to extract and install NuGet packages, run the Deploy.ps1 etc. conventions, modify configuration files, and all the other things that happen during an deployment.
 
 When the solution is built, a new Calamari package is created in the `built-packages` directory.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Calamari is the command-line tool invoked by Tentacle during a deployment. It knows how to extract and install NuGet packages, run the Deploy.ps1 etc. conventions, modify configuration files, and all the other things that happen during an deployment.
+Calamari is the command-line tool invoked by Tentacle during a deployment. It knows how to extract and install NuGet packages, run the build.cmd etc. conventions, modify configuration files, and all the other things that happen during an deployment.
 
 When the solution is built, a new Calamari package is created in the `built-packages` directory.
 

--- a/source/Calamari/app.config
+++ b/source/Calamari/app.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
- Calamari fails to deploy if the path of folders that longer than 240 characters.
- I updated the config file based on https://blogs.msdn.microsoft.com/jeremykuhne/2016/07/30/net-4-6-2-and-long-paths-on-windows-10/ and it works