### PR TITLE
Glob test temp directory fixes

### DIFF
--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSytemFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSytemFixture.cs
@@ -103,14 +103,10 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         [TestCase(@"Config/Feature2/*.config", "f2.config")]
         public void GlobTestMutiple(string pattern, string expectedFileMatchName, int expectedQty = 1)
         {
-            var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+            var fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();
             var rootPath = fileSystem.CreateTemporaryDirectory();
-            var content = "file-content" + Environment.NewLine;
 
-            if (CalamariEnvironment.IsRunningOnWindows)
-            {
-                pattern = pattern.Replace(@"/", @"\");
-            }
+            var content = "file-content" + Environment.NewLine;
 
             try
             {

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/TestCalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/TestCalamariPhysicalFileSystem.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Calamari.Integration.FileSystem;
+
+namespace Calamari.Tests.Fixtures.Integration.FileSystem
+{
+    public class TestCalamariPhysicalFileSystem : CalamariPhysicalFileSystem
+    {
+        public new static ICalamariFileSystem GetPhysicalFileSystem()
+        {
+            if (CalamariEnvironment.IsRunningOnNix || CalamariEnvironment.IsRunningOnMac)
+            {
+                return new TestNixCalamariPhysicalFileSystem();
+            }
+
+            return new TestWindowsPhysicalFileSystem();
+        }
+
+        protected override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
+        {
+            throw new NotImplementedException("*testing* this is in TestCalamariPhysicalFileSystem");
+        }
+
+        private class TestNixCalamariPhysicalFileSystem : NixCalamariPhysicalFileSystem, ICalamariFileSystem
+        {
+            public new string CreateTemporaryDirectory()
+            {
+                var path = Path.Combine("/tmp", Guid.NewGuid().ToString());
+
+                if (!Directory.Exists(path))
+                {
+                    Directory.CreateDirectory(path);
+                }
+
+                return path;
+            }
+        }
+        private class TestWindowsPhysicalFileSystem : WindowsPhysicalFileSystem, ICalamariFileSystem
+        {
+            public new string CreateTemporaryDirectory()
+            {
+#if NET40
+        var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+#else
+                var path = Environment.GetEnvironmentVariable("LOCALAPPDATA")
+                            ?? Environment.GetEnvironmentVariable("TMPDIR")
+                            ?? Environment.GetEnvironmentVariable("TEMP")
+                            ?? @"C:\temp";
+#endif
+                path = Path.Combine(path, Assembly.GetEntryAssembly()?.GetName().Name ?? Guid.NewGuid().ToString());
+
+                path = Path.Combine(path, Guid.NewGuid().ToString());
+
+                if (!Directory.Exists(path))
+                {
+                    Directory.CreateDirectory(path);
+                }
+
+                return path;
+            }
+        }
+    }
+}

--- a/source/Calamari/Util/CrossPlatformExtensions.cs
+++ b/source/Calamari/Util/CrossPlatformExtensions.cs
@@ -16,14 +16,11 @@ namespace Calamari.Util
 #if NET40
             var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 #else
-            var path = Environment.GetEnvironmentVariable("LOCALAPPDATA")
-                   ?? Environment.GetEnvironmentVariable("TMPDIR")
-                   ?? Environment.GetEnvironmentVariable("TEMP")
-                   ?? "/tmp";
+            var path = Environment.GetEnvironmentVariable("LOCALAPPDATA") ?? Environment.GetEnvironmentVariable("TMPDIR") ?? "/tmp";
 #endif
-            path = Assembly.GetEntryAssembly()?.GetName().Name ?? Guid.NewGuid().ToString();
-
-            return Path.Combine(path, "Temp");
+            path = Path.Combine(path, Assembly.GetEntryAssembly()?.GetName().Name);
+            path = Path.Combine(path, "Temp");
+            return path;
         }
 
         public static string ExpandPathEnvironmentVariables(string path)


### PR DESCRIPTION
- Restoring CrossPlatform.GetApplicationTempDir
- Make use of new TestCalamariPhysicalFileSystem