### PR TITLE
Handle no thumbprint/no certificate variable for a binding

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -471,7 +471,7 @@ if ($deployAsWebSite)
 			# Otherwise, the certificate thumbprint was supplied directly in the binding
 			$sslCertificateThumbprint = $_.thumbprint.Trim()
 		} else {
-			write-error "Cannot configure a https binding when neither certificate thumbprint nor certificate variable is not supplied on the binding.";
+			[Console]::Error.WriteLine("Cannot configure a https binding when neither certificate thumbprint nor certificate variable is not supplied on the binding.")
 			exit 1
 		}
 

--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -471,10 +471,11 @@ if ($deployAsWebSite)
 			# Otherwise, the certificate thumbprint was supplied directly in the binding
 			$sslCertificateThumbprint = $_.thumbprint.Trim()
 		} else {
-			throw "Cannot configure a https binding when neither certificate thumbprint nor certificate variable is not supplied on the binding.";
+			write-error "Cannot configure a https binding when neither certificate thumbprint nor certificate variable is not supplied on the binding.";
+			exit 1
 		}
 
-		Write-Host "Finding SSL certificate with thumbprint $sslCertificateThumbprint"
+		Write-Host "Finding SSL certificate with thumbprint $sslC\ertificateThumbprint"
 	
 		$certificate = Get-ChildItem Cert:\LocalMachine -Recurse | Where-Object { $_.Thumbprint -eq $sslCertificateThumbprint -and $_.HasPrivateKey -eq $true } | Select-Object -first 1
 		if (! $certificate) 

--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -471,11 +471,11 @@ if ($deployAsWebSite)
 			# Otherwise, the certificate thumbprint was supplied directly in the binding
 			$sslCertificateThumbprint = $_.thumbprint.Trim()
 		} else {
-			[Console]::Error.WriteLine("Cannot configure a https binding when neither certificate thumbprint nor certificate variable is not supplied on the binding.")
+			[Console]::Error.WriteLine("To configure an HTTPS binding please choose a certificate which is managed by Octopus, or provide the thumbprint for a certificate which is already available in the Machine certificate store.")
 			exit 1
 		}
 
-		Write-Host "Finding SSL certificate with thumbprint $sslC\ertificateThumbprint"
+		Write-Host "Finding SSL certificate with thumbprint $sslCertificateThumbprint"
 	
 		$certificate = Get-ChildItem Cert:\LocalMachine -Recurse | Where-Object { $_.Thumbprint -eq $sslCertificateThumbprint -and $_.HasPrivateKey -eq $true } | Select-Object -first 1
 		if (! $certificate) 

--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -445,7 +445,7 @@ if ($deployAsWebSite)
 
 		if ($binding.certificateVariable) {
 			$bindingObj.certificateVariable = $binding.certificateVariable.Trim();
-		} elseif ($binding.thumbprint){
+		} elseif ($binding.thumbprint -and ($null -ne $binding.thumbprint)){
 			$bindingObj.thumbprint=$binding.thumbprint.Trim();
 		}
 
@@ -467,9 +467,11 @@ if ($deployAsWebSite)
 		# in the deployment process
 		if ($_.certificateVariable) {
 			$sslCertificateThumbprint = $OctopusParameters[$_.certificateVariable + ".Thumbprint"]
-		} else {
+		} elseif ($_.thumbprint){
 			# Otherwise, the certificate thumbprint was supplied directly in the binding
 			$sslCertificateThumbprint = $_.thumbprint.Trim()
+		} else {
+			throw "Cannot configure a https binding when neither certificate thumbprint nor certificate variable is not supplied on the binding.";
 		}
 
 		Write-Host "Finding SSL certificate with thumbprint $sslCertificateThumbprint"


### PR DESCRIPTION
Relates to https://github.com/OctopusDeploy/OctopusDeploy/pull/3705 and https://github.com/OctopusDeploy/Issues/issues/5480