### PR TITLE
Globbing support in 'Substitute variables in files' and 'JSON configuration variables'

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////
 // TOOLS
 //////////////////////////////////////////////////////////////////////
-#tool "nuget:?package=GitVersion.CommandLine&version=4.0.0-beta0007"
+#tool "nuget:?package=GitVersion.CommandLine&version=4.0.0-beta0009"
 #addin "MagicChunks"
 
 using Path = System.IO.Path;

--- a/source/Calamari.Tests/Fixtures/Conventions/JsonConfigurationVariablesConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/JsonConfigurationVariablesConventionFixture.cs
@@ -41,7 +41,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         [Test]
         public void ShouldFindAndCallModifyOnTargetFile()
         {
-            fileSystem.EnumerateFiles(Arg.Any<string>(), "appsettings.environment.json")
+            fileSystem.EnumerateFilesWithGlob(Arg.Any<string>(), "appsettings.environment.json")
                 .Returns(new[] {TestEnvironment.ConstructRootedPath("applications" ,"Acme", "1.0.0", "appsettings.environment.json")});
 
             deployment.Variables.Set(SpecialVariables.Package.JsonConfigurationVariablesEnabled, "true");
@@ -61,9 +61,9 @@ namespace Calamari.Tests.Fixtures.Conventions
                 "config.prod.json"
             };
 
-            fileSystem.EnumerateFiles(Arg.Any<string>(), "config.json")
+            fileSystem.EnumerateFilesWithGlob(Arg.Any<string>(), "config.json")
                 .Returns(new[] {targetFiles[0]}.Select(t => TestEnvironment.ConstructRootedPath("applications", "Acme", "1.0.0", t)));
-            fileSystem.EnumerateFiles(Arg.Any<string>(), "config.*.json")
+            fileSystem.EnumerateFilesWithGlob(Arg.Any<string>(), "config.*.json")
                 .Returns(targetFiles.Skip(1).Select(t => TestEnvironment.ConstructRootedPath("applications", "Acme", "1.0.0", t)));
 
             deployment.Variables.Set(SpecialVariables.Package.JsonConfigurationVariablesEnabled, "true");

--- a/source/Calamari.Tests/Fixtures/Conventions/SubstituteInFilesConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/SubstituteInFilesConventionFixture.cs
@@ -38,60 +38,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         }
 
         [Test]
