### PR TITLE
Set number of powershell variables to maximum possible

### DIFF
--- a/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -313,6 +313,7 @@ Log-VersionTable
 # Variables
 # -----------------------------------------------------------------
 {{BeforeVariablesDebugLocation}}
+$MaximumVariableCount=32768
 {{VariableDeclarations}}
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
Fixes: https://github.com/OctopusDeploy/Issues/issues/3913

Powershell has some set limits including on number of variables https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-5.1

This just sets the max for our invocations to the max possible.

In powerhshell 6 these limits will go away.

