### PR TITLE
Fixes in Readme (missing '=' and wrong folder name) + automated creation of artifacts folder

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -88,6 +88,7 @@ if(!$PSScriptRoot){
 }
 
 $TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$ARTIFACTS_DIR = Join-Path $PSScriptRoot "artifacts"
 $ADDINS_DIR = Join-Path $TOOLS_DIR "addins"
 $MODULES_DIR = Join-Path $TOOLS_DIR "modules"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
@@ -122,6 +123,12 @@ if($WhatIf.IsPresent) {
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
     Write-Verbose -Message "Creating tools directory..."
     New-Item -Path $TOOLS_DIR -Type directory | out-null
+}
+
+# Make sure artifacts folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $ARTIFACTS_DIR)) {
+    Write-Verbose -Message "Creating artifacts directory..."
+    New-Item -Path $ARTIFACTS_DIR -Type directory | out-null
 }
 
 # Make sure that packages.config exist.

--- a/source/Calamari.Azure/Calamari.Azure.csproj
+++ b/source/Calamari.Azure/Calamari.Azure.csproj
@@ -44,10 +44,10 @@
     <PackageReference Include="Microsoft.Data.Edm" Version="5.6.4" />
     <PackageReference Include="Microsoft.Data.OData" Version="5.6.4" />
     <PackageReference Include="Microsoft.Data.Services.Client" Version="5.6.4" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.13.9" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="2.19.208020213" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.2" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.1" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="2.2.0" />
     <PackageReference Include="Microsoft.Web.Deployment" Version="3.6.0" />
     <PackageReference Include="Microsoft.WindowsAzure.Common" Version="1.4.1" />
     <PackageReference Include="Microsoft.WindowsAzure.Common.Dependencies" Version="1.1.1" />
@@ -61,7 +61,7 @@
     <PackageReference Include="Octostache" Version="2.1.5" />
     <PackageReference Include="Sprache" Version="2.1.0" />
     <PackageReference Include="System.Spatial" Version="5.6.4" />
-    <PackageReference Include="WindowsAzure.Storage" Version="7.2.1" />
+    <PackageReference Include="WindowsAzure.Storage" Version="4.3.0" />
     <PackageReference Include="OctoDiff" Version="1.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi

I have noticed few flaws

- missing '=' in command adding custom folder
- wrong folder name (currently package is created in artifacts folder)
- I changed build.ps1 so artifacts folder will be created automatically like tools folder 