### PR TITLE
Implement CopyWorkingDirectoryIncludingKeyTo for all script types

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/ScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/ScriptEngine.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using Calamari.Deployment;
+using Calamari.Integration.FileSystem;
+using Calamari.Integration.Processes;
+
+namespace Calamari.Integration.Scripting
+{
+    public abstract class ScriptEngine : IScriptEngine
+    {
+        public abstract ScriptSyntax[] GetSupportedTypes();
+
+        public CommandResult Execute(Script script, CalamariVariableDictionary variables, ICommandLineRunner commandLineRunner,
+            StringDictionary environmentVars = null)
+        {
+            var prepared = PrepareExecution(script, variables, environmentVars);
+
+            if (variables.IsSet(SpecialVariables.CopyWorkingDirectoryIncludingKeyTo))
+            {
+                CopyWorkingDirectory(variables, prepared.CommandLineInvocation.WorkingDirectory,
+                    prepared.CommandLineInvocation.Arguments);
+            }
+
+            try
+            {
+                return commandLineRunner.Execute(prepared.CommandLineInvocation);
+            }
+            finally
+            {
+                foreach (var temporaryFile in prepared.TemporaryFiles)
+                {
+                    var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+                    fileSystem.DeleteFile(temporaryFile, FailureOptions.IgnoreFailure);
+                }
+            }
+        }
+
+        protected abstract ScriptExecution PrepareExecution(Script script, CalamariVariableDictionary variables,
+             StringDictionary environmentVars = null);
+        
+        static void CopyWorkingDirectory(CalamariVariableDictionary variables, string workingDirectory, string arguments)
+        {
+            var fs = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+
+            var copyToParent = Path.Combine(
+                variables.Get(SpecialVariables.CopyWorkingDirectoryIncludingKeyTo),
+                fs.RemoveInvalidFileNameChars(variables.Get(SpecialVariables.Project.Name, "Non-Project")),
+                variables.Get(SpecialVariables.Deployment.Id, "Non-Deployment"),
+                fs.RemoveInvalidFileNameChars(variables.Get(SpecialVariables.Action.Name, "Non-Action"))
+            );
+
+            string copyTo;
+            var n = 1;
+            do
+            {
+                copyTo = Path.Combine(copyToParent, $"{n++}");
+            } while (Directory.Exists(copyTo));
+
+            Log.Verbose($"Copying working directory '{workingDirectory}' to '{copyTo}'");
+            fs.CopyDirectory(workingDirectory, copyTo);
+            File.WriteAllText(Path.Combine(copyTo, "Arguments.txt"), arguments);
+            File.WriteAllText(Path.Combine(copyTo, "CopiedFromDirectory.txt"), workingDirectory);
+        }
+
+        protected class ScriptExecution
+        {
+            public ScriptExecution(CommandLineInvocation commandLineInvocation, IEnumerable<string> temporaryFiles)
+            {
+                CommandLineInvocation = commandLineInvocation;
+                TemporaryFiles = temporaryFiles;
+            }
+            
+            public CommandLineInvocation CommandLineInvocation { get; }
+            public IEnumerable<string> TemporaryFiles { get; }
+        }
+    }
+}


### PR DESCRIPTION
All script-engine implementations now copy the working dir if `Octopus.Calamari.CopyWorkingDirectoryIncludingKeyTo` set.