### PR TITLE
Add handling for special headers when uploading to S3 buckets

### DIFF
--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -379,9 +379,6 @@ namespace Calamari.Aws.Deployment.Conventions
             }
         }
 
- 
-
-
         /// <summary>
         /// The AmazonServiceException can hold additional information that is useful to include in
         /// the log.

--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -316,7 +317,7 @@ namespace Calamari.Aws.Deployment.Conventions
                 if (!await ShouldUpload(client, request))
                 {
                     Log.Verbose(
-                        $"Object key {request.Key} exists for bucket {request.BucketName} with same content hash. Skipping upload.");
+                        $"Object key {request.Key} exists for bucket {request.BucketName} with same content hash and metadata. Skipping upload.");
                     return new S3UploadResult(request, Maybe<PutObjectResponse>.None);
                 }
 
@@ -365,7 +366,7 @@ namespace Calamari.Aws.Deployment.Conventions
                     return true;
 
                 var metadata = await client.GetObjectMetadataAsync(request.BucketName, request.Key);
-                return !metadata.GetEtag().IsSameAsRequestMd5Digest(request);
+                return !metadata.GetEtag().IsSameAsRequestMd5Digest(request) || !S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), metadata.ToCombinedMetadata());
             }
             catch (AmazonServiceException exception)
             {
@@ -377,6 +378,8 @@ namespace Calamari.Aws.Deployment.Conventions
                 throw;
             }
         }
+
+ 
 
 
         /// <summary>

--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -365,8 +365,8 @@ namespace Calamari.Aws.Deployment.Conventions
                 if (!md5HashSupported)
                     return true;
 
