### PR TITLE
Add and Test `FileNameEncoder`

### DIFF
--- a/source/Calamari.Tests/Fixtures/Integration/Packages/FileNameEncoderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/FileNameEncoderFixture.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.Integration.Packages;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Integration.Packages
+{
+    [TestFixture]
+    public class FileNameEncoderFixture
+    {
+        [Test]
+        [TestCase("Hello", "Hello", Description = "Standard no pecial characters")]
+        [TestCase("Hel%lo", "Hel%25lo", Description = "Percent symbol in input  (signal character)")]
+        [TestCase("Hel%%lo", "Hel%25%25lo", Description = "Percent symbol in input")]
+        [TestCase("Hel%25lo", "Hel%2525lo", Description = "Pre-encoded input double encoded")]
+        [TestCase("Hel+lo", "Hel+lo", Description = "Url-unsafe but filename-safe character left alone")]
+        [TestCase("1.0.1+beta", "1.0.1+beta", Description = "Standard version name unchanged")]
+        public void Encode(string input, string expected)
+        {
+            Assert.AreEqual(expected, FileNameEscaper.Escape(input));
+        }
+
+        [Test]
+        public void AllInvalidCharactersEncoded()
+        {
+            var reallyUnsafeString = "H%<>:\"/\\|?I";
+            var encoded = FileNameEscaper.Escape(reallyUnsafeString);
+
+            var encodedCharacters = FileNameEscaper.EscapedCharacters.ToList();
+            encodedCharacters.Remove('%'); //Since they are encoded with a %
+
+            Assert.IsFalse(encoded.Any(encodedCharacters.Contains));
+        }
+
+        [Test]
+        [TestCase("Hello", "Hello")]
+        [TestCase("Hel%25lo", "Hel%lo", Description = "Percent decoding (signal character)")]
+        [TestCase("Hel%2Flo", "Hel/lo", Description = "Simple character decoding")]
+        [TestCase("Hel%2F%5Clo", "Hel/\\lo", Description = "Double encoding decodes")]
+        [TestCase("Hel+%/lo", "Hel+%/lo", Description = "Already invalid characters just pass through")]
+        [TestCase("1.0.1+beta", "1.0.1+beta", Description = "Standard version name unchanged")]
+        public void Decode(string input, string expected)
+        {
+            Assert.AreEqual(expected, FileNameEscaper.Unescape(input));
+        }
+    }
+}

--- a/source/Calamari/Deployment/ApplicationDirectory.cs
+++ b/source/Calamari/Deployment/ApplicationDirectory.cs
@@ -19,8 +19,8 @@ namespace Calamari.Deployment
         {
             return EnsureTargetPathExistsAndIsEmpty(
                 Path.Combine(GetEnvironmentApplicationDirectory(fileSystem, variables),
-                    Uri.EscapeDataString(packageFileNameMetadata.PackageId),
-                    Uri.EscapeDataString(packageFileNameMetadata.Version.ToString())),
+                    FileNameEscaper.Escape(packageFileNameMetadata.PackageId),
+                    FileNameEscaper.Escape(packageFileNameMetadata.Version.ToString())),
                 fileSystem);
         }
 

--- a/source/Calamari/Integration/Packages/FileNameEscaper.cs
+++ b/source/Calamari/Integration/Packages/FileNameEscaper.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Calamari.Integration.Packages
+{
+    public static class FileNameEscaper
+    {
+        private static readonly HashSet<char> InvalidCharacterSet = new HashSet<char> {
+            '%', '<', '>', ':', '"', '/', '\\', '|', '?'
+        };
+
+        public static char[] EscapedCharacters => InvalidCharacterSet.ToArray();
+
+        /// <summary>
+        /// Encodes invalid Windows filename characters < > : " / \ | ? *
+        /// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+        /// </summary>
+        /// <returns></returns>
+        public static string Escape(string input)
+        {
+            var sb = new StringBuilder();
+            foreach (var c in input)
+            {
+                if (!InvalidCharacterSet.Contains(c))
+                {
+                    sb.Append(c);
+                }
+                else
+                {
+                    sb.Append(Uri.EscapeDataString(c.ToString()));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        public static string Unescape(string input)
+        {
+            return Uri.UnescapeDataString(input);
+        }
+    }
+}

--- a/source/Calamari/Integration/Packages/PackageName.cs
+++ b/source/Calamari/Integration/Packages/PackageName.cs
@@ -186,12 +186,12 @@ namespace Calamari.Integration.Packages
 
         static string Encode(string input)
         {
-            return Uri.EscapeDataString(input);
+            return FileNameEscaper.Escape(input);
         }
 
         static string Decode(string input)
         {
-            return Uri.UnescapeDataString(input);
+            return FileNameEscaper.Unescape(input);
         }
 
         static string EncodeVersion(IVersion version)


### PR DESCRIPTION
Fixes problem that appears when IIS deployments crash due to invalid characters in file name. This occurs with new package cache naming changes that was causing the + to be replace with a url encoded character. This fix is more conservative and should only replace characters known to be invalid for (windows) filesystems.