### PR TITLE
Prevents use of characters that trigger an azure CLI bug.

### DIFF
--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -81,6 +81,14 @@ Execute-WithRetry{
 
 			If (!$OctopusDisableAzureCLI -or $OctopusDisableAzureCLI -like [Boolean]::FalseString) {
 				try {
+				    $badCharsRegex = '.*[&|].*'
+				    $passwordContainsBadChars = $OctopusAzureADPassword -match $badCharsRegex
+                    $userNameContainsBadChars = $OctopusAzureADClientId -match $badCharsRegex
+                    if ($passwordContainsBadChars -or $userNameContainsBadChars) {
+                        Write-Warning 'The Azure Account credentials contains either a | or a & character. This can cause issues with the azure CLI invocation and should be avoided.'
+                        throw 'Invalid characters were passed into azure login credentials'
+                    }
+				
 					# authenticate with the Azure CLI
 					Write-Host "##octopus[stdout-verbose]"
                 
@@ -91,9 +99,9 @@ Execute-WithRetry{
 					$ErrorActionPreference = "Continue"
 					az cloud set --name $OctopusAzureEnvironment 2>$null 3>$null 
 					$ErrorActionPreference = $previousErrorAction
-
+                    
 					Write-Host "Azure CLI: Authenticating with Service Principal"
-					az login --service-principal -u $OctopusAzureADClientId -p $OctopusAzureADPassword --tenant $OctopusAzureADTenantId 
+					az login --service-principal -u "$OctopusAzureADClientId" -p "$OctopusAzureADPassword" --tenant $OctopusAzureADTenantId 
         
 					Write-Host "Azure CLI: Setting active subscription to $OctopusAzureSubscriptionId"
 					az account set --subscription $OctopusAzureSubscriptionId


### PR DESCRIPTION
Introduces a warning if bad chars have been passed in, and bails out of the login proocess pre-emptively.

Intended to be temporary - pending advice from MS regarding the issue in the Azure CLI

Closes https://github.com/OctopusDeploy/OctopusDeploy/issues/3119