### PR TITLE
Terraform output in command outputs have sensitive info

### DIFF
--- a/source/Calamari.Shared/Integration/Processes/SplitCommandOutput.cs
+++ b/source/Calamari.Shared/Integration/Processes/SplitCommandOutput.cs
@@ -25,4 +25,15 @@ namespace Calamari.Integration.Processes
             foreach (var output in outputs) output.WriteError(line);
         }
     }
+
+    public class IgnoreCommandOutput : ICommandOutput
+    {
+        public void WriteInfo(string line)
+        {
+        }
+
+        public void WriteError(string line)
+        {
+        }
+    }
 }

--- a/source/Calamari.Terraform/ApplyTerraformConvention.cs
+++ b/source/Calamari.Terraform/ApplyTerraformConvention.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Calamari.Deployment;
 using Calamari.Integration.FileSystem;
+using Calamari.Integration.Processes;
 using Newtonsoft.Json.Linq;
 
 namespace Calamari.Terraform
@@ -20,7 +21,8 @@ namespace Calamari.Terraform
                     cli.TerraformVariableFiles, cli.ActionParams);
 
                 // Attempt to get the outputs. This will fail if none are defined in versions prior to v0.11.8
-                if (cli.ExecuteCommand(out var result, "output", "-no-color", "-json").ExitCode != 0)
+                // Please note that we really don't want to log the following command output as it can contain sensitive variables etc. hence the IgnoreCommandOutput()
+                if (cli.ExecuteCommand(out var result, new IgnoreCommandOutput(), "output", "-no-color", "-json").ExitCode != 0)
                 {
                     return;
                 }

--- a/source/Calamari.Terraform/TerraformCliExecutor.cs
+++ b/source/Calamari.Terraform/TerraformCliExecutor.cs
@@ -76,6 +76,13 @@ namespace Calamari.Terraform
             return commandResult;
         }
 
+        public CommandResult ExecuteCommand(out string result, ICommandOutput output, params string[] arguments)
+        {
+            var commandResult = ExecuteCommandInternal(ToSpaceSeparated(arguments), out result, output);
+
+            return commandResult;
+        }
+
         public void Dispose()
         {
             if (AttachLogFile)
@@ -99,7 +106,7 @@ namespace Calamari.Terraform
             return string.Join(" ", items.Where(_ => !String.IsNullOrEmpty(_)));
         }
 
-        CommandResult ExecuteCommandInternal(string arguments, out string result)
+        CommandResult ExecuteCommandInternal(string arguments, out string result, ICommandOutput output = null)
         {
             var environmentVar = defaultEnvironmentVariables;
             if (environmentVariables != null)
@@ -109,8 +116,8 @@ namespace Calamari.Terraform
 
             var commandLineInvocation = new CommandLineInvocation(TerraformExecutable,
                 arguments, TemplateDirectory, environmentVar);
-
-            var commandOutput = new CaptureOutput(new ConsoleCommandOutput());
+            
+            var commandOutput = new CaptureOutput(output ?? new ConsoleCommandOutput());
             var cmd = new CommandLineRunner(commandOutput);
             
             Log.Info(commandLineInvocation.ToString());


### PR DESCRIPTION
This PR modifies the terraform apply step to not include output from the `terraform output` command as it may include sensitive information.