### PR TITLE
Remove unused odata and system.spatial references

### DIFF
--- a/source/Calamari.Azure/Calamari.Azure.csproj
+++ b/source/Calamari.Azure/Calamari.Azure.csproj
@@ -59,7 +59,6 @@
     <PackageReference Include="Octopus.Dependencies.AzureBinaries" Version="2.9.0" />
     <PackageReference Include="Octopus.Dependencies.AzureCmdlets" Version="6.11.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.Spatial" Version="5.8.3" />
     <PackageReference Include="WindowsAzure.Storage" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -60,9 +60,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="BouncyCastle" Version="1.8.1-octopus" />
     <PackageReference Include="MarkdownSharp" Version="1.13.0.0" />
-    <PackageReference Include="Microsoft.Data.Edm" Version="5.8.3" />
-    <PackageReference Include="Microsoft.Data.OData" Version="5.8.3" />
-    <PackageReference Include="Microsoft.Data.Services.Client" Version="5.8.3" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="Microsoft.Web.Administration" Version="7.0.0.0" />
     <PackageReference Include="Microsoft.Web.Deployment" Version="3.6.0" />


### PR DESCRIPTION
Microsoft.Data.OData was causing an alert - CVE-2018-8269