### PR TITLE
Package search for exact match only

### DIFF
--- a/source/Calamari/Commands/FindPackageCommand.cs
+++ b/source/Calamari/Commands/FindPackageCommand.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.Linq;
 using Calamari.Commands.Support;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Packages;
-using Calamari.Integration.Packages.Java;
-using Calamari.Integration.Processes;
-using Calamari.Integration.ServiceMessages;
 #if USE_NUGET_V2_LIBS
 using Calamari.NuGet.Versioning;
 #else
@@ -22,12 +16,14 @@ namespace Calamari.Commands
         string packageId;
         string packageVersion;
         string packageHash;
+        bool exactMatchOnly;
 
         public FindPackageCommand()
         {
             Options.Add("packageId=", "Package ID to find", v => packageId = v);
             Options.Add("packageVersion=", "Package version to find", v => packageVersion = v);
             Options.Add("packageHash=", "Package hash to compare against", v => packageHash = v);
+            Options.Add("exactMatch=", "Only return exact matches", v => exactMatchOnly = bool.Parse(v));
         }
 
         public override int Execute(string[] commandLineArguments)
@@ -37,42 +33,24 @@ namespace Calamari.Commands
             Guard.NotNullOrWhiteSpace(packageId, "No package ID was specified. Please pass --packageId YourPackage");
             Guard.NotNullOrWhiteSpace(packageVersion, "No package version was specified. Please pass --packageVersion 1.0.0.0");
             Guard.NotNullOrWhiteSpace(packageHash, "No package hash was specified. Please pass --packageHash YourPackageHash");
-            
+
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-            var commandLineRunner = new CommandLineRunner(
-                new SplitCommandOutput(
-                    new ConsoleCommandOutput(), 
-                    new ServiceMessageCommandOutput(
-                        new CalamariVariableDictionary())));
-            
-            NuGetVersion version;
-            if(!NuGetVersion.TryParse(packageVersion, out version))
-                throw new CommandException(String.Format("Package version '{0}' is not a valid Semantic Version", packageVersion));
+
+            if (!NuGetVersion.TryParse(packageVersion, out var version))
+                throw new CommandException($"Package version '{packageVersion}' is not a valid Semantic Version");
 
             var packageStore = new PackageStore(
                 new GenericPackageExtractorFactory().createJavaGenericPackageExtractor(fileSystem));
-            var packageMetadata = new ExtendedPackageMetadata() {Id = packageId, Version = packageVersion, Hash = packageHash};
+            var packageMetadata = new ExtendedPackageMetadata {Id = packageId, Version = packageVersion, Hash = packageHash};
             var package = packageStore.GetPackage(packageMetadata);
             if (package == null)
             {
-                Log.VerboseFormat("Package {0} version {1} hash {2} has not been uploaded.", 
-                    packageMetadata.Id, packageMetadata.Version, packageMetadata.Hash);
+                Log.Verbose($"Package {packageMetadata.Id} version {packageMetadata.Version} hash {packageMetadata.Hash} has not been uploaded.");
 
-                Log.VerboseFormat("Finding earlier packages that have been uploaded to this Tentacle.");
-                var nearestPackages = packageStore.GetNearestPackages(packageId, version).ToList();
-                if (!nearestPackages.Any())
-                {
-                    Log.VerboseFormat("No earlier packages for {0} has been uploaded", packageId);
+                if (exactMatchOnly)
                     return 0;
-                }
 
-                Log.VerboseFormat("Found {0} earlier {1} of {2} on this Tentacle", 
-                    nearestPackages.Count, nearestPackages.Count == 1 ? "version" : "versions", packageId);
-                foreach(var nearestPackage in nearestPackages)
-                {
-                    Log.VerboseFormat("  - {0}: {1}", nearestPackage.Metadata.Version, nearestPackage.FullPath);
-                    Log.ServiceMessages.PackageFound(nearestPackage.Metadata.Id, nearestPackage.Metadata.Version, nearestPackage.Metadata.Hash, nearestPackage.Metadata.FileExtension, nearestPackage.FullPath);
-                }
+                FindEarlierPackages(packageStore, version);
 
                 return 0;
             }
@@ -80,6 +58,24 @@ namespace Calamari.Commands
             Log.VerboseFormat("Package {0} {1} hash {2} has already been uploaded", package.Metadata.Id, package.Metadata.Version, package.Metadata.Hash);
             Log.ServiceMessages.PackageFound(package.Metadata.Id, package.Metadata.Version, package.Metadata.Hash, package.Metadata.FileExtension, package.FullPath, true);
             return 0;
+        }
+
+        void FindEarlierPackages(PackageStore packageStore, NuGetVersion version)
+        {
+            Log.Verbose("Finding earlier packages that have been uploaded to this Tentacle.");
+            var nearestPackages = packageStore.GetNearestPackages(packageId, version).ToList();
+            if (!nearestPackages.Any())
+            {
+                Log.VerboseFormat("No earlier packages for {0} has been uploaded", packageId);
+                return;
+            }
+
+            Log.Verbose($"Found {nearestPackages.Count} earlier {(nearestPackages.Count == 1 ? "version" : "versions")} of {packageId} on this Tentacle");
+            foreach (var nearestPackage in nearestPackages)
+            {
+                Log.VerboseFormat("  - {0}: {1}", nearestPackage.Metadata.Version, nearestPackage.FullPath);
+                Log.ServiceMessages.PackageFound(nearestPackage.Metadata.Id, nearestPackage.Metadata.Version, nearestPackage.Metadata.Hash, nearestPackage.Metadata.FileExtension, nearestPackage.FullPath);
+            }
         }
     }
 }


### PR DESCRIPTION
Adds the `exactMatch` parameter to package find command.

Relates to OctopusDeploy/Issues#3871