-                var metadata = await client.GetObjectMetadataAsync(request.BucketName, request.Key);
-                return !metadata.GetEtag().IsSameAsRequestMd5Digest(request) || !S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), metadata.ToCombinedMetadata());
+                var metadataResponse = await client.GetObjectMetadataAsync(request.BucketName, request.Key);
+                return !metadataResponse.GetEtag().IsSameAsRequestMd5Digest(request) || !request.HasSameMetadata(metadataResponse);
             }
             catch (AmazonServiceException exception)
             {

--- a/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
@@ -14,6 +14,17 @@ namespace Calamari.Aws.Integration.S3
 {
     public static class S3ObjectExtensions
     {
+        private static readonly HashSet<string> SupportedSpecialHeaders = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
+        {
+            "Cache-Control",
+            "Content-Disposition",
+            "Content-Encoding",
+            "Expect",
+            "Expires",
+            "x-amz-website​-redirect-location",
+            "x-amz-object-lock-mode",
+        };
+
         public static List<Tag> ToTagSet(this IEnumerable<KeyValuePair<string, string>> source)
         {
             return source?.Select(x => new Tag {Key = x.Key.Trim(), Value = x.Value?.Trim()}).ToList() ?? new List<Tag>();
@@ -25,7 +36,15 @@ namespace Calamari.Aws.Integration.S3
             {
                 foreach (var item in source)
                 {
-                    x.Metadata.Add(item.Key.Trim(), item.Value?.Trim());
+                    var key = item.Key.Trim();
+                    if (!SupportedSpecialHeaders.Contains(key))
+                    {
+                        x.Metadata.Add(key, item.Value?.Trim());
+                    }
+                    else
+                    {
+                        x.Headers[key] = item.Value?.Trim();
+                    }
                 }
             });
         }

--- a/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
@@ -36,6 +36,11 @@ namespace Calamari.Aws.Integration.S3
             return values;
         }
 
+        public static IEnumerable<string> GetKnownSpecialHeaderKeys()
+        {
+            return SupportedSpecialHeaders.Keys;
+        }
+
         public static bool MetadataEq(IDictionary<string, string> next, IDictionary<string, string> current)
         {
             var allKeys = next.Keys.Union(current.Keys).Distinct();
@@ -49,7 +54,7 @@ namespace Calamari.Aws.Integration.S3
             return collection.Keys.ToDictionary(key => key, key => collection[key]);
         }
 
-        private static IDictionary<string, string> GetCombinedMetadata(HeadersCollection headers, MetadataCollection metadata)
+        public static IDictionary<string, string> GetCombinedMetadata(HeadersCollection headers, MetadataCollection metadata)
         {
             var result = new Dictionary<string, string>();
 

--- a/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
@@ -62,6 +62,11 @@ namespace Calamari.Aws.Integration.S3
             return missingKeys.Count == 0 && keysInBoth.All(x => string.Compare(next[x], current[x], StringComparison.CurrentCultureIgnoreCase) == 0);
         }
 
+        public static bool HasSameMetadata(this PutObjectRequest request, GetObjectMetadataResponse response)
+        {
+            return MetadataEq(request.ToCombinedMetadata(), response.ToCombinedMetadata());
+        }
+
         public static IDictionary<string, string> ToDictionary(this MetadataCollection collection)
         {
             return collection.Keys.ToDictionary(key => key, key => collection[key]);

--- a/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
@@ -43,23 +43,12 @@ namespace Calamari.Aws.Integration.S3
 
         public static bool MetadataEq(IDictionary<string, string> next, IDictionary<string, string> current)
         {
-            var allKeys = next.Keys.Union(current.Keys).Distinct();
-            var keysInBoth = new List<string>();
-            var missingKeys = new List<string>();
-            
-            foreach (var key in allKeys)
-            {
-                if (next.ContainsKey(key) && current.ContainsKey(key))
-                {
-                    keysInBoth.Add(key);
-                }
-                else
-                {
-                    missingKeys.Add(key);
-                }
-            }
+            var allKeys = next.Keys.Union(current.Keys).Distinct().ToList();
+            var keysInBoth = allKeys.Where(key => next.ContainsKey(key) && current.ContainsKey(key)).ToList();
+            var missingKeys = allKeys.Except(keysInBoth).ToList();
+            var differentValues = keysInBoth.Where(key => string.Compare(next[key], current[key], StringComparison.CurrentCultureIgnoreCase) != 0).ToList();
 
-            return missingKeys.Count == 0 && keysInBoth.All(x => string.Compare(next[x], current[x], StringComparison.CurrentCultureIgnoreCase) == 0);
+            return missingKeys.Count == 0 && differentValues.Count == 0;
         }
 
         public static bool HasSameMetadata(this PutObjectRequest request, GetObjectMetadataResponse response)

--- a/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
@@ -3,20 +3,18 @@
 using System.Linq;
 using Amazon.S3.Model;
 ﻿using System;
- using System.Diagnostics;
- using System.IO;
- using System.Security.Cryptography;
- using System.Text;
- using Calamari.Integration.FileSystem;
+using System.Security.Cryptography;
+using Calamari.Integration.FileSystem;
 using Calamari.Util;
 using Octopus.CoreUtilities;
 using Octopus.CoreUtilities.Extensions;
- using Tag = Amazon.S3.Model.Tag;
+using Tag = Amazon.S3.Model.Tag;
 
 namespace Calamari.Aws.Integration.S3
 {
     public static class S3ObjectExtensions
     {
+        //Special headers as per AWS docs - https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
         private static readonly IDictionary<string, Func<HeadersCollection, string>> SupportedSpecialHeaders =
             new Dictionary<string, Func<HeadersCollection, string>>(StringComparer.InvariantCultureIgnoreCase)
                 .WithHeaderFrom("Cache-Control", headers => headers.CacheControl)
@@ -76,21 +74,6 @@ namespace Calamari.Aws.Integration.S3
         public static IDictionary<string, string> ToCombinedMetadata(this GetObjectMetadataResponse response)
         {
             return GetCombinedMetadata(response.Headers, response.Metadata);
-        }
-
-        public static string GetMetadataHash(HeadersCollection collection, IDictionary<string, string> metadata)
-        {
-            var all = string.Join(string.Empty,
-                collection.Keys.Where(SupportedSpecialHeaders.ContainsKey)
-                    .OrderBy(x => x)
-                    .Select(x => $"{x}:{SupportedSpecialHeaders[x](collection)}"),
-                metadata.Keys.OrderBy(x => x)
-                    .Select(x => $"{x}:{metadata[x]}"));
-
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(all));
-
-            var bytes = HashCalculator.Hash(stream, MD5.Create);
-            return Encoding.UTF8.GetString(bytes);
         }
 
         private static (IList<T> filtered, IList<T> excluded) SelectWithExclusions<T>(this IEnumerable<T> values, Func<T, bool> predicate)

--- a/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
@@ -3,7 +3,10 @@
 using System.Linq;
 using Amazon.S3.Model;
 ﻿using System;
-using System.Security.Cryptography;
+ using System.Diagnostics;
+ using System.IO;
+ using System.Security.Cryptography;
+ using System.Text;
  using Calamari.Integration.FileSystem;
 using Calamari.Util;
 using Octopus.CoreUtilities;
@@ -14,16 +17,96 @@ namespace Calamari.Aws.Integration.S3
 {
     public static class S3ObjectExtensions
     {
-        private static readonly HashSet<string> SupportedSpecialHeaders = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
+        private static readonly IDictionary<string, Func<HeadersCollection, string>> SupportedSpecialHeaders =
+            new Dictionary<string, Func<HeadersCollection, string>>(StringComparer.InvariantCultureIgnoreCase)
+                .WithHeaderFrom("Cache-Control", headers => headers.CacheControl)
+                .WithHeaderFrom("Content-Disposition", headers => headers.ContentDisposition)
+                .WithHeaderFrom("Content-Encoding", headers => headers.ContentEncoding)
+                .WithHeaderFrom("Expires")
+                .WithHeaderFrom("x-amz-website​-redirect-location")
+                .WithHeaderFrom("x-amz-object-lock-mode");
+
+        private static T WithHeaderFrom<T>(this T values, string key) where T : IDictionary<string, Func<HeadersCollection, string>>
         {
-            "Cache-Control",
-            "Content-Disposition",
-            "Content-Encoding",
-            "Expect",
-            "Expires",
-            "x-amz-website​-redirect-location",
-            "x-amz-object-lock-mode",
-        };
+            values.Add(key, (headers) => headers[key]);
+            return values;
+        }
+
+        private static T WithHeaderFrom<T>(this T values, string key, Func<HeadersCollection, string> accessor) where T : IDictionary<string, Func<HeadersCollection, string>>
+        {
+            values.Add(key, accessor);
+            return values;
+        }
+
+        public static bool MetadataEq(IDictionary<string, string> next, IDictionary<string, string> current)
+        {
+            var allKeys = next.Keys.Union(current.Keys).Distinct();
+            var (filtered, excluded) = SelectWithExclusions(allKeys, (val) => next.ContainsKey(val) && current.ContainsKey(val));
+
+            return excluded.Count == 0 && filtered.All(x => string.Compare(next[x], current[x], StringComparison.CurrentCultureIgnoreCase) == 0);
+        }
+
+        public static IDictionary<string, string> ToDictionary(this MetadataCollection collection)
+        {
+            return collection.Keys.ToDictionary(key => key, key => collection[key]);
+        }
+
+        private static IDictionary<string, string> GetCombinedMetadata(HeadersCollection headers, MetadataCollection metadata)
+        {
+            var result = new Dictionary<string, string>();
+
+            foreach (var key in headers.Keys.Where(SupportedSpecialHeaders.ContainsKey))
+            {
+                result.Add(key, SupportedSpecialHeaders[key](headers));
+            }
+
+            foreach (var key in metadata.Keys)
+            {
+                result.Add(key, metadata[key]);
+            }
+
+            return result;
+        }
+
+        public static IDictionary<string, string> ToCombinedMetadata(this PutObjectRequest request)
+        {
+            return GetCombinedMetadata(request.Headers, request.Metadata);
+        }
+
+        public static IDictionary<string, string> ToCombinedMetadata(this GetObjectMetadataResponse response)
+        {
+            return GetCombinedMetadata(response.Headers, response.Metadata);
+        }
+
+        public static string GetMetadataHash(HeadersCollection collection, IDictionary<string, string> metadata)
+        {
+            var all = string.Join(string.Empty,
+                collection.Keys.Where(SupportedSpecialHeaders.ContainsKey)
+                    .OrderBy(x => x)
+                    .Select(x => $"{x}:{SupportedSpecialHeaders[x](collection)}"),
+                metadata.Keys.OrderBy(x => x)
+                    .Select(x => $"{x}:{metadata[x]}"));
+
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(all));
+
+            var bytes = HashCalculator.Hash(stream, MD5.Create);
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        private static (IList<T> filtered, IList<T> excluded) SelectWithExclusions<T>(this IEnumerable<T> values, Func<T, bool> predicate)
+        {
+            return values.Aggregate((new List<T>(), new List<T>()), (prev, current) =>
+            {
+                var (valid, excluded) = prev;
+
+                if (predicate(current))
+                    valid.Add(current);
+                else
+                    excluded.Add(current);
+
+                return prev;
+            });
+        }
 
         public static List<Tag> ToTagSet(this IEnumerable<KeyValuePair<string, string>> source)
         {
@@ -37,7 +120,7 @@ namespace Calamari.Aws.Integration.S3
                 foreach (var item in source)
                 {
                     var key = item.Key.Trim();
-                    if (!SupportedSpecialHeaders.Contains(key))
+                    if (!SupportedSpecialHeaders.ContainsKey(key))
                     {
                         x.Metadata.Add(key, item.Value?.Trim());
                     }

--- a/source/Calamari.Tests/AWS/S3/S3ObjectExtensionsFixture.cs
+++ b/source/Calamari.Tests/AWS/S3/S3ObjectExtensionsFixture.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.S3.Model;
+using Calamari.Aws.Integration.S3;
+using NUnit.Framework;
+using Octopus.CoreUtilities.Extensions;
+
+namespace Calamari.Tests.AWS.S3
+{
+    [TestFixture]
+    public class S3ObjectExtensionsFixture
+    {
+        [Test]
+        public void MetadataComparisonIsTrueWhenHeadersMatch()
+        {
+            var useHeaderValues = GetKnownSpecialKeyApplier();
+
+            PutObjectRequest request = new PutObjectRequest().Tee(r =>
+            {
+                useHeaderValues(r.Headers);
+            });
+
+            GetObjectMetadataResponse response = new GetObjectMetadataResponse().Tee(r =>
+            {
+                useHeaderValues(r.Headers);
+            });
+
+            var result = S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), response.ToCombinedMetadata());
+            Assert.IsTrue(result, "Metadata was found to be not equal, but should match.");
+        }
+
+        [Test]
+        public void MetadataComparisonPicksUpDifferencesInSpecialHeaders()
+        {
+            var useHeaderValues = GetKnownSpecialKeyApplier();
+            var useDifferentHeaderValues = GetKnownSpecialKeyApplier();
+
+            PutObjectRequest request = new PutObjectRequest().Tee(r =>
+            {
+                useHeaderValues(r.Headers);
+            });
+
+            GetObjectMetadataResponse response = new GetObjectMetadataResponse().Tee(r =>
+            {
+                useDifferentHeaderValues(r.Headers);
+            });
+
+            var result = S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), response.ToCombinedMetadata());
+            Assert.IsFalse(result, "The comparison was found to be equal, however the special headers differ.");
+        }
+
+
+        [Test]
+        public void MetadataComparisonIsPicksUpDifferenceInMetadataValues()
+        {
+            var useHeaderValues = GetKnownSpecialKeyApplier();
+
+            PutObjectRequest request = new PutObjectRequest().Tee(r =>
+            {
+                useHeaderValues(r.Headers);
+                r.Metadata.Add("Cowabunga", "Baby");
+            });
+
+            GetObjectMetadataResponse response = new GetObjectMetadataResponse().Tee(r =>
+            {
+                useHeaderValues(r.Headers);
+                r.Metadata.Add("Cowabunga", "Baby2");
+            });
+            
+            var result = S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), response.ToCombinedMetadata());
+            Assert.IsFalse(result, "Metadata comparison was found to be match, but should differ");
+        }
+
+        [Test]
+        public void MetadataComparisonIsPicksUpDifferenceInMetadataKeys()
+        {
+            var useHeaderValues = GetKnownSpecialKeyApplier();
+
+            PutObjectRequest request = new PutObjectRequest().Tee(r =>
+            {
+                useHeaderValues(r.Headers);
+                r.Metadata.Add("Meep Meep", "Baby2");
+            });
+
+            GetObjectMetadataResponse response = new GetObjectMetadataResponse().Tee(r =>
+            {
+                useHeaderValues(r.Headers);
+                r.Metadata.Add("Cowabunga", "Baby2");
+            });
+
+            var result = S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), response.ToCombinedMetadata());
+            Assert.IsFalse(result, "Metadata comparison was found to be match, but should differ");
+        }
+
+        [Test]
+        public void MetadataComparisonIgnoresUnknownSpecialHeaders()
+        {
+            PutObjectRequest request = new PutObjectRequest().Tee(r =>
+            {
+                r.Headers["Geppetto"] = "Pinocchio ";
+
+                r.Metadata.Add("Cowabunga", "Baby");
+            });
+
+            GetObjectMetadataResponse response = new GetObjectMetadataResponse().Tee(r =>
+            {
+                r.Headers["Crazy"] = "Town";
+
+                r.Metadata.Add("Cowabunga", "Baby");
+            });
+
+            var result = S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), response.ToCombinedMetadata());
+            Assert.IsTrue(result, "Metadata was found to be equal, but should differ");
+        }
+
+        private Action<HeadersCollection> GetKnownSpecialKeyApplier()
+        {
+            var keys = S3ObjectExtensions.GetKnownSpecialHeaderKeys().Select((x) => new KeyValuePair<string, string>(x, $"value-{Guid.NewGuid()}" )).ToList();
+
+            return (collection) =>
+            {
+                foreach (var keyValuePair in keys)
+                {
+                    collection[keyValuePair.Key] = keyValuePair.Value;
+                }
+            };
+        }
+
+    }
+}


### PR DESCRIPTION
This PR addresses the following issues:
* https://github.com/OctopusDeploy/Issues/issues/5302
* https://github.com/OctopusDeploy/Issues/issues/5323

It adds special handling where the AWS SDK has failed to do so by moving common Metadata into headers where it's necessary. This PR adds support for the following headers from metadata:

* Cache-Control
* Content-Disposition
* Content-Encoding
* Expires
* x-amz-website​-redirect-location
* x-amz-object-lock-mode

As part of this PR, metadata comparisons have also been added in order to ensure that changes will be applied to S3 objects when their content has not changed.