### PR TITLE
Add a flag that gets apply-delta to write a service message on error

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -60,7 +60,7 @@ Task("__Clean")
 });
 
 Task("__Restore")
-    .Does(() => DotNetCoreRestore());
+    .Does(() => DotNetCoreRestore("source"));
 
 Task("__UpdateAssemblyVersionInformation")
     .Does(() =>

--- a/build.cake
+++ b/build.cake
@@ -60,7 +60,7 @@ Task("__Clean")
 });
 
 Task("__Restore")
-    .Does(() => DotNetCoreRestore("source"));
+    .Does(() => DotNetCoreRestore());
 
 Task("__UpdateAssemblyVersionInformation")
     .Does(() =>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "source" ],
   "sdk": {
-    "version": "1.0.0-preview2-003131" // DotNetCore.1.0.1-VS2015Tools.Preview2.0.3.exe
+    "version": "1.0.0-preview2-003133" // https://github.com/dotnet/core/blob/master/release-notes/download-archives/1.0.1-preview2-download.md
   }
 }

--- a/source/Calamari.Tests/Fixtures/ApplyDelta/ApplyDeltaFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ApplyDelta/ApplyDeltaFixture.cs
@@ -103,81 +103,60 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
         }
 
         [Test]
-        public void ShouldFailWhenNoBasisFileIsSpecified()
+        public void ShouldWriteErrorWhenNoBasisFileIsSpecified()
         {
             var result = ApplyDelta("", "Hash", "Delta", "New");
 
-            result.AssertFailure();
-            result.AssertErrorOutput("No basis file was specified. Please pass --basisFileName MyPackage.1.0.0.0.nupkg");
+            result.AssertSuccess();
+            result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: "No basis file was specified. Please pass --basisFileName MyPackage.1.0.0.0.nupkg");
         }
 
         [Test]
-        public void ShouldFailWhenNoFileHashIsSpecified()
+        public void ShouldWriteErrorWhenNoFileHashIsSpecified()
         {
             var result = ApplyDelta("Basis", "", "Delta", "New");
 
-            result.AssertFailure();
-            result.AssertErrorOutput("No file hash was specified. Please pass --fileHash MyFileHash");
+            result.AssertSuccess();
+            result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: "No file hash was specified. Please pass --fileHash MyFileHash");
         }
         [Test]
-        public void ShouldFailWhenNoDeltaFileIsSpecified()
+        public void ShouldWriteErrorWhenNoDeltaFileIsSpecified()
         {
             var result = ApplyDelta("Basis", "Hash", "", "New");
 
-            result.AssertFailure();
-            result.AssertErrorOutput("No delta file was specified. Please pass --deltaFileName MyPackage.1.0.0.0_to_1.0.0.1.octodelta");
+            result.AssertSuccess();
+            result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: $"No delta file was specified. Please pass --deltaFileName MyPackage.1.0.0.0_to_1.0.0.1.octodelta");
         }
 
         [Test]
-        public void ShouldFailWhenNoNewFileIsSpecified()
+        public void ShouldWriteErrorWhenNoNewFileIsSpecified()
         {
             var result = ApplyDelta("Basis", "Hash", "Delta", "");
 
-            result.AssertFailure();
-            result.AssertErrorOutput("No new file name was specified. Please pass --newFileName MyPackage.1.0.0.1.nupkg");
+            result.AssertSuccess();
+            result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: "No new file name was specified. Please pass --newFileName MyPackage.1.0.0.1.nupkg");
         }
 
         [Test]
-        public void ShouldFailWhenBasisFileCannotBeFound()
+        public void ShouldWriteErrorWhenBasisFileCannotBeFound()
         {
             var basisFile = Path.Combine(DownloadPath, "MyPackage.1.0.0.0.nupkg");
             var result = ApplyDelta(basisFile, "Hash", "Delta", "New");
 
-            result.AssertFailure();
-            result.AssertErrorOutput("Could not find basis file: " + basisFile);
+            result.AssertSuccess();
+            result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: "Could not find basis file: " + basisFile);
         }
 
         [Test]
-        public void ShouldFailWhenDeltaFileCannotBeFound()
+        public void ShouldWriteErrorWhenDeltaFileCannotBeFound()
         {
             using (var basisFile = new TemporaryFile(PackageBuilder.BuildSamplePackage("Acme.Web", "1.0.0.0")))
             {
                 var deltaFilePath = Path.Combine(DownloadPath, "Acme.Web.1.0.0.0_to_1.0.0.1.octodelta");
                 var result = ApplyDelta(basisFile.FilePath, basisFile.Hash, deltaFilePath, "New");
 
-                result.AssertFailure();
-                result.AssertErrorOutput("Could not find delta file: " + deltaFilePath);
-            }
-        }
-
-        [Test]
-        public void ShouldFailWhenBasisFileHashDoesNotMatchSpecifiedFileHash()
-        {
-            var otherBasisFileHash = "2e9407c9eae20ffa94bf050283f9b4292a48504c";
-            using (var basisFile = new TemporaryFile(PackageBuilder.BuildSamplePackage("Acme.Web", "1.0.0.0")))
-            {
-                var deltaFilePath = Path.Combine(DownloadPath,
-                    "Acme.Web.1.0.0.0_to_1.0.0.1.octodelta");
-                using (var deltaFile = File.CreateText(deltaFilePath))
-                {
-                    deltaFile.WriteLine("This is a delta file!");
-                    deltaFile.Flush();
-                }
-
-                var result = ApplyDelta(basisFile.FilePath, otherBasisFileHash, deltaFilePath, NewFileName);
-
-                result.AssertFailure();
-                result.AssertErrorOutput("Basis file hash {0} does not match the file hash specified {1}", basisFile.Hash, otherBasisFileHash);
+                result.AssertSuccess();
+                result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: "Could not find delta file: " + deltaFilePath);
             }
         }
 

