### PR TITLE
Log nested error messages for a failed ARM deployment submission

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/DeployAzureResourceGroupConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/DeployAzureResourceGroupConvention.cs
@@ -236,11 +236,20 @@ namespace Calamari.Azure.Deployment.Conventions
             }
 
             if (error != null)
-            {
+            {   
                 string indent = new string(' ', count * 4);
-                Log.Error($"{indent}Message: {error.Message}");
-                Log.Error($"{indent}Code: {error.Code}");
-                Log.Error($"{indent}Target: {error.Target}");
+                if (!string.IsNullOrEmpty(error.Message))
+                {
+                    Log.Error($"{indent}Message: {error.Message}"); 
+                }
+                if (!string.IsNullOrEmpty(error.Code))
+                {
+                    Log.Error($"{indent}Code: {error.Code}"); 
+                }
+                if (!string.IsNullOrEmpty(error.Target))
+                {
+                    Log.Error($"{indent}Target: {error.Target}"); 
+                }
                 foreach (var errorDetail in error.Details)
                 {
                     LogCloudError(errorDetail, ++count);

--- a/source/Calamari.Azure/Deployment/Conventions/DeployAzureResourceGroupConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/DeployAzureResourceGroupConvention.cs
@@ -109,18 +109,26 @@ namespace Calamari.Azure.Deployment.Conventions
 
             using (var armClient = createArmClient())
             {
-                var createDeploymentResult = armClient.Deployments.BeginCreateOrUpdate(resourceGroupName, deploymentName,
-                    new Microsoft.Azure.Management.ResourceManager.Models.Deployment
-                    {
-                        Properties = new DeploymentProperties
+                try
+                {
+                    var createDeploymentResult = armClient.Deployments.BeginCreateOrUpdate(resourceGroupName,
+                        deploymentName,
+                        new Microsoft.Azure.Management.ResourceManager.Models.Deployment
                         {
-                            Mode = deploymentMode,
-                            Template = template,
-                            Parameters = parameters
-                        }
-                    });
+                            Properties = new DeploymentProperties
+                            {
+                                Mode = deploymentMode, Template = template, Parameters = parameters
+                            }
+                        });
 
-                Log.Info($"Deployment created: {createDeploymentResult.Id}");
+                    Log.Info($"Deployment created: {createDeploymentResult.Id}");
+                }
+                catch (Microsoft.Rest.Azure.CloudException ex)
+                {
+                    Log.Error("Error submitting deployment");
+                    Log.Error(ex.Message);
+                    LogCloudError(ex.Body, 0);       
+                }
             }
         }
 
@@ -190,7 +198,7 @@ namespace Calamari.Azure.Deployment.Conventions
             {
                 if (operation?.Properties == null)
                     continue;
-
+                
                 log.AppendLine($"Resource: {operation.Properties.TargetResource?.ResourceName}");
                 log.AppendLine($"Type: {operation.Properties.TargetResource?.ResourceType}");
                 log.AppendLine($"Timestamp: {operation.Properties.Timestamp?.ToLocalTime():s}");
@@ -217,6 +225,26 @@ namespace Calamari.Azure.Deployment.Conventions
             foreach (var output in outputs)
             {
                 Log.SetOutputVariable($"AzureRmOutputs[{output.Key}]", output.Value["value"].ToString(), variables);
+            }
+        }
+
+        static void LogCloudError(Microsoft.Rest.Azure.CloudError error, int count)
+        {
+            if (count > 5)
+            {
+                return;
+            }
+
+            if (error != null)
+            {
+                string indent = new string(' ', count * 4);
+                Log.Error($"{indent}Message: {error.Message}");
+                Log.Error($"{indent}Code: {error.Code}");
+                Log.Error($"{indent}Target: {error.Target}");
+                foreach (var errorDetail in error.Details)
+                {
+                    LogCloudError(errorDetail, ++count);
+                }
             }
         }
     }


### PR DESCRIPTION
https://github.com/OctopusDeploy/Issues/issues/4616

Adds the following example to the log for a template error:
```
Message: The template deployment 'deploy-192bb6b7ca84448385f0704b53d8dab4' is not valid according to the validation procedure. The tracking id is 'c7a75862-7148-4171-a5f7-39e955d9639b'. See inner errors for details. Please see https://aka.ms/arm-deploy for usage details. 
Code: InvalidTemplateDeployment 
Target:  
    Message: The domain name label GEN-UNIQUE is invalid. It must conform to the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$. 
    Code: InvalidDomainNameLabel 
    Target:  
```

Will log up to 5 levels of nested errors