### PR TITLE
Print variables in name order

### DIFF
--- a/source/Calamari/Integration/Processes/VariableDictionaryExtensions.cs
+++ b/source/Calamari/Integration/Processes/VariableDictionaryExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text;
 using Calamari.Deployment;
 using Octostache;
@@ -67,7 +68,7 @@ namespace Calamari.Integration.Processes
         {
             var text = new StringBuilder();
 
-            foreach (var name in variables.GetNames())
+            foreach (var name in variables.GetNames().OrderBy(name => name))
             {
                 if (!nameFilter(name))
                     continue;


### PR DESCRIPTION
![First Order](https://cdn.shopify.com/s/files/1/0748/0217/products/victory_miller.jpg?v=1462059484)

I didn't realise these were not ordered predictably. Source: https://help.octopus.com/t/awsaccount-variables-secretkey-easily-exposed/19691/5