### PR TITLE
Add a shortcircuit to the RetryTracker

### DIFF
--- a/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
+++ b/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
@@ -135,7 +135,7 @@ namespace Calamari.Azure.Integration.Websites.Publishing
                         if (retry.ShouldLogWarning())
                         {
                             Log.Warn(
-                                $"Azure Site query failed to return the resource group, trying again in {retry.Sleep()} ms.");
+                                $"Azure Site query failed to return the resource group, trying again in {retry.Sleep().TotalMilliseconds:n0} ms.");
                         }
 
                         matchingSite = null;

--- a/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -39,10 +39,10 @@ namespace Calamari.Integration.FileSystem
         /// Windows services can hang on to files for ~30s after the service has stopped as background
         /// threads shutdown or are killed for not shutting down in a timely fashion
         /// </remarks>
-        protected static RetryTracker GetRetryTracker()
+        protected static RetryTracker GetFileOperationRetryTracker()
         {
             return new RetryTracker(maxRetries:10000, 
-                timeLimit: TimeSpan.FromMinutes(0.2), 
+                timeLimit: TimeSpan.FromMinutes(1), 
                 retryInterval: RetryIntervalForFileOperations);
         }
 
@@ -74,7 +74,7 @@ namespace Calamari.Integration.FileSystem
             if (string.IsNullOrWhiteSpace(path))
                 return;
             
-            retry = retry ?? GetRetryTracker();
+            retry = retry ?? GetFileOperationRetryTracker();
             cancel = cancel ?? CancellationToken.None;
 
             retry.Reset();
@@ -124,7 +124,7 @@ namespace Calamari.Integration.FileSystem
             if (string.IsNullOrWhiteSpace(path))
                 return;
 
-            var retry = GetRetryTracker();
+            var retry = GetFileOperationRetryTracker();
             while (retry.Try())
             {
                 try
@@ -161,7 +161,7 @@ namespace Calamari.Integration.FileSystem
 
         void EnsureDirectoryDeleted(string path, FailureOptions failureOptions)
         {
-            var retry = GetRetryTracker(); 
+            var retry = GetFileOperationRetryTracker(); 
 
             while (retry.Try())
             {
@@ -409,7 +409,7 @@ namespace Calamari.Integration.FileSystem
                 return;
             }
 
-            retry = retry ?? GetRetryTracker();
+            retry = retry ?? GetFileOperationRetryTracker();
 
             foreach (var file in EnumerateFiles(targetDirectory))
             {
@@ -546,7 +546,7 @@ namespace Calamari.Integration.FileSystem
 
         private static void RetryTrackerFileAction(Action fileAction, string target, string action)
         {
-            var retry = GetRetryTracker();
+            var retry = GetFileOperationRetryTracker();
             while (retry.Try())
             {
                 try

--- a/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -42,7 +42,7 @@ namespace Calamari.Integration.FileSystem
         protected static RetryTracker GetRetryTracker()
         {
             return new RetryTracker(maxRetries:10000, 
-                timeLimit: TimeSpan.FromMinutes(1), 
+                timeLimit: TimeSpan.FromMinutes(0.2), 
                 retryInterval: RetryIntervalForFileOperations);
         }
 
@@ -68,20 +68,19 @@ namespace Calamari.Integration.FileSystem
             }
         }
 
-        public void DeleteFile(string path)
-        {
-            DeleteFile(path, FailureOptions.ThrowOnFailure);
-        }
 
-        public virtual void DeleteFile(string path, FailureOptions options)
+        public virtual void DeleteFile(string path, FailureOptions options = FailureOptions.ThrowOnFailure, RetryTracker retry = null, CancellationToken? cancel = null)
         {
             if (string.IsNullOrWhiteSpace(path))
                 return;
+            
+            retry = retry ?? GetRetryTracker();
+            cancel = cancel ?? CancellationToken.None;
 
-            var retry = GetRetryTracker();
-
+            retry.Reset();
             while (retry.Try())
             {
+                cancel.Value.ThrowIfCancellationRequested();
                 try
                 {
                     if (File.Exists(path))
@@ -401,7 +400,7 @@ namespace Calamari.Integration.FileSystem
             PurgeDirectory(targetDirectory, check, options, CancellationToken.None);
         }
 
-        void PurgeDirectory(string targetDirectory, Predicate<IFileSystemInfo> exclude, FailureOptions options, CancellationToken cancel, bool includeTarget = false)
+        void PurgeDirectory(string targetDirectory, Predicate<IFileSystemInfo> exclude, FailureOptions options, CancellationToken cancel, bool includeTarget = false, RetryTracker retry = null)
         {
             exclude = exclude?? (fi => false);
 
@@ -409,6 +408,8 @@ namespace Calamari.Integration.FileSystem
             {
                 return;
             }
+
+            retry = retry ?? GetRetryTracker();
 
             foreach (var file in EnumerateFiles(targetDirectory))
             {
@@ -420,7 +421,7 @@ namespace Calamari.Integration.FileSystem
                     continue;
                 }
 
-                DeleteFile(file, options);
+                DeleteFile(file, options, retry, cancel);
             }
 
             foreach (var directory in EnumerateDirectories(targetDirectory))
@@ -440,7 +441,7 @@ namespace Calamari.Integration.FileSystem
                 }
                 else
                 {
-                    PurgeDirectory(directory, exclude, options, cancel, includeTarget: true);
+                    PurgeDirectory(directory, exclude, options, cancel, true, retry);
                 }
             }
 

--- a/source/Calamari.Shared/Integration/FileSystem/ICalamariFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/ICalamariFileSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading;
+using Calamari.Integration.Retry;
 
 namespace Calamari.Integration.FileSystem
 {
@@ -11,8 +12,7 @@ namespace Calamari.Integration.FileSystem
         bool FileExists(string path);
         bool DirectoryExists(string path);
         bool DirectoryIsEmpty(string path);
-        void DeleteFile(string path);
-        void DeleteFile(string path, FailureOptions options);
+        void DeleteFile(string path, FailureOptions options = FailureOptions.ThrowOnFailure, RetryTracker retry = null, CancellationToken? cancel = null);
         void DeleteDirectory(string path);
         void DeleteDirectory(string path, FailureOptions options);
         IEnumerable<string> EnumerateDirectories(string parentDirectoryPath);

--- a/source/Calamari.Shared/Integration/Packages/NuGet/InternalNuGetPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/InternalNuGetPackageDownloader.cs
@@ -65,7 +65,7 @@ namespace Calamari.Integration.Packages.NuGet
 
                     if (retry.CanRetry())
                     {
-                        var wait = TimeSpan.FromMilliseconds(retry.Sleep());
+                        var wait = retry.Sleep();
                         Log.Verbose($"Going to wait {wait.TotalSeconds}s before attempting the download from the external feed again.");
                         Thread.Sleep(wait);
                     }

--- a/source/Calamari.Shared/Integration/Retry/LimitedExponentialRetryInterval.cs
+++ b/source/Calamari.Shared/Integration/Retry/LimitedExponentialRetryInterval.cs
@@ -22,11 +22,11 @@ namespace Calamari.Integration.Retry
             this.multiplier = multiplier;
         }
 
-        public override int GetInterval(int retryCount)
+        public override TimeSpan GetInterval(int retryCount)
         {
             double delayTime = retryInterval * Math.Pow(multiplier, retryCount);
-            if (delayTime > maxInterval) return maxInterval;
-            return (int)delayTime;
+            if (delayTime > maxInterval) return TimeSpan.FromMilliseconds(maxInterval);
+            return TimeSpan.FromMilliseconds((int) delayTime);
         }
     }
 }

--- a/source/Calamari.Shared/Integration/Retry/LinearRetryInterval.cs
+++ b/source/Calamari.Shared/Integration/Retry/LinearRetryInterval.cs
@@ -14,9 +14,9 @@ namespace Calamari.Integration.Retry
             this.retryInterval = retryInterval;
         }
 
