### PR TITLE
Provide friendlier errors when loading a script module causes an error

### DIFF
--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -333,6 +333,30 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Windows)]
+        public void ShouldShowFriendlyErrorWithInvalidSyntaxInScriptModule()
+        {
+            var variablesFile = Path.GetTempFileName();
+
+            var variables = new VariableDictionary();
+            variables.Set("Octopus.Script.Module[Foo]", "function SayHello() { Write-Host \"Hello from module! }");
+            variables.Save(variablesFile);
+
+            using (new TemporaryFile(variablesFile))
+            {
+                var output = Invoke(Calamari()
+                    .Action("run-script")
+                    .Argument("script", GetFixtureResouce("Scripts", "UseModule.ps1"))
+                    .Argument("variables", variablesFile));
+
+                output.AssertFailure();
+                output.AssertOutput("Failed to import Script Module 'Foo'");
+                output.AssertErrorOutput("Write-Host \"Hello from module!");
+                output.AssertErrorOutput("The string is missing the terminator: \".");
+            }
+        }
+
+        [Test]
+        [Category(TestEnvironment.CompatibleOS.Windows)]
         public void ShouldFailIfAModuleHasASyntaxError()
         {
             var variablesFile = Path.GetTempFileName();

--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -113,6 +113,20 @@ function SafelyLog-ComputerInfoVars
 	}
 }
 
+function Import-ScriptModule([string]$moduleName, [string]$moduleFilePath)
+{
+	Try 
+	{
+		Write-Verbose "Importing Script Module '$moduleName' from '$moduleFilePath'"
+		Import-Module $moduleFilePath
+	}
+	Catch
+	{
+		Write-Warning "Failed to import Script Module '$moduleName'"
+		Throw
+	}
+}
+
 function Convert-ServiceMessageValue([string]$value)
 {
 	$valueBytes = [System.Text.Encoding]::UTF8.GetBytes($value)


### PR DESCRIPTION
This PR was to include a friendlier error for the users profile script as well, but it looks like the error message thrown when an issue is detected in there already points to the file and code that caused the error to be thrown.

![image](https://user-images.githubusercontent.com/1035315/31158799-bc6d85ca-a907-11e7-82c6-090574f11569.png)

Resolves OctopusDeploy/Issues#2662