### PR TITLE
Fix for ARM template convention to consider 'Canceled' state

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/DeployAzureResourceGroupConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/DeployAzureResourceGroupConvention.cs
@@ -152,6 +152,10 @@ namespace Calamari.Azure.Deployment.Conventions
                             throw new CommandException($"Azure Resource Group deployment {deploymentName} failed:\n" +
                                                        GetOperationResults(armClient, resourceGroupName, deploymentName));
 
+                        case "Canceled":
+                            throw new CommandException($"Azure Resource Group deployment {deploymentName} was canceled:\n" +
+                                                       GetOperationResults(armClient, resourceGroupName, deploymentName));
+
                         default:
                             if (currentPollWait < maxWaitSeconds)
                             {


### PR DESCRIPTION
Adding a canceled state to the ARM convention to detect when the task is canceled from the Azure-side.

Relates to OctopusDeploy/Issues#3391