### PR TITLE
Add optional flag to output kubeconfig as part of logs

### DIFF
--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -3,6 +3,7 @@
 Octopus_K8S_ClusterUrl=$(get_octopusvariable "Octopus.Action.Kubernetes.ClusterUrl")
 Octopus_K8S_Namespace=$(get_octopusvariable "Octopus.Action.Kubernetes.Namespace")
 Octopus_K8S_SkipTlsVerification=$(get_octopusvariable "Octopus.Action.Kubernetes.SkipTlsVerification")
+Octopus_K8S_OutputKubeConfig=$(get_octopusvariable "Octopus.Action.Kubernetes.OutputKubeConfig")
 Octopus_AccountType=$(get_octopusvariable "Octopus.Account.AccountType")
 Octopus_K8S_KubectlExe=$(get_octopusvariable "Octopus.Action.Kubernetes.CustomKubectlExecutable")
 Octopus_K8S_Client_Cert=$(get_octopusvariable "Octopus.Action.Kubernetes.ClientCertificate")
@@ -48,6 +49,10 @@ function setup_context {
 
   if [[ -z $Octopus_K8S_SkipTlsVerification ]]; then
     Octopus_K8S_SkipTlsVerification=true
+  fi
+
+  if [[ -z $Octopus_K8S_OutputKubeConfig ]]; then
+    Octopus_K8S_OutputKubeConfig=false
   fi
 
   kubectl version --client=true
@@ -111,7 +116,7 @@ function setup_context {
 		# so build this manually
 		Octopus_K8S_ClusterName=$(get_octopusvariable "Octopus.Action.Kubernetes.ClusterName")
         echo "Creating kubectl context to $K8S_ClusterUrl using EKS cluster name $K8S_ClusterName"
-		
+
 		# The call to set-cluster above will create a file with empty users. We need to call
 		# set-cluster first, because if we try to add the exec user first, set-cluster will
 		# delete those settings. So we now delete the users line (the last line of the yaml file)
@@ -143,13 +148,13 @@ function configure_kubectl_path {
 
 function create_namespace {
 	if [[ -n "$Octopus_K8S_Namespace" ]]; then
-		kubectl get namespace $Octopus_K8S_Namespace > /dev/null 2>&1 
+		kubectl get namespace $Octopus_K8S_Namespace > /dev/null 2>&1
 		if [[ $? -ne 0 ]]; then
 			echo "##octopus[stdout-default]"
 			kubectl create namespace $Octopus_K8S_Namespace
 			echo "##octopus[stdout-verbose]"
 		fi
-		
+
 	fi
 }
 
@@ -159,8 +164,9 @@ get_kubectl
 configure_kubectl_path
 setup_context
 create_namespace
-echo "##octopus[stdout-verbose]"
-cat $KUBECONFIG
+if [[ "$Octopus_K8S_OutputKubeConfig" = true ]]; then
+    cat $KUBECONFIG
+fi
 echo "Invoking target script \"$(get_octopusvariable "OctopusKubernetesTargetScript")\" with $(get_octopusvariable "OctopusKubernetesTargetScriptParameters") parameters"
 echo "##octopus[stdout-default]"
 

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -20,7 +20,8 @@ function GetKubectl() {
 $K8S_ClusterUrl=$OctopusParameters["Octopus.Action.Kubernetes.ClusterUrl"]
 $K8S_Namespace=$OctopusParameters["Octopus.Action.Kubernetes.Namespace"]
 $K8S_SkipTlsVerification=$OctopusParameters["Octopus.Action.Kubernetes.SkipTlsVerification"]
-$K8S_AccountType=$OctopusParameters["Octopus.Account.AccountType"]	
+$K8S_OutputKubeConfig=$OctopusParameters["Octopus.Action.Kubernetes.OutputKubeConfig"]
+$K8S_AccountType=$OctopusParameters["Octopus.Account.AccountType"]
 $K8S_Namespace=$OctopusParameters["Octopus.Action.Kubernetes.Namespace"]
 $K8S_Client_Cert = $OctopusParameters["Octopus.Action.Kubernetes.ClientCertificate"]
 $K8S_Client_Cert_Pem = $OctopusParameters["$($K8S_Client_Cert).CertificatePem"]
@@ -29,7 +30,7 @@ $K8S_Server_Cert = $OctopusParameters["Octopus.Action.Kubernetes.CertificateAuth
 $K8S_Server_Cert_Pem = $OctopusParameters["$($K8S_Server_Cert).CertificatePem"]
 $Kubectl_Exe=GetKubectl
 
-function SetupContext {	
+function SetupContext {
 	if($K8S_AccountType -ne "AzureServicePrincipal" -and [string]::IsNullOrEmpty($K8S_ClusterUrl)){
 		Write-Error "Kubernetes cluster URL is missing"
 		Exit 1
@@ -49,6 +50,10 @@ function SetupContext {
         $K8S_SkipTlsVerification = $false;
     }
 
+	if([string]::IsNullOrEmpty($K8S_OutputKubeConfig)) {
+        $K8S_OutputKubeConfig = $false;
+    }
+
 	if ((Get-Command $Kubectl_Exe -ErrorAction SilentlyContinue) -eq $null) {
 		Write-Error "Could not find $Kubectl_Exe. Make sure kubectl is on the PATH. See https://g.octopushq.com/KubernetesTarget for more information."
 		Exit 1
@@ -56,7 +61,7 @@ function SetupContext {
 
 	# When using an Azure account, use the az command line tool to build the
 	# kubeconfig file.
-	if($K8S_AccountType -eq "AzureServicePrincipal") {		
+	if($K8S_AccountType -eq "AzureServicePrincipal") {
 		$K8S_Azure_Resource_Group=$OctopusParameters["Octopus.Action.Kubernetes.AksClusterResourceGroup"]
 		$K8S_Azure_Cluster=$OctopusParameters["Octopus.Action.Kubernetes.AksClusterName"]
 		Write-Host "Creating kubectl context to AKS Cluster in resource group $K8S_Azure_Resource_Group called $K8S_Azure_Cluster (namespace $K8S_Namespace) using a AzureServicePrincipal"
@@ -120,7 +125,7 @@ function SetupContext {
 			# so build this manually
 			$K8S_ClusterName=$OctopusParameters["Octopus.Action.Kubernetes.EksClusterName"]
 			Write-Host "Creating kubectl context to $K8S_ClusterUrl (namespace $K8S_Namespace) using EKS cluster name $K8S_ClusterName"
-		
+
 			# The call to set-cluster above will create a file with empty users. We need to call
 			# set-cluster first, because if we try to add the exec user first, set-cluster will
 			# delete those settings. So we now delete the users line (the last line of the yaml file)
@@ -138,13 +143,13 @@ function SetupContext {
 			Add-Content -NoNewline -Path $env:KUBECONFIG -Value "      args:`n"
 			Add-Content -NoNewline -Path $env:KUBECONFIG -Value "        - `"token`"`n"
 			Add-Content -NoNewline -Path $env:KUBECONFIG -Value "        - `"-i`"`n"
-			Add-Content -NoNewline -Path $env:KUBECONFIG -Value "        - `"$K8S_ClusterName`""        
-		}	
+			Add-Content -NoNewline -Path $env:KUBECONFIG -Value "        - `"$K8S_ClusterName`""
+		}
 		elseif ([string]::IsNullOrEmpty($K8S_Client_Cert)) {
 
 			Write-Error "Account Type $K8S_AccountType is currently not valid for kubectl contexts"
 			Exit 1
-		}  
+		}
 	}
 }
 
@@ -155,7 +160,7 @@ function ConfigureKubeCtlPath {
 
 function CreateNamespace {
 	if (-not [string]::IsNullOrEmpty($K8S_Namespace)) {
-		
+
 		try
 		{
 			# We need to continue if "kubectl get namespace" fails
@@ -183,9 +188,10 @@ Write-Host "##octopus[stdout-verbose]"
 ConfigureKubeCtlPath
 SetupContext
 CreateNamespace
-echo "##octopus[stdout-verbose]"
-Get-Content $env:KUBECONFIG
+if ($K8S_OutputKubeConfig == $true) {
+	Get-Content $env:KUBECONFIG
+}
 Write-Verbose "Invoking target script $OctopusKubernetesTargetScript with $OctopusKubernetesTargetScriptParameters parameters"
-echo "##octopus[stdout-default]"
+Write-Host "##octopus[stdout-default]"
 
 Invoke-Expression ". `"$OctopusKubernetesTargetScript`" $OctopusKubernetesTargetScriptParameters"

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -188,7 +188,7 @@ Write-Host "##octopus[stdout-verbose]"
 ConfigureKubeCtlPath
 SetupContext
 CreateNamespace
-if ($K8S_OutputKubeConfig == $true) {
+if ($K8S_OutputKubeConfig -eq $true) {
 	Get-Content $env:KUBECONFIG
 }
 Write-Verbose "Invoking target script $OctopusKubernetesTargetScript with $OctopusKubernetesTargetScriptParameters parameters"

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -7,6 +7,7 @@
         public const string EksClusterName = "Octopus.Action.Kubernetes.EksClusterName";
         public const string Namespace = "Octopus.Action.Kubernetes.Namespace";
         public const string SkipTlsVerification = "Octopus.Action.Kubernetes.SkipTlsVerification";
+        public const string OutputKubeConfig = "Octopus.Action.Kubernetes.OutputKubeConfig";
 
         public static class Helm
         {
@@ -20,7 +21,7 @@
             public const string Timeout = "Octopus.Action.Helm.Timeout";
             public const string TillerNamespace = "Octopus.Action.Helm.TillerNamespace";
             public const string TillerTimeout = "Octopus.Action.Helm.TillerTimeout";
-            
+
             public static class Packages
             {
                 public const string CustomHelmExePackageKey = "HelmExe";


### PR DESCRIPTION
Fixes a security issue where kubeconfig is dumped as part of logs, including private keys and tokens. This output is useful for debugging, but should not be done by default.

Now to turn on logging `Octopus.Action.Kubernetes.OutputKubeConfig' must be set and then the config is output in the verbose logs.