### PR TITLE
JsonConfigurationVariableReplacer.MapNumber - value from tryparse not being used

### DIFF
--- a/source/Calamari.Tests/Fixtures/JsonVariables/JsonConfigurationVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/JsonVariables/JsonConfigurationVariableReplacerFixture.cs
@@ -262,6 +262,28 @@ namespace Calamari.Tests.Fixtures.JsonVariables
             AssertJsonEquivalent(replaced, expected);
         }
 
+
+        [Test]
+        public void ShouldReplaceDecimal()
+        {
+            const string expected =
+                @"{" +
+                "  \"DecimalValue\": 50.0," +
+                "  \"FloatValue\": 456e-5," +
+                "  \"StringValue\": \"60.0\"," +
+                "  \"IntegerValue\": 70," +
+                "}";
+
+            var variables = new VariableDictionary();
+            variables.Set("DecimalValue", "50.0");
+            variables.Set("FloatValue", "456e-5");
+            variables.Set("StringValue", "60.0");
+            variables.Set("IntegerValue", "70");
+
+            var replaced = Replace(variables, existingFile: "appsettings.decimals.json");
+            AssertJsonEquivalent(replaced, expected);
+        }
+
         [Test]
         public void ShouldReplaceBoolean()
         {

--- a/source/Calamari.Tests/Fixtures/JsonVariables/Samples/appsettings.decimals.json
+++ b/source/Calamari.Tests/Fixtures/JsonVariables/Samples/appsettings.decimals.json
@@ -1,0 +1,6 @@
+﻿{
+	"DecimalValue": 10.0,
+	"FloatValue": 123e-5,
+	"StringValue": "20.0",
+	"IntegerValue": 30
+}

--- a/source/Calamari/Integration/JsonVariables/JsonConfigurationVariableReplacer.cs
+++ b/source/Calamari/Integration/JsonVariables/JsonConfigurationVariableReplacer.cs
@@ -125,7 +125,7 @@ namespace Calamari.Integration.JsonVariables
                 double doublevalue;
                 if (double.TryParse(t, out doublevalue))
                 {
-                    value.Replace(JToken.FromObject(longvalue));
+                    value.Replace(JToken.FromObject(doublevalue));
                     return;
                 }
                 value.Replace(JToken.FromObject(t));


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/3324