### PR TITLE
Add runtime config for enabling long paths in Calamari.Azure as it was missing

### DIFF
--- a/source/Calamari.Azure/app.config
+++ b/source/Calamari.Azure/app.config
@@ -3,5 +3,6 @@
   <runtime>
     <!-- Prevent CRL check for signed assemblies -->
     <generatePublisherEvidence enabled="false"/>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
   </runtime>
 </configuration>


### PR DESCRIPTION
Fixes OctopusDeploy/Issues#4204