### PR TITLE
Use a mutex instead of semaphore

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -143,7 +143,7 @@ function Execute-WithRetry([ScriptBlock] $command, $noLock) {
 			Core-Execute-WithRetry -command $command
 		}
 		Finally {
-			$result = $mutex.ReleaseMutex()
+			$mutex.ReleaseMutex()
 			$mutex.Dispose()
 		}
 	}


### PR DESCRIPTION
Mutex has the advantage of thread termination notification so is more appropriate to use interprocess. When the process holding the mutex is killed, the mutex is also released.

Tested by acquiring the mutex in PowerShell, running an IIS deployment and then closing PowerShell.

```
$mutexId= 'Global\Octopus-IIS-Metabase-Mutex'
$mutex = New-Object System.Threading.Mutex -ArgumentList False, $mutexId

$mutex .WaitOne(100)
```

Relates to OctopusDeploy/Issues#3851