### PR TITLE
Add HTTP_PROXY support to script steps

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
@@ -197,22 +197,24 @@ function setup_proxy_configuration
     if [ $HTTP_PROXY ] || [ $HTTPS_PROXY ]
     then
         echo "##octopus[stdout-verbose]"    
-        echo "HTTP_PROXY already set"
+        echo "Proxy already set"
         echo "##octopus[stdout-default]"
         return 0
     fi 
 
     if [ $TentacleProxyHost ] 
     then
+        proxyHost=$TentacleProxyHost:${TentacleProxyPort:-80}
+        
         echo "##octopus[stdout-verbose]"
-        echo "Setting HTTP_PROXY to $TentacleProxyHost:${TentacleProxyPort:-80}"
+        echo "Setting HTTP_PROXY to $proxyHost"
         echo "##octopus[stdout-default]"    
         if [ $TentacleProxyUsername ]
         then
-            proxyAuth = "$TentacleProxyUsername:$TentacleProxyPassword@"    
+            proxyAuth="$TentacleProxyUsername:$TentacleProxyPassword@"    
         fi
         
-        proxyUri = "http://$proxyAuth$TentacleProxyHost:${TentacleProxyPort:-80}"
+        proxyUri="http://$proxyAuth$proxyHost"
         export HTTP_PROXY=$proxyUri
         export HTTPS_PROXY=$proxyUri
     fi

--- a/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
@@ -188,4 +188,24 @@ function log_environment_information
 	echo "##octopus[stdout-default]"
 }
 
+function setup_proxy_configuration
+{
+    if [ $HTTP_PROXY ] || [ $HTTPS_PROXY ]
+    then
+        return 0
+    fi 
+
+    if [ $TentacleProxyHost ] 
+    then
+        if [ $TentacleProxyUsername ]
+        then
+            proxyAuth = "$TentacleProxyUsername:$TentacleProxyPassword@"    
+        fi
+        
+        proxyUri = "http://$proxyAuth$TentacleProxyHost:${TentacleProxyPort:-80}"
+        export HTTP_PROXY=$proxyUri
+        export HTTPS_PROXY=$proxyUri
+    fi
+}
+
 log_environment_information

--- a/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
@@ -193,15 +193,7 @@ function setup_proxy_configuration
     echo "##octopus[stdout-verbose]"    
     echo "Configuring proxy"
     echo "##octopus[stdout-default]"
-        
-    if [ $HTTP_PROXY ] || [ $HTTPS_PROXY ]
-    then
-        echo "##octopus[stdout-verbose]"    
-        echo "Proxy already set"
-        echo "##octopus[stdout-default]"
-        return 0
-    fi 
-
+    
     if [ $TentacleProxyHost ] 
     then
         proxyHost=$TentacleProxyHost:${TentacleProxyPort:-80}
@@ -215,9 +207,10 @@ function setup_proxy_configuration
         fi
         
         proxyUri="http://$proxyAuth$proxyHost"
-        export HTTP_PROXY=$proxyUri
-        export HTTPS_PROXY=$proxyUri
-        export NO_PROXY="127.0.0.1,localhost,169.254.169.254"
+
+        export HTTP_PROXY=${HTTP_PROXY:-$proxyUri}
+        export HTTPS_PROXY=${HTTPS_PROXY:-$proxyUri}
+        export NO_PROXY=${NO_PROXY:-"127.0.0.1,localhost,169.254.169.254"}
     fi
 }
 

--- a/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
@@ -190,6 +190,10 @@ function log_environment_information
 
 function setup_proxy_configuration
 {
+    echo "##octopus[stdout-verbose]"    
+    echo "Configuring proxy"
+    echo "##octopus[stdout-default]"
+        
     if [ $HTTP_PROXY ] || [ $HTTPS_PROXY ]
     then
         echo "##octopus[stdout-verbose]"    

--- a/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
@@ -217,6 +217,7 @@ function setup_proxy_configuration
         proxyUri="http://$proxyAuth$proxyHost"
         export HTTP_PROXY=$proxyUri
         export HTTPS_PROXY=$proxyUri
+        export NO_PROXY="127.0.0.1,localhost,169.254.169.254"
     fi
 }
 

