### PR TITLE
Update Calamari to .Net Core 2.2

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -125,19 +125,19 @@ Task("Pack")
     Zip("./source/Calamari.Tests/bin/Release/net452/", Path.Combine(artifactsDir, "Binaries.zip"));
 
     // Create a portable .NET Core package
-    DoPackage("Calamari", "netcoreapp2.0", nugetVersion, "portable");
+    DoPackage("Calamari", "netcoreapp2.2", nugetVersion, "portable");
 
     // Create the self-contained Calamari packages for each runtime ID defined in Calamari.csproj
     foreach(var rid in GetProjectRuntimeIds(@".\source\Calamari\Calamari.csproj"))
     {
-        DoPackage("Calamari", "netcoreapp2.0", nugetVersion, rid);
+        DoPackage("Calamari", "netcoreapp2.2", nugetVersion, rid);
     }
 	
 	// Create a Zip for each runtime for testing
 	foreach(var rid in GetProjectRuntimeIds(@".\source\Calamari.Tests\Calamari.Tests.csproj"))
     {
-		var publishedLocation = DoPublish("Calamari.Tests", "netcoreapp2.0", nugetVersion, rid);
-		var zipName = $"Calamari.Tests.netcoreapp2.{rid}.{nugetVersion}.zip";
+		var publishedLocation = DoPublish("Calamari.Tests", "netcoreapp2.2", nugetVersion, rid);
+		var zipName = $"Calamari.Tests.netcoreapp2.2.{rid}.{nugetVersion}.zip";
 		Zip(Path.Combine(publishedLocation, rid), Path.Combine(artifactsDir, zipName));
     }
 });

--- a/build.cake
+++ b/build.cake
@@ -137,7 +137,7 @@ Task("Pack")
 	foreach(var rid in GetProjectRuntimeIds(@".\source\Calamari.Tests\Calamari.Tests.csproj"))
     {
 		var publishedLocation = DoPublish("Calamari.Tests", "netcoreapp2.2", nugetVersion, rid);
-		var zipName = $"Calamari.Tests.netcoreapp2.2.{rid}.{nugetVersion}.zip";
+		var zipName = $"Calamari.Tests.netcoreapp2.{rid}.{nugetVersion}.zip";
 		Zip(Path.Combine(publishedLocation, rid), Path.Combine(artifactsDir, zipName));
     }
 });

--- a/source/Calamari.Kubernetes/Calamari.Kubernetes.csproj
+++ b/source/Calamari.Kubernetes/Calamari.Kubernetes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.0.0</Version>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PlatformTarget>anycpu</PlatformTarget>
     <AssemblyName>Calamari.Kubernetes</AssemblyName>

--- a/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
@@ -204,7 +204,7 @@ namespace Calamari.Integration.Packages.Download
             Guard.NotNull(mavenPackageId, "mavenPackageId can not be null");
             Guard.NotNull(feedUri, "feedUri can not be null");
 
-            var errors = new ConcurrentDictionary<string, string>();
+            var errors = new ConcurrentBag<string>();
             var fileChecks = JarExtractor.EXTENSIONS
                 .Union(AdditionalExtensions)
                 .AsParallel()
@@ -213,7 +213,7 @@ namespace Calamari.Integration.Packages.Download
                     var packageId = new MavenPackageID(mavenPackageId.Group, mavenPackageId.Artifact,
                         mavenPackageId.Version, Regex.Replace(extension, "^\\.", ""));
                     var result = MavenPackageExists(packageId, feedUri, feedCredentials, snapshotMetadata);
-                    errors[result.ErrorMsg] = result.ErrorMsg;
+                    errors.Add(result.ErrorMsg);
                     return new
                     {
                         result.Found,
@@ -228,7 +228,7 @@ namespace Calamari.Integration.Packages.Download
                 return firstFound.MavenPackageId;
             }
 
