### PR TITLE
Detect and handle/takeover a semaphore that is abandoned

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -57,7 +57,7 @@ function Recover-Semaphore {
 		Write-Verbose "Forcing semaphore release, the result was (it should be zero): $result"
 	}
 	Catch [System.UnauthorizedAccessException] {
-		Write-Verbose "Sempahore timeout cleanup failed or wasn't needed"
+		Write-Verbose "Semaphore timeout cleanup failed or wasn't needed"
 	}
 }
 
@@ -68,15 +68,15 @@ function Wait-OnSemaphore {
 
 	Try	{
 		$attemptCount = 0
-		$maxFailures = 25 #25*5sec sleep = ~2 min
+		$maxAttempts = 25 #25*5sec sleep = ~2 min
 		$SemaphoreInstance = New-Object System.Threading.Semaphore -ArgumentList 1, 1, $SemaphoreId
 
 		while (-not $SemaphoreInstance.WaitOne(100))
 		{
 			$attemptCount++;
-			Write-Verbose "Cannot start this IIS website related task yet. There is already another task running that cannot be run in conjunction with any other task. Attempt $attemptCount. Please wait..."
+			Write-Verbose "Cannot start this IIS website related task yet. There is already another task running that cannot be run in conjunction with any other task. Attempt $attemptCount of $maxAttempts. Please wait..."
 			Start-Sleep -m 5000;
-			if($attemptCount -gt $maxFailures)
+			if($attemptCount -gt $maxAttempts)
 			{
 				Recover-Semaphore -SemaphoreId $SemaphoreId
 				$attemptCount = 0
@@ -91,7 +91,7 @@ function Wait-OnSemaphore {
 		return Wait-OnSemaphore -SemaphoreId $SemaphoreId
 	}
 	Catch [System.SystemException]{
-		Write-Verbose "Wait-OnSemaphore had a major issue, possibly not running with sufficient privileges to force the semaphore unlock, details: $_.Exception.Message"
+		Write-Verbose "Wait-OnSemaphore had a major issue, possibly not running with sufficient privileges recover the semaphore, details: $_.Exception.Message"
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/3561

Reproducing this was the most difficult part it involved adding sleeps to ensure termination of the calamari process would be at the right spot before the semaphore released. Once it was confirmed to be a real issue then it's ok to just simulate the abandoned semaphore.

In an admin powershell create a new semaphore that will block deployments:
```
[System.Reflection.Assembly]::LoadWithPartialName("System.Threading")

$i = New-Object System.Threading.Semaphore -ArgumentList 1, 1,'Global\Octopus-IIS-Metabase'
$i.WaitOne(100)

# it should return True
#to release it do $i.Release()
```

If you need to cleanup: 
```
$sem = [System.Threading.Semaphore]::OpenExisting('Global\Octopus-IIS-Metabase') ; 
$sem.Release()
```