### PR TITLE
Removed `ExpandString` from the bootstrapper as this is now handled using Octostache variables

### DIFF
--- a/source/Calamari.Azure/Integration/AzurePowershellContext.cs
+++ b/source/Calamari.Azure/Integration/AzurePowershellContext.cs
@@ -27,7 +27,6 @@ namespace Calamari.Azure.Integration
         const int PasswordSizeBytes = 20;
 
         public const string DefaultAzureEnvironment = "AzureCloud";
-        public static readonly string BuiltInAzurePowershellModulePath = Path.Combine(Path.GetDirectoryName(typeof(AzurePowerShellContext).Assembly.Location), "PowerShell");
 
         public AzurePowerShellContext(CalamariVariableDictionary variables)
         {
@@ -59,8 +58,6 @@ namespace Calamari.Azure.Integration
             variables.Set("OctopusAzureTargetScript", "\"" + script.File + "\"");
             variables.Set("OctopusAzureTargetScriptParameters", script.Parameters);
 
-            SetAzureModulesLoadingMethod(variables);
-
             SetOutputVariable(SpecialVariables.Action.Azure.Output.SubscriptionId, variables.Get(SpecialVariables.Action.Azure.SubscriptionId), variables);
             SetOutputVariable("OctopusAzureStorageAccountName", variables.Get(SpecialVariables.Action.Azure.StorageAccountName), variables);
             var azureEnvironment = variables.Get(SpecialVariables.Action.Azure.Environment, DefaultAzureEnvironment);
@@ -90,22 +87,7 @@ namespace Calamari.Azure.Integration
                 }
             }
         }
-
-        // TODO: Remove this and the code that uses SpecialVariables.Action.Azure.Output.ModulePath when the old pipeline Azure steps are removed
-        static void SetAzureModulesLoadingMethod(VariableDictionary variables)
-        {
-            if (!string.IsNullOrEmpty(variables.Get(SpecialVariables.Bootstrapper.ModulePaths)))
-            {
-                SetOutputVariable("OctopusUseBundledAzureModules", "false", variables);
-                return;
-            }
-            
-            // By default use the Azure PowerShell modules bundled with Calamari
-            // If the flag below is set to 'false', then we will rely on PowerShell module auto-loading to find the Azure modules installed on the server
-            SetOutputVariable("OctopusUseBundledAzureModules", variables.GetFlag(SpecialVariables.Action.Azure.UseBundledAzurePowerShellModules, true).ToString(), variables);
-            SetOutputVariable(SpecialVariables.Action.Azure.Output.ModulePath, BuiltInAzurePowershellModulePath, variables);
-        }
-
+      
         string CreateContextScriptFile(string workingDirectory)
         {
             var azureContextScriptFile = Path.Combine(workingDirectory, "Octopus.AzureContext.ps1");

--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -5,8 +5,6 @@
 ##
 ## The script is passed the following parameters.
 ##
-##   $OctopusUseBundledAzureModules = "true"
-##   $OctopusAzureModulePath = "...\Calamari\PowerShell\"
 ##   $OctopusAzureTargetScript = "..."
 ##   $OctopusAzureTargetScriptParameters = "..."
 ##   $OctopusUseServicePrincipal = "false"
@@ -53,18 +51,6 @@ function Execute-WithRetry([ScriptBlock] $command) {
             }
         }
     }
-}
-
-if ([System.Convert]::ToBoolean($OctopusUseBundledAzureModules)) {
-    # Add bundled Azure PowerShell modules to PSModulePath
-
-    $StorageModulePath = Join-Path "$OctopusAzureModulePath" -ChildPath "Azure.Storage" | Join-Path -ChildPath "4.2.1"
-    $ServiceManagementModulePath = Join-Path "$OctopusAzureModulePath" -ChildPath "Azure" | Join-Path -ChildPath "5.1.2"
-    $ResourceManagerModulePath = $OctopusAzureModulePath
-    Write-Verbose "Adding bundled Azure PowerShell modules to PSModulePath"
-        
-    $env:PSModulePath = $ResourceManagerModulePath + ";" + $ServiceManagementModulePath + ";" + $StorageModulePath + ";" + $env:PSModulePath
-    Write-Verbose $env:PSModulePath
 }
 
 Execute-WithRetry{

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -271,7 +271,6 @@
                 public static class Output
                 {
                     public static readonly string SubscriptionId = "OctopusAzureSubscriptionId";
-                    public static readonly string ModulePath = "OctopusAzureModulePath";
                     public static readonly string ConfigurationFile = "OctopusAzureConfigurationFile";
                     public static readonly string CloudServiceDeploymentSwapped = "OctopusAzureCloudServiceDeploymentSwapped";
                 }

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -454,7 +454,7 @@ function Import-CalamariModules() {
 		$calamariModulePaths = $OctopusParameters["Octopus.Calamari.Bootstrapper.ModulePaths"].Split(";", [StringSplitOptions]'RemoveEmptyEntries')
 		foreach ($calamariModulePath in $calamariModulePaths) {
 		    if($calamariModulePath.EndsWith(".psd1")) {
-		        Import-Module –Name $ExecutionContext.InvokeCommand.ExpandString($calamariModulePath)
+		        Import-Module –Name $calamariModulePath
 		    } else {
         		$env:PSModulePath = $calamariModulePath + ";" + $env:PSModulePath
 		    }


### PR DESCRIPTION
Related to https://github.com/OctopusDeploy/OctopusDeploy/pull/2356

Also removed the `BuiltInAzurePowershellModulePath`, which used to refer to the Azure Cmdlets bundled with Calamari, but these have not been bundled for quite some time.