--- a/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Shared/Integration/Scripting/Bash/Bootstrap.sh
@@ -192,11 +192,17 @@ function setup_proxy_configuration
 {
     if [ $HTTP_PROXY ] || [ $HTTPS_PROXY ]
     then
+        echo "##octopus[stdout-verbose]"    
+        echo "HTTP_PROXY already set"
+        echo "##octopus[stdout-default]"
         return 0
     fi 
 
     if [ $TentacleProxyHost ] 
     then
+        echo "##octopus[stdout-verbose]"
+        echo "Setting HTTP_PROXY to $TentacleProxyHost:${TentacleProxyPort:-80}"
+        echo "##octopus[stdout-default]"    
         if [ $TentacleProxyUsername ]
         then
             proxyAuth = "$TentacleProxyUsername:$TentacleProxyPassword@"    
@@ -209,3 +215,4 @@ function setup_proxy_configuration
 }
 
 log_environment_information
+setup_proxy_configuration

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -402,6 +402,9 @@ function Initialize-ProxySettings()
 	{
 		$proxyUri = [System.Uri]"http://${proxyHost}:$proxyPort"
 		$proxy = New-Object System.Net.WebProxy($proxyUri)
+
+        $env:HTTP_PROXY = "http://$proxyUri"
+        $env:HTTPS_PROXY = "https://$proxyUri"
 	}
 
 	if ([string]::IsNullOrEmpty($proxyUsername)) 
@@ -418,7 +421,15 @@ function Initialize-ProxySettings()
 	else 
 	{
 		$proxy.Credentials = New-Object System.Net.NetworkCredential($proxyUsername, $proxyPassword)
+
+        Add-Type -AssemblyName System.Web
+        $proxyUrl = "$( [System.Web.HttpUtility]::UrlEncode($proxyUsername) ):$( [System.Web.HttpUtility]::UrlEncode($proxyPassword) )@$( $proxyHost ):$( $proxyPort )"
+        $env:HTTP_PROXY = "http://$proxyUrl"
+        $env:HTTPS_PROXY = "https://$proxyUrl"
 	}
+
+    Write-Host "HTTP Proxy " $env:HTTP_PROXY; 
+    Write-Host "HTTPS Proxy " $env:HTTPS_PROXY; 
 
 	[System.Net.WebRequest]::DefaultWebProxy = $proxy
 }

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -405,7 +405,7 @@ function Initialize-ProxySettings()
 
         $env:HTTP_PROXY = "$proxyUri"
         $env:HTTPS_PROXY = "$proxyUri"
-        $env:NO_PROXY="127.0.0.1,localhost"
+        $env:NO_PROXY="127.0.0.1,localhost,169.254.169.254"
 	}
 
 	if ([string]::IsNullOrEmpty($proxyUsername)) 
@@ -427,7 +427,7 @@ function Initialize-ProxySettings()
         $proxyUrl = "$( [System.Web.HttpUtility]::UrlEncode($proxyUsername) ):$( [System.Web.HttpUtility]::UrlEncode($proxyPassword) )@$( $proxyHost ):$( $proxyPort )"
         $env:HTTP_PROXY = "http://$proxyUrl"
         $env:HTTPS_PROXY = "https://$proxyUrl"
-        $env:NO_PROXY="127.0.0.1,localhost"
+        $env:NO_PROXY="127.0.0.1,localhost,169.254.169.254"
 	}
 
 	[System.Net.WebRequest]::DefaultWebProxy = $proxy

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -402,10 +402,18 @@ function Initialize-ProxySettings()
 	{
 		$proxyUri = [System.Uri]"http://${proxyHost}:$proxyPort"
 		$proxy = New-Object System.Net.WebProxy($proxyUri)
+        
+        if([string]::IsNullOrEmpty($env:HTTP_PROXY)) {
+            $env:HTTP_PROXY = "$proxyUri"
+        }
+    
+        if([string]::IsNullOrEmpty($env:HTTPS_PROXY)) {
+            $env:HTTPS_PROXY = "$proxyUri"
+        }
 
-        $env:HTTP_PROXY = "$proxyUri"
-        $env:HTTPS_PROXY = "$proxyUri"
-        $env:NO_PROXY="127.0.0.1,localhost,169.254.169.254"
+        if([string]::IsNullOrEmpty($env:NO_PROXY)) {
+            $env:NO_PROXY="127.0.0.1,localhost,169.254.169.254"
+        }
 	}
 
 	if ([string]::IsNullOrEmpty($proxyUsername)) 
