### PR TITLE
Changed to use a FIPS verified algorithm

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/RePackageCloudServiceConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/RePackageCloudServiceConvention.cs
@@ -146,7 +146,7 @@ namespace Calamari.Azure.Deployment.Conventions
                     fileStream.CopyTo(partStream);
                     partStream.Flush();
                     fileStream.Position = 0;
-                    var hashAlgorithm = SHA256.Create();
+                    var hashAlgorithm = SHA256.Create("SHA256");
                     hashAlgorithm.ComputeHash(fileStream);
                     manifest.Contents.Add(new ContentDefinition
                     {

--- a/source/Calamari.Azure/Deployment/Conventions/RePackageCloudServiceConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/RePackageCloudServiceConvention.cs
@@ -146,7 +146,7 @@ namespace Calamari.Azure.Deployment.Conventions
                     fileStream.CopyTo(partStream);
                     partStream.Flush();
                     fileStream.Position = 0;
-                    var hashAlgorithm = new SHA256Managed();
+                    var hashAlgorithm = SHA256.Create();
                     hashAlgorithm.ComputeHash(fileStream);
                     manifest.Contents.Add(new ContentDefinition
                     {

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -7,6 +7,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Security.Cryptography;
 using Calamari.Commands;
 using Calamari.Deployment;
 using Calamari.Extensions;
@@ -30,6 +31,7 @@ namespace Calamari
 
         static int Main(string[] args)
         {
+            CryptoConfig.AddAlgorithm(typeof(SHA256CryptoServiceProvider), "SHA256");
             EnableAllSecurityProtocols();
             using (var container = BuildContainer(args))
             {

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -31,7 +31,12 @@ namespace Calamari
 
         static int Main(string[] args)
         {
-            CryptoConfig.AddAlgorithm(typeof(SHA256CryptoServiceProvider), "SHA256");
+            //sanity checking the builds
+            var cryptoProviderType = typeof(SHA256CryptoServiceProvider);
+            if(cryptoProviderType == null)
+                throw new Exception("SHA256CryptoServiceProvider isn't here");
+                
+            CryptoConfig.AddAlgorithm(cryptoProviderType, "SHA256");
             EnableAllSecurityProtocols();
             using (var container = BuildContainer(args))
             {


### PR DESCRIPTION
Recently a customer bumped into a FIPS error on their server after upgrading to `2018.10.2` in a search for that issue, I came across a potential issue here. Since [our documentation](https://octopus.com/docs/administration/security/fips-and-octopus-deploy) calls out that we want to remain compliant to FIPS-140, I thought I'd adjust this.

Calls to `new SHA256Managed()` aren't [FIPS verified](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.sha256managed.-ctor?view=netframework-4.7.2#exceptions), so I've modified this code to use the same approach as Octopus Server.