### PR TITLE
If reading package metadata with schema validation fails, try without schema validation

### DIFF
--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -20,6 +20,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         static readonly string DownloadPath = TestEnvironment.GetTestPath(TentacleHome, "Files");
 
         static readonly string PublicFeedUri = "https://www.myget.org/F/octopusdeploy-tests";
+        static readonly string NuGetFeedUri = "https://api.nuget.org/v3/index.json";
         static readonly string AuthFeedUri = Environment.GetEnvironmentVariable(FeedUriEnvironmentVariable);
         static readonly string FeedUsername = Environment.GetEnvironmentVariable(FeedUsernameEnvironmentVariable);
         static readonly string FeedPassword = Environment.GetEnvironmentVariable(FeedPasswordEnvironmentVariable);
@@ -28,6 +29,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         static readonly Feed PublicFeed = new Feed() { Id = "feeds-myget", Version = "1.0.0", PackageId =  "OctoConsole" };
         static readonly Feed FileShare = new Feed() { Id = "feeds-local", Version = "1.0.0", PackageId = "Acme.Web" };
         static readonly Feed AuthFeed = new Feed() { Id = "feeds-authmyget", PackageId =  "OctoConsole", Version = "1.0.0" };
+        static readonly Feed NuGetFeed = new Feed() {Id = "feeds-nuget", Version = "2.1.0", PackageId = "abp.castle.log4net" };
 
         [SetUp]
         public void SetUp()
@@ -65,6 +67,20 @@ namespace Calamari.Tests.Fixtures.PackageDownload
             AssertPackageSizeMatchesExpected(result, ExpectedPackageSize);
             AssertStagePackageOutputVariableSet(result, PublicFeed.File);
             result.AssertOutput("Package {0} {1} successfully downloaded from feed: '{2}'", PublicFeed.PackageId, PublicFeed.Version, PublicFeedUri);
+        }
+
+        [Test]
+        public void ShouldDownloadPackageWithRepositoryMetadata()
+        {
+            var result = DownloadPackage(NuGetFeed.PackageId, NuGetFeed.Version, NuGetFeed.Id, NuGetFeedUri);
+            result.AssertSuccess();
+
+            result.AssertOutput(
+                $"Downloading NuGet package {NuGetFeed.PackageId} {NuGetFeed.Version} from feed: '{NuGetFeedUri}'");
+            result.AssertOutput($"Downloaded package will be stored in: '{NuGetFeed.DownloadFolder}");
+
+            AssertStagePackageOutputVariableSet(result, NuGetFeed.File);
+            result.AssertOutput($"Package {NuGetFeed.PackageId} {NuGetFeed.Version} successfully downloaded from feed: '{NuGetFeedUri}'");
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -20,7 +20,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         static readonly string DownloadPath = TestEnvironment.GetTestPath(TentacleHome, "Files");
 
         static readonly string PublicFeedUri = "https://www.myget.org/F/octopusdeploy-tests";
-        static readonly string NuGetFeedUri = "https://api.nuget.org/v3/index.json";
+        static readonly string NuGetFeedUri = "https://www.nuget.org/api/v2/";
         static readonly string AuthFeedUri = Environment.GetEnvironmentVariable(FeedUriEnvironmentVariable);
         static readonly string FeedUsername = Environment.GetEnvironmentVariable(FeedUsernameEnvironmentVariable);
         static readonly string FeedPassword = Environment.GetEnvironmentVariable(FeedPasswordEnvironmentVariable);
@@ -73,6 +73,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         public void ShouldDownloadPackageWithRepositoryMetadata()
         {
             var result = DownloadPackage(NuGetFeed.PackageId, NuGetFeed.Version, NuGetFeed.Id, NuGetFeedUri);
+
             result.AssertSuccess();
 
             result.AssertOutput(

--- a/source/Calamari/Integration/Packages/NuGet/LocalNuGetPackage.cs
+++ b/source/Calamari/Integration/Packages/NuGet/LocalNuGetPackage.cs
@@ -50,6 +50,10 @@ namespace Calamari.Integration.Packages.NuGet
 
                     using (var manifestStream = entry.OpenEntryStream())
                     {
+                        // NuGet keeps adding new elements to the NuSpec schema,
+                        // which in turn breaks us when we try to read the manifest,
+                        // so we now read the manifest without schema validation
+                        // https://github.com/OctopusDeploy/Issues/issues/3487
                         var manifest = Manifest.ReadFrom(manifestStream, false);
                         return manifest.Metadata;
                     }

--- a/source/Calamari/Integration/Packages/NuGet/LocalNuGetPackage.cs
+++ b/source/Calamari/Integration/Packages/NuGet/LocalNuGetPackage.cs
@@ -50,8 +50,21 @@ namespace Calamari.Integration.Packages.NuGet
 
                     using (var manifestStream = entry.OpenEntryStream())
                     {
-                        var manifest = Manifest.ReadFrom(manifestStream, true);
-                        return manifest.Metadata;
+                        using (var ms = new MemoryStream())
+                        {
+                            manifestStream.CopyTo(ms);
+                            Manifest manifest;
+                            try
+                            {
+                                manifest = Manifest.ReadFrom(ms, true);
+                            }
+                            catch
+                            {
+                                ms.Seek(0, SeekOrigin.Begin);
+                                manifest = Manifest.ReadFrom(ms, false);
+                            }
+                            return manifest.Metadata;
+                        }
                     }
                 }
 

--- a/source/Calamari/Integration/Packages/NuGet/LocalNuGetPackage.cs
+++ b/source/Calamari/Integration/Packages/NuGet/LocalNuGetPackage.cs
@@ -50,21 +50,8 @@ namespace Calamari.Integration.Packages.NuGet
 
                     using (var manifestStream = entry.OpenEntryStream())
                     {
-                        using (var ms = new MemoryStream())
-                        {
-                            manifestStream.CopyTo(ms);
-                            Manifest manifest;
-                            try
-                            {
-                                manifest = Manifest.ReadFrom(ms, true);
-                            }
-                            catch
-                            {
-                                ms.Seek(0, SeekOrigin.Begin);
-                                manifest = Manifest.ReadFrom(ms, false);
-                            }
-                            return manifest.Metadata;
-                        }
+                        var manifest = Manifest.ReadFrom(manifestStream, false);
+                        return manifest.Metadata;
                     }
                 }
 


### PR DESCRIPTION
- [x] Add test

I'm not 100% sure this is the right solution, but it's the only way I could come up with...~(might be worth investigating if using newer NuGet dependencies resolves this issue without the need for calling `Manifest.ReadFrom(path, false)`)~

Tested with latest (`4.3.0`) `NuGet.Packaging` version and it works correctly with schema validation. So the question is, do we want to update our custom build of NuGet with latest NuGet dependencies...?