### PR TITLE
Bug fail script on error output variable causes successful script to fail 

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -134,7 +134,8 @@ if ((Test-Path $PSScriptRoot) -and !(Test-Path $ARTIFACTS_DIR)) {
 # Make sure that packages.config exist.
 if (!(Test-Path $PACKAGES_CONFIG)) {
     Write-Verbose -Message "Downloading packages.config..."
-    try { (New-Object System.Net.WebClient).DownloadFile("http://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    try { (New-Object System.Net.WebClient).DownloadFile("https://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
         Throw "Could not download packages.config."
     }
 }

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/VhdBuilder.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/VhdBuilder.cs
@@ -29,8 +29,8 @@ namespace Calamari.Tests.Fixtures.Deployment.Packages
                 // can't use New-VHD cmdlet as it requires the Hyper-V service which
                 // won't run in EC2
                 File.WriteAllText(scriptFile.FilePath, CreateVhdDiskPartScrtipt(vhdPath));
-                var exitCode = SilentProcessRunner.ExecuteCommand("diskpart", $"/s {scriptFile.FilePath}", output, Console.WriteLine, Console.Error.WriteLine);
-                exitCode.Should().Be(0);
+                var silentProcessResult = SilentProcessRunner.ExecuteCommand("diskpart", $"/s {scriptFile.FilePath}", output, Console.WriteLine, Console.Error.WriteLine);
+                silentProcessResult.ExitCode.Should().Be(0);
             }
 
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -532,6 +532,27 @@ namespace Calamari.Tests.Fixtures.PowerShell
         }
 
         [Test]
+        [Category(TestEnvironment.CompatibleOS.Windows)]
+        public void ShoulPassOnStdInfoWithTreatScriptWarningsAsErrors()
+        {
+            var variablesFile = Path.GetTempFileName();
+            var variables = new VariableDictionary();
+            variables.Set("Octopus.Action.FailScriptOnErrorOutput", "True");
+            variables.Save(variablesFile);
+
+            using (new TemporaryFile(variablesFile))
+            {
+                var output = Invoke(Calamari()
+                    .Action("run-script")
+                    .Argument("variables", variablesFile)
+                    .Argument("script", GetFixtureResouce("Scripts", "Hello.ps1")));
+
+                output.AssertSuccess();
+                output.AssertOutput("Hello!");
+            }
+        }
+
+        [Test]
         [Category(TestEnvironment.CompatibleOS.Nix)]
         [Category(TestEnvironment.CompatibleOS.Mac)]
         public void ThrowsExceptionOnNixOrMac()

--- a/source/Calamari/Integration/Processes/CommandLineRunner.cs
+++ b/source/Calamari/Integration/Processes/CommandLineRunner.cs
@@ -27,8 +27,8 @@ namespace Calamari.Integration.Processes
 
                 return new CommandResult(
                     invocation.ToString(), 
-                    exitCode, 
-                    null, 
+                    exitCode.ExitCode,
+                    exitCode.ErrorOutput, 
                     invocation.WorkingDirectory);
             }
             catch (Exception ex)

--- a/source/Calamari/Integration/Processes/CommandResult.cs
+++ b/source/Calamari/Integration/Processes/CommandResult.cs
@@ -25,20 +25,11 @@
             this.workingDirectory = workingDirectory;
         }
 
-        public int ExitCode
-        {
-            get { return exitCode; }
-        }
+        public int ExitCode => exitCode;
 
-        public string Errors
-        {
-            get { return additionalErrors; }
-        }
+        public string Errors => additionalErrors;
 
-        public bool HasErrors
-        {
-            get { return string.IsNullOrWhiteSpace(additionalErrors); }
-        }
+        public bool HasErrors => !string.IsNullOrWhiteSpace(additionalErrors);
 
         public CommandResult VerifySuccess()
         {

--- a/source/Calamari/Integration/Processes/SilentProcessRunnerResult.cs
+++ b/source/Calamari/Integration/Processes/SilentProcessRunnerResult.cs
@@ -1,0 +1,15 @@
+﻿namespace Calamari.Integration.Processes
+{
+    public class SilentProcessRunnerResult
+    {
+        public int ExitCode { get; }
+
+        public string ErrorOutput { get; }
+
+        public SilentProcessRunnerResult(int exitCode, string errorOutput)
+        {
+            ExitCode = exitCode;
+            ErrorOutput = errorOutput;
+        }
+    }
+}


### PR DESCRIPTION
Fixes the issue where setting the Octopus.Action.FailScriptOnErrorOutput variable to true causes successful script to fail.
Fixes OctopusDeploy/Issues#3773