### PR TITLE
Enh multiscriptsyntax

### DIFF
--- a/source/Calamari.Aws/Integration/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.Aws/Integration/AwsEnvironmentGeneration.cs
@@ -225,14 +225,14 @@ namespace Calamari.Aws.Integration
         public bool Enabled { get; } = true;
         public IScriptWrapper NextWrapper { get; set; }
 
-        public CommandResult ExecuteScript(
-            Script script, 
-            CalamariVariableDictionary variables, 
+        public CommandResult ExecuteScript(Script script,
+            ScriptSyntax scriptSyntax,
+            CalamariVariableDictionary variables,
             ICommandLineRunner commandLineRunner,
             StringDictionary environmentVars)
         {
             return NextWrapper.ExecuteScript(
-                script, 
+                script, scriptSyntax, 
                 variables, 
                 commandLineRunner,
                 environmentVars.MergeDictionaries(EnvironmentVars));

--- a/source/Calamari.Azure/Integration/AzurePowershellContext.cs
+++ b/source/Calamari.Azure/Integration/AzurePowershellContext.cs
@@ -41,8 +41,8 @@ namespace Calamari.Azure.Integration
 
         public IScriptWrapper NextWrapper { get; set; }
 
-        public CommandResult ExecuteScript(
-            Script script,
+        public CommandResult ExecuteScript(Script script,
+            ScriptSyntax scriptSyntax,
             CalamariVariableDictionary variables,
             ICommandLineRunner commandLineRunner,
             StringDictionary environmentVars)
@@ -76,14 +76,14 @@ namespace Calamari.Azure.Integration
                     SetOutputVariable("OctopusAzureADTenantId", variables.Get(SpecialVariables.Action.Azure.TenantId), variables);
                     SetOutputVariable("OctopusAzureADClientId", variables.Get(SpecialVariables.Action.Azure.ClientId), variables);
                     variables.Set("OctopusAzureADPassword", variables.Get(SpecialVariables.Action.Azure.Password));
-                    return NextWrapper.ExecuteScript(new Script(contextScriptFile.FilePath), variables, commandLineRunner, environmentVars);
+                    return NextWrapper.ExecuteScript(new Script(contextScriptFile.FilePath), scriptSyntax, variables, commandLineRunner, environmentVars);
                 }
 
                 //otherwise use management certificate
                 SetOutputVariable("OctopusUseServicePrincipal", false.ToString(), variables);
                 using (new TemporaryFile(CreateAzureCertificate(workingDirectory, variables)))
                 {
-                    return NextWrapper.ExecuteScript(new Script(contextScriptFile.FilePath), variables, commandLineRunner, environmentVars);
+                    return NextWrapper.ExecuteScript(new Script(contextScriptFile.FilePath), scriptSyntax, variables, commandLineRunner, environmentVars);
                 }
             }
         }

--- a/source/Calamari.Azure/Integration/AzureServiceFabricPowerShellContext.cs
+++ b/source/Calamari.Azure/Integration/AzureServiceFabricPowerShellContext.cs
@@ -32,11 +32,11 @@ namespace Calamari.Azure.Integration
 
         public IScriptWrapper NextWrapper { get; set; }
 
-        public CommandResult ExecuteScript(
-            Script script,
+        public CommandResult ExecuteScript(Script script,
+            ScriptSyntax scriptSyntax,
             CalamariVariableDictionary variables,
             ICommandLineRunner commandLineRunner,
-            StringDictionary environmentVars = null)
+            StringDictionary environmentVars)
         {
             // We only execute this hook if the connection endpoint has been set
             if (!Enabled)
@@ -81,7 +81,7 @@ namespace Calamari.Azure.Integration
             using (new TemporaryFile(Path.Combine(workingDirectory, "AzureProfile.json")))
             using (var contextScriptFile = new TemporaryFile(CreateContextScriptFile(workingDirectory)))
             {
-                return NextWrapper.ExecuteScript(new Script(contextScriptFile.FilePath), variables, commandLineRunner, environmentVars);
+                return NextWrapper.ExecuteScript(new Script(contextScriptFile.FilePath), scriptSyntax, variables, commandLineRunner, environmentVars);
             }
         }
 