-            throw new MavenDownloadException($"Failed to find the Maven artifact.\r\nReceived Error(s):\r\n{string.Join("\r\n", errors.Values.ToList())}");
+            throw new MavenDownloadException($"Failed to find the Maven artifact.\r\nReceived Error(s):\r\n{string.Join("\r\n", errors.Distinct().ToList())}");
         }
 
         /// <summary>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Calamari.Tests</AssemblyName>
     <PackageId>Calamari.Tests</PackageId>
@@ -12,7 +12,7 @@
     <StartupObject />
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
     <DefineConstants>$(DefineConstants);NETCORE;USE_OCTOPUS_XMLT;JAVA_SUPPORT</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
@@ -234,23 +234,23 @@
     </CreateItem>
     <PropertyGroup>
       <FSharpCompilerTools>@(FSharpCompilerToolsRef->'%(ResolvedPath)')/tools/*.*</FSharpCompilerTools>
-      <FSharpCompilerToolsExe Condition="'$(TargetFramework)' == 'netcoreapp2.0'">@(FSharpCompilerToolsRef->'%(ResolvedPath)')/tools/*.exe</FSharpCompilerToolsExe>
+      <FSharpCompilerToolsExe Condition="'$(TargetFramework)' == 'netcoreapp2.2'">@(FSharpCompilerToolsRef->'%(ResolvedPath)')/tools/*.exe</FSharpCompilerToolsExe>
       <ScriptCS>@(ScriptCSRef->'%(ResolvedPath)')/tools/*.*</ScriptCS>
-      <ScriptCSExe Condition="'$(TargetFramework)' == 'netcoreapp2.0'">@(ScriptCSRef->'%(ResolvedPath)')/tools/*.exe</ScriptCSExe>
+      <ScriptCSExe Condition="'$(TargetFramework)' == 'netcoreapp2.2'">@(ScriptCSRef->'%(ResolvedPath)')/tools/*.exe</ScriptCSExe>
       <NuGetCommandLine>@(NuGetCommandLineRef->'%(ResolvedPath)')/tools/*.*</NuGetCommandLine>
     </PropertyGroup>
     <ItemGroup>
       <FSharpFiles Include="$(FSharpCompilerTools)" />
-      <FSharpFilesExe Condition="'$(TargetFramework)' == 'netcoreapp2.0'" Include="$(FSharpCompilerToolsExe)" />
+      <FSharpFilesExe Condition="'$(TargetFramework)' == 'netcoreapp2.2'" Include="$(FSharpCompilerToolsExe)" />
       <ScriptCSFiles Include="$(ScriptCS)" />
-      <ScriptCSFilesExe Condition="'$(TargetFramework)' == 'netcoreapp2.0'" Include="$(ScriptCSExe)" />
+      <ScriptCSFilesExe Condition="'$(TargetFramework)' == 'netcoreapp2.2'" Include="$(ScriptCSExe)" />
       <NuGetFiles Include="$(NuGetCommandLine)" Condition=" '$(TargetFramework)' == 'net452'" />
     </ItemGroup>
     <Copy SourceFiles="@(FSharpFiles)" DestinationFolder="$(OutDir)/FSharp/" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(ScriptCSFiles)" DestinationFolder="$(OutDir)/ScriptCS/" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(NuGetFiles)" DestinationFolder="$(OutDir)/NuGet/" SkipUnchangedFiles="true" Condition="'$(TargetFramework)' == 'net452'" />
-    <Exec Command="chmod +x %(FSharpFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
-    <Exec Command="chmod +x %(ScriptCSFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
+    <Exec Command="chmod +x %(FSharpFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
+    <Exec Command="chmod +x %(ScriptCSFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
     <Copy SourceFiles="@(FSharpFiles)" DestinationFolder="$(PublishDir)/FSharp/" Condition="'$(PublishDir)' != ''" />
     <Copy SourceFiles="@(ScriptCSFiles)" DestinationFolder="$(PublishDir)/ScriptCS/" Condition="'$(PublishDir)' != ''" />
   </Target>

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
@@ -219,7 +219,6 @@ namespace Calamari.Tests.Fixtures.Conventions
 
         [Test]
         [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
         [TestCase("bar.blah => *.Bar.Blah", "xyz.bar.blah", "bar.blah")]
         [TestCase("*.Bar.Blah => bar.blah", "bar.blah", "xyz.bar.blah")]
         [TestCase("foo.bar.config => Foo.Config", "foo.config", "foo.bar.config")]

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
@@ -224,6 +224,9 @@ namespace Calamari.Tests.Fixtures.Conventions
         [TestCase("foo.bar.config => Foo.Config", "foo.config", "foo.bar.config")]
         public void CaseSensitiveOnNix(string pattern, string from, string to)
         {
+            if (!CalamariEnvironment.IsRunningOnNix)
+                Assert.Ignore("This test is designed to run on *nix");
+
             variables.Set(SpecialVariables.Package.AdditionalXmlConfigurationTransforms, pattern);
             variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, false.ToString());
 

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -18,13 +18,13 @@
     <Product>Calamari</Product>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm</RuntimeIdentifiers>
     <ApplicationManifest>Calamari.exe.manifest</ApplicationManifest>
-    <TargetFrameworks>netcoreapp2.0;net452;net40</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;net452;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);USE_NUGET_V2_LIBS;IIS_SUPPORT;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT;USE_ALPHAFS_FOR_LONG_FILE_PATH_SUPPORT</DefineConstants>
     <PlatformTarget>anycpu</PlatformTarget>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
     <DefineConstants>$(DefineConstants);USE_OCTOPUS_XMLT;USE_SYSTEM_IO_DIRECTORY;USE_NUGET_V3_LIBS;WORKAROUND_FOR_EMPTY_STRING_BUG</DefineConstants>
   </PropertyGroup>
   <!--
@@ -36,7 +36,7 @@
     <ProjectReference Include="..\Calamari.Azure\Calamari.Azure.csproj" />
     <ProjectReference Include="..\Calamari.Terraform\Calamari.Terraform.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
     <ProjectReference Include="..\Calamari.Terraform\Calamari.Terraform.csproj" />
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />
   </ItemGroup>
@@ -69,7 +69,7 @@
     <Reference Include="WindowsBase" />
     <Reference Include="System" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' OR '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2' OR '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Autofac" Version="4.8.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -21,7 +21,7 @@
     <TargetFrameworks>netcoreapp2.2;net452;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
-    <DefineConstants>$(DefineConstants);USE_NUGET_V2_LIBS;IIS_SUPPORT;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT;USE_ALPHAFS_FOR_LONG_FILE_PATH_SUPPORT</DefineConstants>
+    <DefineConstants>$(DefineConstants);USE_NUGET_V2_LIBS;IIS_SUPPORT;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT;USE_ALPHAFS_FOR_LONG_FILE_PATH_SUPPORT;HAS_SSL3</DefineConstants>
     <PlatformTarget>anycpu</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -122,7 +122,7 @@ namespace Calamari
             //https://central.sonatype.org/articles/2018/May/04/discontinue-support-for-tlsv11-and-below/
 
             var securityProcotolTypes =
-#if !NETCOREAPP2_2
+#if HAS_SSL3
                 SecurityProtocolType.Ssl3 |
 #endif
                 SecurityProtocolType.Tls;

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -122,7 +122,7 @@ namespace Calamari
             //https://central.sonatype.org/articles/2018/May/04/discontinue-support-for-tlsv11-and-below/
 
             var securityProcotolTypes =
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_2
                 SecurityProtocolType.Ssl3 |
 #endif
                 SecurityProtocolType.Tls;


### PR DESCRIPTION
- Fixes https://github.com/OctopusDeploy/Issues/issues/4619
- [x] Flag end of Ubuntu 14.04 support ([docs](https://github.com/OctopusDeploy/docs/pull/416))
- [x] Check Ubuntu 14.04 behavior, to determine whether this is a patch or minor release --> an ad hoc test of script and package deployment steps completed successfully
- [x] Fix Mac OS X tests
- [ ] Upgrade Calamari in Server
- [ ] Retire Ubuntu 14.04 Calamari builds