### PR TITLE
Change run-script command to allow using scriptBody from variables

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/SubstituteVariablesInAzureServiceFabricPackageConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/SubstituteVariablesInAzureServiceFabricPackageConvention.cs
@@ -21,7 +21,6 @@ namespace Calamari.Azure.Deployment.Conventions
             var configurationFiles = fileSystem.EnumerateFilesRecursively(deployment.CurrentDirectory, "*.config", "*.xml");
             foreach (var configurationFile in configurationFiles)
             {
-                Log.Verbose($"Performing variable substitution on '{configurationFile}'");
                 substituter.PerformSubstitution(configurationFile, deployment.Variables);
             }
         }

--- a/source/Calamari.Shared/Deployment/Conventions/ConfiguredScriptConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/ConfiguredScriptConvention.cs
@@ -32,7 +32,7 @@ namespace Calamari.Deployment.Conventions
             if (!features.Contains(SpecialVariables.Features.CustomScripts))
                 return;
 
-            foreach (ScriptType scriptType in Enum.GetValues(typeof(ScriptType)))
+            foreach (ScriptSyntax scriptType in Enum.GetValues(typeof(ScriptSyntax)))
             {
                 var scriptName = GetScriptName(deploymentStage, scriptType);
                 
@@ -76,9 +76,9 @@ namespace Calamari.Deployment.Conventions
             }
         }
 
-        public static string GetScriptName(string deploymentStage, ScriptType scriptType)
+        public static string GetScriptName(string deploymentStage, ScriptSyntax scriptSyntax)
         {
-            return "Octopus.Action.CustomScripts." + deploymentStage + "." + scriptType.FileExtension();
+            return "Octopus.Action.CustomScripts." + deploymentStage + "." + scriptSyntax.FileExtension();
         }
 
 

--- a/source/Calamari.Shared/Deployment/Conventions/SubstituteInFilesConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/SubstituteInFilesConvention.cs
@@ -52,7 +52,6 @@ namespace Calamari.Deployment.Conventions
 
                 foreach (var file in matchingFiles)
                 {
-                    Log.Info("Performing variable substitution on '{0}'", file);
                     substituter.PerformSubstitution(file, deployment.Variables);
                 }
             }

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -303,7 +303,11 @@
 
             public static class Script
             {
-                public const string SuppressEnvironmentLogging = "Octopus.Action.Script.SuppressEnvironmentLogging";
+                public static readonly string Syntax = "Octopus.Action.Script.Syntax";
+                public static readonly string ScriptBody = "Octopus.Action.Script.ScriptBody";
+                public static readonly string ScriptFileName = "Octopus.Action.Script.ScriptFileName";
+                public static readonly string ScriptParameters = "Octopus.Action.Script.ScriptParameters";
+                public static readonly string ScriptSource = "Octopus.Action.Script.ScriptSource";
             }
 
             public static class Java

--- a/source/Calamari.Shared/Integration/Processes/VariableDictionaryExtensions.cs
+++ b/source/Calamari.Shared/Integration/Processes/VariableDictionaryExtensions.cs
@@ -47,8 +47,6 @@ namespace Calamari.Integration.Processes
             variables.Set(machineIndexedVariableName, value);
         }
 
-
-
         public static void LogVariables(this VariableDictionary variables)
         {
             if (variables.GetFlag(SpecialVariables.PrintVariables))
@@ -84,5 +82,8 @@ namespace Calamari.Integration.Processes
         {
             return !variableName.Contains("CustomScripts.");
         }
+
+        public static T GetEnum<T>(this VariableDictionary variables, string value, T @default)
+            => (T)Enum.Parse(typeof(T), variables.Get(value, @default.ToString()), true);
     }
 }

