### PR TITLE
Set octopus output variables for use in other steps

### DIFF
--- a/source/Calamari.Azure/Scripts/DeployAzureCloudService.ps1
+++ b/source/Calamari.Azure/Scripts/DeployAzureCloudService.ps1
@@ -51,8 +51,12 @@ function CreateNewDeployment()
 function WaitForComplete() 
 {
     $completeDeployment = Get-AzureDeployment -ServiceName $OctopusAzureServiceName -Slot $OctopusAzureSlot
-
     $completeDeploymentID = $completeDeployment.DeploymentId
+    $completeDeploymentUrl = $completeDeployment.Url
+        
+    Set-OctopusVariable -name "AzureDeploymentID" -value $completeDeploymentID
+    Set-OctopusVariable -name "AzureDeploymentUrl" -value $completeDeploymentUrl
+    
     Write-Host "Deployment complete; Deployment ID: $completeDeploymentID"
 }
 

--- a/source/Calamari.Azure/Scripts/DeployAzureCloudService.ps1
+++ b/source/Calamari.Azure/Scripts/DeployAzureCloudService.ps1
@@ -54,8 +54,8 @@ function WaitForComplete()
     $completeDeploymentID = $completeDeployment.DeploymentId
     $completeDeploymentUrl = $completeDeployment.Url
         
-    Set-OctopusVariable -name "AzureDeploymentID" -value $completeDeploymentID
-    Set-OctopusVariable -name "AzureDeploymentUrl" -value $completeDeploymentUrl
+    Set-OctopusVariable -name "OctopusAzureCloudServiceDeploymentID" -value $completeDeploymentID
+    Set-OctopusVariable -name "OctopusAzureCloudServiceDeploymentUrl" -value $completeDeploymentUrl
     
     Write-Host "Deployment complete; Deployment ID: $completeDeploymentID"
 }


### PR DESCRIPTION
In order to run further processing against the staging slot, the deployment ID is needed - this will deploy the octopus variable back out for use in another process.

My specific scenario is in a blue/green deployment to Azure Cloud Services, I wish to run some smoke test against our staging slot before swapping to production. In order to access a URL is generated using the deployment ID. This enables the variables to be used in further processes.