### PR TITLE
Updated Bindings-AreCorrect method to improve performance

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -557,10 +557,6 @@ if ($deployAsWebSite)
 	Assign-ToApplicationPool -iisPath $sitePath -applicationPoolName $applicationPoolName
 	Set-Path -virtualPath $sitePath -physicalPath $webRoot
 
-	function Bindings-AreEqual($bindingA, $bindingB) {
-		return ($bindingA.protocol -eq $bindingB.protocol) -and ($bindingA.bindingInformation -eq $bindingB.bindinginformation) -and ($bindingA.sslFlags -eq $bindingB.sslFlags)
-	}
-	
 	function Convert-ToHashTable($bindingArray) {
 		$hash = @{}
 		$bindingArray | %{

--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -560,14 +560,31 @@ if ($deployAsWebSite)
 	function Bindings-AreEqual($bindingA, $bindingB) {
 		return ($bindingA.protocol -eq $bindingB.protocol) -and ($bindingA.bindingInformation -eq $bindingB.bindinginformation) -and ($bindingA.sslFlags -eq $bindingB.sslFlags)
 	}
+	
+	function Convert-ToHashTable($bindingArray) {
+		$hash = @{}
+		$bindingArray | %{
+		    $key = Get-BindingKey $_
+		    $hash[$key] = $_
+		}
+		return $hash
+	}
+
+	function Get-BindingKey($binding) {
+		return $binding.protocol + "|" + $binding.bindingInformation + "|" + $binding.sslFlags
+	}
 
 	# Returns $true if existing IIS bindings are as specified in configuration, otherwise $false
 	function Bindings-AreCorrect($existingBindings, $configuredBindings) {
+		$existingBindingsLookup = Convert-ToHashTable $existingBindings.Collection
+		$configuredBindingsLookup = Convert-ToHashTable $configuredBindings
+	
 		# Are there existing assigned bindings that are not configured
 		for ($i = 0; $i -lt $existingBindings.Collection.Count; $i = $i+1) {
 			$binding = $existingBindings.Collection[$i]
+			$bindingKey = Get-BindingKey $binding
 
-			$matching = $configuredBindings | Where-Object {Bindings-AreEqual $binding $_ }
+			$matching = $configuredBindingsLookup[$bindingKey]
 		
 			if ($matching -eq $null) {
 				Write-Host "Found existing non-configured binding: $($binding.protocol) $($binding.bindingInformation)"
@@ -578,8 +595,9 @@ if ($deployAsWebSite)
 		# Are there configured bindings which are not assigned
 		for ($i = 0; $i -lt $configuredBindings.Count; $i = $i+1) {
 			$wsbinding = $configuredBindings[$i]
+            		$wsBindingKey = Get-BindingKey $wsbinding
 
-			$matching = $existingBindings.Collection | Where-Object {Bindings-AreEqual $wsbinding $_ }
+			$matching = $existingBindingsLookup[$wsBindingKey]
 
 			if ($matching -eq $null) {
 				Write-Host "Found configured binding which is not assigned: $($wsbinding.protocol) $($wsbinding.bindingInformation)"


### PR DESCRIPTION
The existing Bindings-AreCorrect method is noticeably slow when dealing with a large number of bindings e.g. 500+. The check to find a matching binding has been updated to use a hashtable to improve the performance.