### PR TITLE
Now signing all unsigned exe's and dll's

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -240,7 +240,8 @@ private bool HasAuthenticodeSignature(FilePath fileInfo)
     {
         X509Certificate.CreateFromSignedFile(fileInfo.FullPath);
         return true;
-    } catch
+    }
+    catch
     {
         return false;
     }

--- a/build.cake
+++ b/build.cake
@@ -234,11 +234,11 @@ private void SignBinaries(string outputDirectory)
 }
 // note: Doesn't check if existing signatures are valid, only that one exists 
 // source: https://blogs.msdn.microsoft.com/windowsmobile/2006/05/17/programmatically-checking-the-authenticode-signature-on-a-file/
-private bool HasAuthenticodeSignature(FilePath fileInfo)
+private bool HasAuthenticodeSignature(FilePath filePath)
 {
     try
     {
-        X509Certificate.CreateFromSignedFile(fileInfo.FullPath);
+        X509Certificate.CreateFromSignedFile(filePath.FullPath);
         return true;
     }
     catch

--- a/build.cake
+++ b/build.cake
@@ -213,8 +213,9 @@ private void SignBinaries(string outputDirectory)
 
     // check that any unsigned libraries get signed, to play nice with security scanning tools
     // refer: https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1551655877004400
-    // note: "we are signing dll's we have written (& some we don't own),
-    // but we are asserting that they are distributed by us, and are not altered after this step
+    // note: we are signing both dll's we have written & some we haven't, not because we are
+    //       claiming we own them, but rather asserting that they are distributed by us, and
+    //       have not been subsequently altered
     
      var unsignedExecutablesAndLibraries = 
          GetFiles(outputDirectory + "/*.exe")

--- a/build.cake
+++ b/build.cake
@@ -211,8 +211,10 @@ private void SignBinaries(string outputDirectory)
 {
     Information($"Signing binaries in {outputDirectory}");
 
-    // check that any unsigned executables or libraries get signed, to play nice with security scanning tools
+    // check that any unsigned libraries get signed, to play nice with security scanning tools
     // refer: https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1551655877004400
+    // note: "we are signing dll's we have written (& some we don't own),
+    // but we are asserting that they are distributed by us, and are not altered after this step
     
      var unsignedExecutablesAndLibraries = 
          GetFiles(outputDirectory + "/*.exe")


### PR DESCRIPTION
As a result of some recent customer requests I thought I'd look into authenticode signing our dependencies so that security scanning tools don't have a bad day. Thanks @matt-richardson for the assist.

[internal discussion forum link](https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1551655877004400)