### PR TITLE
[WIP] Limiting signed assemblies to Calamari* and Octopus*

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -2,6 +2,7 @@
 // TOOLS
 //////////////////////////////////////////////////////////////////////
 #tool "nuget:?package=GitVersion.CommandLine&version=4.0.0-beta0012"
+#addin "nuget:?package=Cake.Incubator&version=5.0.1"
 
 using Path = System.IO.Path;
 using System.Xml;
@@ -227,10 +228,11 @@ private void SignAndTimestampBinaries(string outputDirectory)
     //       have not been subsequently altered
     
      var unsignedExecutablesAndLibraries = 
-         GetFiles(outputDirectory + "/Calamari*.exe")
-         .Union(GetFiles(outputDirectory + "/Calamari*.dll"))
-         .Union(GetFiles(outputDirectory + "/Octo*.exe"))
-         .Union(GetFiles(outputDirectory + "/Octo*.dll"))
+         GetFiles(
+            outputDirectory + "/Calamari*.exe",
+            outputDirectory + "/Calamari*.dll",
+            outputDirectory + "/Octo*.exe",
+            outputDirectory + "/Octo*.dll")
          .Where(f => !HasAuthenticodeSignature(f))
          .ToArray();
 

--- a/build.cake
+++ b/build.cake
@@ -227,8 +227,10 @@ private void SignAndTimestampBinaries(string outputDirectory)
     //       have not been subsequently altered
     
      var unsignedExecutablesAndLibraries = 
-         GetFiles(outputDirectory + "/*.exe")
-         .Union(GetFiles(outputDirectory + "/*.dll"))
+         GetFiles(outputDirectory + "/Calamari*.exe")
+         .Union(GetFiles(outputDirectory + "/Calamari*.dll"))
+         .Union(GetFiles(outputDirectory + "/Octo*.exe"))
+         .Union(GetFiles(outputDirectory + "/Octo*.dll"))
          .Where(f => !HasAuthenticodeSignature(f))
          .ToArray();
 


### PR DESCRIPTION
[Internal discussion](https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1556587012067600)

This PR finds a middle ground, rather than a full revert, it keeps the benefit of the timestamping approach, and only backs off signing as far as `[calamari|octo]*[dll|exe]`, (prior to our initial change in this area, only Calamari.[dll|exe] were signed)