### PR TITLE
Extra logging for Azure endpoint overrides

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
@@ -72,12 +72,22 @@ namespace Calamari.Azure.Deployment.Conventions
             var siteName = variables.Get(SpecialVariables.Action.Azure.WebAppName);
 
             var accountType = variables.Get(SpecialVariables.Account.AccountType);
-            var activeDirectoryEndpoint = variables.Get(SpecialVariables.Action.Azure.ActiveDirectoryEndPoint, DefaultVariables.ActiveDirectoryEndpoint);
 
             switch (accountType)
             {
                 case AzureAccountTypes.ServicePrincipalAccountType:
                     var resourceManagementEndpoint = variables.Get(SpecialVariables.Action.Azure.ResourceManagementEndPoint, DefaultVariables.ResourceManagementEndpoint);
+                    if (resourceManagementEndpoint != DefaultVariables.ResourceManagementEndpoint)
+                    {
+                        Log.Info("Using override for resource management endpoint - {0}", resourceManagementEndpoint);
+                    }
+
+                    var activeDirectoryEndpoint = variables.Get(SpecialVariables.Action.Azure.ActiveDirectoryEndPoint, DefaultVariables.ActiveDirectoryEndpoint);
+                    if (activeDirectoryEndpoint != DefaultVariables.ActiveDirectoryEndpoint)
+                    {
+                        Log.Info("Using override for Azure Active Directory endpoint - {0}", activeDirectoryEndpoint);
+                    }
+
                     return ResourceManagerPublishProfileProvider.GetPublishProperties(subscriptionId,
                         variables.Get(SpecialVariables.Action.Azure.ResourceGroupName, string.Empty),
                         siteName,
@@ -89,6 +99,10 @@ namespace Calamari.Azure.Deployment.Conventions
 
                 case AzureAccountTypes.ManagementCertificateAccountType:
                     var serviceManagementEndpoint = variables.Get(SpecialVariables.Action.Azure.ServiceManagementEndPoint, DefaultVariables.ServiceManagementEndpoint);
+                    if (serviceManagementEndpoint != DefaultVariables.ServiceManagementEndpoint)
+                    {
+                        Log.Info("Using override for service management endpoint - {0}", serviceManagementEndpoint);
+                    }
                     return ServiceManagementPublishProfileProvider.GetPublishProperties(subscriptionId,
                         Convert.FromBase64String(variables.Get(SpecialVariables.Action.Azure.CertificateBytes)),
                         siteName,

--- a/source/Calamari.Azure/Deployment/Conventions/DeployAzureResourceGroupConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/DeployAzureResourceGroupConvention.cs
@@ -46,7 +46,12 @@ namespace Calamari.Azure.Deployment.Conventions
             var tenantId = variables[SpecialVariables.Action.Azure.TenantId];
             var clientId = variables[SpecialVariables.Action.Azure.ClientId];
             var password = variables[SpecialVariables.Action.Azure.Password];
-            var serviceManagementEndPoint = variables.Get(SpecialVariables.Action.Azure.ServiceManagementEndPoint, DefaultVariables.ServiceManagementEndpoint);
+            var resourceManagementEndpoint = variables.Get(SpecialVariables.Action.Azure.ResourceManagementEndPoint, DefaultVariables.ResourceManagementEndpoint);
+            if (resourceManagementEndpoint != DefaultVariables.ResourceManagementEndpoint)
+            {
+                Log.Info("Using override for resource management endpoint - {0}", resourceManagementEndpoint);
+            }
+
             var activeDirectoryEndPoint = variables.Get(SpecialVariables.Action.Azure.ActiveDirectoryEndPoint, DefaultVariables.ActiveDirectoryEndpoint);
             var resourceGroupName = variables[SpecialVariables.Action.Azure.ResourceGroupName];
             var deploymentName = !string.IsNullOrWhiteSpace(variables[SpecialVariables.Action.Azure.ResourceGroupDeploymentName])
@@ -63,7 +68,7 @@ namespace Calamari.Azure.Deployment.Conventions
                 $"Deploying Resource Group {resourceGroupName} in subscription {subscriptionId}.\nDeployment name: {deploymentName}\nDeployment mode: {deploymentMode}");
 
             // We re-create the client each time it is required in order to get a new authorization-token. Else, the token can expire during long-running deployments.
-            Func<IResourceManagementClient> createArmClient = () => new ResourceManagementClient(new TokenCloudCredentials(subscriptionId, ServicePrincipal.GetAuthorizationToken(tenantId, clientId, password,serviceManagementEndPoint, activeDirectoryEndPoint)));
+            Func<IResourceManagementClient> createArmClient = () => new ResourceManagementClient(new TokenCloudCredentials(subscriptionId, ServicePrincipal.GetAuthorizationToken(tenantId, clientId, password, resourceManagementEndpoint, activeDirectoryEndPoint)));
 
             CreateDeployment(createArmClient, resourceGroupName, deploymentName, deploymentMode, template, parameters);
             PollForCompletion(createArmClient, resourceGroupName, deploymentName, variables);

--- a/source/Calamari.Azure/Integration/AzurePowershellContext.cs
+++ b/source/Calamari.Azure/Integration/AzurePowershellContext.cs
@@ -42,7 +42,12 @@ namespace Calamari.Azure.Integration
 
             SetOutputVariable(SpecialVariables.Action.Azure.Output.SubscriptionId, variables.Get(SpecialVariables.Action.Azure.SubscriptionId), variables);
             SetOutputVariable("OctopusAzureStorageAccountName", variables.Get(SpecialVariables.Action.Azure.StorageAccountName), variables);
-            SetOutputVariable("OctopusAzureEnvrionment",variables.Get(SpecialVariables.Action.Azure.Environment, DefaultAzureEnvironment),variables);
+            var azureEnvironment = variables.Get(SpecialVariables.Action.Azure.Environment, DefaultAzureEnvironment);
+            if (azureEnvironment != DefaultAzureEnvironment)
+            {
+                Log.Info("Using Azure Environment override - {0}", azureEnvironment);
+            }
+            SetOutputVariable("OctopusAzureEnvironment", azureEnvironment, variables);
 
             using (new TemporaryFile(Path.Combine(workingDirectory, "AzureProfile.json")))
             using (var contextScriptFile = new TemporaryFile(CreateContextScriptFile(workingDirectory)))

--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -17,7 +17,7 @@
 ##   $OctopusAzureADTenantId = "...."
 ##   $OctopusAzureADClientId = "...."
 ##   $OctopusAzureADPassword = "...."
-##   $OctopusAzureEnvrionment = "...."
+##   $OctopusAzureEnvironment = "...."
 
 $ErrorActionPreference = "Stop"
 
@@ -65,10 +65,10 @@ Execute-WithRetry{
         # Authenticate via Service Principal
         $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
         $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
-        $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvrionment
+        $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
         if (!$AzureEnvironment)
         {
-            Write-Error "No Azure environment could be matched given name $OctopusAzureEnvrionment"
+            Write-Error "No Azure environment could be matched given name $OctopusAzureEnvironment"
             exit -2
         }
 
@@ -79,11 +79,11 @@ Execute-WithRetry{
         Write-Verbose "Loading the management certificate"
         Add-Type -AssemblyName "System"
         $certificate = new-object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList @($OctopusAzureCertificateFileName, $OctopusAzureCertificatePassword, ([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags] "PersistKeySet", "Exportable"))
-        $AzureEnvironment = Get-AzureEnvironment | Where-Object {$_.Name -eq $OctopusAzureEnvrionment}
+        $AzureEnvironment = Get-AzureEnvironment | Where-Object {$_.Name -eq $OctopusAzureEnvironment}
 
         if (!$AzureEnvironment)
         {
-            Write-Error "No Azure environment could be matched given name $OctopusAzureEnvrionment"
+            Write-Error "No Azure environment could be matched given name $OctopusAzureEnvironment"
             exit -2
         }
 


### PR DESCRIPTION
Added extra logging info when the endpoints are being overridden.

DeployAzureResourceGroupConvention was also using Service endpoint instead of Resource endpoint.

Relates to OctopusDeploy/Issues#2628