### PR TITLE
Allow Calamari's Write-* functions to take pipeline input 

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -363,43 +363,76 @@ function New-OctopusArtifact
     }
 }
 
-function Write-Debug([string]$message)
+function Write-Debug
 {
-	Write-Verbose $message
+	[CmdletBinding()]
+	param([Parameter(ValueFromPipeline=$true)][string]$message)
+
+	begin {}
+	process {
+		Write-Verbose $message
+	}
+	end {}
 }
 
-function Write-Verbose([string]$message)
+function Write-Verbose
 {
-	Write-Host "##octopus[stdout-verbose]"
-	Write-Host $message
-	Write-Host "##octopus[stdout-default]"
+	[CmdletBinding()]
+	param([Parameter(ValueFromPipeline=$true)][string]$message)
+
+	begin {}
+	process {
+		Write-Host "##octopus[stdout-verbose]"
+		Write-Host $message
+		Write-Host "##octopus[stdout-default]"
+	}
+	end {}
 }
 
-function Write-Highlight([string]$message)
+function Write-Highlight
 {
-	Write-Host "##octopus[stdout-highlight]"
-	Write-Host $message
-	Write-Host "##octopus[stdout-default]"
+	[CmdletBinding()]
+	param([Parameter(ValueFromPipeline=$true)][string]$message)
+
+	begin {}
+	process {
+		Write-Host "##octopus[stdout-highlight]"
+		Write-Host $message
+		Write-Host "##octopus[stdout-default]"
+	}
+	end {}
 }
 
-function Write-Wait([string]$message)
+function Write-Wait
 {
-	Write-Host "##octopus[stdout-wait]"
-	Write-Host $message
-	Write-Host "##octopus[stdout-default]"
+    [CmdletBinding()]
+    param([Parameter(ValueFromPipeline=$true)][string]$message)
+
+	begin {}
+	process {
+		Write-Host "##octopus[stdout-wait]"
+		Write-Host $message
+		Write-Host "##octopus[stdout-default]"
+	}
+	end {}
 }
 
 function Write-Warning()
 {
 	[CmdletBinding()]
-	param([string]$message)
+	param([Parameter(ValueFromPipeline=$true)][string]$message)
 
-	if ($WarningPreference -eq 'SilentlyContinue') {
-		return
+	begin {
+		if ($WarningPreference -eq 'SilentlyContinue') {
+			return
+		}
 	}
-	Write-Host "##octopus[stdout-warning]"
-	Write-Host $message
-	Write-Host "##octopus[stdout-default]"
+	process {
+		Write-Host "##octopus[stdout-warning]"
+		Write-Host $message
+		Write-Host "##octopus[stdout-default]"
+	}
+    end{}
 }
 
 function Decrypt-Variables($iv, $Encrypted)

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -422,15 +422,14 @@ function Write-Warning()
 	[CmdletBinding()]
 	param([Parameter(ValueFromPipeline=$true)][string]$message)
 
-	begin {
-		if ($WarningPreference -eq 'SilentlyContinue') {
-			return
-		}
-	}
+	begin {}
 	process {
-		Write-Host "##octopus[stdout-warning]"
-		Write-Host $message
-		Write-Host "##octopus[stdout-default]"
+		if($WarningPreference -ne 'SilentlyContinue')
+		{
+			Write-Host "##octopus[stdout-warning]"
+			Write-Host $message
+			Write-Host "##octopus[stdout-default]"
+		}
 	}
     end{}
 }

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -380,13 +380,15 @@ function Write-Verbose
 	[CmdletBinding()]
 	param([Parameter(ValueFromPipeline=$true)][string]$message)
 
-	begin {}
-	process {
+	begin {
 		Write-Host "##octopus[stdout-verbose]"
+	}
+	process {
 		Write-Host $message
+	}
+	end {
 		Write-Host "##octopus[stdout-default]"
 	}
-	end {}
 }
 
 function Write-Highlight
@@ -394,13 +396,15 @@ function Write-Highlight
 	[CmdletBinding()]
 	param([Parameter(ValueFromPipeline=$true)][string]$message)
 
-	begin {}
-	process {
+	begin {
 		Write-Host "##octopus[stdout-highlight]"
+	}
+	process {
 		Write-Host $message
+	}
+	end {
 		Write-Host "##octopus[stdout-default]"
 	}
-	end {}
 }
 
 function Write-Wait
@@ -408,13 +412,15 @@ function Write-Wait
     [CmdletBinding()]
     param([Parameter(ValueFromPipeline=$true)][string]$message)
 
-	begin {}
-	process {
+	begin {
 		Write-Host "##octopus[stdout-wait]"
+	}
+	process {
 		Write-Host $message
+	}
+	end {
 		Write-Host "##octopus[stdout-default]"
 	}
-	end {}
 }
 
 function Write-Warning()
@@ -422,16 +428,18 @@ function Write-Warning()
 	[CmdletBinding()]
 	param([Parameter(ValueFromPipeline=$true)][string]$message)
 
-	begin {}
+	begin {
+		Write-Host "##octopus[stdout-warning]"
+	}
 	process {
 		if($WarningPreference -ne 'SilentlyContinue')
 		{
-			Write-Host "##octopus[stdout-warning]"
 			Write-Host $message
-			Write-Host "##octopus[stdout-default]"
 		}
 	}
-    end{}
+    end {
+		Write-Host "##octopus[stdout-default]"
+	}
 }
 
 function Decrypt-Variables($iv, $Encrypted)


### PR DESCRIPTION
Previously, we could only use Write-Verbose thus

`Write-Verbose "this is a message"`

Calling it in a pipeline would produce no output

Now, we can do the following:

```
Write-Verbose "this is a message"
"this is a message" | Write-Verbose
@("this is a message", "this is another message") | Write-Verbose
```