### PR TITLE
Cannot remove SSL cert brindings here if SNI is not enabled

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -696,10 +696,6 @@ if ($deployAsWebSite)
 		# try to remove ssl cert bindings for IIS bindings that are being removed
 		$bindingsToRemove | where-object { $_.protocol -eq "https" } | foreach-object {
 			$bindingParts = $_.bindingInformation.Split(':')
-			$ipAddress = $bindingParts[0]
-			if ((! $ipAddress) -or ($ipAddress -eq '*')) {
-				$ipAddress = "0.0.0.0"
-			}
 			$port = $bindingParts[1]
 			$hostname = $bindingParts[2]
 
@@ -712,16 +708,7 @@ if ($deployAsWebSite)
 						throw
 					}
 				}
-			} else { # SNI off so we will have created against the ip
-				$existing = & netsh http show sslcert ipport="$($ipAddress):$port"
-				if ($LastExitCode -eq 0) {
-					Write-Host ("Removing unused SSL certificate binding: $($ipAddress):$port")				
-					& netsh http delete sslcert ipport="$($ipAddress):$port"
-					if ($LastExitCode -ne 0 ){
-						throw
-					}
-				}
-			}
+			} 
 		}
 	}
 


### PR DESCRIPTION
[In this commit](https://github.com/jacobnlsn/Calamari/commit/5fc29d6d31714eac9aea3099a1abe7c08adbcfd2) a chunk of code was added to attempt to remove SSL cert bindings from IP:Port combinations that are no longer being used.  This had a impact that if any other bindings on that site, or any other sites on the IIS server was using the same IP:Port combination it cleared the SSL cert for all of the sites, breaking SSL for those sites.

This pull request is related to this git issue: https://github.com/OctopusDeploy/Issues/issues/3414