--- a/source/Calamari.Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari.Kubernetes/KubernetesContextScriptWrapper.cs
@@ -59,10 +59,10 @@ namespace Calamari.Kubernetes
                     throw new InvalidOperationException("No kubernetes context wrapper exists for "+ syntax);
             }
 
-            var azureContextScriptFile = Path.Combine(workingDirectory, $"Octopus.{contextFile}");
+            var k8sContextScriptFile = Path.Combine(workingDirectory, $"Octopus.{contextFile}");
             var contextScript = embeddedResources.GetEmbeddedResourceText(Assembly.GetExecutingAssembly(), $"Calamari.Kubernetes.Scripts.{contextFile}");
-            fileSystem.OverwriteFile(azureContextScriptFile, contextScript);
-            return azureContextScriptFile;
+            fileSystem.OverwriteFile(k8sContextScriptFile, contextScript);
+            return k8sContextScriptFile;
         }
     }
 }

--- a/source/Calamari.Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari.Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -74,4 +74,4 @@ Write-Host "##octopus[stdout-default]"
 
 Write-Verbose "Invoking target script $OctopusKubernetesTargetScript with $OctopusKubernetesTargetScriptParameters parameters"
 
-Invoke-Expression ". "$OctopusKubernetesTargetScript" $OctopusKubernetesTargetScriptParameters"
+Invoke-Expression ". `"$OctopusKubernetesTargetScript`" $OctopusKubernetesTargetScriptParameters"

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -1,4 +1,6 @@
-﻿namespace Calamari.Deployment
+﻿using Calamari.Integration.Scripting;
+
+namespace Calamari.Deployment
 {
     public static class SpecialVariables
     {
@@ -312,6 +314,11 @@
                 public static readonly string ScriptFileName = "Octopus.Action.Script.ScriptFileName";
                 public static readonly string ScriptParameters = "Octopus.Action.Script.ScriptParameters";
                 public static readonly string ScriptSource = "Octopus.Action.Script.ScriptSource";
+
+                public static string ScriptBodyBySyntax(ScriptSyntax syntax)
+                {
+                    return $"Octopus.Action.Script.ScriptBody[{syntax.ToString()}]";
+                }
             }
 
             public static class Java

--- a/source/Calamari.Shared/Hooks/IScriptWrapper.cs
+++ b/source/Calamari.Shared/Hooks/IScriptWrapper.cs
@@ -26,8 +26,8 @@ namespace Calamari.Hooks
         /// Execute the wrapper. The call to this is usually expected to
         /// call the NextWrapper.ExecuteScript() method as it's final step.
         /// </summary>
-        CommandResult ExecuteScript(
-            Script script,
+        CommandResult ExecuteScript(Script script,
+            ScriptSyntax scriptSyntax,
             CalamariVariableDictionary variables,
             ICommandLineRunner commandLineRunner,
             StringDictionary environmentVars);

--- a/source/Calamari.Shared/Hooks/TerminalScriptWrapper.cs
+++ b/source/Calamari.Shared/Hooks/TerminalScriptWrapper.cs
@@ -25,9 +25,9 @@ namespace Calamari.Hooks
             this.scriptEngine = scriptEngine;
         }
 
-        public CommandResult ExecuteScript(
-            Script script, 
-            CalamariVariableDictionary variables, 
+        public CommandResult ExecuteScript(Script script,
+            ScriptSyntax scriptSyntax,
+            CalamariVariableDictionary variables,
             ICommandLineRunner commandLineRunner,
             StringDictionary environmentVars) => 
             scriptEngine.Execute(script, variables, commandLineRunner, environmentVars);

--- a/source/Calamari.Shared/Integration/Scripting/CombinedScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/CombinedScriptEngine.cs
@@ -35,19 +35,20 @@ namespace Calamari.Integration.Scripting
         {
             return (CalamariEnvironment.IsRunningOnNix || CalamariEnvironment.IsRunningOnMac)
                 ? new[] { ScriptSyntax.Bash, ScriptSyntax.CSharp, ScriptSyntax.FSharp }
-                : new[] { ScriptSyntax.Powershell, ScriptSyntax.CSharp, ScriptSyntax.FSharp };
+                : new[] { ScriptSyntax.PowerShell, ScriptSyntax.CSharp, ScriptSyntax.FSharp };
         }
 
         public CommandResult Execute(
             Script script,
             CalamariVariableDictionary variables,
             ICommandLineRunner commandLineRunner,
-            StringDictionary environmentVars = null) =>
-                BuildWrapperChain(ValidateScriptType(script)).ExecuteScript(
-                    script,
-                    variables,
-                    commandLineRunner,
-                    environmentVars);
+            StringDictionary environmentVars = null)
+        {
+            var syntax = ValidateScriptType(script);
+            return BuildWrapperChain(syntax)
+                .ExecuteScript(script, syntax, variables, commandLineRunner, environmentVars);
+        }
+            
 
 
         /// <summary>

--- a/source/Calamari.Shared/Integration/Scripting/CombinedScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/CombinedScriptEngine.cs
@@ -34,8 +34,8 @@ namespace Calamari.Integration.Scripting
         public ScriptSyntax[] GetSupportedTypes()
         {
             return (CalamariEnvironment.IsRunningOnNix || CalamariEnvironment.IsRunningOnMac)
-                ? new[] { ScriptSyntax.CSharp, ScriptSyntax.Bash, ScriptSyntax.FSharp }
-                : new[] { ScriptSyntax.CSharp, ScriptSyntax.Powershell, ScriptSyntax.FSharp };
+                ? new[] { ScriptSyntax.Bash, ScriptSyntax.CSharp, ScriptSyntax.FSharp }
+                : new[] { ScriptSyntax.Powershell, ScriptSyntax.CSharp, ScriptSyntax.FSharp };
         }
 
         public CommandResult Execute(
@@ -82,9 +82,7 @@ namespace Calamari.Integration.Scripting
         
         private ScriptSyntax ValidateScriptType(Script script)
         {
-            var scriptExtension = Path.GetExtension(script.File)?.TrimStart('.');
-            var type = scriptExtension.ToScriptType();
-
+            var type = ScriptTypeExtensions.FileNameToScriptType(script.File);
             if (!GetSupportedTypes().Contains(type))
                 throw new CommandException($"{type} scripts are not supported on this platform");
 

--- a/source/Calamari.Shared/Integration/Scripting/ScriptEngineRegistry.cs
+++ b/source/Calamari.Shared/Integration/Scripting/ScriptEngineRegistry.cs
@@ -10,7 +10,7 @@ namespace Calamari.Integration.Scripting
     {
         private readonly Dictionary<ScriptSyntax, IScriptEngine> scriptEngines = new Dictionary<ScriptSyntax, IScriptEngine>
         {
-            {ScriptSyntax.Powershell, new PowerShellScriptEngine() },
+            {ScriptSyntax.PowerShell, new PowerShellScriptEngine() },
             {ScriptSyntax.CSharp, new ScriptCSScriptEngine() },
             {ScriptSyntax.Bash, new BashScriptEngine()},
             {ScriptSyntax.FSharp, new FSharpEngine()}

--- a/source/Calamari.Shared/Integration/Scripting/ScriptSyntax.cs
+++ b/source/Calamari.Shared/Integration/Scripting/ScriptSyntax.cs
@@ -7,7 +7,7 @@ namespace Calamari.Integration.Scripting
     public enum ScriptSyntax
     {
         [FileExtension("ps1")]
-        Powershell,
+        PowerShell,
 
         [FileExtension("csx")]
         CSharp,

--- a/source/Calamari.Shared/Integration/Scripting/ScriptSyntax.cs
+++ b/source/Calamari.Shared/Integration/Scripting/ScriptSyntax.cs
@@ -23,38 +23,24 @@ namespace Calamari.Integration.Scripting
     {
         public static string FileExtension(this ScriptSyntax scriptSyntax)
         {
-            return typeof (ScriptSyntax).GetField(scriptSyntax.ToString())
-                    .GetCustomAttributes(typeof (FileExtensionAttribute), false)
-                    .Select(attr => ((FileExtensionAttribute) attr).Extension)
-                    .FirstOrDefault();
+            return typeof(ScriptSyntax).GetField(scriptSyntax.ToString())
+                .GetCustomAttributes(typeof(FileExtensionAttribute), false)
+                .Select(attr => ((FileExtensionAttribute)attr).Extension)
+                .FirstOrDefault();
         }
 
         public static ScriptSyntax FileNameToScriptType(string filename)
         {
             var extension = Path.GetExtension(filename)?.TrimStart('.');
-            if (extension.TryToScriptType(out var syntax))
-            {
-                return syntax;
-            }
-
-            throw new CommandException("Unknown script-extension: " + extension);
-        }
-
-        public static bool TryToScriptType(this string extension, out ScriptSyntax syntax)
-        {
             var scriptTypeField = typeof(ScriptSyntax).GetFields()
                 .SingleOrDefault(
                     field => field.GetCustomAttributes(typeof(FileExtensionAttribute), false)
                         .Any(attr => ((FileExtensionAttribute)attr).Extension == extension.ToLower()));
 
             if (scriptTypeField != null)
-            {
-                syntax = (ScriptSyntax) scriptTypeField.GetValue(null);
-                return true;
-            }
+                return (ScriptSyntax)scriptTypeField.GetValue(null);
 
-            syntax = 0;
-            return false;
+            throw new CommandException("Unknown script-extension: " + extension);
         }
     }
 }

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
@@ -12,7 +12,7 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
     {
         public ScriptSyntax[] GetSupportedTypes()
         {
-            return new[] {ScriptSyntax.Powershell};
+            return new[] {ScriptSyntax.PowerShell};
         }
 
         public CommandResult Execute(
@@ -70,9 +70,9 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
 
             var copyToParent = Path.Combine(
                 variables.Get(SpecialVariables.CopyWorkingDirectoryIncludingKeyTo),
-                fs.RemoveInvalidFileNameChars(variables.Get(SpecialVariables.Project.Name)),
-                variables.Get(SpecialVariables.Deployment.Id),
-                fs.RemoveInvalidFileNameChars(variables.Get(SpecialVariables.Action.Name))
+                fs.RemoveInvalidFileNameChars(variables.Get(SpecialVariables.Project.Name, "Non-Project")),
+                variables.Get(SpecialVariables.Deployment.Id, "Non-Deployment"),
+                fs.RemoveInvalidFileNameChars(variables.Get(SpecialVariables.Action.Name, "Non-Action"))
             );
 
             string copyTo;

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
@@ -31,7 +31,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             scriptEngine = Substitute.For<IScriptEngine>();
             commandLineRunner = Substitute.For<ICommandLineRunner>();
 
-            scriptEngine.GetSupportedTypes().Returns(new[] { ScriptSyntax.Powershell });
+            scriptEngine.GetSupportedTypes().Returns(new[] { ScriptSyntax.PowerShell });
 
             variables = new CalamariVariableDictionary();
             variables.Set(SpecialVariables.Package.EnabledFeatures, SpecialVariables.Features.CustomScripts);
@@ -44,7 +44,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             const string stage = DeploymentStages.PostDeploy;
             const string scriptBody = "lorem ipsum blah blah blah";
-            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptSyntax.Powershell);
+            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptSyntax.PowerShell);
             var scriptPath = Path.Combine(stagingDirectory, scriptName);
             var script = new Script(scriptPath);
             variables.Set(scriptName, scriptBody);
@@ -61,7 +61,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldRemoveScriptFileAfterRunning()
         {
             const string stage = DeploymentStages.PostDeploy;
-            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptSyntax.Powershell);
+            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptSyntax.PowerShell);
             var scriptPath = Path.Combine(stagingDirectory, scriptName);
             var script = new Script(scriptPath);
             variables.Set(scriptName, "blah blah");
@@ -78,7 +78,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             deployment.Variables.Set(SpecialVariables.DeleteScriptsOnCleanup, false.ToString());
             const string stage = DeploymentStages.PostDeploy;
-            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptSyntax.Powershell);
+            var scriptName = ConfiguredScriptConvention.GetScriptName(stage, ScriptSyntax.PowerShell);
             var scriptPath = Path.Combine(stagingDirectory, scriptName);
             variables.Set(scriptName, "blah blah");
 

--- a/source/Calamari.Tests/Fixtures/Conventions/FeatureScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/FeatureScriptConventionFixture.cs
@@ -32,7 +32,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             scriptEngine = Substitute.For<IScriptEngine>();
             commandLineRunner = Substitute.For<ICommandLineRunner>();
 
-            scriptEngine.GetSupportedTypes().Returns(new[] { ScriptSyntax.Powershell });
+            scriptEngine.GetSupportedTypes().Returns(new[] { ScriptSyntax.PowerShell });
 
             variables = new CalamariVariableDictionary();
             variables.Set(SpecialVariables.Package.EnabledFeatures, "Octopus.Features.blah");

--- a/source/Calamari.Tests/Fixtures/Conventions/PackagedScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/PackagedScriptConventionFixture.cs
@@ -35,7 +35,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             commandResult = new CommandResult("PowerShell.exe foo bar", 0, null);
             scriptEngine = Substitute.For<IScriptEngine>();
             scriptEngine.Execute(Arg.Any<Script>(), Arg.Any<CalamariVariableDictionary>(), Arg.Any<ICommandLineRunner>()).Returns(c => commandResult);
-            scriptEngine.GetSupportedTypes().Returns(new[] {ScriptSyntax.CSharp, ScriptSyntax.Powershell});
+            scriptEngine.GetSupportedTypes().Returns(new[] {ScriptSyntax.CSharp, ScriptSyntax.PowerShell});
             runner = Substitute.For<ICommandLineRunner>();
             deployment = new RunningDeployment(TestEnvironment.ConstructRootedPath("Packages"), new CalamariVariableDictionary());
         }

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -226,7 +226,7 @@ namespace Calamari.Tests.Fixtures.Deployment
             }
             else
             {
-                Variables.Set(ConfiguredScriptConvention.GetScriptName(DeploymentStages.Deploy, ScriptSyntax.Powershell), "Write-Host 'The wheels on the bus go round...'");
+                Variables.Set(ConfiguredScriptConvention.GetScriptName(DeploymentStages.Deploy, ScriptSyntax.PowerShell), "Write-Host 'The wheels on the bus go round...'");
             }
 
             var result = DeployPackage();

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -487,7 +487,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
         public void PowershellThrowsExceptionOnNixOrMac()
         {
             var (output, _) = RunScript("Hello.ps1");
-            output.AssertErrorOutput("Powershell scripts are not supported on this platform");
+            output.AssertErrorOutput("PowerShell scripts are not supported on this platform");
         }
 
         [Test]
@@ -507,7 +507,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
             var variablesFile = Path.GetTempFileName();
 
             var variables = new VariableDictionary();
-            variables.Set(SpecialVariables.Action.Script.ScriptBodyBySyntax(ScriptSyntax.Powershell), "Write-Host Hello Powershell");
+            variables.Set(SpecialVariables.Action.Script.ScriptBodyBySyntax(ScriptSyntax.PowerShell), "Write-Host Hello Powershell");
             variables.Set(SpecialVariables.Action.Script.ScriptBodyBySyntax(ScriptSyntax.CSharp), "Write-Host Hello CSharp");
             variables.Set(SpecialVariables.Action.Script.ScriptBodyBySyntax(ScriptSyntax.Bash), "echo Hello Bash");
             variables.Save(variablesFile);

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -7,6 +7,7 @@ using Assent;
 using Assent.Namers;
 using Calamari.Deployment;
 using Calamari.Integration.FileSystem;
+using Calamari.Integration.Scripting;
 using Calamari.Tests.Helpers;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -18,7 +19,6 @@ namespace Calamari.Tests.Fixtures.PowerShell
     public class PowerShellFixture : CalamariFixture
     {
         [Test]
-        [Ignore("This hangs locally")]
         [Category(TestEnvironment.CompatibleOS.Windows)]
         [TestCase("2", "PSVersion                      2.0")]
         [TestCase("2.0", "PSVersion                      2.0")]
@@ -484,7 +484,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
         [Test]
         [Category(TestEnvironment.CompatibleOS.Nix)]
         [Category(TestEnvironment.CompatibleOS.Mac)]
-        public void ThrowsExceptionOnNixOrMac()
+        public void PowershellThrowsExceptionOnNixOrMac()
         {
             var (output, _) = RunScript("Hello.ps1");
             output.AssertErrorOutput("Powershell scripts are not supported on this platform");
@@ -498,6 +498,29 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
             output.AssertSuccess();
             output.AssertOutput("45\r\n226\r\n128\r\n147");
+        }
+
+
+        [Test]
+        public void ShouldAllowPlatformSpecificScriptToExecute()
+        {
+            var variablesFile = Path.GetTempFileName();
+
+            var variables = new VariableDictionary();
+            variables.Set(SpecialVariables.Action.Script.ScriptBodyBySyntax(ScriptSyntax.Powershell), "Write-Host Hello Powershell");
+            variables.Set(SpecialVariables.Action.Script.ScriptBodyBySyntax(ScriptSyntax.CSharp), "Write-Host Hello CSharp");
+            variables.Set(SpecialVariables.Action.Script.ScriptBodyBySyntax(ScriptSyntax.Bash), "echo Hello Bash");
+            variables.Save(variablesFile);
+
+            using (new TemporaryFile(variablesFile))
+            {
+                var output = Invoke(Calamari()
+                    .Action("run-script")
+                    .Argument("variables", variablesFile));
+
+                output.AssertSuccess();
+                output.AssertOutput(CalamariEnvironment.IsRunningOnWindows ? "Hello Powershell" : "Hello Bash");
+            }
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -18,6 +18,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
     public class PowerShellFixture : CalamariFixture
     {
         [Test]
+        [Ignore("This hangs locally")]
         [Category(TestEnvironment.CompatibleOS.Windows)]
         [TestCase("2", "PSVersion                      2.0")]
         [TestCase("2.0", "PSVersion                      2.0")]

--- a/source/Calamari.Tests/Hooks/ScriptHookMock.cs
+++ b/source/Calamari.Tests/Hooks/ScriptHookMock.cs
@@ -17,14 +17,14 @@ namespace Calamari.Tests.Hooks
         public bool Enabled { get; } = true;
         public IScriptWrapper NextWrapper { get; set; }
 
-        public CommandResult ExecuteScript(
-            Script script, 
-            CalamariVariableDictionary variables, 
+        public CommandResult ExecuteScript(Script script,
+            ScriptSyntax scriptSyntax,
+            CalamariVariableDictionary variables,
             ICommandLineRunner commandLineRunner,
             StringDictionary environmentVars)
         {
             WasCalled = true;
-            return NextWrapper.ExecuteScript(script, variables, commandLineRunner, environmentVars);
+            return NextWrapper.ExecuteScript(script, scriptSyntax, variables, commandLineRunner, environmentVars);
         }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -65,7 +65,7 @@ namespace Calamari.Tests.KubernetesFixtures
             var capture = new CaptureCommandOutput();
             var runner = new CommandLineRunner(capture);
             wrapper.NextWrapper = new TerminalScriptWrapper(new PowerShellScriptEngine());
-            var result = wrapper.ExecuteScript(new Script(scriptName), variables, runner, new StringDictionary());
+            var result = wrapper.ExecuteScript(new Script(scriptName), ScriptSyntax.PowerShell, variables, runner, new StringDictionary());
             //var result = psse.Execute(new Script(scriptName), variables, runner);
             return new CalamariResult(result.ExitCode, capture);
         }

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -55,9 +55,8 @@ namespace Calamari.Commands
             deployment = new RunningDeployment(packageFile, (CalamariVariableDictionary)variables);
 
             ValidateArguments();
-            var scriptFilePath = DetermineScriptFilePath(variables);
 
-            var result = ExecuteScriptFromPackage(scriptFilePath) ??
+            var result = ExecuteScriptFromPackage() ??
                          ExecuteScriptFromVariables() ??
                          ExecuteScriptFromParameters();
 
@@ -107,9 +106,6 @@ namespace Calamari.Commands
             {
                 return null;
             }
-            scriptBody = variables.Get(SpecialVariables.Action.Script.ScriptBody);
-            
-            syntax = ScriptSyntax.Powershell;
             var fullPath = Path.GetFullPath(scriptFileName);
             using (new TemporaryFile(fullPath))
             {
@@ -169,13 +165,14 @@ namespace Calamari.Commands
             return false;
         }
 
-        private int? ExecuteScriptFromPackage(string scriptFilePath)
+        private int? ExecuteScriptFromPackage()
         {
             if (!WasProvided(packageFile))
             {
                 return null;
             }
 
+            var scriptFilePath = DetermineScriptFilePath(variables);
             ExtractScriptFromPackage(variables);
             SubstituteVariablesInScript(scriptFilePath, variables);
             return InvokeScript(scriptFilePath, variables);

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -107,6 +107,7 @@ namespace Calamari.Commands
                 return null;
             }
             var fullPath = Path.GetFullPath(scriptFileName);
+            
             using (new TemporaryFile(fullPath))
             {
                 //Bash files need SheBang as first few characters. This does not play well with BOM characters
@@ -114,6 +115,7 @@ namespace Calamari.Commands
                     ? scriptBody.EncodeInUtf8NoBom()
                     : scriptBody.EncodeInUtf8Bom();
                 File.WriteAllBytes(fullPath, scriptBytes);
+
                 return InvokeScript(fullPath, variables);
             }
         }
@@ -127,6 +129,7 @@ namespace Calamari.Commands
                 if (WasProvided(scriptFileName))
                 {
                     syntax = ScriptTypeExtensions.FileNameToScriptType(scriptFileName);
+                 
                     return true;
                 }
 
@@ -138,7 +141,7 @@ namespace Calamari.Commands
                 }
                 else if (!Enum.TryParse(scriptSyntax, out syntax))
                 {
-                    throw new CommandException("Unknown script syntax `{scriptSyntax}` provided");
+                    throw new CommandException($"Unknown script syntax `{scriptSyntax}` provided");
                 }
 
                 scriptFileName = "Script." + syntax.FileExtension();
@@ -214,7 +217,7 @@ namespace Calamari.Commands
                 return fileArgSyntax;
             }
 
-            return variables.GetEnum(SpecialVariables.Action.Script.Syntax, ScriptSyntax.Powershell);
+            return variables.GetEnum(SpecialVariables.Action.Script.Syntax, ScriptSyntax.PowerShell);
         }
 
         private string DetermineScriptFilePath(VariableDictionary variables)
@@ -250,6 +253,7 @@ namespace Calamari.Commands
 
         private int InvokeScript(string scriptFileName, CalamariVariableDictionary variables)
         {
+
             // Any additional files extracted from the packages or sent by the action handler are processed here
             SubstituteVariablesInAdditionalFiles();
 
@@ -263,6 +267,7 @@ namespace Calamari.Commands
             var runner = new CommandLineRunner(new SplitCommandOutput(new ConsoleCommandOutput(), new ServiceMessageCommandOutput(variables)));
             Log.VerboseFormat("Executing '{0}'", scriptFileName);
             var result = scriptEngine.Execute(new Script(scriptFileName, scriptParametersArg ?? scriptParameters), variables, runner);
+
             var shouldWriteJournal = CanWriteJournal(variables) && deployment != null && !deployment.SkipJournal;
 
             if (result.ExitCode == 0 && result.HasErrors && variables.GetFlag(SpecialVariables.Action.FailScriptOnErrorOutput, false))


### PR DESCRIPTION
This change allows us to supply multiple scripts to Calamari, and have it decide on the most appropriate one to use based on supported languages. Typically this would be a decision between `Bash` and `Powershell`