--- a/source/Calamari.Tests/Helpers/CalamariResult.cs
+++ b/source/Calamari.Tests/Helpers/CalamariResult.cs
@@ -87,6 +87,12 @@ namespace Calamari.Tests.Helpers
                     }
                     break;
                 case ServiceMessageNames.PackageDeltaVerification.Name:
+                    if (!string.IsNullOrWhiteSpace(message))
+                    {
+                        Assert.That(captured.DeltaError, Is.EqualTo(message));
+                        break;
+                    }
+
                     Assert.That(captured.DeltaVerification, Is.Not.Null);
                     if (properties != null)
                     {

--- a/source/Calamari.Tests/Helpers/CaptureCommandOutput.cs
+++ b/source/Calamari.Tests/Helpers/CaptureCommandOutput.cs
@@ -58,6 +58,8 @@ namespace Calamari.Tests.Helpers
 
         public StoredPackage DeltaVerification { get; protected set; }
 
+        public string DeltaError { get; protected set; }
+
         void ParseServiceMessage(ServiceMessage message)
         {
             switch (message.Name)
@@ -89,11 +91,14 @@ namespace Calamari.Tests.Helpers
                 case ServiceMessageNames.PackageDeltaVerification.Name:
                     var pdvHash = message.GetValue(ServiceMessageNames.PackageDeltaVerification.HashAttribute);
                     var pdvSize = message.GetValue(ServiceMessageNames.PackageDeltaVerification.SizeAttribute);
-                    var pdvRemotePath =
-                        message.GetValue(ServiceMessageNames.PackageDeltaVerification.RemotePathAttribute);
-                    DeltaVerification =
-                        new StoredPackage(new ExtendedPackageMetadata { Hash = pdvHash},
-                            pdvRemotePath);
+                    var pdvRemotePath = message.GetValue(ServiceMessageNames.PackageDeltaVerification.RemotePathAttribute);
+                    DeltaError = message.GetValue(ServiceMessageNames.PackageDeltaVerification.Error);
+                    if (pdvHash != null)
+                    {
+                        DeltaVerification =
+                            new StoredPackage(new ExtendedPackageMetadata {Hash = pdvHash},
+                                pdvRemotePath);
+                    }
                     break;
             }
         }

--- a/source/Calamari/Commands/ApplyDeltaCommand.cs
+++ b/source/Calamari/Commands/ApplyDeltaCommand.cs
@@ -16,7 +16,6 @@ namespace Calamari.Commands
         string newFileName;
         bool showProgress;
         bool skipVerification;
-        bool serviceMessageOnError;
         readonly PackageStore packageStore = new PackageStore(new GenericPackageExtractor());
         readonly ICalamariFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
@@ -27,9 +26,6 @@ namespace Calamari.Commands
             Options.Add("deltaFileName=", "The delta to apply to the basis file", v => deltaFileName = v);
             Options.Add("newFileName=", "The file to write the result to.", v => newFileName = v);
             Options.Add("progress", "Whether progress should be written to stdout", v => showProgress = true);
-            Options.Add("serviceMessageOnError",
-                "Write a service message on error rather than returning a non-zero exit code",
-                v => serviceMessageOnError = true);
             Options.Add("skipVerification",
                 "Skip checking whether the basis file is the same as the file used to produce the signature that created the delta.",
                 v => skipVerification = true);
@@ -81,12 +77,8 @@ namespace Calamari.Commands
             }
             catch (CommandException e)
             {
-                if(serviceMessageOnError)
-                {
-                    Log.ServiceMessages.DeltaVerificationError(e.Message);
-                    return 0;
-                }
-                throw;
+                Log.ServiceMessages.DeltaVerificationError(e.Message);
+                return 0;
             }
 
             var package = packageStore.GetPackage(newFilePath);

--- a/source/Calamari/Integration/ServiceMessages/ServiceMessageNames.cs
+++ b/source/Calamari/Integration/ServiceMessages/ServiceMessageNames.cs
@@ -29,6 +29,7 @@
             public const string RemotePathAttribute = "remotePath";
             public const string HashAttribute = "hash";
             public const string SizeAttribute = "size";
+            public const string Error = "error";
         }
     }
 }

--- a/source/Calamari/Log.cs
+++ b/source/Calamari/Log.cs
@@ -179,7 +179,6 @@ namespace Calamari
                     ConvertServiceMessageValue(packageHash),
                     ConvertServiceMessageValue(packageFullPath),
                     ConvertServiceMessageValue(packageFileExtension));
-
             }
 
             public static void DeltaVerification(string remotePath, string hash, long size)
@@ -188,6 +187,11 @@ namespace Calamari
                     ConvertServiceMessageValue(remotePath),
                     ConvertServiceMessageValue(hash),
                     ConvertServiceMessageValue(size.ToString(CultureInfo.InvariantCulture)));
+            }
+
+            public static void DeltaVerificationError(string error)
+            {
+                VerboseFormat("##octopus[deltaVerification error=\"{0}\"]", ConvertServiceMessageValue(error));
             }
         }
     }


### PR DESCRIPTION
Usually we can recover from an apply-delta error, since we just download the entire package. But we end up with errors in the octopus log. Have an option to have the command succeed but write a service message that octopus can check for.

I'm only catching "known" problems we run in to at this point, rather than if we throw some random exception, even though we recover fine either way.