### PR TITLE
Fix for DeployFailed.ps1 not automatically cleaned up after successful deployment

### DIFF
--- a/source/Calamari/Commands/TransferPackageCommand.cs
+++ b/source/Calamari/Commands/TransferPackageCommand.cs
@@ -8,9 +8,6 @@ using Calamari.Deployment.Journal;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Processes.Semaphores;
-using Calamari.Integration.Scripting;
-using Calamari.Integration.ServiceMessages;
-using Calamari.Util;
 
 namespace Calamari.Commands
 {
@@ -46,8 +43,7 @@ namespace Calamari.Commands
 
             fileSystem.FreeDiskSpaceOverrideInMegaBytes = variables.GetInt32(SpecialVariables.FreeDiskSpaceOverrideInMegaBytes);
             fileSystem.SkipFreeDiskSpaceCheck = variables.GetFlag(SpecialVariables.SkipFreeDiskSpaceCheck);
-
-            var commandLineRunner = new CommandLineRunner(new SplitCommandOutput(new ConsoleCommandOutput(), new ServiceMessageCommandOutput(variables)));
+            
             var journal = new DeploymentJournal(fileSystem, SemaphoreFactory.Get(), variables);
             
             var conventions = new List<IConvention>
@@ -58,7 +54,6 @@ namespace Calamari.Commands
                 new LogVariablesConvention(),
                 new AlreadyInstalledConvention(journal),
                 new TransferPackageConvention(fileSystem),
-                new RollbackScriptConvention(DeploymentStages.DeployFailed, fileSystem, new CombinedScriptEngine(), commandLineRunner),
             };
 
             var deployment = new RunningDeployment(packageFile, variables);

--- a/source/Calamari/Deployment/ConventionProcessor.cs
+++ b/source/Calamari/Deployment/ConventionProcessor.cs
@@ -76,6 +76,11 @@ namespace Calamari.Deployment
         {
             foreach (var convention in conventions.OfType<IRollbackConvention>())
             {
+                if (deployment.Variables.GetFlag(SpecialVariables.Action.SkipRemainingConventions))
+                {
+                    break;
+                }
+
                 convention.Cleanup(deployment);
             }
         }

--- a/source/Calamari/Deployment/Conventions/RollbackScriptConvention.cs
+++ b/source/Calamari/Deployment/Conventions/RollbackScriptConvention.cs
@@ -18,6 +18,10 @@ namespace Calamari.Deployment.Conventions
 
         public void Cleanup(RunningDeployment deployment)
         {
+            if (deployment.Variables.GetFlag(SpecialVariables.DeleteScriptsOnCleanup, true))
+            {
+                DeleteScripts(deployment);
+            }
         }
     }
 }


### PR DESCRIPTION
- Added an implementation for the method Cleanup on RollbackScriptConvention to delete the script. Cleanup was already being called, it was just missing an implementation. 
- Removed RollbackScriptConvention from TransferPackageCommand as it doesn't extract the package, so rollback scripts aren't available.

Fixes OctopusDeploy/Issues#3608