### PR TITLE
Fix S3 broken bucket keys for multiple file selections

### DIFF
--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -195,7 +195,7 @@ namespace Calamari.Aws.Deployment.Conventions
             foreach (var matchedFile in files)
             {
                 
-                yield return CreateRequest(matchedFile.FilePath, () => $"{selection.BucketKeyPrefix}{matchedFile.MappedRelativePath.Replace("\\","/")}", selection)
+                yield return CreateRequest(matchedFile.FilePath, () => $"{selection.BucketKeyPrefix}{matchedFile.MappedRelativePath}", selection)
                     .Tee(x => LogPutObjectRequest(matchedFile.FilePath, x))
                     //We only warn on multi file uploads 
                     .Map(x => HandleUploadRequest(clientFactory(), x, WarnAndIgnoreException));

--- a/source/Calamari.Shared/Util/RelativeGlobber.cs
+++ b/source/Calamari.Shared/Util/RelativeGlobber.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Calamari.Integration.FileSystem;
+
+namespace Calamari.Util
+{
+     public class RelativeGlobMatch
+    {
+        public string MappedRelativePath { get; }
+        public string WorkingDirectory { get; }
+        public string FilePath { get; }
+
+        public RelativeGlobMatch(string filePath, string mappedRelativePath, string workingDirectory)
+        {
+            MappedRelativePath = mappedRelativePath;
+            WorkingDirectory = workingDirectory;
+            FilePath = filePath;
+        }
+    }
+    
+    public class RelativeGlobber
+    {
+        private readonly Func<string, string, IEnumerable<string>> enumerateWithGlob;
+        public ICalamariFileSystem FileSystem { get; }
+        public string WorkingDirectory { get; }
+        
+        public RelativeGlobber(Func<string, string, IEnumerable<string>> enumerateWithGlob, string workingDirectory)
+        {
+            this.enumerateWithGlob = enumerateWithGlob;
+            WorkingDirectory = workingDirectory;
+        }
+        
+        private (string glob, string output) ParsePattern(string pattern)
+        {
+            var segments = Regex.Split(pattern, "=>");
+            var output = segments.Length > 1 ? segments[1].Trim() : null;
+            var glob = segments.First().Trim();
+
+            return (glob, output);
+        }
+
+        public IEnumerable<RelativeGlobMatch> EnumerateFilesWithGlob(string pattern)
+        {
+            var (glob, outputPattern) = ParsePattern(pattern);
+            var strategy = GetBasePathStrategy(outputPattern);
+            var result = enumerateWithGlob(WorkingDirectory, glob);
+
+            return result.Select(x => new RelativeGlobMatch(x, strategy(glob, WorkingDirectory, x).Replace("\\","/"), WorkingDirectory));
+        }
+        
+        private Func<string, string, string, string> GetBasePathStrategy(string outputPattern)
+        {
+            if (string.IsNullOrEmpty(outputPattern))
+            {
+                return (pattern, cwd, file) => GetGlobBase("*", GetBaseSegmentFromGlob(pattern), file.AsRelativePathFrom(cwd));
+            }
+
+            if (outputPattern.Contains("**") || !outputPattern.Contains("*"))
+            {
+                return (pattern, cwd, file) => GetGlobBase(outputPattern, GetBaseSegmentFromGlob(pattern), file.AsRelativePathFrom(cwd));
+            }
+            
+            return (pattern, cwd, file) => Path.Combine(outputPattern.Replace("*", string.Empty), Path.GetFileName(file));
+        }
+
+        private string GetBaseSegmentFromGlob(string pattern)
+        {
+            var segments = pattern.Split('/', '\\');
+            var result = string.Empty;
+
+            foreach (var segment in segments)
+            {
+                if (!segment.Contains("*"))
+                {
+                    result = $"{result}{segment}/";
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return result;
+        }
+
+        private string GetGlobBase(string outputPattern, string segmentBase, string fileSegment)
+        {
+            return Path.Combine(outputPattern.Replace("*", string.Empty), string.IsNullOrEmpty(segmentBase) ? fileSegment : fileSegment.Replace(segmentBase.EnsureSuffix("/"), string.Empty));
+        }
+    }
+}

--- a/source/Calamari.Shared/Util/RelativeGlobber.cs
+++ b/source/Calamari.Shared/Util/RelativeGlobber.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Calamari.Integration.FileSystem;
 
 namespace Calamari.Util
 {
@@ -24,7 +23,6 @@ namespace Calamari.Util
     public class RelativeGlobber
     {
         private readonly Func<string, string, IEnumerable<string>> enumerateWithGlob;
-        public ICalamariFileSystem FileSystem { get; }
         public string WorkingDirectory { get; }
         
         public RelativeGlobber(Func<string, string, IEnumerable<string>> enumerateWithGlob, string workingDirectory)
@@ -63,7 +61,8 @@ namespace Calamari.Util
                 return (pattern, cwd, file) => GetGlobBase(outputPattern, GetBaseSegmentFromGlob(pattern), file.AsRelativePathFrom(cwd));
             }
             
-            return (pattern, cwd, file) => Path.Combine(outputPattern.Replace("*", string.Empty), Path.GetFileName(file));
+            //Be careful of Path.GetFileName, it will bite you on linux
+            return (pattern, cwd, file) => Path.Combine(outputPattern.Replace("*", string.Empty), new Uri(file).Segments.Last());
         }
 
         private string GetBaseSegmentFromGlob(string pattern)
@@ -88,7 +87,7 @@ namespace Calamari.Util
 
         private string GetGlobBase(string outputPattern, string segmentBase, string fileSegment)
         {
-            return Path.Combine(outputPattern.Replace("*", string.Empty), string.IsNullOrEmpty(segmentBase) ? fileSegment : fileSegment.Replace(segmentBase.EnsureSuffix("/"), string.Empty));
+            return Path.Combine(outputPattern.Replace("*", string.Empty), string.IsNullOrEmpty(segmentBase) ? fileSegment : fileSegment.Replace(segmentBase, string.Empty));
         }
     }
 }

--- a/source/Calamari.Shared/Util/StringExtensions.cs
+++ b/source/Calamari.Shared/Util/StringExtensions.cs
@@ -30,7 +30,7 @@ namespace Calamari.Util
             return !source.EndsWith(suffix) ? $"{source}{suffix}" : source;
         }
 
