### PR TITLE
 Add type annotations to path argument of createArtifact function

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/FSharp/Bootstrap.fsx
+++ b/source/Calamari.Shared/Integration/Scripting/FSharp/Bootstrap.fsx
@@ -90,7 +90,7 @@ let setSensitiveVariable name value =
     let content = sprintf "name='%s' value='%s' sensitive='%s'" encodedName encodedValue (encode "True")
     writeServiceMessage "setVariable" content
 
-let createArtifact (path: String, fileName: Option<String>) =
+let createArtifact (path: String) fileName =
     let plainFileName = match fileName with
                             | Some value -> value
                             | None -> System.IO.Path.GetFileName(path)

--- a/source/Calamari.Shared/Integration/Scripting/FSharp/Bootstrap.fsx
+++ b/source/Calamari.Shared/Integration/Scripting/FSharp/Bootstrap.fsx
@@ -90,7 +90,7 @@ let setSensitiveVariable name value =
     let content = sprintf "name='%s' value='%s' sensitive='%s'" encodedName encodedValue (encode "True")
     writeServiceMessage "setVariable" content
 
-let createArtifact path fileName =
+let createArtifact (path: String, fileName: Option<String>) =
     let plainFileName = match fileName with
                             | Some value -> value
                             | None -> System.IO.Path.GetFileName(path)


### PR DESCRIPTION
`mono` version `5.16.0` introduces a new `System.IO.Path.GetFileName` method overload taken from the .NET `corefx` code base. Because our `createArtifact` method in our F# bootstrap script doesn't provide a type annotation for the `path` argument, the code can't determine which of the `System.IO.Path.GetFileName` methods to use.

Related to: https://github.com/OctopusDeploy/Issues/issues/5091