### PR TITLE
Script syntax conditions on script wrappers

### DIFF
--- a/source/Calamari.Aws/Integration/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.Aws/Integration/AwsEnvironmentGeneration.cs
@@ -232,7 +232,7 @@ namespace Calamari.Aws.Integration
         }
 
         public int Priority => ScriptWrapperPriorities.CloudAuthenticationPriority;
-        public bool Enabled { get; } = true;
+        public bool IsEnabled(ScriptSyntax scriptSyntax) => true;
         public IScriptWrapper NextWrapper { get; set; }
 
         public CommandResult ExecuteScript(Script script,

--- a/source/Calamari.Azure/Integration/AzurePowershellContext.cs
+++ b/source/Calamari.Azure/Integration/AzurePowershellContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -21,7 +22,9 @@ namespace Calamari.Azure.Integration
         readonly ICalamariFileSystem fileSystem;
         readonly ICertificateStore certificateStore;
         readonly ICalamariEmbeddedResources embeddedResources;
-        private readonly CalamariVariableDictionary variables;
+        readonly CalamariVariableDictionary variables;
+
+        readonly ScriptSyntax[] supportedScriptSyntax = {ScriptSyntax.PowerShell};
 
         const string CertificateFileName = "azure_certificate.pfx";
         const int PasswordSizeBytes = 20;
@@ -38,8 +41,9 @@ namespace Calamari.Azure.Integration
 
         public int Priority => ScriptWrapperPriorities.CloudAuthenticationPriority;
 
-        public bool Enabled => variables.Get(SpecialVariables.Account.AccountType, "").StartsWith("Azure") &&
-                               string.IsNullOrEmpty(variables.Get(SpecialVariables.Action.ServiceFabric.ConnectionEndpoint));
+        public bool IsEnabled(ScriptSyntax syntax) => variables.Get(SpecialVariables.Account.AccountType, "").StartsWith("Azure") &&
+                                string.IsNullOrEmpty(variables.Get(SpecialVariables.Action.ServiceFabric.ConnectionEndpoint)) &&
+                                supportedScriptSyntax.Contains(syntax);
 
         public IScriptWrapper NextWrapper { get; set; }
 
@@ -50,7 +54,7 @@ namespace Calamari.Azure.Integration
             StringDictionary environmentVars)
         {
             // Only run this hook if we have an azure account
-            if (!Enabled)
+            if (!IsEnabled(scriptSyntax))
             {
                 throw new InvalidOperationException(
                     "This script wrapper hook is not enabled, and should not have been run");

--- a/source/Calamari.Azure/Integration/AzureServiceFabricPowerShellContext.cs
+++ b/source/Calamari.Azure/Integration/AzureServiceFabricPowerShellContext.cs
@@ -10,6 +10,7 @@ using Octostache;
 using System;
 using System.Collections.Specialized;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace Calamari.Azure.Integration
@@ -18,7 +19,9 @@ namespace Calamari.Azure.Integration
     {
         readonly ICalamariFileSystem fileSystem;
         readonly ICalamariEmbeddedResources embeddedResources;
-        private readonly CalamariVariableDictionary variables;
+        readonly CalamariVariableDictionary variables;
+
+        readonly ScriptSyntax[] supportedScriptSyntax = {ScriptSyntax.PowerShell};
 
         public AzureServiceFabricPowerShellContext(CalamariVariableDictionary variables)
         {
@@ -29,8 +32,9 @@ namespace Calamari.Azure.Integration
 
         public int Priority => ScriptWrapperPriorities.CloudAuthenticationPriority;
 
-        public bool Enabled =>
-            !string.IsNullOrEmpty(variables.Get(SpecialVariables.Action.ServiceFabric.ConnectionEndpoint));
+        public bool IsEnabled(ScriptSyntax syntax) =>
+            !string.IsNullOrEmpty(variables.Get(SpecialVariables.Action.ServiceFabric.ConnectionEndpoint)) &&
+            supportedScriptSyntax.Contains(syntax);
 
         public IScriptWrapper NextWrapper { get; set; }
 
@@ -41,7 +45,7 @@ namespace Calamari.Azure.Integration
             StringDictionary environmentVars)
         {
             // We only execute this hook if the connection endpoint has been set
-            if (!Enabled)
+            if (!IsEnabled(scriptSyntax))
             {
                 throw new InvalidOperationException(
                     "This script wrapper hook is not enabled, and should not have been run");

--- a/source/Calamari.Shared/Hooks/IScriptWrapper.cs
+++ b/source/Calamari.Shared/Hooks/IScriptWrapper.cs
@@ -14,12 +14,12 @@ namespace Calamari.Hooks
         /// run first.
         /// </summary>
         int Priority { get; }
-        
+
         /// <summary>
         /// true if this wrapper is enabled, and false otherwise. If
         /// Enabled is false, this wrapper is not used during execution.
         /// </summary>
-        bool Enabled { get; }
+        bool IsEnabled(ScriptSyntax syntax);
 
         /// <summary>
         /// The next wrapper to call. IScriptWrapper objects essentially form
@@ -37,6 +37,5 @@ namespace Calamari.Hooks
             CalamariVariableDictionary variables,
             ICommandLineRunner commandLineRunner,
             StringDictionary environmentVars);
-
     }
 }

--- a/source/Calamari.Shared/Hooks/TerminalScriptWrapper.cs
+++ b/source/Calamari.Shared/Hooks/TerminalScriptWrapper.cs
@@ -10,9 +10,9 @@ namespace Calamari.Hooks
     /// </summary>
     public class TerminalScriptWrapper : IScriptWrapper
     {
-        private readonly IScriptEngine scriptEngine;
+        readonly IScriptEngine scriptEngine;
 
-        public bool Enabled { get; } = true;
+        public bool IsEnabled(ScriptSyntax syntax) => true;
 
         public int Priority => ScriptWrapperPriorities.TerminalScriptPriority;
 

--- a/source/Calamari.Shared/Integration/Scripting/CombinedScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/CombinedScriptEngine.cs
@@ -68,7 +68,7 @@ namespace Calamari.Integration.Scripting
         IScriptWrapper BuildWrapperChain(ScriptSyntax scriptSyntax) =>
             // get the type of script
             scriptWrapperHooks
-                .Where(hook => hook.Enabled)
+                .Where(hook => hook.IsEnabled(scriptSyntax))
                 /*
                  * Sort the list in descending order of priority to ensure that
                  * authentication script wrappers are called before any tool

--- a/source/Calamari.Tests/AzureFixtures/AzurePowerShellContextFixture.cs
+++ b/source/Calamari.Tests/AzureFixtures/AzurePowerShellContextFixture.cs
@@ -1,0 +1,32 @@
+#if AZURE
+using Calamari.Azure.Integration;
+using Calamari.Deployment;
+using Calamari.Integration.Processes;
+using Calamari.Integration.Scripting;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.AzureFixtures
+{
+    [TestFixture]
+    public class AzurePowerShellContextFixture
+    {
+        [Test]
+        [TestCase("Azure", "", ScriptSyntax.PowerShell, true)]
+        [TestCase("Nope", "", ScriptSyntax.PowerShell, false)]
+        [TestCase("Azure", "Nope", ScriptSyntax.PowerShell, false)]
+        [TestCase("Azure", "", ScriptSyntax.FSharp, false)]
+        public void ShouldBeEnabled(string accountType, string connectionEndpoint, ScriptSyntax syntax, bool expected)
+        {
+            var variables = new CalamariVariableDictionary
+            {
+                {SpecialVariables.Account.AccountType, accountType},
+                {SpecialVariables.Action.ServiceFabric.ConnectionEndpoint, connectionEndpoint}
+            };
+            var target = new AzurePowerShellContext(variables);
+            var actual = target.IsEnabled(syntax);
+            actual.Should().Be(expected);
+        }
+    }
+}
+#endif

--- a/source/Calamari.Tests/AzureFixtures/AzureServiceFabricPowerShellContextFixture.cs
+++ b/source/Calamari.Tests/AzureFixtures/AzureServiceFabricPowerShellContextFixture.cs
@@ -1,0 +1,31 @@
+#if AZURE
+using Calamari.Azure.Integration;
+using Calamari.Deployment;
+using Calamari.Integration.Processes;
+using Calamari.Integration.Scripting;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.AzureFixtures
+{
+    [TestFixture]
+    public class AzureServiceFabricPowerShellContextFixture
+    {
+        [Test]
+        [TestCase("Endpoint", ScriptSyntax.PowerShell, true)]
+        [TestCase("", ScriptSyntax.PowerShell, false)]
+        [TestCase("Endpoint", ScriptSyntax.FSharp, false)]
+        public void ShouldBeEnabled(string connectionEndpoint, ScriptSyntax syntax, bool expected)
+        {
+            var variables = new CalamariVariableDictionary
+            {
+                {SpecialVariables.Action.ServiceFabric.ConnectionEndpoint, connectionEndpoint}
+            };
+            var target = new AzureServiceFabricPowerShellContext(variables);
+            var actual = target.IsEnabled(syntax);
+            actual.Should().Be(expected);
+
+        }
+    }
+}
+#endif

--- a/source/Calamari.Tests/Hooks/ScriptHookMock.cs
+++ b/source/Calamari.Tests/Hooks/ScriptHookMock.cs
@@ -15,7 +15,7 @@ namespace Calamari.Tests.Hooks
         /// </summary>
         public bool WasCalled { get; private set; } = false;
         public int Priority => 1;
-        public bool Enabled { get; } = true;
+        public bool IsEnabled(ScriptSyntax scriptSyntax) => true;
         public IScriptWrapper NextWrapper { get; set; }
 
         public CommandResult ExecuteScript(Script script,

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -31,9 +31,9 @@ namespace Calamari.Kubernetes
         /// <summary>
         /// One of these fields must be present for a k8s step
         /// </summary>
-        public bool IsEnabled(ScriptSyntax syntax) => !string.IsNullOrEmpty(variables.Get(SpecialVariables.ClusterUrl, "")) ||
+        public bool IsEnabled(ScriptSyntax syntax) => (!string.IsNullOrEmpty(variables.Get(SpecialVariables.ClusterUrl, "")) ||
                                !string.IsNullOrEmpty(variables.Get(SpecialVariables.AksClusterName, "")) ||
-                               !string.IsNullOrEmpty(variables.Get(SpecialVariables.EksClusterName, "")) &&
+                               !string.IsNullOrEmpty(variables.Get(SpecialVariables.EksClusterName, ""))) &&
                                 supportedScriptSyntax.Contains(syntax);
 
         public IScriptWrapper NextWrapper { get; set; }

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Calamari.Hooks;
 using Calamari.Integration.EmbeddedResources;
@@ -12,9 +13,11 @@ namespace Calamari.Kubernetes
 {
     public class KubernetesContextScriptWrapper : IScriptWrapper
     {
-        private readonly CalamariVariableDictionary variables;
-        private readonly WindowsPhysicalFileSystem fileSystem;
-        private readonly AssemblyEmbeddedResources embeddedResources;
+        readonly CalamariVariableDictionary variables;
+        readonly WindowsPhysicalFileSystem fileSystem;
+        readonly AssemblyEmbeddedResources embeddedResources;
+
+        readonly ScriptSyntax[] supportedScriptSyntax = {ScriptSyntax.Bash, ScriptSyntax.PowerShell};
 
         public KubernetesContextScriptWrapper(CalamariVariableDictionary variables)
         {
@@ -28,9 +31,11 @@ namespace Calamari.Kubernetes
         /// <summary>
         /// One of these fields must be present for a k8s step
         /// </summary>
-        public bool Enabled => !string.IsNullOrEmpty(variables.Get(SpecialVariables.ClusterUrl, "")) ||
+        public bool IsEnabled(ScriptSyntax syntax) => !string.IsNullOrEmpty(variables.Get(SpecialVariables.ClusterUrl, "")) ||
                                !string.IsNullOrEmpty(variables.Get(SpecialVariables.AksClusterName, "")) ||
-                               !string.IsNullOrEmpty(variables.Get(SpecialVariables.EksClusterName, ""));
+                               !string.IsNullOrEmpty(variables.Get(SpecialVariables.EksClusterName, "")) &&
+                                supportedScriptSyntax.Contains(syntax);
+
         public IScriptWrapper NextWrapper { get; set; }
 
         public CommandResult ExecuteScript(Script script,


### PR DESCRIPTION
Currently we are attempting to run script types that are not PowerShell in the Azure PowerShell Context. The Azure PowerShell Context is only compatible with PowerShell scripts, so add a condition to ensure the Azure PowerShell wrapper and other wrappers are only included in the chain for the script syntax they are compatible with.

Relates to OctopusDeploy/Issues#5178