--- a/source/Calamari.Shared/Integration/Scripting/Bash/BashScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/Bash/BashScriptEngine.cs
@@ -7,9 +7,9 @@ namespace Calamari.Integration.Scripting.Bash
 {
     public class BashScriptEngine : IScriptEngine
     {
-        public ScriptType[] GetSupportedTypes()
+        public ScriptSyntax[] GetSupportedTypes()
         {
-            return new[] {ScriptType.Bash};
+            return new[] {ScriptSyntax.Bash};
         }
 
         public CommandResult Execute(

--- a/source/Calamari.Shared/Integration/Scripting/CombinedScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/CombinedScriptEngine.cs
@@ -31,11 +31,11 @@ namespace Calamari.Integration.Scripting
             this.scriptWrapperHooks = scriptWrapperHooks;
         }
 
-        public ScriptType[] GetSupportedTypes()
+        public ScriptSyntax[] GetSupportedTypes()
         {
             return (CalamariEnvironment.IsRunningOnNix || CalamariEnvironment.IsRunningOnMac)
-                ? new[] { ScriptType.ScriptCS, ScriptType.Bash, ScriptType.FSharp }
-                : new[] { ScriptType.ScriptCS, ScriptType.Powershell, ScriptType.FSharp };
+                ? new[] { ScriptSyntax.CSharp, ScriptSyntax.Bash, ScriptSyntax.FSharp }
+                : new[] { ScriptSyntax.CSharp, ScriptSyntax.Powershell, ScriptSyntax.FSharp };
         }
 
         public CommandResult Execute(
@@ -58,19 +58,19 @@ namespace Calamari.Integration.Scripting
         /// that is to be run, with all other wrappers contributing to the script
         /// context.
         /// </summary>
-        /// <param name="scriptType">The type of the script being run</param>
+        /// <param name="scriptSyntax">The type of the script being run</param>
         /// <returns>
         /// The start of the wrapper chain. Because each IScriptWrapper is expected to call its NextWrapper,
         /// calling ExecuteScript() on the start of the chain will result in every part of the chain being
         /// executed, down to the final TerminalScriptWrapper.
         /// </returns>
-        IScriptWrapper BuildWrapperChain(ScriptType scriptType) =>
+        IScriptWrapper BuildWrapperChain(ScriptSyntax scriptSyntax) =>
             // get the type of script
             scriptWrapperHooks
                 .Where(hook => hook.Enabled)
                 .Aggregate(
                 // The last wrapper is always the TerminalScriptWrapper
-                new TerminalScriptWrapper(ScriptEngineRegistry.Instance.ScriptEngines[scriptType]),
+                new TerminalScriptWrapper(ScriptEngineRegistry.Instance.ScriptEngines[scriptSyntax]),
                 (IScriptWrapper current, IScriptWrapper next) =>
                 {
                     // the next wrapper is pointed to the current one
@@ -80,7 +80,7 @@ namespace Calamari.Integration.Scripting
                 });
                  
         
-        private ScriptType ValidateScriptType(Script script)
+        private ScriptSyntax ValidateScriptType(Script script)
         {
             var scriptExtension = Path.GetExtension(script.File)?.TrimStart('.');
             var type = scriptExtension.ToScriptType();

--- a/source/Calamari.Shared/Integration/Scripting/FSharp/FSharpEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/FSharp/FSharpEngine.cs
@@ -7,9 +7,9 @@ namespace Calamari.Integration.Scripting.FSharp
 {
     public class FSharpEngine : IScriptEngine
     {
-        public ScriptType[] GetSupportedTypes()
+        public ScriptSyntax[] GetSupportedTypes()
         {
-            return new[] {ScriptType.FSharp};
+            return new[] {ScriptSyntax.FSharp};
         }
 
         public CommandResult Execute(

--- a/source/Calamari.Shared/Integration/Scripting/IScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/IScriptEngine.cs
@@ -5,7 +5,7 @@ namespace Calamari.Integration.Scripting
 {
     public interface IScriptEngine  
     {
-        ScriptType[] GetSupportedTypes();
+        ScriptSyntax[] GetSupportedTypes();
         CommandResult Execute(
             Script script, 
             CalamariVariableDictionary variables, 

--- a/source/Calamari.Shared/Integration/Scripting/Script.cs
+++ b/source/Calamari.Shared/Integration/Scripting/Script.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Calamari.Integration.Scripting
 {
     public class Script
@@ -12,7 +14,6 @@ namespace Calamari.Integration.Scripting
         public Script(string file, string parameters)
         {
             if (string.IsNullOrEmpty(file)) throw new InvalidScriptException("File can not be null or empty.");
-
             File = file;
             Parameters = parameters;
         }

--- a/source/Calamari.Shared/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/ScriptCS/ScriptCSScriptEngine.cs
@@ -7,9 +7,9 @@ namespace Calamari.Integration.Scripting.ScriptCS
 {
     public class ScriptCSScriptEngine : IScriptEngine
     {
-        public ScriptType[] GetSupportedTypes()
+        public ScriptSyntax[] GetSupportedTypes()
         {
-            return new[] {ScriptType.ScriptCS};
+            return new[] {ScriptSyntax.CSharp};
         }
 
         public CommandResult Execute(

--- a/source/Calamari.Shared/Integration/Scripting/ScriptEngineRegistry.cs
+++ b/source/Calamari.Shared/Integration/Scripting/ScriptEngineRegistry.cs
@@ -8,17 +8,17 @@ namespace Calamari.Integration.Scripting
 {
     public class ScriptEngineRegistry
     {
-        private readonly Dictionary<ScriptType, IScriptEngine> scriptEngines = new Dictionary<ScriptType, IScriptEngine>
+        private readonly Dictionary<ScriptSyntax, IScriptEngine> scriptEngines = new Dictionary<ScriptSyntax, IScriptEngine>
         {
-            {ScriptType.Powershell, new PowerShellScriptEngine() },
-            {ScriptType.ScriptCS, new ScriptCSScriptEngine() },
-            {ScriptType.Bash, new BashScriptEngine()},
-            {ScriptType.FSharp, new FSharpEngine()}
+            {ScriptSyntax.Powershell, new PowerShellScriptEngine() },
+            {ScriptSyntax.CSharp, new ScriptCSScriptEngine() },
+            {ScriptSyntax.Bash, new BashScriptEngine()},
+            {ScriptSyntax.FSharp, new FSharpEngine()}
         }; 
 
         public static readonly ScriptEngineRegistry Instance = new ScriptEngineRegistry();
 
-        public IDictionary<ScriptType, IScriptEngine> ScriptEngines { get { return scriptEngines; } }
+        public IDictionary<ScriptSyntax, IScriptEngine> ScriptEngines { get { return scriptEngines; } }
     }
 
 }

--- a/source/Calamari.Shared/Integration/Scripting/ScriptSyntax.cs
+++ b/source/Calamari.Shared/Integration/Scripting/ScriptSyntax.cs
@@ -1,16 +1,15 @@
 ﻿using System.Linq;
-using System.Reflection;
 using Calamari.Commands.Support;
 
 namespace Calamari.Integration.Scripting
 {
-    public enum ScriptType
+    public enum ScriptSyntax
     {
         [FileExtension("ps1")]
         Powershell,
 
         [FileExtension("csx")]
-        ScriptCS,
+        CSharp,
 
         [FileExtension("sh")]
         Bash,
@@ -21,23 +20,23 @@ namespace Calamari.Integration.Scripting
 
     public static class ScriptTypeExtensions
     {
-        public static string FileExtension(this ScriptType scriptType)
+        public static string FileExtension(this ScriptSyntax scriptSyntax)
         {
-            return typeof (ScriptType).GetField(scriptType.ToString())
+            return typeof (ScriptSyntax).GetField(scriptSyntax.ToString())
                     .GetCustomAttributes(typeof (FileExtensionAttribute), false)
                     .Select(attr => ((FileExtensionAttribute) attr).Extension)
                     .FirstOrDefault();
         }
 
-        public static ScriptType ToScriptType(this string extension)
+        public static ScriptSyntax ToScriptType(this string extension)
         {
-            var scriptTypeField = typeof (ScriptType).GetFields()
+            var scriptTypeField = typeof (ScriptSyntax).GetFields()
                 .SingleOrDefault(
                     field => field.GetCustomAttributes(typeof (FileExtensionAttribute), false)
                             .Any(attr => ((FileExtensionAttribute) attr).Extension == extension.ToLower()));
 
             if (scriptTypeField != null)
-                return (ScriptType)scriptTypeField.GetValue(null);
+                return (ScriptSyntax)scriptTypeField.GetValue(null);
 
             throw new CommandException("Unknown script-extension: " + extension);
         }

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
@@ -10,9 +10,9 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
 {
     public class PowerShellScriptEngine : IScriptEngine
     {
-        public ScriptType[] GetSupportedTypes()
+        public ScriptSyntax[] GetSupportedTypes()
         {
-            return new[] {ScriptType.Powershell};
+            return new[] {ScriptSyntax.Powershell};
         }
 
         public CommandResult Execute(

--- a/source/Calamari.Shared/Integration/Substitutions/FileSubstituter.cs
+++ b/source/Calamari.Shared/Integration/Substitutions/FileSubstituter.cs
@@ -22,12 +22,12 @@ namespace Calamari.Integration.Substitutions
 
         public void PerformSubstitution(string sourceFile, VariableDictionary variables, string targetFile)
         {
-            Encoding sourceFileEncoding;
-            var source = fileSystem.ReadFile(sourceFile, out sourceFileEncoding);
+            Log.Verbose($"Performing variable substitution on '{sourceFile}'");
+
+            var source = fileSystem.ReadFile(sourceFile, out var sourceFileEncoding);
             var encoding = GetEncoding(variables, sourceFileEncoding);
 
-            string error;
-            var result = variables.Evaluate(source, out error, haltOnError: false);
+            var result = variables.Evaluate(source, out var error, haltOnError: false);
 
             if (!string.IsNullOrEmpty(error))
                 Log.VerboseFormat("Parsing file '{0}' with Octostache returned the following error: `{1}`", sourceFile, error);

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -16,7 +16,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [Category(TestEnvironment.CompatibleOS.Mac)]
         public void ShouldPrintEncodedVariable()
         {
-            var (output, _) = RunScript("print-encoded-variabl.sh");
+            var (output, _) = RunScript("print-encoded-variable.sh");
 
             output.AssertSuccess();
             output.AssertOutput("##octopus[setVariable name='U3VwZXI=' value='TWFyaW8gQnJvcw==']");
@@ -50,7 +50,7 @@ namespace Calamari.Tests.Fixtures.Bash
         public void ShouldConsumeParametersWithQuotes()
         {
             var (output, _) = RunScript("parameters.sh", new Dictionary<string, string>()
-                { [SpecialVariables.Action.Script.ScriptParameters] = "\"Para meter0\" 'Para meter1" });
+                { [SpecialVariables.Action.Script.ScriptParameters] = "\"Para meter0\" 'Para meter1'" });
 
             output.AssertSuccess();
             output.AssertOutput("Parameters Para meter0Para meter1");

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -61,7 +61,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [Category(TestEnvironment.CompatibleOS.Mac)]
         public void ShouldCallHello()
         {
-            var (output, _) = RunScript("Hello.sh", new Dictionary<string, string>()
+            var (output, _) = RunScript("hello.sh", new Dictionary<string, string>()
             {
                 ["Name"] = "Paul",
                 ["Variable2"] = "DEF",

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
@@ -97,7 +97,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             variables.Set(scriptName, "blah blah");
             var convention = CreateConvention(stage);
             Action exec = () => convention.Install(deployment);
-            exec.ShouldThrow<CommandException>().WithMessage("ScriptCS scripts are not supported on this platform (PostDeploy)");
+            exec.ShouldThrow<CommandException>().WithMessage("CSharp scripts are not supported on this platform (PostDeploy)");
         }
 
         private ConfiguredScriptConvention CreateConvention(string deployStage)

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
@@ -31,7 +31,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             scriptEngine = Substitute.For<IScriptEngine>();
             commandLineRunner = Substitute.For<ICommandLineRunner>();
 
-            scriptEngine.GetSupportedTypes().Returns(new[] { ScriptType.Powershell });
+            scriptEngine.GetSupportedTypes().Returns(new[] { ScriptSyntax.Powershell });
 
             variables = new CalamariVariableDictionary();
             variables.Set(SpecialVariables.Package.EnabledFeatures, SpecialVariables.Features.CustomScripts);
@@ -44,7 +44,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             const string stage = DeploymentStages.PostDeploy;
             const string scriptBody = "lorem ipsum blah blah blah";
-            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptType.Powershell);
+            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptSyntax.Powershell);
             var scriptPath = Path.Combine(stagingDirectory, scriptName);
             var script = new Script(scriptPath);
             variables.Set(scriptName, scriptBody);
@@ -61,7 +61,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldRemoveScriptFileAfterRunning()
         {
             const string stage = DeploymentStages.PostDeploy;
-            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptType.Powershell);
+            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptSyntax.Powershell);
             var scriptPath = Path.Combine(stagingDirectory, scriptName);
             var script = new Script(scriptPath);
             variables.Set(scriptName, "blah blah");
@@ -78,7 +78,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             deployment.Variables.Set(SpecialVariables.DeleteScriptsOnCleanup, false.ToString());
             const string stage = DeploymentStages.PostDeploy;
-            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptType.Powershell);
+            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptSyntax.Powershell);
             var scriptPath = Path.Combine(stagingDirectory, scriptName);
             variables.Set(scriptName, "blah blah");
 
@@ -93,7 +93,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldThrowAnErrorIfAScriptExistsWithTheWrongType()
         {
             const string stage = DeploymentStages.PostDeploy;
-            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptType.ScriptCS);
+            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptSyntax.CSharp);
             variables.Set(scriptName, "blah blah");
             var convention = CreateConvention(stage);
             Action exec = () => convention.Install(deployment);

--- a/source/Calamari.Tests/Fixtures/Conventions/FeatureScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/FeatureScriptConventionFixture.cs
@@ -32,7 +32,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             scriptEngine = Substitute.For<IScriptEngine>();
             commandLineRunner = Substitute.For<ICommandLineRunner>();
 
-            scriptEngine.GetSupportedTypes().Returns(new[] { ScriptType.Powershell });
+            scriptEngine.GetSupportedTypes().Returns(new[] { ScriptSyntax.Powershell });
 
             variables = new CalamariVariableDictionary();
             variables.Set(SpecialVariables.Package.EnabledFeatures, "Octopus.Features.blah");

--- a/source/Calamari.Tests/Fixtures/Conventions/PackagedScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/PackagedScriptConventionFixture.cs
@@ -35,7 +35,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             commandResult = new CommandResult("PowerShell.exe foo bar", 0, null);
             scriptEngine = Substitute.For<IScriptEngine>();
             scriptEngine.Execute(Arg.Any<Script>(), Arg.Any<CalamariVariableDictionary>(), Arg.Any<ICommandLineRunner>()).Returns(c => commandResult);
-            scriptEngine.GetSupportedTypes().Returns(new[] {ScriptType.ScriptCS, ScriptType.Powershell});
+            scriptEngine.GetSupportedTypes().Returns(new[] {ScriptSyntax.CSharp, ScriptSyntax.Powershell});
             runner = Substitute.For<ICommandLineRunner>();
             deployment = new RunningDeployment(TestEnvironment.ConstructRootedPath("Packages"), new CalamariVariableDictionary());
         }

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -222,11 +222,11 @@ namespace Calamari.Tests.Fixtures.Deployment
 
             if (CalamariEnvironment.IsRunningOnNix || CalamariEnvironment.IsRunningOnMac)
             {
-                Variables.Set(ConfiguredScriptConvention.GetScriptName(DeploymentStages.Deploy, ScriptType.Bash), "echo 'The wheels on the bus go round...'");
+                Variables.Set(ConfiguredScriptConvention.GetScriptName(DeploymentStages.Deploy, ScriptSyntax.Bash), "echo 'The wheels on the bus go round...'");
             }
             else
             {
-                Variables.Set(ConfiguredScriptConvention.GetScriptName(DeploymentStages.Deploy, ScriptType.Powershell), "Write-Host 'The wheels on the bus go round...'");
+                Variables.Set(ConfiguredScriptConvention.GetScriptName(DeploymentStages.Deploy, ScriptSyntax.Powershell), "Write-Host 'The wheels on the bus go round...'");
             }
 
             var result = DeployPackage();

--- a/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
+++ b/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
@@ -105,8 +105,7 @@ namespace Calamari.Tests.Fixtures.FSharp
                 var output = Invoke(Calamari()
                     .Action("run-script")
                     .Argument("script", GetFixtureResouce("Scripts", "HelloVariableSubstitution.fsx"))
-                    .Argument("variables", variablesFile)
-                    .Flag("substituteVariables"));
+                    .Argument("variables", variablesFile));
 
                 output.AssertSuccess();
                 output.AssertOutput("Hello SubstitutedValue");

--- a/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
+++ b/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using Calamari.Deployment;
 using Calamari.Integration.FileSystem;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
@@ -18,27 +19,24 @@ namespace Calamari.Tests.Fixtures.FSharp
             output.AssertSuccess();
             output.AssertOutput("##octopus[setVariable name='RG9ua2V5' value='S29uZw==']");
         }
-        
+
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldPrintSensitiveVariable()
         {
-
-            var output = Invoke(Calamari()
-                .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", "SensitiveOutputVariable.fsx")));
+            var (output, _) = RunScript("SensitiveOutputVariable.fsx", new Dictionary<string, string>()
+                {["Name"] = null});
 
             output.AssertSuccess();
-            output.AssertOutput("##octopus[setVariable name='UGFzc3dvcmQ=' value='Y29ycmVjdCBob3JzZSBiYXR0ZXJ5IHN0YXBsZQ==' sensitive='VHJ1ZQ==']");
+            output.AssertOutput(
+                "##octopus[setVariable name='UGFzc3dvcmQ=' value='Y29ycmVjdCBob3JzZSBiYXR0ZXJ5IHN0YXBsZQ==' sensitive='VHJ1ZQ==']");
         }
 
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldCreateArtifact()
         {
-            var output = Invoke(Calamari()
-                .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", "CreateArtifact.fsx")));
+            var (output, _) = RunScript("CreateArtifact.fsx", new Dictionary<string, string>()
+                {["Name"] = null});
 
-            output.AssertSuccess();
             output.AssertOutput("##octopus[createArtifact");
             output.AssertOutput("name='bXlGaWxlLnR4dA==' length='MTAw']");
         }
@@ -46,48 +44,29 @@ namespace Calamari.Tests.Fixtures.FSharp
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldCallHello()
         {
-            var variablesFile = Path.GetTempFileName();
-
-            var variables = new VariableDictionary();
-            variables.Set("Name", "Paul");
-            variables.Set("Variable2", "DEF");
-            variables.Set("Variable3", "GHI");
-            variables.Set("Foo_bar", "Hello");
-            variables.Set("Host", "Never");
-            variables.Save(variablesFile);
-
-            using (new TemporaryFile(variablesFile))
+            var (output, _) = RunScript("Hello.fsx", new Dictionary<string, string>()
             {
-                var output = Invoke(Calamari()
-                    .Action("run-script")
-                    .Argument("script", GetFixtureResouce("Scripts", "Hello.fsx"))
-                    .Argument("variables", variablesFile));
+                ["Name"] = "Paul",
+                ["Variable2"] = "DEF",
+                ["Variable3"] = "GHI",
+                ["Foo_bar"] = "Hello",
+                ["Host"] = "Never",
+            });
 
-                output.AssertSuccess();
-                output.AssertOutput("Hello Paul");
-            }
+            output.AssertSuccess();
+            output.AssertOutput("Hello Paul");
         }
 
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldCallHelloWithSensitiveVariable()
         {
-            var variablesFile = Path.GetTempFileName();
 
-            var variables = new VariableDictionary();
-            variables.Set("Name", "NameToEncrypt");
-            variables.SaveEncrypted("5XETGOgqYR2bRhlfhDruEg==", variablesFile);
+            var (output, _) = RunScript("Hello.fsx",
+                new Dictionary<string, string>() {["Name"] = "NameToEncrypt"},
+                sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
 
-            using (new TemporaryFile(variablesFile))
-            {
-                var output = Invoke(Calamari()
-                    .Action("run-script")
-                    .Argument("script", GetFixtureResouce("Scripts", "Hello.fsx"))
-                    .Argument("sensitiveVariables", variablesFile)
-                    .Argument("sensitiveVariablesPassword", "5XETGOgqYR2bRhlfhDruEg=="));
-
-                output.AssertSuccess();
-                output.AssertOutput("Hello NameToEncrypt");
-            }
+            output.AssertSuccess();
+            output.AssertOutput("Hello NameToEncrypt");
         }
 
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
@@ -103,89 +82,51 @@ namespace Calamari.Tests.Fixtures.FSharp
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldCallHelloDirectValue()
         {
-            var variablesFile = Path.GetTempFileName();
+            var (output, _) = RunScript("Hello.fsx", new Dictionary<string, string>()
+                {["Name"] = "direct value"});
 
-            var variables = new VariableDictionary();
-            variables.Set("Name", "direct value");
-            variables.Save(variablesFile);
-
-            using (new TemporaryFile(variablesFile))
-            {
-                var output = Invoke(Calamari()
-                    .Action("run-script")
-                    .Argument("script", GetFixtureResouce("Scripts", "Hello.fsx"))
-                    .Argument("variables", variablesFile));
-
-                output.AssertSuccess();
-                output.AssertOutput("Hello direct value");
-            }
+            output.AssertSuccess();
+            output.AssertOutput("Hello direct value");
         }
 
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldCallHelloDefaultValue()
         {
-            var output = Invoke(Calamari()
-                .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", "HelloDefaultValue.fsx")));
+             var (output, _) = RunScript("HelloDefaultValue.fsx", new Dictionary<string, string>()
+                {["Name"] = "direct value"});
 
             output.AssertSuccess();
             output.AssertOutput("Hello default value");
         }
-        
+
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldCallHelloWithNullVariable()
         {
-            var variablesFile = Path.GetTempFileName();
+            var (output, _) = RunScript("Hello.fsx", new Dictionary<string, string>()
+                {["Name"] = null});
 
-            var variables = new VariableDictionary();
-            variables.Set("Name", null);
-            variables.Save(variablesFile);
-
-            using (new TemporaryFile(variablesFile))
-            {
-                var output = Invoke(Calamari()
-                    .Action("run-script")
-                    .Argument("script", GetFixtureResouce("Scripts", "Hello.fsx"))
-                    .Argument("variables", variablesFile));
-
-                output.AssertSuccess();
-                output.AssertOutput("Hello ");
-            }
+            output.AssertSuccess();
+            output.AssertOutput("Hello ");
         }
-        
+
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldCallHelloWithNullSensitiveVariable()
         {
-            var variablesFile = Path.GetTempFileName();
+            var (output, _) = RunScript("Hello.fsx", new Dictionary<string, string>()
+                {["Name"] = null}, sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
 
-            var variables = new VariableDictionary();
-            variables.Set("Name", null);
-            variables.SaveEncrypted("5XETGOgqYR2bRhlfhDruEg==", variablesFile);
-
-            using (new TemporaryFile(variablesFile))
-            {
-                var output = Invoke(Calamari()
-                    .Action("run-script")
-                    .Argument("script", GetFixtureResouce("Scripts", "Hello.fsx"))
-                    .Argument("sensitiveVariables", variablesFile)
-                    .Argument("sensitiveVariablesPassword", "5XETGOgqYR2bRhlfhDruEg=="));
-
-                output.AssertSuccess();
-                output.AssertOutput("Hello ");
-            }
+            output.AssertSuccess();
+            output.AssertOutput("Hello ");
         }
 
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldConsumeParametersWithQuotes()
         {
-            var output = Invoke(Calamari()
-                .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", "Parameters.fsx"))
-                .Argument("scriptParameters", "\"Para meter0\" Parameter1")); ;
+            var (output, _) = RunScript("Parameters.fsx", new Dictionary<string, string>()
+                { [SpecialVariables.Action.Script.ScriptParameters] = "\"Para meter0\" Parameter1" });
 
             output.AssertSuccess();
             output.AssertOutput("Parameters Para meter0-Parameter1");
         }
-        
     }
 }

--- a/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
+++ b/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
@@ -13,10 +13,7 @@ namespace Calamari.Tests.Fixtures.FSharp
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldPrintEncodedVariable()
         {
-            var output = Invoke(Calamari()
-                .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", "OutputVariable.fsx")));
-
+            var (output, _) = RunScript("OutputVariable.fsx");
             output.AssertSuccess();
             output.AssertOutput("##octopus[setVariable name='RG9ua2V5' value='S29uZw==']");
         }
@@ -24,6 +21,7 @@ namespace Calamari.Tests.Fixtures.FSharp
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldPrintSensitiveVariable()
         {
+
             var output = Invoke(Calamari()
                 .Action("run-script")
                 .Argument("script", GetFixtureResouce("Scripts", "SensitiveOutputVariable.fsx")));

--- a/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
+++ b/source/Calamari.Tests/Fixtures/FSharp/FSharpFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using Calamari.Integration.FileSystem;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
@@ -92,22 +93,11 @@ namespace Calamari.Tests.Fixtures.FSharp
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldCallHelloWithVariableSubstitution()
         {
-            var variablesFile = Path.GetTempFileName();
+            var (output, _) = RunScript("HelloVariableSubstitution.fsx", new Dictionary<string, string>()
+                {["Name"] = "SubstitutedValue"});
 
-            var variables = new VariableDictionary();
-            variables.Set("Name", "SubstitutedValue");
-            variables.Save(variablesFile);
-
-            using (new TemporaryFile(variablesFile))
-            {
-                var output = Invoke(Calamari()
-                    .Action("run-script")
-                    .Argument("script", GetFixtureResouce("Scripts", "HelloVariableSubstitution.fsx"))
-                    .Argument("variables", variablesFile));
-
-                output.AssertSuccess();
-                output.AssertOutput("Hello SubstitutedValue");
-            }
+            output.AssertSuccess();
+            output.AssertOutput("Hello SubstitutedValue");
         }
 
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -450,7 +450,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
         [Category(TestEnvironment.CompatibleOS.Windows)]
         public void ShouldPassOnStdInfoWithTreatScriptWarningsAsErrors()
         {
-            var (output, _) = RunScript("stderr.ps1", new Dictionary<string, string>()
+            var (output, _) = RunScript("Hello.ps1", new Dictionary<string, string>()
                 {["Octopus.Action.FailScriptOnErrorOutput"] = "True"});
 
             output.AssertSuccess();

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -203,7 +203,10 @@ namespace Calamari.Tests.Fixtures.PowerShell
         [Category(TestEnvironment.CompatibleOS.Windows)]
         public void ShouldAllowDotSourcing()
         {
-            var (output, _) = RunScript("CanDotSource.ps1");
+            var output = Invoke(Calamari()
+                .Action("run-script")
+                .Argument("script", GetFixtureResouce("Scripts", "CanDotSource.ps1")));
+
             output.AssertSuccess();
             output.AssertOutput("Hello!");
         }
@@ -434,7 +437,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Windows)]
-        public void ShoulFailOnStdErrWithTreatScriptWarningsAsErrors()
+        public void ShouldFailOnStdErrWithTreatScriptWarningsAsErrors()
         {
             var (output, _) = RunScript("stderr.ps1", new Dictionary<string, string>()
                 {["Octopus.Action.FailScriptOnErrorOutput"] = "True"});
@@ -445,7 +448,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Windows)]
-        public void ShoulPassOnStdInfoWithTreatScriptWarningsAsErrors()
+        public void ShouldPassOnStdInfoWithTreatScriptWarningsAsErrors()
         {
             var (output, _) = RunScript("stderr.ps1", new Dictionary<string, string>()
                 {["Octopus.Action.FailScriptOnErrorOutput"] = "True"});

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -440,7 +440,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                     .Argument("variables", variablesFile));
 
                 output.AssertSuccess();
-                output.AssertOutput("Substituting variables");
+                output.AssertOutput("Performing variable substitution");
                 output.AssertOutput("Hello Production!");
             }
         }
@@ -465,7 +465,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
                 output.AssertSuccess();
                 output.AssertOutput("Extracting package");
-                output.AssertOutput("Substituting variables");
+                output.AssertOutput("Performing variable substitution");
                 output.AssertOutput("OctopusParameter: Production");
                 output.AssertOutput("InlineVariable: Production");
                 output.AssertOutput("VariableSubstitution: Production");

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -154,11 +154,23 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Windows)]
-        public void ShouldConsumeParametersWithQuotes()
+        public void ShouldConsumeParametersWithQuotesUsingDepricatedArgument()
         {
             var (output, _) = RunScript("Parameters.ps1", additionalParameters: new Dictionary<string, string>()
             {
                 ["scriptParameters"] = "-Parameter0 \"Para meter0\" -Parameter1 'Para meter1'"
+            });
+            output.AssertSuccess();
+            output.AssertOutput("Parameters Para meter0Para meter1");
+        }
+
+        [Test]
+        [Category(TestEnvironment.CompatibleOS.Windows)]
+        public void ShouldConsumeParametersWithQuotes()
+        {
+            var (output, _) = RunScript("Parameters.ps1", new Dictionary<string, string>()
+            {
+                [SpecialVariables.Action.Script.ScriptParameters] = "-Parameter0 \"Para meter0\" -Parameter1 'Para meter1'"
             });
             output.AssertSuccess();
             output.AssertOutput("Parameters Para meter0Para meter1");
@@ -340,7 +352,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
         [Test]
         [Category(TestEnvironment.CompatibleOS.Windows)]
-        public void ShouldSubstituteVariablesInNonPackagedScript()
+        public void ShouldNotSubstituteVariablesInNonPackagedScript()
         {
             // Use a temp file for the script to avoid mutating the script file for other tests
             var scriptFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".ps1");
@@ -360,8 +372,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                     .Argument("variables", variablesFile));
 
                 output.AssertSuccess();
-                output.AssertOutput("Performing variable substitution");
-                output.AssertOutput("Hello Production!");
+                output.AssertOutput("Hello #{Octopus.Environment.Name}!");
             }
         }
 

--- a/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
@@ -14,10 +14,8 @@ namespace Calamari.Tests.Fixtures.ScriptCS
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldPrintEncodedVariable()
         {
-            var output = Invoke(Calamari()
-                .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", "PrintEncodedVariable.csx")));
-            
+            var (output, _) = RunScript("PrintEncodedVariable.csx");
+
             output.AssertSuccess();
             output.AssertOutput("##octopus[setVariable name='RG9ua2V5' value='S29uZw==']");
         }
@@ -25,10 +23,8 @@ namespace Calamari.Tests.Fixtures.ScriptCS
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldPrintSensitiveVariable()
         {
-            var output = Invoke(Calamari()
-                .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", "PrintSensitiveVariable.csx")));
-            
+            var (output, _) = RunScript("PrintSensitiveVariable.csx");
+
             output.AssertSuccess();
             output.AssertOutput("##octopus[setVariable name='UGFzc3dvcmQ=' value='Y29ycmVjdCBob3JzZSBiYXR0ZXJ5IHN0YXBsZQ==' sensitive='VHJ1ZQ==']");
         }
@@ -36,9 +32,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
         [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
         public void ShouldCreateArtifact()
         {
-            var output = Invoke(Calamari()
-                .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", "CreateArtifact.csx")));
+            var (output, _) = RunScript("CreateArtifact.csx");
 
             output.AssertSuccess();
             output.AssertOutput("##octopus[createArtifact");

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -75,8 +75,6 @@ namespace Calamari.Commands
 
         private void SubstituteVariablesInScript(CalamariVariableDictionary variables)
         {
-            Log.Info("Substituting variables in: " + scriptFile);
-
             var validatedScriptFilePath = AssertScriptFileExists();
             var substituter = new FileSubstituter(CalamariPhysicalFileSystem.GetPhysicalFileSystem());
             substituter.PerformSubstitution(validatedScriptFilePath, variables);

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -22,7 +22,6 @@ namespace Calamari.Commands
         private static readonly IVariableDictionaryUtils VariableDictionaryUtils = new VariableDictionaryUtils();
         private string scriptFile;
         private string packageFile;
-        private bool substituteVariables;
         private string scriptParameters;
         private DeploymentJournal journal;
         private RunningDeployment deployment;
@@ -36,7 +35,6 @@ namespace Calamari.Commands
             Options.Add("package=", "Path to the package to extract that contains the package.", v => packageFile = Path.GetFullPath(v));
             Options.Add("script=", "Path to the script to execute. If --package is used, it can be a script inside the package.", v => scriptFile = Path.GetFullPath(v));
             Options.Add("scriptParameters=", "Parameters to pass to the script.", v => scriptParameters = v);
-            Options.Add("substituteVariables", "Perform variable substitution on the script body before executing it.", v => substituteVariables = true);
             VariableDictionaryUtils.PopulateOptions(Options);
             this.variables = variables;
             this.scriptEngine = scriptEngine;
@@ -55,7 +53,7 @@ namespace Calamari.Commands
             deployment = new RunningDeployment(packageFile, (CalamariVariableDictionary)variables);
 
             ExtractPackage(variables);
-            SubstituteVariablesInScript(variables);           
+            SubstituteVariablesInScript(variables);
             return InvokeScript(variables);
         }
 
@@ -77,8 +75,6 @@ namespace Calamari.Commands
 
         private void SubstituteVariablesInScript(CalamariVariableDictionary variables)
         {
-            if (!substituteVariables) return;
-
             Log.Info("Substituting variables in: " + scriptFile);
 
             var validatedScriptFilePath = AssertScriptFileExists();

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -73,7 +73,9 @@ namespace Calamari.Commands
                 return ExecuteScriptFromParameters();
             }
 
-            throw new CommandException("No script details provided.");
+            throw new CommandException("No script details provided.\r\n" +
+                                       $"Pleave provide the script either via the `{SpecialVariables.Action.Script.ScriptBody}` variable, " +
+                                       "through a package provided via the `--package` argument or directly via the `--script` argument.");
         }
 
         void ExtractScriptFromPackage(VariableDictionary variables)

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -129,7 +129,7 @@ namespace Calamari.Commands
 
             if (!WasProvided(scriptFileName) && !WasProvided(scriptFileArg))
             {
-                scriptFileName = "Script."+ variables.GetEnum(SpecialVariables.Action.Script.Syntax, ScriptType.Powershell).FileExtension();
+                scriptFileName = "Script."+ variables.GetEnum(SpecialVariables.Action.Script.Syntax, ScriptSyntax.Powershell).FileExtension();
             }
 
             return Path.GetFullPath(WasProvided(scriptFileName) ? scriptFileName : scriptFileArg);


### PR DESCRIPTION
Currently exists a few inconsistencies with inline scripts where the variable replacement takes place on the server, while scripts from packages are replaced on calamari.

Since we already pass the script body through in the provided variable collection, this change allows calamari to pull the body out of  the variables and write it to disk, replacing the variables in the process.

The old `--script` param will still be supported for the time being for backwards compatibility  however a warning will be logged since we will be no longer doing the replace on the server (to avoid double substitution).