-        public static string EnsurePreix(this string source, string prefix)
+        public static string EnsurePrefix(this string source, string prefix)
         {
             return !source.StartsWith(prefix) ? $"{prefix}{source}" : source;
         }

--- a/source/Calamari.Shared/Util/StringExtensions.cs
+++ b/source/Calamari.Shared/Util/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -22,6 +23,27 @@ namespace Calamari.Util
         public static byte[] EncodeInUtf8NoBom(this string source)
         {
             return Encoding.UTF8.GetBytes(source);
+        }
+
+        public static string EnsureSuffix(this string source, string suffix)
+        {
+            return !source.EndsWith(suffix) ? $"{source}{suffix}" : source;
+        }
+
+        public static string EnsurePreix(this string source, string prefix)
+        {
+            return !source.StartsWith(prefix) ? $"{prefix}{source}" : source;
+        }
+
+        public static string AsRelativePathFrom(this string source, string baseDirectory)
+        {
+            var uri = new Uri(source);
+            if (!baseDirectory.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            {
+                baseDirectory += Path.DirectorySeparatorChar.ToString();
+            }
+            var baseUri = new Uri(baseDirectory);
+            return baseUri.MakeRelativeUri(uri).ToString();
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Util/RelativeGlobFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/RelativeGlobFixture.cs
@@ -1,0 +1,65 @@
+﻿using Calamari.Util;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Calamari.Tests.Fixtures.Util
+{
+    [TestFixture]
+    public class RelativeGlobFixture
+    {
+        [Test]
+        public void HasCorrectRelativePathsForRootGlobAll()
+        {
+            var files = new List<string>{ @"c:\staging\content\first.txt", @"c:\staging\content\nested\two.txt" };
+            var matches = new RelativeGlobber((@base, pattern) => files, @"c:\staging").EnumerateFilesWithGlob("**/*").ToList();
+            Assert.AreEqual(@"content/first.txt", matches[0].MappedRelativePath);
+            Assert.AreEqual( @"content/nested/two.txt", matches[1].MappedRelativePath);
+        }
+        
+        [Test]
+        public void HasCorrectRelativePathsForFolderGlob()
+        {
+            var files = new List<string>{ @"c:\staging\content\first.txt", @"c:\staging\content\nested\two.txt" };
+            var matches = new RelativeGlobber((@base, pattern) => files, @"c:\staging").EnumerateFilesWithGlob("content/**/*").ToList();
+            Assert.AreEqual(@"first.txt", matches[0].MappedRelativePath);
+            Assert.AreEqual(@"nested/two.txt", matches[1].MappedRelativePath);
+        }
+        
+        [Test]
+        public void HasCorrectRelativePathsForRootGlobAllAndOverride()
+        {
+            var files = new List<string>{ @"c:\staging\content\first.txt", @"c:\staging\content\nested\two.txt" };
+            var matches = new RelativeGlobber((@base, pattern) => files, @"c:\staging").EnumerateFilesWithGlob("**/* => bob").ToList();
+            Assert.AreEqual(@"bob/content/first.txt", matches[0].MappedRelativePath);
+            Assert.AreEqual(@"bob/content/nested/two.txt", matches[1].MappedRelativePath);
+        }
+        
+        [Test]
+        public void HasCorrectRelativePathsForFolderGlobAndOverride()
+        {
+            var files = new List<string>{ @"c:\staging\content\first.txt", @"c:\staging\content\nested\two.txt" };
+            var matches = new RelativeGlobber((@base, pattern) => files, @"c:\staging").EnumerateFilesWithGlob("content/**/* => bob").ToList();
+            Assert.AreEqual(@"bob/first.txt", matches[0].MappedRelativePath);
+            Assert.AreEqual(@"bob/nested/two.txt", matches[1].MappedRelativePath);
+        }
+        
+        [Test]
+        public void CanFlattenUsingOverride()
+        {
+            var files = new List<string>{ @"c:\staging\content\first.txt", @"c:\staging\content\nested\two.txt" };
+            var matches = new RelativeGlobber((@base, pattern) => files, @"c:\staging").EnumerateFilesWithGlob("content/**/* => bob/*").ToList();
+            Assert.AreEqual(@"bob/first.txt", matches[0].MappedRelativePath);
+            Assert.AreEqual(@"bob/two.txt", matches[1].MappedRelativePath);
+        }
+        
+        [Test]
+        public void DropsAllBaseFoldersForOverride()
+        {
+            var files = new List<string>{ @"c:\staging\content\nested\deep\first.txt", @"c:\staging\content\nested\deep\deeper\two.txt" };
+            var matches = new RelativeGlobber((@base, pattern) => files, @"c:\staging").EnumerateFilesWithGlob("content/nested/**/* => bob").ToList();
+            Assert.AreEqual(@"bob/deep/first.txt", matches[0].MappedRelativePath);
+            Assert.AreEqual(@"bob/deep/deeper/two.txt", matches[1].MappedRelativePath);
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/OctopusDeploy/Issues/issues/5066

Changing the AlphaFS version broke the S3 upload step which previously used the library in order to calculate the bucket keys relative to the current working directory. This change does away with that requirement.