-        [TestCase(@"**/*.txt", "f1.txt", 2)]
-        [TestCase(@"**/*.txt", "r.txt", 2)]
-        [TestCase(@"*.txt", "r.txt")]
-        [TestCase(@"**/*.config", "root.config", 5)]
-        [TestCase(@"*.config", "root.config")]
-        [TestCase(@"Config/*.config", "c.config")]
-        [TestCase(@"Config/Feature1/*.config", "f1-a.config", 2)]
-        [TestCase(@"Config/Feature1/*.config", "f1-b.config", 2)]
-        [TestCase(@"Config/Feature2/*.config", "f2.config")]
-        public void GlobTestMutiple(string pattern, string expectedFileMatchName, int expectedQty = 1)
-        {
-            var realFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-            var rootPath = realFileSystem.CreateTemporaryDirectory();
-            var content = "file-content" + Environment.NewLine;
-
-            if (CalamariEnvironment.IsRunningOnWindows)
-            {
-                pattern = pattern.Replace(@"/", @"\");
-            }
-
-            try
-            {
-                var configPath = Path.Combine(rootPath, "Config");
-
-                realFileSystem.CreateDirectory(configPath);
-                realFileSystem.CreateDirectory(Path.Combine(configPath, "Feature1"));
-                realFileSystem.CreateDirectory(Path.Combine(configPath, "Feature2"));
-
-                Action<string, string, string> writeFile = (p1, p2, p3) => 
-                    realFileSystem.OverwriteFile(p3 == null ? Path.Combine(p1, p2) : Path.Combine(p1, p2, p3), content);
-
-                // NOTE: create all the files in *every case*, and TestCases help supply the assert expectations
-                writeFile(rootPath, "root.config", null);
-                writeFile(rootPath, "r.txt", null);
-                writeFile(configPath, "c.config", null);
-
-                writeFile(configPath, "Feature1", "f1.txt");
-                writeFile(configPath, "Feature1", "f1-a.config");
-                writeFile(configPath, "Feature1", "f1-b.config");
-                writeFile(configPath, "Feature2", "f2.config");
-
-                var result = Glob.Expand(Path.Combine(rootPath, pattern)).ToList();
-
-                Assert.AreEqual(expectedQty, result.Count, $"{pattern} should have found {expectedQty}, but found {result.Count}");
-                Assert.True(result.Any(r => r.Name.Equals(expectedFileMatchName)), $"{pattern} should have found {expectedFileMatchName}, but didn't");
-            }
-            finally
-            {
-                realFileSystem.DeleteDirectory(rootPath);
-            }
-        }
-
-        [Test]
-        public void ShouldPerformSubstitutionsWithGlobs()
+        public void ShouldPerformSubstitutions()
         {
             string glob = "**\\*config.json";
             string actualMatch = "config.json";

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSytemFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSytemFixture.cs
@@ -91,5 +91,57 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             return filename;
         }
 
+        [Test]
+        [TestCase(@"**/*.txt", "f1.txt", 2)]
+        [TestCase(@"**/*.txt", "r.txt", 2)]
+        [TestCase(@"*.txt", "r.txt")]
+        [TestCase(@"**/*.config", "root.config", 5)]
+        [TestCase(@"*.config", "root.config")]
+        [TestCase(@"Config/*.config", "c.config")]
+        [TestCase(@"Config/Feature1/*.config", "f1-a.config", 2)]
+        [TestCase(@"Config/Feature1/*.config", "f1-b.config", 2)]
+        [TestCase(@"Config/Feature2/*.config", "f2.config")]
+        public void GlobTestMutiple(string pattern, string expectedFileMatchName, int expectedQty = 1)
+        {
+            var realFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+            var rootPath = realFileSystem.CreateTemporaryDirectory();
+            var content = "file-content" + Environment.NewLine;
+
+            if (CalamariEnvironment.IsRunningOnWindows)
+            {
+                pattern = pattern.Replace(@"/", @"\");
+            }
+
+            try
+            {
+                var configPath = Path.Combine(rootPath, "Config");
+
+                realFileSystem.CreateDirectory(configPath);
+                realFileSystem.CreateDirectory(Path.Combine(configPath, "Feature1"));
+                realFileSystem.CreateDirectory(Path.Combine(configPath, "Feature2"));
+
+                Action<string, string, string> writeFile = (p1, p2, p3) =>
+                    realFileSystem.OverwriteFile(p3 == null ? Path.Combine(p1, p2) : Path.Combine(p1, p2, p3), content);
+
+                // NOTE: create all the files in *every case*, and TestCases help supply the assert expectations
+                writeFile(rootPath, "root.config", null);
+                writeFile(rootPath, "r.txt", null);
+                writeFile(configPath, "c.config", null);
+
+                writeFile(configPath, "Feature1", "f1.txt");
+                writeFile(configPath, "Feature1", "f1-a.config");
+                writeFile(configPath, "Feature1", "f1-b.config");
+                writeFile(configPath, "Feature2", "f2.config");
+
+                var result = Glob.Expand(Path.Combine(rootPath, pattern)).ToList();
+
+                Assert.AreEqual(expectedQty, result.Count, $"{pattern} should have found {expectedQty}, but found {result.Count}");
+                Assert.True(result.Any(r => r.Name.Equals(expectedFileMatchName)), $"{pattern} should have found {expectedFileMatchName}, but didn't");
+            }
+            finally
+            {
+                realFileSystem.DeleteDirectory(rootPath);
+            }
+        }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSytemFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSytemFixture.cs
@@ -103,8 +103,8 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         [TestCase(@"Config/Feature2/*.config", "f2.config")]
         public void GlobTestMutiple(string pattern, string expectedFileMatchName, int expectedQty = 1)
         {
-            var realFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-            var rootPath = realFileSystem.CreateTemporaryDirectory();
+            var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+            var rootPath = fileSystem.CreateTemporaryDirectory();
             var content = "file-content" + Environment.NewLine;
 
             if (CalamariEnvironment.IsRunningOnWindows)
@@ -116,12 +116,12 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             {
                 var configPath = Path.Combine(rootPath, "Config");
 
-                realFileSystem.CreateDirectory(configPath);
-                realFileSystem.CreateDirectory(Path.Combine(configPath, "Feature1"));
-                realFileSystem.CreateDirectory(Path.Combine(configPath, "Feature2"));
+                Directory.CreateDirectory(configPath);
+                Directory.CreateDirectory(Path.Combine(configPath, "Feature1"));
+                Directory.CreateDirectory(Path.Combine(configPath, "Feature2"));
 
                 Action<string, string, string> writeFile = (p1, p2, p3) =>
-                    realFileSystem.OverwriteFile(p3 == null ? Path.Combine(p1, p2) : Path.Combine(p1, p2, p3), content);
+                    fileSystem.OverwriteFile(p3 == null ? Path.Combine(p1, p2) : Path.Combine(p1, p2, p3), content);
 
                 // NOTE: create all the files in *every case*, and TestCases help supply the assert expectations
                 writeFile(rootPath, "root.config", null);
@@ -140,7 +140,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             }
             finally
             {
-                realFileSystem.DeleteDirectory(rootPath);
+                fileSystem.DeleteDirectory(rootPath);
             }
         }
     }

--- a/source/Calamari/Deployment/Conventions/JsonConfigurationVariablesConvention.cs
+++ b/source/Calamari/Deployment/Conventions/JsonConfigurationVariablesConvention.cs
@@ -48,11 +48,11 @@ namespace Calamari.Deployment.Conventions
 
         private List<string> MatchingFiles(RunningDeployment deployment, string target)
         {
-            var files = fileSystem.EnumerateFiles(deployment.CurrentDirectory, target).Select(Path.GetFullPath).ToList();
+            var files = fileSystem.EnumerateFilesWithGlob(deployment.CurrentDirectory, target).Select(Path.GetFullPath).ToList();
 
             foreach (var path in deployment.Variables.GetStrings(SpecialVariables.Action.AdditionalPaths).Where(s => !string.IsNullOrWhiteSpace(s)))
             {
-                var pathFiles = fileSystem.EnumerateFiles(path, target).Select(Path.GetFullPath);
+                var pathFiles = fileSystem.EnumerateFilesWithGlob(path, target).Select(Path.GetFullPath);
                 files.AddRange(pathFiles);
             }
 

--- a/source/Calamari/Deployment/Conventions/SubstituteInFilesConvention.cs
+++ b/source/Calamari/Deployment/Conventions/SubstituteInFilesConvention.cs
@@ -43,11 +43,12 @@ namespace Calamari.Deployment.Conventions
 
         private List<string> MatchingFiles(RunningDeployment deployment, string target)
         {
-            var files = fileSystem.EnumerateFiles(deployment.CurrentDirectory, target).Select(Path.GetFullPath).ToList();
+            var files = fileSystem.EnumerateFilesWithGlob(deployment.CurrentDirectory, target).Select(Path.GetFullPath).ToList();
 
-            foreach (var path in deployment.Variables.GetStrings(SpecialVariables.Action.AdditionalPaths).Where(s => !string.IsNullOrWhiteSpace(s)))
+            foreach (var path in deployment.Variables.GetStrings(SpecialVariables.Action.AdditionalPaths)
+                .Where(s => !string.IsNullOrWhiteSpace(s)))
             {
-                var pathFiles = fileSystem.EnumerateFiles(path, target).Select(Path.GetFullPath);
+                var pathFiles = fileSystem.EnumerateFilesWithGlob(path, target).Select(Path.GetFullPath);
                 files.AddRange(pathFiles);
             }
 

--- a/source/Calamari/Glob.cs
+++ b/source/Calamari/Glob.cs
@@ -1,0 +1,563 @@
+﻿// Based on Glob.cs from https://github.com/mganss/Glob.cs/
+// NuGet is licensed under the Apache license: https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Collections.Concurrent;
+
+namespace Calamari
+{
+    /// <summary>
+    /// Finds files and directories by matching their path names against a pattern.
+    /// </summary>
+    public class Glob
+    {
+        /// <summary>
+        /// Gets or sets a value indicating the pattern to match file and directory names against.
+        /// The pattern can contain the following special characters:
+        /// <list type="table">
+        /// <item>
+        /// <term>?</term>
+        /// <description>Matches any single character in a file or directory name.</description>
+        /// </item>
+        /// <item>
+        /// <term>*</term>
+        /// <description>Matches zero or more characters in a file or directory name.</description>
+        /// </item>
+        /// <item>
+        /// <term>**</term>
+        /// <description>Matches zero or more recursve directories.</description>
+        /// </item>
+        /// <item>
+        /// <term>[...]</term>
+        /// <description>Matches a set of characters in a name. Syntax is equivalent to character groups in <see cref="System.Text.RegularExpressions.Regex"/>.</description>
+        /// </item>
+        /// <item>
+        /// <term>{group1,group2,...}</term>
+        /// <description>Matches any of the pattern groups. Groups can contain groups and patterns.</description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        public string Pattern { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating an action to be performed when an error occurs during pattern matching.
+        /// </summary>
+        public Action<string> ErrorLog { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating that a running pattern match should be cancelled.
+        /// </summary>
+        public bool Cancelled { get; private set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether exceptions that occur during matching should be rethrown. Default is false.
+        /// </summary>
+        public bool ThrowOnError { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether case should be ignored in file and directory names. Default is true.
+        /// </summary>
+        public bool IgnoreCase { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether only directories should be matched. Default is false.
+        /// </summary>
+        public bool DirectoriesOnly { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether <see cref="Regex"/> objects should be cached. Default is true.
+        /// </summary>
+        public bool CacheRegexes { get; set; }
+
+        /// <summary>
+        /// Cancels a running pattern match.
+        /// </summary>
+        public void Cancel()
+        {
+            Cancelled = true;
+        }
+
+        private void Log(string s, params object[] args)
+        {
+            if (ErrorLog != null) ErrorLog(string.Format(s, args));
+        }
+
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        public Glob()
+        {
+            IgnoreCase = true;
+            CacheRegexes = true;
+        }
+
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        /// <param name="pattern">The pattern to be matched. See <see cref="Pattern"/> for syntax.</param>
+        public Glob(string pattern): this()
+        {
+            Pattern = pattern;
+        }
+
+        /// <summary>
+        /// Performs a pattern match.
+        /// </summary>
+        /// <param name="pattern">The pattern to be matched.</param>
+        /// <param name="ignoreCase">true if case should be ignored; false, otherwise.</param>
+        /// <param name="dirOnly">true if only directories shoud be matched; false, otherwise.</param>
+        /// <returns>The matched path names</returns>
+        public static IEnumerable<string> ExpandNames(string pattern, bool ignoreCase = true, bool dirOnly = false)
+        {
+            return new Glob(pattern) { IgnoreCase = ignoreCase, DirectoriesOnly = dirOnly }.ExpandNames();
+        }
+
+        /// <summary>
+        /// Performs a pattern match.
+        /// </summary>
+        /// <param name="pattern">The pattern to be matched.</param>
+        /// <param name="ignoreCase">true if case should be ignored; false, otherwise.</param>
+        /// <param name="dirOnly">true if only directories shoud be matched; false, otherwise.</param>
+        /// <returns>The matched <see cref="FileSystemInfo"/> objects</returns>
+        public static IEnumerable<FileSystemInfo> Expand(string pattern, bool ignoreCase = true, bool dirOnly = false)
+        {
+            return new Glob(pattern) { IgnoreCase = ignoreCase, DirectoriesOnly = dirOnly }.Expand();
+        }
+
+        /// <summary>
+        /// Performs a pattern match.
+        /// </summary>
+        /// <returns>The matched path names</returns>
+        public IEnumerable<string> ExpandNames()
+        {
+            return Expand(Pattern, DirectoriesOnly).Select(f => f.FullName);
+        }
+
+        /// <summary>
+        /// Performs a pattern match.
+        /// </summary>
+        /// <returns>The matched <see cref="FileSystemInfo"/> objects</returns>
+        public IEnumerable<FileSystemInfo> Expand()
+        {
+            return Expand(Pattern, DirectoriesOnly);
+        }
+
+        class RegexOrString
+        {
+            public Regex Regex { get; set; }
+            public string Pattern { get; set; }
+            public bool IgnoreCase { get; set; }
+
+            public RegexOrString(string pattern, string rawString, bool ignoreCase, bool compileRegex)
+            {
+                IgnoreCase = ignoreCase;
+
+                try
+                {
+                    Regex = new Regex(pattern, RegexOptions.CultureInvariant | (ignoreCase ? RegexOptions.IgnoreCase : 0)
+                        | (compileRegex ? RegexOptions.Compiled : 0));
+                    Pattern = pattern;
+                }
+                catch
+                {
+                    Pattern = rawString;
+                }
+            }
+
+            public bool IsMatch(string input)
+            {
+                return Regex != null ? Regex.IsMatch(input) : Pattern.Equals(input, IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+            }
+        }
+
+        private static ConcurrentDictionary<string, RegexOrString> RegexOrStringCache = new ConcurrentDictionary<string, RegexOrString>();
+
+        private RegexOrString CreateRegexOrString(string pattern)
+        {
+            if (!CacheRegexes) return new RegexOrString(GlobToRegex(pattern), pattern, IgnoreCase, compileRegex: false);
+
+            RegexOrString regexOrString;
+
+            if (!RegexOrStringCache.TryGetValue(pattern, out regexOrString))
+            {
+                regexOrString = new RegexOrString(GlobToRegex(pattern), pattern, IgnoreCase, compileRegex: true);
+                RegexOrStringCache[pattern] = regexOrString;
+            }
+
+            return regexOrString;
+        }
+
+        private static char[] GlobCharacters = "*?[]{}".ToCharArray();
+
+        private IEnumerable<FileSystemInfo> Expand(string path, bool dirOnly)
+        {
+            if (Cancelled) yield break;
+
+            if (string.IsNullOrEmpty(path))
+            {
+                yield break;
+            }
+
+            // stop looking if there are no more glob characters in the path.
+            // but only if ignoring case because FileSystemInfo.Exists always ignores case.
+            if (IgnoreCase && path.IndexOfAny(GlobCharacters) < 0)
+            {
+                FileSystemInfo fsi = null;
+                bool exists = false;
+
+                try
+                {
+                    fsi = dirOnly ? (FileSystemInfo)new DirectoryInfo(path) : new FileInfo(path);
+                    exists = fsi.Exists;
+                }
+                catch (Exception ex)
+                {
+                    Log("Error getting FileSystemInfo for '{0}': {1}", path, ex);
+                    if (ThrowOnError) throw;
+                }
+
+                if (exists) yield return fsi;
+                yield break;
+            }
+
+            string parent = null;
+
+            try
+            {
+                parent = Path.GetDirectoryName(path);
+            }
+            catch (Exception ex)
+            {
+                Log("Error getting directory name for '{0}': {1}", path, ex);
+                if (ThrowOnError) throw;
+                yield break;
+            }
+
+            if (parent == null)
+            {
+                DirectoryInfo dir = null;
+
+                try
+                {
+                    dir = new DirectoryInfo(path);
+                }
+                catch (Exception ex)
+                {
+                    Log("Error getting DirectoryInfo for '{0}': {1}", path, ex);
+                    if (ThrowOnError) throw;
+                }
+
+                if (dir != null) yield return dir;
+                yield break;
+            }
+
+            if (parent == "")
+            {
+                try
+                {
+                    parent = Directory.GetCurrentDirectory();
+                }
+                catch (Exception ex)
+                {
+                    Log("Error getting current working directory: {1}", ex);
+                    if (ThrowOnError) throw;
+                }
+            }
+
+            var child = Path.GetFileName(path);
+
+            // handle groups that contain folders
+            // child will contain unmatched closing brace
+            if (child.Count(c => c == '}') > child.Count(c => c == '{'))
+            {
+                foreach (var group in Ungroup(path))
+                {
+                    foreach (var item in Expand(group, dirOnly))
+                    {
+                        yield return item;
+                    }
+                }
+
+                yield break;
+            }
+
+            if (child == "**")
+            {
+                foreach (DirectoryInfo dir in Expand(parent, true).DistinctBy(d => d.FullName))
+                {
+                    DirectoryInfo[] recursiveDirectories;
+
+                    try
+                    {
+                        recursiveDirectories = GetDirectories(dir).ToArray();
+                    }
+                    catch (Exception ex)
+                    {
+                        Log("Error finding recursive directory in {0}: {1}.", dir, ex);
+                        if (ThrowOnError) throw;
+                        continue;
+                    }
+
+                    yield return dir;
+
+                    foreach (var subDir in recursiveDirectories)
+                    {
+                        yield return subDir;
+                    }
+                }
+
+                yield break;
+            }
+
+            var childRegexes = Ungroup(child).Select(s => CreateRegexOrString(s)).ToList();
+
+            foreach (DirectoryInfo parentDir in Expand(parent, true).DistinctBy(d => d.FullName))
+            {
+                IEnumerable<FileSystemInfo> fileSystemEntries;
+
+                try
+                {
+                    fileSystemEntries = dirOnly ? parentDir.GetDirectories() : parentDir.GetFileSystemInfos();
+                }
+                catch (Exception ex)
+                {
+                    Log("Error finding file system entries in {0}: {1}.", parentDir, ex);
+                    if (ThrowOnError) throw;
+                    continue;
+                }
+
+                foreach (var fileSystemEntry in fileSystemEntries)
+                {
+                    if (childRegexes.Any(r => r.IsMatch(fileSystemEntry.Name)))
+                    {
+                        yield return fileSystemEntry;
+                    }
+                }
+
+                if (childRegexes.Any(r => r.Pattern == @"^\.\.$")) yield return parentDir.Parent ?? parentDir;
+                if (childRegexes.Any(r => r.Pattern == @"^\.$")) yield return parentDir;
+            }
+        }
+
+        private static HashSet<char> RegexSpecialChars = new HashSet<char>(new[] { '[', '\\', '^', '$', '.', '|', '?', '*', '+', '(', ')' });
+
+        private static string GlobToRegex(string glob)
+        {
+            StringBuilder regex = new StringBuilder();
+            bool characterClass = false;
+
+            regex.Append("^");
+
+            foreach (var c in glob)
+            {
+                if (characterClass)
+                {
+                    if (c == ']') characterClass = false;
+                    regex.Append(c);
+                    continue;
+                }
+
+                switch (c)
+                {
+                    case '*':
+                        regex.Append(".*");
+                        break;
+                    case '?':
+                        regex.Append(".");
+                        break;
+                    case '[':
+                        characterClass = true;
+                        regex.Append(c);
+                        break;
+                    default:
+                        if (RegexSpecialChars.Contains(c)) regex.Append('\\');
+                        regex.Append(c);
+                        break;
+                }
+            }
+
+            regex.Append("$");
+
+            return regex.ToString();
+        }
+
+        private static Regex GroupRegex = new Regex(@"{([^}]*)}");
+
+        private static IEnumerable<string> Ungroup(string path)
+        {
+            if (!path.Contains('{'))
+            {
+                yield return path;
+                yield break;
+            }
+
+            int level = 0;
+            string option = "";
+            string prefix = "";
+            string postfix = "";
+            List<string> options = new List<string>();
+
+            for (int i = 0; i < path.Length; i++)
+            {
+                var c = path[i];
+
+                switch (c)
+                {
+                    case '{':
+                        level++;
+                        if (level == 1)
+                        {
+                            prefix = option;
+                            option = "";
+                        }
+                        else option += c;
+                        break;
+                    case ',':
+                        if (level == 1)
+                        {
+                            options.Add(option);
+                            option = "";
+                        }
+                        else option += c;
+                        break;
+                    case '}':
+                        level--;
+                        if (level == 0)
+                        {
+                            options.Add(option);
+                            break;
+                        }
+                        else option += c;
+                        break;
+                    default:
+                        option += c;
+                        break;
+                }
+
+                if (level == 0 && c == '}' && (i + 1) < path.Length)
+                {
+                    postfix = path.Substring(i + 1);
+                    break;
+                }
+            }
+
+            if (level > 0) // invalid grouping
+            {
+                yield return path;
+                yield break;
+            }
+
+            var postGroups = Ungroup(postfix);
+
+            foreach (var opt in options.SelectMany(o => Ungroup(o)))
+            {
+                foreach (var postGroup in postGroups)
+                {
+                    var s = prefix + opt + postGroup;
+                    yield return s;
+                }
+            }
+        }
+
+        private static IEnumerable<string> ExpandGroups(string path)
+        {
+            var match = GroupRegex.Match(path);
+
+            if (!match.Success)
+            {
+                yield return path;
+                yield break;
+            }
+
+            var prefix = path.Substring(0, match.Index);
+            var postfix = path.Substring(match.Index + match.Length);
+            var postGroups = ExpandGroups(postfix);
+
+            foreach (var groupItem in match.Groups[1].Value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                foreach (var postGroup in postGroups)
+                {
+                    var s = prefix + groupItem + postGroup;
+                    yield return s;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return Pattern;
+        }
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return Pattern.GetHashCode();
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            //Check for null and compare run-time types.
+            if (obj == null || GetType() != obj.GetType()) return false;
+
+            Glob g = (Glob)obj;
+            return Pattern == g.Pattern;
+        }
+
+        private static IEnumerable<DirectoryInfo> GetDirectories(DirectoryInfo root)
+        {
+            DirectoryInfo[] subDirs = null;
+
+            try
+            {
+                subDirs = root.GetDirectories();
+            }
+            catch (Exception)
+            {
+                yield break;
+            }
+
+            foreach (DirectoryInfo dirInfo in subDirs)
+            {
+                yield return dirInfo;
+
+                foreach (var recursiveDir in GetDirectories(dirInfo))
+                {
+                    yield return recursiveDir;
+                }
+            }
+        }
+    }
+
+    static class Extensions
+    {
+        internal static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector)
+        {
+            HashSet<TKey> knownKeys = new HashSet<TKey>();
+            foreach (TSource element in source)
+            {
+                if (knownKeys.Add(keySelector(element)))
+                {
+                    yield return element;
+                }
+            }
+        }
+    }
+}

--- a/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -351,11 +351,6 @@ namespace Calamari.Integration.FileSystem
         public string CreateTemporaryDirectory()
         {
             var path = Path.Combine(GetTempBasePath(), Guid.NewGuid().ToString());
-            return CreateDirectory(path);
-        }
-
-        public string CreateDirectory(string path)
-        {
             if (!Directory.Exists(path))
             {
                 Directory.CreateDirectory(path);

--- a/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -351,7 +351,15 @@ namespace Calamari.Integration.FileSystem
         public string CreateTemporaryDirectory()
         {
             var path = Path.Combine(GetTempBasePath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(path);
+            return CreateDirectory(path);
+        }
+
+        public string CreateDirectory(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
             return path;
         }
 

--- a/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -178,6 +178,15 @@ namespace Calamari.Integration.FileSystem
             Log.Verbose(message);
         }
 
+        public virtual IEnumerable<string> EnumerateFilesWithGlob(string parentDirectoryPath, params string[] globPattern)
+        {
+            return globPattern.Length == 0
+                ? Glob.Expand(Path.Combine(parentDirectoryPath, "*")).Select(fi => fi.FullName)
+                : globPattern
+                    .SelectMany(pattern => Glob.Expand(Path.Combine(parentDirectoryPath, pattern))
+                    .Select(fi => fi.FullName));
+        }
+
         public virtual IEnumerable<string> EnumerateFiles(string parentDirectoryPath, params string[] searchPatterns)
         {
             var parentDirectoryInfo = new DirectoryInfo(parentDirectoryPath);

--- a/source/Calamari/Integration/FileSystem/Glob.cs
+++ b/source/Calamari/Integration/FileSystem/Glob.cs
@@ -9,7 +9,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Collections.Concurrent;
 
-namespace Calamari
+namespace Calamari.Integration.FileSystem
 {
     /// <summary>
     /// Finds files and directories by matching their path names against a pattern.

--- a/source/Calamari/Integration/FileSystem/ICalamariFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/ICalamariFileSystem.cs
@@ -17,6 +17,7 @@ namespace Calamari.Integration.FileSystem
         void DeleteDirectory(string path, FailureOptions options);
         IEnumerable<string> EnumerateDirectories(string parentDirectoryPath);
         IEnumerable<string> EnumerateDirectoriesRecursively(string parentDirectoryPath);
+        IEnumerable<string> EnumerateFilesWithGlob(string parentDirectoryPath, params string[] globPatterns);
         IEnumerable<string> EnumerateFiles(string parentDirectoryPath, params string[] searchPatterns);
         IEnumerable<string> EnumerateFilesRecursively(string parentDirectoryPath, params string[] searchPatterns);
         long GetFileSize(string path);

--- a/source/Calamari/Util/CrossPlatformExtensions.cs
+++ b/source/Calamari/Util/CrossPlatformExtensions.cs
@@ -16,11 +16,17 @@ namespace Calamari.Util
 #if NET40
             var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 #else
-            var path = Environment.GetEnvironmentVariable("LOCALAPPDATA") ?? Environment.GetEnvironmentVariable("TMPDIR") ?? "/tmp";
+            var path = Environment.GetEnvironmentVariable("LOCALAPPDATA")
+                   ?? Environment.GetEnvironmentVariable("TMPDIR")
+                   ?? Environment.GetEnvironmentVariable("TEMP")
+                   ?? "/tmp";
 #endif
-            path = Path.Combine(path, Assembly.GetEntryAssembly().GetName().Name);
-            path = Path.Combine(path, "Temp");
-            return path;
+            if (Assembly.GetEntryAssembly() != null)
+                path = Path.Combine(path, Assembly.GetEntryAssembly().GetName().Name);
+            else
+                path = Path.Combine(path, Guid.NewGuid().ToString());
+
+            return Path.Combine(path, "Temp");
         }
 
         public static string ExpandPathEnvironmentVariables(string path)

--- a/source/Calamari/Util/CrossPlatformExtensions.cs
+++ b/source/Calamari/Util/CrossPlatformExtensions.cs
@@ -21,10 +21,7 @@ namespace Calamari.Util
                    ?? Environment.GetEnvironmentVariable("TEMP")
                    ?? "/tmp";
 #endif
-            if (Assembly.GetEntryAssembly() != null)
-                path = Path.Combine(path, Assembly.GetEntryAssembly().GetName().Name);
-            else
-                path = Path.Combine(path, Guid.NewGuid().ToString());
+            path = Assembly.GetEntryAssembly()?.GetName().Name ?? Guid.NewGuid().ToString();
 
             return Path.Combine(path, "Temp");
         }


### PR DESCRIPTION
https://octopusdeploy.uservoice.com/forums/170787-general/suggestions/6261527-allow-for-wildcard-directory-searching-for-substit

http://help.octopusdeploy.com/discussions/problems/39746-substitute-variables-in-files-recursive-octopus-312

Implemented (via the 'Target Files' inputs) for, `JSON and Substitute Variables in Files`

![image](https://cloud.githubusercontent.com/assets/119096/23151644/54cc3c38-f848-11e6-8646-0379dc4b5047.png)
