### PR TITLE
Fix tools.jar location

### DIFF
--- a/source/Calamari/Deployment/Features/Java/JavaBaseFeature.cs
+++ b/source/Calamari/Deployment/Features/Java/JavaBaseFeature.cs
@@ -10,8 +10,7 @@ namespace Calamari.Deployment.Features.Java
     /// </summary>
     public abstract class JavaBaseFeature
     {
-        private const string JavaLibraryEnvVar = "JavaIntegrationLibraryPackagePath";
-        private const string JavaBinEnvVar = "OctopusEnvironment_Java_Bin";
+        
         private readonly ICommandLineRunner commandLineRunner;
         
         protected JavaBaseFeature(ICommandLineRunner commandLineRunner)
@@ -30,11 +29,11 @@ namespace Calamari.Deployment.Features.Java
                 variable. If OctopusEnvironment_Java_Bin is empty or null, it means that the precondition
                 found java on the path.
             */
-            var javaBin = Environment.GetEnvironmentVariable(JavaBinEnvVar) ?? "";
+            var javaBin = Environment.GetEnvironmentVariable(SpecialVariables.Action.Java.JavaBinEnvVar) ?? "";
             /*
                 The precondition script will also set the location of the calamari.jar file
             */
-            var javaLib = Environment.GetEnvironmentVariable(JavaLibraryEnvVar) ?? "";
+            var javaLib = Environment.GetEnvironmentVariable(SpecialVariables.Action.Java.JavaLibraryEnvVar) ?? "";
             var result = commandLineRunner.Execute(new CommandLineInvocation(
                 Path.Combine(javaBin, "java"), 
                 $"-cp calamari.jar {mainClass}",

--- a/source/Calamari/Deployment/SpecialVariables.cs
+++ b/source/Calamari/Deployment/SpecialVariables.cs
@@ -291,6 +291,9 @@
 
             public static class Java
             {
+                public static readonly string JavaLibraryEnvVar = "JavaIntegrationLibraryPackagePath";
+                public static readonly string JavaBinEnvVar = "OctopusEnvironment_Java_Bin";
+                
                 public static readonly string JavaArchiveExtractionDisabled = "Octopus.Action.Java.JavaArchiveExtractionDisabled";
 
                 public static readonly string DeployExploded = "Octopus.Action.JavaArchive.DeployExploded"; 

--- a/source/Calamari/Integration/Packages/Java/JarTool.cs
+++ b/source/Calamari/Integration/Packages/Java/JarTool.cs
@@ -25,7 +25,7 @@ namespace Calamari.Integration.Packages.Java
             this.commandOutput = commandOutput;
             
             /*
-                The precondition script will also set the location of the calamari.jar file
+                The precondition script will also set the location of the java libray files
             */
             toolsPath = Path.Combine(
                 Environment.GetEnvironmentVariable(SpecialVariables.Action.Java.JavaLibraryEnvVar) ?? "", 
@@ -45,7 +45,7 @@ namespace Calamari.Integration.Packages.Java
                      variable. If OctopusEnvironment_Java_Bin is empty or null, it means that the precondition
                      found java on the path.
                  */
-                var javaBin = Environment.GetEnvironmentVariable("OctopusEnvironment_Java_Bin") ?? "";
+                var javaBin = Environment.GetEnvironmentVariable(SpecialVariables.Action.Java.JavaBinEnvVar) ?? "";
                 var createJarCommand = new CommandLineInvocation(
                     Path.Combine(javaBin, "java"),
                     $"-cp \"{toolsPath}\" sun.tools.jar.Main cvf \"{targetJarPath}\" -C \"{contentsDirectory}\" .",
@@ -79,7 +79,7 @@ namespace Calamari.Integration.Packages.Java
                  variable. If OctopusEnvironment_Java_Bin is empty or null, it means that the precondition
                  found java on the path.
              */
-            var javaBin = Environment.GetEnvironmentVariable("OctopusEnvironment_Java_Bin") ?? "";
+            var javaBin = Environment.GetEnvironmentVariable(SpecialVariables.Action.Java.JavaBinEnvVar) ?? "";
 
             try
             {


### PR DESCRIPTION
Calamari was not using the supplied tools.jar file, which means any installation without the JDK would fail.