### PR TITLE
Fix for Resource Group deployments in alternate Azure environments

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/DeployAzureResourceGroupConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/DeployAzureResourceGroupConvention.cs
@@ -53,6 +53,11 @@ namespace Calamari.Azure.Deployment.Conventions
             }
 
             var activeDirectoryEndPoint = variables.Get(SpecialVariables.Action.Azure.ActiveDirectoryEndPoint, DefaultVariables.ActiveDirectoryEndpoint);
+            if (activeDirectoryEndPoint != DefaultVariables.ActiveDirectoryEndpoint)
+            {
+                Log.Info("Using override for Azure Active Directory endpoint - {0}", activeDirectoryEndPoint);
+            }
+
             var resourceGroupName = variables[SpecialVariables.Action.Azure.ResourceGroupName];
             var deploymentName = !string.IsNullOrWhiteSpace(variables[SpecialVariables.Action.Azure.ResourceGroupDeploymentName])
                     ? variables[SpecialVariables.Action.Azure.ResourceGroupDeploymentName]
@@ -68,7 +73,7 @@ namespace Calamari.Azure.Deployment.Conventions
                 $"Deploying Resource Group {resourceGroupName} in subscription {subscriptionId}.\nDeployment name: {deploymentName}\nDeployment mode: {deploymentMode}");
 
             // We re-create the client each time it is required in order to get a new authorization-token. Else, the token can expire during long-running deployments.
-            Func<IResourceManagementClient> createArmClient = () => new ResourceManagementClient(new TokenCloudCredentials(subscriptionId, ServicePrincipal.GetAuthorizationToken(tenantId, clientId, password, resourceManagementEndpoint, activeDirectoryEndPoint)));
+            Func<IResourceManagementClient> createArmClient = () => new ResourceManagementClient(new TokenCloudCredentials(subscriptionId, ServicePrincipal.GetAuthorizationToken(tenantId, clientId, password, resourceManagementEndpoint, activeDirectoryEndPoint)), new Uri(resourceManagementEndpoint));
 
             CreateDeployment(createArmClient, resourceGroupName, deploymentName, deploymentMode, template, parameters);
             PollForCompletion(createArmClient, resourceGroupName, deploymentName, variables);


### PR DESCRIPTION
resource management endpoint override was being passed in some but not all the right places when creating the ResourceManagementClient for Resource Group deployments

Relates to Octopus/Issues#3184