### PR TITLE
Set account domain when launching process

### DIFF
--- a/source/Calamari/Integration/Processes/SilentProcessRunner.cs
+++ b/source/Calamari/Integration/Processes/SilentProcessRunner.cs
@@ -152,8 +152,6 @@ namespace Calamari.Integration.Processes
 
             processStartInfo.Password = password;
 
-            
-
             // Environment variables (such as {env:TentacleHome}) are usually inherited from the parent process.
             // When running as a different user they are not inherited, so manually add them to the process.
             AddTentacleEnvironmentVariablesToProcess(processStartInfo);


### PR DESCRIPTION
When a user is specified to run PowerShell as and in the format `domain\user`, parses the domain and sets it in `StartInfo` for the process.  If the user is specified in UPN format (`user@domain`) this is not required.

Relates to OctopusDeploy/Issues#3852