### PR TITLE
Bug 5560 terraform output

### DIFF
--- a/source/Calamari.Terraform/TerraformCliExecutor.cs
+++ b/source/Calamari.Terraform/TerraformCliExecutor.cs
@@ -53,7 +53,7 @@ namespace Calamari.Terraform
 
                 TemplateDirectory = templateDirectoryTemp;
             }
-            
+
             InitializeTerraformEnvironmentVariables();
 
             InitializePlugins();
@@ -85,6 +85,8 @@ namespace Calamari.Terraform
                     Log.NewOctopusArtifact(fileSystem.GetFullPath(logPath), fileSystem.GetFileName(logPath), fileSystem.GetFileSize(logPath));
                 }
                 
+                //When terraform crashes, the information would be contained in the crash.log file. We should attach this since
+                //we don't want to blow that information away in case it provides something relevant https://www.terraform.io/docs/internals/debugging.html#interpreting-a-crash-log
                 if (fileSystem.FileExists(crashLogPath))
                 {
                     Log.NewOctopusArtifact(fileSystem.GetFullPath(crashLogPath), fileSystem.GetFileName(crashLogPath), fileSystem.GetFileSize(crashLogPath));

--- a/source/Calamari.Terraform/TerraformCliExecutor.cs
+++ b/source/Calamari.Terraform/TerraformCliExecutor.cs
@@ -19,6 +19,7 @@ namespace Calamari.Terraform
         readonly Dictionary<string, string> environmentVariables;
         private Dictionary<string, string> defaultEnvironmentVariables;
         private readonly string logPath;
+        readonly string crashLogPath;
         
         public TerraformCLIExecutor(ICalamariFileSystem fileSystem, RunningDeployment deployment,
             Dictionary<string, string> environmentVariables)
@@ -39,6 +40,7 @@ namespace Calamari.Terraform
             TerraformVariableFiles = GenerateVarFiles();
 
             logPath = Path.Combine(deployment.CurrentDirectory, "terraform.log");
+            crashLogPath = Path.Combine(deployment.CurrentDirectory, "crash.log");
 
             if (!String.IsNullOrEmpty(TemplateDirectory))
             {
@@ -82,6 +84,11 @@ namespace Calamari.Terraform
                 if (fileSystem.FileExists(logPath))
                 {
                     Log.NewOctopusArtifact(fileSystem.GetFullPath(logPath), fileSystem.GetFileName(logPath), fileSystem.GetFileSize(logPath));
+                }
+                
+                if (fileSystem.FileExists(crashLogPath))
+                {
+                    Log.NewOctopusArtifact(fileSystem.GetFullPath(crashLogPath), fileSystem.GetFileName(crashLogPath), fileSystem.GetFileSize(crashLogPath));
                 }
             }
         }

--- a/source/Calamari.Terraform/TerraformCliExecutor.cs
+++ b/source/Calamari.Terraform/TerraformCliExecutor.cs
@@ -2,14 +2,12 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Calamari.Deployment;
 using Calamari.Extensions;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Proxies;
-using Calamari.Integration.Scripting.WindowsPowerShell;
 using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Terraform
@@ -21,7 +19,7 @@ namespace Calamari.Terraform
         readonly Dictionary<string, string> environmentVariables;
         private Dictionary<string, string> defaultEnvironmentVariables;
         private readonly string logPath;
-
+        
         public TerraformCLIExecutor(ICalamariFileSystem fileSystem, RunningDeployment deployment,
             Dictionary<string, string> environmentVariables)
         {
@@ -106,24 +104,9 @@ namespace Calamari.Terraform
 
             var commandOutput = new CaptureOutput();
             var cmd = new CommandLineRunner(commandOutput);
-#if NET452
-            var usePsEngine = true;
-#else
-            var usePsEngine = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#endif
-
+            
             Log.Info(commandLineInvocation.ToString());
-
-            if (usePsEngine)
-            {
-                var psFilePath = Path.Combine(TemplateDirectory, $"{Path.GetRandomFileName()}.ps1");
-                File.WriteAllText(psFilePath, $"{TerraformExecutable} {arguments}");
-
-                var args = PowerShellBootstrapper.FormatCommandArguments(psFilePath, psFilePath, new CalamariVariableDictionary());
-                commandLineInvocation = new CommandLineInvocation(PowerShellBootstrapper.PathToPowerShellExecutable(),
-                    args, TemplateDirectory, environmentVar);
-            }
-
+            
             var commandResult = cmd.Execute(commandLineInvocation);
             
             result = String.Join("\n", commandOutput.Infos);

--- a/source/Calamari.Tests/Terraform/TerraformFixture.cs
+++ b/source/Calamari.Tests/Terraform/TerraformFixture.cs
@@ -105,7 +105,6 @@ namespace Calamari.Tests.Terraform
         }
 
         [Test]
-        [TestCase("-backend-config='backend.tfvars'", TestName = "Using single quotes", IncludePlatform = "WIN")]
         [TestCase("-backend-config=\"backend.tfvars\"", TestName = "Using double quotes")]
         [TestCase("--backend-config=backend.tfvars", TestName = "Using no quotes, this one needs to use -- for the argument!")]
         public void ExtraInitParametersAreSet(string additionalParams)


### PR DESCRIPTION
This PR drops the Powershell execution from Calamari and includes all output generated from executing the associated terraform commands. 

*Please Note* that dropping Powershell means that we now have the behavior as per the usual command line which means single quotes for additional parameters will no longer work, for example `-backend-config='backend.tfvars'` would not work whereas `-backend-config="backend-config"` would work on both windows and linux.