### PR TITLE
Returned empty string instead of `Unrecognized variable` if a variable does not exist

### DIFF
--- a/source/Calamari/Integration/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari/Integration/Scripting/Bash/Bootstrap.sh
@@ -48,7 +48,7 @@ function get_octopusvariable
   case $INPUT in
 #### VariableDeclarations ####
     *)
-      echo "Unrecognized variable \"$1\""
+      echo ""
     ;;
     esac
 }


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/3747