@@ -425,9 +433,17 @@ function Initialize-ProxySettings()
 
         Add-Type -AssemblyName System.Web
         $proxyUrl = "$( [System.Web.HttpUtility]::UrlEncode($proxyUsername) ):$( [System.Web.HttpUtility]::UrlEncode($proxyPassword) )@$( $proxyHost ):$( $proxyPort )"
-        $env:HTTP_PROXY = "http://$proxyUrl"
-        $env:HTTPS_PROXY = "https://$proxyUrl"
-        $env:NO_PROXY="127.0.0.1,localhost,169.254.169.254"
+        if([string]::IsNullOrEmpty($env:HTTP_PROXY)) {
+            $env:HTTP_PROXY = "$proxyUri"
+        }
+    
+        if([string]::IsNullOrEmpty($env:HTTPS_PROXY)) {
+            $env:HTTPS_PROXY = "$proxyUri"
+        }
+
+        if([string]::IsNullOrEmpty($env:NO_PROXY)) {
+            $env:NO_PROXY="127.0.0.1,localhost,169.254.169.254"
+        }
 	}
 
 	[System.Net.WebRequest]::DefaultWebProxy = $proxy

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -403,8 +403,9 @@ function Initialize-ProxySettings()
 		$proxyUri = [System.Uri]"http://${proxyHost}:$proxyPort"
 		$proxy = New-Object System.Net.WebProxy($proxyUri)
 
-        $env:HTTP_PROXY = "http://$proxyUri"
-        $env:HTTPS_PROXY = "https://$proxyUri"
+        $env:HTTP_PROXY = "$proxyUri"
+        $env:HTTPS_PROXY = "$proxyUri"
+        $env:NO_PROXY="127.0.0.1,localhost"
 	}
 
 	if ([string]::IsNullOrEmpty($proxyUsername)) 
@@ -426,10 +427,8 @@ function Initialize-ProxySettings()
         $proxyUrl = "$( [System.Web.HttpUtility]::UrlEncode($proxyUsername) ):$( [System.Web.HttpUtility]::UrlEncode($proxyPassword) )@$( $proxyHost ):$( $proxyPort )"
         $env:HTTP_PROXY = "http://$proxyUrl"
         $env:HTTPS_PROXY = "https://$proxyUrl"
+        $env:NO_PROXY="127.0.0.1,localhost"
 	}
-
-    Write-Host "HTTP Proxy " $env:HTTP_PROXY; 
-    Write-Host "HTTPS Proxy " $env:HTTPS_PROXY; 
 
 	[System.Net.WebRequest]::DefaultWebProxy = $proxy
 }


### PR DESCRIPTION
This will set the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables based on the web request proxy configuration for the worker context that is executing the script. If using the built-in worker, this will be the server, for external workers, it will be the Tentacle web request proxy.
This will support AWS CLI, Azure CLI, and Kubernetes `kubectl`.

If authentication details are provided in the relevant proxy configuration the proxy environment variables will use the URI format `http://username:password@host:port/`
Port will default to 80 if not supplied.

If the proxy environment variables are already set on in the system variables, they will not be overridden.

The `NO_PROXY` variable also explicitly includes the AWS EC2 Metadata endpoint, as per https://docs.aws.amazon.com/cli/latest/userguide/cli-http-proxy.html

**Exception**: `kubectl` does not seem to support authentication in the proxy configuration.

The changes made to `bootstrap.sh` are future proofing for Linux Tentacle and will only work if the `TentacleProxyHost` environment variable is set. The current Windows Tentacle also sets these as an environment variable.

Scenarios tested:
AWS CLI and Azure CLI through a proxy from both built-in worker and external worker
`kubectl` through a proxy (without auth) from the built-in worker and external worker.
