### PR TITLE
Adhere to PowerShell common output preferences

### DIFF
--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -166,6 +166,9 @@ namespace Calamari.Tests.Fixtures.PowerShell
             output.AssertOutput("Hello, write-verbose!");
             output.AssertOutput("Hello, write-warning!");
             output.AssertErrorOutput("Hello-Error!");
+
+            output.AssertNoOutput("This warning should not appear in logs!");
+            output.AssertNoOutput("This verbose should not appear in logs!");
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/Output.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/Output.ps1
@@ -1,5 +1,24 @@
-﻿Write-Host "Hello, write-host!"
+﻿$SilentlyContinuePreference = 'SilentlyContinue'
+
+Write-Host "Hello, write-host!"
 Write-Verbose "Hello, write-verbose!"
 Write-Output "Hello, write-output!"
 Write-Warning "Hello, write-warning!"
 Write-Error "Hello-Error!"
+
+
+Write-Warning "This warning should not appear in logs!" -WarningAction $SilentlyContinuePreference
+
+$VerbosePreferenceToRestore = $VerbosePreference
+$VerbosePreference = $SilentlyContinuePreference
+$WarningPreferenceToRestore = $WarningPreference
+$WarningPreference = $SilentlyContinuePreference
+
+Write-Warning "This warning should not appear in logs!"
+Write-Verbose "This verbose should not appear in logs!"
+
+$VerbosePreference = $VerbosePreferenceToRestore
+$WarningPreference = $WarningPreferenceToRestore
+
+# It would be nice to support the following but I haven't figure it out:
+# Test-NetConnection -ComputerName abc123 -WarningAction SilentlyContinue

--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/Output.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/Output.ps1
@@ -4,8 +4,6 @@ Write-Host "Hello, write-host!"
 Write-Verbose "Hello, write-verbose!"
 Write-Output "Hello, write-output!"
 Write-Warning "Hello, write-warning!"
-Write-Error "Hello-Error!"
-
 
 Write-Warning "This warning should not appear in logs!" -WarningAction $SilentlyContinuePreference
 
@@ -22,3 +20,5 @@ $WarningPreference = $WarningPreferenceToRestore
 
 # It would be nice to support the following but I haven't figure it out:
 # Test-NetConnection -ComputerName abc123 -WarningAction SilentlyContinue
+
+Write-Error "Hello-Error!"

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -2,6 +2,7 @@
 
 {{StartOfBootstrapScriptDebugLocation}}
 $ErrorActionPreference = 'Stop'
+$VerbosePreference = 'Continue'
 
 # All PowerShell scripts invoked by Calamari will be bootstrapped using this script. This script:
 #  1. Declares/overrides various functions for scripts to use
@@ -177,8 +178,11 @@ function Write-Verbose([string]$message)
 	Write-Host "##octopus[stdout-default]"
 }
 
-function Write-Warning([string]$message)
+function Write-Warning()
 {
+	[CmdletBinding()]
+	param([string]$message)
+
 	if ($WarningPreference -eq 'SilentlyContinue') {
 		return
 	}

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -169,6 +169,9 @@ function Write-Debug([string]$message)
 
 function Write-Verbose([string]$message)
 {
+	if ($VerbosePreference -eq 'SilentlyContinue') {
+		return
+	}
 	Write-Host "##octopus[stdout-verbose]"
 	Write-Host $message
 	Write-Host "##octopus[stdout-default]"
@@ -176,6 +179,9 @@ function Write-Verbose([string]$message)
 
 function Write-Warning([string]$message)
 {
+	if ($WarningPreference -eq 'SilentlyContinue') {
+		return
+	}
 	Write-Host "##octopus[stdout-warning]"
 	Write-Host $message
 	Write-Host "##octopus[stdout-default]"


### PR DESCRIPTION
Will not log verbose and warning output if the common parameters `$VerbosePreference` and `$WarningPreference` (respectively) are set to `SilentlyContinue`.

The parameter `-WarningAction` for the method `Write-Warning` can be set to `SilentlyContinue` to avoid writing warning output.

A limitation of this implementation is that passing `-WarningAction` to any other method will still result in the warning being written.  For example this will result in a warning being written:
```
Test-NetConnection -ComputerName abc123 -WarningAction SilentlyContinue
```