-        public override int GetInterval(int retryCount)
+        public override TimeSpan GetInterval(int retryCount)
         {
-            return (int)retryInterval.TotalMilliseconds * retryCount;
+            return TimeSpan.FromMilliseconds((int) retryInterval.TotalMilliseconds * retryCount);
         }
     }
 }

--- a/source/Calamari.Shared/Integration/Retry/RetryInterval.cs
+++ b/source/Calamari.Shared/Integration/Retry/RetryInterval.cs
@@ -1,7 +1,9 @@
-﻿namespace Calamari.Integration.Retry
+﻿using System;
+
+namespace Calamari.Integration.Retry
 {
     public abstract class RetryInterval
     {
-        public abstract int GetInterval(int retryCount);
+        public abstract TimeSpan GetInterval(int retryCount);
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/RetryFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/RetryFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Calamari.Integration.Retry;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures.Integration.FileSystem
@@ -44,6 +45,41 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
 
             Assert.NotNull(caught);
             Assert.AreEqual(retries, retried);
+        }
+
+        [Test]
+        public void ShouldTryOnceAfterMaxIsReachedAndResetting()
+        {
+            var cnt = 0;
+            var subject = new RetryTracker(20, null, new LinearRetryInterval(TimeSpan.Zero));
+            while (subject.Try())
+                cnt++;
+
+            cnt.Should().Be(21);
+            
+            subject.Reset();
+
+            cnt = 0;
+            while (subject.Try())
+                cnt++;
+
+            cnt.Should().Be(1);
+        }
+        
+        [Test]
+        public void ShouldTryToLimitAfterMaxIsNotReachedAndResetting()
+        {
+            var cnt = 0;
+            var subject = new RetryTracker(20, null, new LinearRetryInterval(TimeSpan.Zero));
+            subject.Try();
+            
+            subject.Reset();
+
+            cnt = 0;
+            while (subject.Try())
+                cnt++;
+
+            cnt.Should().Be(21);
         }
     }
 }


### PR DESCRIPTION
Added a shortcircuit to the RetryTracker so that it fails fast once the first operation in a batch fails. This prevents it taking hours from purging directories with many files that are in use.

Fixes https://github.com/OctopusDeploy/Issues/issues/4781