### PR TITLE
Skip content hash checking for s3 step FIPS

### DIFF
--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -84,7 +84,7 @@ namespace Calamari.Aws.Deployment.Conventions
 
             if (!md5HashSupported)
             {
-                Log.Info("Md5 hashes are not supported in executing environment. Files will always be uploaded.");
+                Log.Info("MD5 hashes are not supported in executing environment. Files will always be uploaded.");
             }
 
             var options = optionsProvider.GetOptions(targetMode);

--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography;
 using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
@@ -14,6 +15,7 @@ using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Substitutions;
+using Calamari.Util;
 using Octopus.CoreUtilities;
 using Octopus.CoreUtilities.Extensions;
 
@@ -27,6 +29,7 @@ namespace Calamari.Aws.Deployment.Conventions
         private readonly S3TargetMode targetMode;
         private readonly IProvideS3TargetOptions optionsProvider;
         private readonly IFileSubstituter fileSubstituter;
+        private readonly bool md5HashSupported;
 
         private static readonly HashSet<S3CannedACL> CannedAcls = new HashSet<S3CannedACL>(ConstantHelpers.GetConstantValues<S3CannedACL>());
         
@@ -44,6 +47,7 @@ namespace Calamari.Aws.Deployment.Conventions
             this.targetMode = targetMode;
             this.optionsProvider = optionsProvider;
             this.fileSubstituter = fileSubstituter;
+            this.md5HashSupported = HashCalculator.IsAvailableHashingAlgorithm(MD5.Create);
         }
 
         private static string ExceptionMessageWithFilePath(PutObjectRequest request, Exception exception)
@@ -77,6 +81,11 @@ namespace Calamari.Aws.Deployment.Conventions
         {
             //The bucket should exist at this point
             Guard.NotNull(deployment, "deployment can not be null");
+
+            if (!md5HashSupported)
+            {
+                Log.Info("Md5 hashes are not supported in executing environment. Files will always be uploaded.");
+            }
 
             var options = optionsProvider.GetOptions(targetMode);
             AmazonS3Client Factory() => ClientHelpers.CreateS3Client(awsEnvironmentGeneration);
@@ -240,17 +249,18 @@ namespace Calamari.Aws.Deployment.Conventions
             Guard.NotNullOrWhiteSpace(bucket, "The provided bucket key may not be null");
             Guard.NotNull(properties, "Target properties may not be null");
 
-            return new PutObjectRequest
-            {
-                FilePath = path,
-                BucketName = bucket?.Trim(),
-                Key = bucketKey()?.Trim(),
-                StorageClass = S3StorageClass.FindValue(properties.StorageClass?.Trim()),
-                CannedACL = S3CannedACL.FindValue(properties.CannedAcl?.Trim())
-            }
-            .WithMetadata(properties)
-            .WithTags(properties)
-            .WithMd5Digest(fileSystem);
+            var request = new PutObjectRequest
+                {
+                    FilePath = path,
+                    BucketName = bucket?.Trim(),
+                    Key = bucketKey()?.Trim(),
+                    StorageClass = S3StorageClass.FindValue(properties.StorageClass?.Trim()),
+                    CannedACL = S3CannedACL.FindValue(properties.CannedAcl?.Trim())
+                }
+                .WithMetadata(properties)
+                .WithTags(properties);
+
+            return md5HashSupported ? request.WithMd5Digest(fileSystem) : request;
         }
 
         private static Func<string> GetBucketKey(ICalamariFileSystem fileSystem, string filePath, IHaveBucketKeyBehaviour behaviour)
@@ -341,6 +351,9 @@ namespace Calamari.Aws.Deployment.Conventions
             //This isn't ideal, however the AWS SDK doesn't really provide any means to check the existence of an object.
             try
             {
+                if (!md5HashSupported)
+                    return true;
+
                 var metadata = client.GetObjectMetadata(request.BucketName, request.Key);
                 return !metadata.GetEtag().IsSameAsRequestMd5Digest(request);
             }
@@ -350,7 +363,7 @@ namespace Calamari.Aws.Deployment.Conventions
                 {
                     return true;
                 }
-
+                
                 throw;
             }
         }
@@ -372,4 +385,4 @@ namespace Calamari.Aws.Deployment.Conventions
                 .Tee(message => DisplayWarning("AWS-S3-ERROR-0001", message));
         }
     }
-}
+ }

--- a/source/Calamari.Tests/Fixtures/Util/HashCalculatorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/HashCalculatorFixture.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Calamari.Util;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Util
+{
+    public class MockHashingAlgorithm : HashAlgorithm
+    {
+        public override void Initialize()
+        {
+        }
+
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+        }
+
+        protected override byte[] HashFinal()
+        {
+            return Encoding.UTF8.GetBytes("Supercalifragilisticexpialidocious");
+        }
+    }
+
+    [TestFixture]
+    public class HashCalculatorFixture
+    {
+        public static Func<THash> CreateHashFipsFailure<THash>() where THash: HashAlgorithm
+        {
+            return () => throw new TargetInvocationException(new InvalidOperationException("This implementation is not part of the Windows Platform FIPS validated cryptographic algorithms."));
+        }
+
+        public static Func<THash> CreateNullHashFactory<THash>() where THash : HashAlgorithm
+        {
+            return () => null;
+        }
+
+        [Test]
+        public void ShouldReturnFalseIfHashingAlgorithmIsNotSupported()
+        {
+            Assert.IsFalse(HashCalculator.IsAvailableHashingAlgorithm(CreateHashFipsFailure<MD5>()));
+        }
+
+        [Test]
+        public void ShouldReturnTrueIfHashingAlgorithmIsSupported()
+        {
+            Assert.IsTrue(HashCalculator.IsAvailableHashingAlgorithm(() => new MockHashingAlgorithm()));
+        }
+
+        [Test]
+        public void ShouldReturnFalseIfHashingAlgorithmFactoryReturnsNull()
+        {
+            Assert.IsFalse(HashCalculator.IsAvailableHashingAlgorithm(CreateNullHashFactory<MD5>()));
+        }
+    }
+}

--- a/source/Calamari/Util/HashCalculator.cs
+++ b/source/Calamari/Util/HashCalculator.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
+using System.Reflection;
 using System.Security.Cryptography;
+using Octopus.CoreUtilities;
 
 namespace Calamari.Util
 {
@@ -36,5 +38,25 @@ namespace Calamari.Util
         {
             return SHA1.Create();
         }
+
+        /// <summary>
+        /// When FIPS mode is enabled certain algorithms such as MD5 may not be available.  
+        /// </summary>
+        /// <param name="factory">A callback function used to create the associated algorithm i.e. MD5.Create</param>
+        /// <returns></returns>
+        public static bool IsAvailableHashingAlgorithm(Func<HashAlgorithm> factory)
+        {
+            Guard.NotNull(factory, "Factory method is required");
+
+            try
+            {
+                var result = factory();
+                return result != null; 
+            }
+            catch (TargetInvocationException)
+            {
+                return false;
+            }
+        } 
     }
 }


### PR DESCRIPTION
Skip content hash checking for s3 step when md5 hash algorithm is not available such as when FIPS is enabled.