### PR TITLE
S3 bugbash fixes

### DIFF
--- a/source/Calamari.Aws/Deployment/AmazonFileUploadException.cs
+++ b/source/Calamari.Aws/Deployment/AmazonFileUploadException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Calamari.Aws.Deployment
+{
+    public class AmazonFileUploadException : Exception
+    {
+        public AmazonFileUploadException(){}
+        public AmazonFileUploadException(string message) : base(message){}
+        public AmazonFileUploadException(string message, Exception innerException) : base(message, innerException){}
+        protected AmazonFileUploadException(SerializationInfo info, StreamingContext context) : base(info, context){}
+    }
+}

--- a/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
@@ -9,7 +9,7 @@ namespace Calamari.Aws.Integration.S3
     {
         public static List<Tag> ToTagSet(this IEnumerable<KeyValuePair<string, string>> source)
         {
-            return source?.Select(x => new Tag {Key = x.Key, Value = x.Value}).ToList() ?? new List<Tag>();
+            return source?.Select(x => new Tag {Key = x.Key, Value = x.Value?.Trim()}).ToList() ?? new List<Tag>();
         }
 
         public static PutObjectRequest WithMetadata(this PutObjectRequest request, IEnumerable<KeyValuePair<string, string>> source)
@@ -18,7 +18,7 @@ namespace Calamari.Aws.Integration.S3
             {
                 foreach (var item in source)
                 {
-                    x.Metadata.Add(item.Key, item.Value);
+                    x.Metadata.Add(item.Key, item.Value?.Trim());
                 }
             });
         }


### PR DESCRIPTION
Better error messages when presented with an invalid tag (per upload)
Better error messages when given a bad metadata key / value
Trim metadata and tags, but more specifically metadata to avoid SignatureDoesNotMatch where there is a trailing whitespace provided in a key.