### PR TITLE
Fix full file path resolution for New-OctopusArtifact cmdlet

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -326,6 +326,7 @@ function New-OctopusArtifact
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [Alias('fullname')]
         [Alias('path')]
         [string]$fullpath,
         [string]$name=""""


### PR DESCRIPTION
# [BUG] New-OctopusArtifact takes a relative file name instead of a full name

## Prerequisites

- [x] I have verified the problem exists in the latest version
- [x]  I have searched [open](https://github.com/OctopusDeploy/Issues/issues) and [closed](https://github.com/OctopusDeploy/Issues/issues?utf8=✓&q=is%3Aissue+is%3Aclosed) issues to make sure it isn't already reported
- [x] I have written a descriptive issue title
- [x] I have tagged the issue appropriately (area/*, kind/bug, tag/regression?)

## Labels

- [feature/calamari](https://github.com/OctopusDeploy/Issues/labels/feature%2Fcalamari)
- [kind/bug](https://github.com/OctopusDeploy/Issues/labels/kind%2Fbug)

## The bug

According to the [official documentation](https://octopus.com/docs/deployment-process/artifacts#Artifacts-Collectingartifactsusingscripts) I'm trying to use cmdlet `New-OctopusArtifact` in my pipeline, like this:

```powershell
Get-ChildItem -Path 'D:\Tentacle\Applications\Dev\Server\0.1.2\Logs' -Filter 'Server-*.log' |
    New-OctopusArtifact
```

Actually, I have one file in this directory. But I got error:

```
Artifact Server-20190508.log not found at path
'D:\Tentacle\Config\Work\20190508171813-59288-965\deploy\Server-20190508.log'.
This can happen if the file is deleted before the task completes.
```

Note that the file path is completely different from my recommendation. Calamari tries to take a file in the current execution directory.

## The patch

The `New-OctopusArtifact` cmdlet uses an incorrect alias to capture the full file name. It expects `fullpath`, but PowerShell uses `FullName` for this purpose.

We can't rename the alias because it will break the current behavior of existing scripts. Better choice is to add another alias with "FullName" value.

## What I expected to happen

Calamari has a valid `FileInfo` object that is present on the disc. It should use the full path from `FileInfo` and create a new Octopus artifact.

## Workarounds

Don't use the pipeline version of `New-OctopusArtifact` cmdlet. Use it with an explicit argument name:

```powershell
Get-ChildItem -Path 'D:\Tentacle\Applications\Dev\Server\0.1.2\Logs' -Filter 'Server-*.log' |
    ForEach-Object {
    	New-OctopusArtifact -Path $_.FullName
    }
```

