### PR TITLE
Fix for Azure Web App query not returning resource groups

### DIFF
--- a/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
+++ b/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
@@ -161,7 +161,7 @@ namespace Calamari.Azure.Integration.Websites.Publishing
             bool hasResourceGroup = !string.IsNullOrWhiteSpace(resourceGroupName);
             StringBuilder sb = new StringBuilder($"Could not find Azure WebSite '{azureTargetSite.Site}'");
             sb.Append(hasResourceGroup ? $" in resource group '{resourceGroupName}'" : string.Empty);
-            sb.Append($"in subscription '{account.SubscriptionNumber}'.");
+            sb.Append($" in subscription '{account.SubscriptionNumber}'.");
             sb.Append(hasResourceGroup ? string.Empty : " Please supply a Resource Group name.");
             return sb.ToString();
         }

--- a/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
+++ b/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
@@ -131,11 +131,6 @@ namespace Calamari.Azure.Integration.Websites.Publishing
 
                 matchingSite = matchingSites.Single();
 
-                if (retry.IsFirstAttempt)
-                {
-                    matchingSite = new Site(location: "westus", resourceGroup: null);
-                }
-
                 // ensure the site loaded the resource group
                 if (string.IsNullOrWhiteSpace(matchingSite.ResourceGroup))
                 {

--- a/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
+++ b/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
@@ -47,6 +47,7 @@ namespace Calamari.Azure.Integration.Websites.Publishing
                 if (string.IsNullOrWhiteSpace(resourceGroupName))
                 {
                     matchingSite = FindSiteByNameWithRetry(account, azureTargetSite, webSiteClient) ?? throw new CommandException(GetSiteNotFoundExceptionMessage(account, azureTargetSite));
+                    resourceGroupName = matchingSite.ResourceGroup;
                 }
                 else
                 {
@@ -63,7 +64,7 @@ namespace Calamari.Azure.Integration.Websites.Publishing
 
                 // We allow the slot to be defined on both the target directly (which will come through on the matchingSite.Name) or on the 
                 // step for backwards compatibility with older Azure steps.
-                resourceGroupName = matchingSite.ResourceGroup;
+                
                 var siteAndSlotPath = matchingSite.Name;
                 if (azureTargetSite.HasSlot)
                 {

--- a/source/Calamari.Azure/Util/AzureRetryTracker.cs
+++ b/source/Calamari.Azure/Util/AzureRetryTracker.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Calamari.Integration.Retry;
+
+namespace Calamari.Azure.Util
+{
+    public static class AzureRetryTracker
+    {
+        /// <summary>
+        /// For azure operations, try again after 1s then 2s, 4s etc...
+        /// </summary>
+        private static readonly LimitedExponentialRetryInterval RetryIntervalForAzureOperations = new LimitedExponentialRetryInterval(1000, 30000, 2);
+
+        public static RetryTracker GetDefaultRetryTracker()
+        {
+            return new RetryTracker(maxRetries: 3,
+                timeLimit: TimeSpan.MaxValue,
+                retryInterval: RetryIntervalForAzureOperations);
+        }
+    }
+}


### PR DESCRIPTION
If a resource group is supplied, just query for the web app in the resource group.
If no resource group supplied, query for all resource groups and match by name. If Azure is not returning the resource group - try again.