### PR TITLE
Rollback version of AlphaFS to 2.1.3

### DIFF
--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
     <PackageReference Include="NuGet.CommandLine" Version="2.8.6" />
     <PackageReference Include="NuGet.Core" Version="2.14.0" />
-    <PackageReference Include="AlphaFS" Version="2.2.6" />
+    <PackageReference Include="AlphaFS" Version="2.1.3" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
We have had numerous reports of bugs related to the newest version of AlphaFS, this PR is to rollback to a version before these bugs were introduced.
There is a known issue in version 2.1.3 where Directory.Exists wrongly returns true if a folder has invalid characters, we will be reintroducing this issue buy rolling back version. This was weighed up against all the new issue that were introduced and in comparison is fairly minor.