### PR TITLE
Added option that something something base64 something someline new lines

### DIFF
--- a/source/Calamari/Integration/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari/Integration/Scripting/Bash/Bootstrap.sh
@@ -33,7 +33,7 @@ function decode_servicemessagevalue
 # -----------------------------------------------------------------------------
 function decrypt_variable
 {
-	echo $1 | openssl enc -a -d -aes-128-cbc -nosalt -K $sensitiveVariableKey -iv $2
+	echo $1 | openssl enc -a -A -d -aes-128-cbc -nosalt -K $sensitiveVariableKey -iv $2
 }
 
 #	---------------------------------------------------------------------------


### PR DESCRIPTION
The `-A` option causes openssl to accept base64 strings that don't have line breaks every 64 characters. Why it works without that option in later versions of OpenSSL is a mystery that is wrapped in an enigma.

Fixes OctopusDeploy/Issues#3122