### PR TITLE
`ServiceManagementPublishProfileProvider` was using the wrong method …

### DIFF
--- a/source/Calamari.Azure/Accounts/AzureAccount.cs
+++ b/source/Calamari.Azure/Accounts/AzureAccount.cs
@@ -1,4 +1,5 @@
-﻿using Calamari.Azure.Integration;
+﻿using System;
+using Calamari.Azure.Integration;
 using Calamari.Deployment;
 using Octostache;
 
@@ -13,7 +14,7 @@ namespace Calamari.Azure.Accounts
             ServiceManagementEndpointSuffix = variables.Get(SpecialVariables.Action.Azure.StorageEndPointSuffix, DefaultVariables.StorageEndpointSuffix);
 
             CertificateThumbprint = variables.Get(SpecialVariables.Action.Azure.CertificateThumbprint);
-            CertificateBytes = variables.Get(SpecialVariables.Action.Azure.CertificateBytes);
+            CertificateBytes = Convert.FromBase64String(variables.Get(SpecialVariables.Action.Azure.CertificateBytes));
         }
 
         public string SubscriptionNumber { get; set; }
@@ -23,6 +24,6 @@ namespace Calamari.Azure.Accounts
         public string ServiceManagementEndpointBaseUri { get; set; }
         public string ServiceManagementEndpointSuffix { get; set; }
 
-        public string CertificateBytes { get; set; }
+        public byte[] CertificateBytes { get; set; }
     }
 }

--- a/source/Calamari.Azure/Integration/AzurePowershellContext.cs
+++ b/source/Calamari.Azure/Integration/AzurePowershellContext.cs
@@ -102,7 +102,7 @@ namespace Calamari.Azure.Integration
             var certificatePassword = GenerateCertificatePassword();
             var azureCertificate = certificateStore.GetOrAdd(
                 variables.Get(SpecialVariables.Action.Azure.CertificateThumbprint),
-                variables.Get(SpecialVariables.Action.Azure.CertificateBytes),
+                Convert.FromBase64String(variables.Get(SpecialVariables.Action.Azure.CertificateBytes)),
                 StoreName.My);
 
             variables.Set("OctopusAzureCertificateFileName", certificateFilePath);

--- a/source/Calamari.Azure/Integration/SubscriptionCloudCredentialsFactory.cs
+++ b/source/Calamari.Azure/Integration/SubscriptionCloudCredentialsFactory.cs
@@ -1,4 +1,5 @@
-﻿using Calamari.Deployment;
+﻿using System;
+using Calamari.Deployment;
 using Calamari.Integration.Certificates;
 using Microsoft.Azure;
 using Octostache;
@@ -18,7 +19,7 @@ namespace Calamari.Azure.Integration
         {
             var subscriptionId = variables.Get(SpecialVariables.Action.Azure.SubscriptionId);
             var certificateThumbprint = variables.Get(SpecialVariables.Action.Azure.CertificateThumbprint);
-            var certificateBytes = variables.Get(SpecialVariables.Action.Azure.CertificateBytes);
+            var certificateBytes = Convert.FromBase64String(variables.Get(SpecialVariables.Action.Azure.CertificateBytes));
 
             var certificate = certificateStore.GetOrAdd(certificateThumbprint, certificateBytes);
             return new CertificateCloudCredentials(subscriptionId, certificate);

--- a/source/Calamari.Shared/Integration/Certificates/CalamariCertificateStore.cs
+++ b/source/Calamari.Shared/Integration/Certificates/CalamariCertificateStore.cs
@@ -8,14 +8,14 @@ namespace Calamari.Integration.Certificates
 {
     public class CalamariCertificateStore : ICertificateStore
     {
-        public X509Certificate2 GetOrAdd(string thumbprint, string bytes)
+        public X509Certificate2 GetOrAdd(string thumbprint, byte[] bytes)
         {
-            return GetOrAdd(thumbprint, Convert.FromBase64String(bytes), null, null, new X509Store("Octopus", StoreLocation.CurrentUser), true);
+            return GetOrAdd(thumbprint, bytes, null, null, new X509Store("Octopus", StoreLocation.CurrentUser), true);
         }
 
-        public X509Certificate2 GetOrAdd(string thumbprint, string bytes, StoreName storeName)
+        public X509Certificate2 GetOrAdd(string thumbprint, byte[] bytes, StoreName storeName)
         {
-            return GetOrAdd(thumbprint, Convert.FromBase64String(bytes), null, null, new X509Store(storeName, StoreLocation.CurrentUser), true);
+            return GetOrAdd(thumbprint, bytes, null, null, new X509Store(storeName, StoreLocation.CurrentUser), true);
         }
 
         public X509Certificate2 GetOrAdd(VariableDictionary variables, string certificateVariable, string storeName, string storeLocation = "CurrentUser")

--- a/source/Calamari.Shared/Integration/Certificates/ICertificateStore.cs
+++ b/source/Calamari.Shared/Integration/Certificates/ICertificateStore.cs
@@ -5,8 +5,8 @@ namespace Calamari.Integration.Certificates
 {
     public interface ICertificateStore
     {
-        X509Certificate2 GetOrAdd(string thumbprint, string bytes);
-        X509Certificate2 GetOrAdd(string thumbprint, string bytes, StoreName storeName);
+        X509Certificate2 GetOrAdd(string thumbprint, byte[] bytes);
+        X509Certificate2 GetOrAdd(string thumbprint, byte[] bytes, StoreName storeName);
         X509Certificate2 GetOrAdd(VariableDictionary variables, string certificateVariable, string storeName, string storeLocation = "CurrentUser");
         X509Certificate2 GetOrAdd(VariableDictionary variables, string certificateVariable, StoreName storeName, StoreLocation storeLocation = StoreLocation.CurrentUser);
     }


### PR DESCRIPTION
…overload because AzureAccount.CertificateBytes was a string instead of a byte array. Changed the type so we can't accidentally get it wrong in the future.

Relates to OctopusDeploy/Issues#4798