### PR TITLE
Only run PowerShell version test on OSes that support PowerShell 2

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Assent" Version="1.3.0" />
     <PackageReference Include="Polly" Version="5.4.0" />

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -26,6 +26,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
         [Test]
         [Platform]
         [Category(TestCategory.CompatibleOS.Windows)]
+        // Windows 2016 (has PowerShell 2) will also match Windows 2019 (no PowerShell 2) so have omitted it.
         [TestCase("2", "PSVersion                      2.0", IncludePlatform = "Win2008Server,Win2008ServerR2,Win2012Server,Win2012ServerR2,Windows10")]
         [TestCase("2.0", "PSVersion                      2.0", IncludePlatform = "Win2008Server,Win2008ServerR2,Win2012Server,Win2012ServerR2,Windows10")]
         public void ShouldCustomizePowerShellVersionIfRequested(string customPowerShellVersion, string expectedLogMessage)

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -26,8 +26,8 @@ namespace Calamari.Tests.Fixtures.PowerShell
         [Test]
         [Platform]
         [Category(TestCategory.CompatibleOS.Windows)]
-        [TestCase("2", "PSVersion                      2.0", IncludePlatform = "Win2008Server,Win2008ServerR2,Win2012Server,Win2012ServerR2")]
-        [TestCase("2.0", "PSVersion                      2.0", IncludePlatform = "Win2008Server,Win2008ServerR2,Win2012Server,Win2012ServerR2")]
+        [TestCase("2", "PSVersion                      2.0", IncludePlatform = "Win2008Server,Win2008ServerR2,Win2012Server,Win2012ServerR2,Windows10")]
+        [TestCase("2.0", "PSVersion                      2.0", IncludePlatform = "Win2008Server,Win2008ServerR2,Win2012Server,Win2012ServerR2,Windows10")]
         public void ShouldCustomizePowerShellVersionIfRequested(string customPowerShellVersion, string expectedLogMessage)
         {
             var variablesFile = Path.GetTempFileName();

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-using Assent;
-using Assent.Namers;
 using Calamari.Deployment;
 using Calamari.Integration.FileSystem;
-using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;
 using Calamari.Tests.Helpers;
 using Calamari.Util.Environments;
@@ -28,9 +24,10 @@ namespace Calamari.Tests.Fixtures.PowerShell
         }
 
         [Test]
+        [Platform]
         [Category(TestCategory.CompatibleOS.Windows)]
-        [TestCase("2", "PSVersion                      2.0")]
-        [TestCase("2.0", "PSVersion                      2.0")]
+        [TestCase("2", "PSVersion                      2.0", IncludePlatform = "Win2008Server,Win2008ServerR2,Win2012Server,Win2012ServerR2")]
+        [TestCase("2.0", "PSVersion                      2.0", IncludePlatform = "Win2008Server,Win2008ServerR2,Win2012Server,Win2012ServerR2")]
         public void ShouldCustomizePowerShellVersionIfRequested(string customPowerShellVersion, string expectedLogMessage)
         {
             var variablesFile = Path.GetTempFileName();


### PR DESCRIPTION
Missing Server 2016 but I think there is such a low risk it's not worth the time it would take to implement.