### PR TITLE
Check if there are any bindings on IP:Port before trying to remove the SSL cert

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -697,8 +697,8 @@ if ($deployAsWebSite)
 		$bindingsToRemove | where-object { $_.protocol -eq "https" } | foreach-object {
 			$bindingParts = $_.bindingInformation.Split(':')
 			$ipAddress = $bindingParts[0]
-			if ((! $ipAddress) -or ($ipAddress -eq '*')) {
-				$ipAddress = "0.0.0.0"
+			if (!$ipAddress) {
+				$ipAddress = "*"
 			}
 			$port = $bindingParts[1]
 			$hostname = $bindingParts[2]
@@ -713,10 +713,16 @@ if ($deployAsWebSite)
 					}
 				}
 			} else { # SNI off so we will have created against the ip
-				$existing = & netsh http show sslcert ipport="$($ipAddress):$port"
-				if ($LastExitCode -eq 0) {
-					Write-Host ("Removing unused SSL certificate binding: $($ipAddress):$port")				
+				# check if there are any other bindings to the same IP:Port so that
+				# we don't remove an ssl cert that's used by any other sites on the server
+				$existing = Get-WebBinding -IPAddress $ipAddress -Port $port
+				if (!$existing) {
+					Write-Host ("Removing unused SSL certificate binding: $($ipAddress):$port")
+					if ($ipAddress -eq '*') {
+						$ipAddress = "0.0.0.0"
+					}
 					& netsh http delete sslcert ipport="$($ipAddress):$port"
+
 					if ($LastExitCode -ne 0 ){
 						throw
 					}

--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -715,7 +715,7 @@ if ($deployAsWebSite)
 			} else { # SNI off so we will have created against the ip
 				# check if there are any other bindings to the same IP:Port so that
 				# we don't remove an ssl cert that's used by any other sites on the server
-				$existing = Get-WebBinding -IPAddress $ipAddress -Port $port
+				$existing = Get-WebBinding -IPAddress $ipAddress -Port $port -Protocol "https"
 				if (!$existing) {
 					Write-Host ("Removing unused SSL certificate binding: $($ipAddress):$port")
 					if ($ipAddress -eq '*') {


### PR DESCRIPTION
## Test scenarios
### 1 website

#### 1 HTTPS binding
- Initial deploy
  - Expected result
    - `& netsh http show sslcert` shows entry for the configured `IP:Port` and `Thumbprint` combination
- Remove the binding and deploy again
  - Expected result
    - `& netsh http show sslcert` shows no entry for the configured `IP:Port` and `Thumbprint` combination

#### 2 HTTPS bindings
- Initial deploy
  - Expected result
    -  `& netsh http show sslcert` shows one entry for each of the configured `IP:Port` and `Thumbprint` combination
- Remove 1st binding and update thumbprint of 2nd binding
  - Expected result
    - `& netsh http show sslcert` shows one entry for the configured `IP:Port` and updated `Thumbprint` of the 2ndbinding
- Remove 2nd binding

### 2 websites (on same server with same `IP:Port` combination, different `hostname`, no `SNI`)
#### 1 HTTPS binding per website
- Initial deploy 
  - Expected result
    -  `& netsh http show sslcert` shows one entry the configured `IP:Port` and `Thumbprint` 
    - `Get-WebBinding -IPAddress $IP -Port $Port` shows one entry for each of the configured `IP:Port:hostname` combination
- Remove 1 binding from 1 website
  - Expected result
    -  `& netsh http show sslcert` shows one entry for the configured `IP:Port` and `Thumbprint` 
    - `Get-WebBinding -IPAddress $IP -Port $Port` shows one entry for the configured `IP:Port:hostname` combination
- Remove binding from 2nd website
  - Expected result
    -  `& netsh http show sslcert` shows no entry for the configured `IP:Port` and `Thumbprint` 
    - `Get-WebBinding -IPAddress $IP -Port $Port` shows no entries for the configured `IP:Port:hostname` 

Fixes OctopusDeploy/Issues#3414