### PR TITLE
Ignore some maven tests on the mac

### DIFF
--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -87,8 +87,8 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [RequiresNonFreeBSDPlatform]
         public void ShouldDownloadMavenPackage()
         {
-            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI)
-                Assert.Inconclusive("As of November 2018, this test is failing on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
+            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI && !CalamariEnvironment.IsRunningOnMono)
+                Assert.Inconclusive("As of November 2018, this test is failing under dotnet core on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
 
             var result = DownloadPackage(
                 MavenPublicFeed.PackageId,
@@ -116,8 +116,8 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [RequiresNonFreeBSDPlatform]
         public void ShouldDownloadMavenSnapshotPackage()
         {
-            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI)
-                Assert.Inconclusive("As of November 2018, this test is failing on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
+            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI && !CalamariEnvironment.IsRunningOnMono)
+                Assert.Inconclusive("As of November 2018, this test is failing under dotnet core on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
 
             var result = DownloadPackage(
                 MavenPublicFeed.PackageId, 
@@ -183,8 +183,8 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [RequiresNonFreeBSDPlatform]
         public void ShouldUseMavenPackageFromCache()
         {
-            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI)
-                Assert.Inconclusive("As of November 2018, this test is failing on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
+            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI && !CalamariEnvironment.IsRunningOnMono)
+                Assert.Inconclusive("As of November 2018, this test is failing under dotnet core on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
 
             DownloadPackage(MavenPublicFeed.PackageId,
                     MavenPublicFeed.Version.ToString(),
@@ -215,8 +215,8 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [RequiresNonFreeBSDPlatform]
         public void ShouldUseMavenSnapshotPackageFromCache()
         {
-            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI)
-                Assert.Inconclusive("As of November 2018, this test is failing on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
+            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI && !CalamariEnvironment.IsRunningOnMono)
+                Assert.Inconclusive("As of November 2018, this test is failing under dotnet core on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
 
             DownloadPackage(MavenPublicFeed.PackageId,
                     MavenPublicFeed.Version.ToString(),
@@ -271,8 +271,8 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [RequiresNonFreeBSDPlatform]
         public void ShouldByPassCacheAndDownloadMavenPackage()
         {
-            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI)
-                Assert.Inconclusive("As of November 2018, this test is failing on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
+            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI && !CalamariEnvironment.IsRunningOnMono)
+                Assert.Inconclusive("As of November 2018, this test is failing under dotnet core on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
 
             var firstDownload = DownloadPackage(
                 MavenPublicFeed.PackageId,

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -87,6 +87,9 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [RequiresNonFreeBSDPlatform]
         public void ShouldDownloadMavenPackage()
         {
+            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI)
+                Assert.Inconclusive("As of November 2018, this test is failing on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
+
             var result = DownloadPackage(
                 MavenPublicFeed.PackageId,
                 MavenPublicFeed.Version.ToString(),
@@ -113,6 +116,9 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [RequiresNonFreeBSDPlatform]
         public void ShouldDownloadMavenSnapshotPackage()
         {
+            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI)
+                Assert.Inconclusive("As of November 2018, this test is failing on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
+
             var result = DownloadPackage(
                 MavenPublicFeed.PackageId, 
                 MavenPublicFeed.Version.ToString(), 
@@ -177,6 +183,9 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [RequiresNonFreeBSDPlatform]
         public void ShouldUseMavenPackageFromCache()
         {
+            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI)
+                Assert.Inconclusive("As of November 2018, this test is failing on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
+
             DownloadPackage(MavenPublicFeed.PackageId,
                     MavenPublicFeed.Version.ToString(),
                     MavenPublicFeed.Id,
@@ -206,6 +215,9 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [RequiresNonFreeBSDPlatform]
         public void ShouldUseMavenSnapshotPackageFromCache()
         {
+            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI)
+                Assert.Inconclusive("As of November 2018, this test is failing on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
+
             DownloadPackage(MavenPublicFeed.PackageId,
                     MavenPublicFeed.Version.ToString(),
                     MavenPublicFeed.Id,
@@ -259,6 +271,8 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         [RequiresNonFreeBSDPlatform]
         public void ShouldByPassCacheAndDownloadMavenPackage()
         {
+            if (CalamariEnvironment.IsRunningOnMac && TestEnvironment.IsCI)
+                Assert.Inconclusive("As of November 2018, this test is failing on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. Marking as inconclusive so we can re-enable the build - it had been disabled for months :(");
 
             var firstDownload = DownloadPackage(
                 MavenPublicFeed.PackageId,


### PR DESCRIPTION
As of November 2018, a few tests were failing under dotnet core on the cloudmac under teamcity - we were getting an error 'SSL connect error' when trying to download from  'https://repo.maven.apache.org/maven2/'. 
I've marked as inconclusive instead so we can re-enable the build - it had been disabled for months :(