### PR TITLE
Do not recursively delete symlinked directories

### DIFF
--- a/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -436,7 +436,7 @@ namespace Calamari.Integration.FileSystem
 
                 if ((info.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
                 {
-                    Directory.Delete(directory, true);
+                    Directory.Delete(directory, false);
                 }
                 else
                 {


### PR DESCRIPTION
When the retention policy is applied, just delete the symlink
instead of recursing through the directory so that important
(potentially system) files are not deleted.

Bug was introduced in 77d153639776a2df35e6344b62e3de6c3b8b1e09