### PR TITLE
Used "kubectl config view" instead of printing raw config

### DIFF
--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -3,6 +3,7 @@
 Octopus_K8S_ClusterUrl=$(get_octopusvariable "Octopus.Action.Kubernetes.ClusterUrl")
 Octopus_K8S_Namespace=$(get_octopusvariable "Octopus.Action.Kubernetes.Namespace")
 Octopus_K8S_SkipTlsVerification=$(get_octopusvariable "Octopus.Action.Kubernetes.SkipTlsVerification")
+Octopus_K8S_OutputKubeConfig=$(get_octopusvariable "Octopus.Action.Kubernetes.OutputKubeConfig")
 Octopus_AccountType=$(get_octopusvariable "Octopus.Account.AccountType")
 Octopus_K8S_KubectlExe=$(get_octopusvariable "Octopus.Action.Kubernetes.CustomKubectlExecutable")
 Octopus_K8S_Client_Cert=$(get_octopusvariable "Octopus.Action.Kubernetes.ClientCertificate")
@@ -48,6 +49,10 @@ function setup_context {
 
   if [[ -z $Octopus_K8S_SkipTlsVerification ]]; then
     Octopus_K8S_SkipTlsVerification=true
+  fi
+
+  if [[ -z $Octopus_K8S_OutputKubeConfig ]]; then
+    Octopus_K8S_OutputKubeConfig=false
   fi
 
   kubectl version --client=true
@@ -159,7 +164,9 @@ get_kubectl
 configure_kubectl_path
 setup_context
 create_namespace
-kubectl config view
+if [[ "$Octopus_K8S_OutputKubeConfig" = true ]]; then
+    kubectl config view
+fi
 echo "Invoking target script \"$(get_octopusvariable "OctopusKubernetesTargetScript")\" with $(get_octopusvariable "OctopusKubernetesTargetScriptParameters") parameters"
 echo "##octopus[stdout-default]"
 

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -3,7 +3,6 @@
 Octopus_K8S_ClusterUrl=$(get_octopusvariable "Octopus.Action.Kubernetes.ClusterUrl")
 Octopus_K8S_Namespace=$(get_octopusvariable "Octopus.Action.Kubernetes.Namespace")
 Octopus_K8S_SkipTlsVerification=$(get_octopusvariable "Octopus.Action.Kubernetes.SkipTlsVerification")
-Octopus_K8S_OutputKubeConfig=$(get_octopusvariable "Octopus.Action.Kubernetes.OutputKubeConfig")
 Octopus_AccountType=$(get_octopusvariable "Octopus.Account.AccountType")
 Octopus_K8S_KubectlExe=$(get_octopusvariable "Octopus.Action.Kubernetes.CustomKubectlExecutable")
 Octopus_K8S_Client_Cert=$(get_octopusvariable "Octopus.Action.Kubernetes.ClientCertificate")
@@ -49,10 +48,6 @@ function setup_context {
 
   if [[ -z $Octopus_K8S_SkipTlsVerification ]]; then
     Octopus_K8S_SkipTlsVerification=true
-  fi
-
-  if [[ -z $Octopus_K8S_OutputKubeConfig ]]; then
-    Octopus_K8S_OutputKubeConfig=false
   fi
 
   kubectl version --client=true
@@ -164,9 +159,7 @@ get_kubectl
 configure_kubectl_path
 setup_context
 create_namespace
-if [[ "$Octopus_K8S_OutputKubeConfig" = true ]]; then
-    kubectl config view
-fi
+kubectl config view
 echo "Invoking target script \"$(get_octopusvariable "OctopusKubernetesTargetScript")\" with $(get_octopusvariable "OctopusKubernetesTargetScriptParameters") parameters"
 echo "##octopus[stdout-default]"
 

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -165,7 +165,7 @@ configure_kubectl_path
 setup_context
 create_namespace
 if [[ "$Octopus_K8S_OutputKubeConfig" = true ]]; then
-    cat $KUBECONFIG
+    kubectl config view
 fi
 echo "Invoking target script \"$(get_octopusvariable "OctopusKubernetesTargetScript")\" with $(get_octopusvariable "OctopusKubernetesTargetScriptParameters") parameters"
 echo "##octopus[stdout-default]"

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -20,7 +20,6 @@ function GetKubectl() {
 $K8S_ClusterUrl=$OctopusParameters["Octopus.Action.Kubernetes.ClusterUrl"]
 $K8S_Namespace=$OctopusParameters["Octopus.Action.Kubernetes.Namespace"]
 $K8S_SkipTlsVerification=$OctopusParameters["Octopus.Action.Kubernetes.SkipTlsVerification"]
-$K8S_OutputKubeConfig=$OctopusParameters["Octopus.Action.Kubernetes.OutputKubeConfig"]
 $K8S_AccountType=$OctopusParameters["Octopus.Account.AccountType"]
 $K8S_Namespace=$OctopusParameters["Octopus.Action.Kubernetes.Namespace"]
 $K8S_Client_Cert = $OctopusParameters["Octopus.Action.Kubernetes.ClientCertificate"]
@@ -48,10 +47,6 @@ function SetupContext {
 
 	if([string]::IsNullOrEmpty($K8S_SkipTlsVerification)) {
         $K8S_SkipTlsVerification = $false;
-    }
-
-	if([string]::IsNullOrEmpty($K8S_OutputKubeConfig)) {
-        $K8S_OutputKubeConfig = $false;
     }
 
 	if ((Get-Command $Kubectl_Exe -ErrorAction SilentlyContinue) -eq $null) {
@@ -188,9 +183,7 @@ Write-Host "##octopus[stdout-verbose]"
 ConfigureKubeCtlPath
 SetupContext
 CreateNamespace
-if ($K8S_OutputKubeConfig -eq $true) {
-	& $Kubectl_Exe config view
-}
+& $Kubectl_Exe config view
 Write-Verbose "Invoking target script $OctopusKubernetesTargetScript with $OctopusKubernetesTargetScriptParameters parameters"
 Write-Host "##octopus[stdout-default]"
 

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -20,6 +20,7 @@ function GetKubectl() {
 $K8S_ClusterUrl=$OctopusParameters["Octopus.Action.Kubernetes.ClusterUrl"]
 $K8S_Namespace=$OctopusParameters["Octopus.Action.Kubernetes.Namespace"]
 $K8S_SkipTlsVerification=$OctopusParameters["Octopus.Action.Kubernetes.SkipTlsVerification"]
+$K8S_OutputKubeConfig=$OctopusParameters["Octopus.Action.Kubernetes.OutputKubeConfig"]
 $K8S_AccountType=$OctopusParameters["Octopus.Account.AccountType"]
 $K8S_Namespace=$OctopusParameters["Octopus.Action.Kubernetes.Namespace"]
 $K8S_Client_Cert = $OctopusParameters["Octopus.Action.Kubernetes.ClientCertificate"]
@@ -47,6 +48,10 @@ function SetupContext {
 
 	if([string]::IsNullOrEmpty($K8S_SkipTlsVerification)) {
         $K8S_SkipTlsVerification = $false;
+    }
+
+	if([string]::IsNullOrEmpty($K8S_OutputKubeConfig)) {
+        $K8S_OutputKubeConfig = $false;
     }
 
 	if ((Get-Command $Kubectl_Exe -ErrorAction SilentlyContinue) -eq $null) {
@@ -183,7 +188,9 @@ Write-Host "##octopus[stdout-verbose]"
 ConfigureKubeCtlPath
 SetupContext
 CreateNamespace
-& $Kubectl_Exe config view
+if ($K8S_OutputKubeConfig -eq $true) {
+	& $Kubectl_Exe config view
+}
 Write-Verbose "Invoking target script $OctopusKubernetesTargetScript with $OctopusKubernetesTargetScriptParameters parameters"
 Write-Host "##octopus[stdout-default]"
 

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -189,7 +189,7 @@ ConfigureKubeCtlPath
 SetupContext
 CreateNamespace
 if ($K8S_OutputKubeConfig -eq $true) {
-	Get-Content $env:KUBECONFIG
+	& $Kubectl_Exe config view
 }
 Write-Verbose "Invoking target script $OctopusKubernetesTargetScript with $OctopusKubernetesTargetScriptParameters parameters"
 Write-Host "##octopus[stdout-default]"


### PR DESCRIPTION
Using `kubectl config view` will take advantage of the built in masking provided by kubectl. See the screenshot below - the top verbose output is our masking, and the bottom output is the result of  calling `kubectl config view` - note the `DATA+OMITTED` fields.

FYI - `kubectl` still leaks data, so we need to leave the variable guard in place. Details are at https://github.com/kubernetes/kubectl/issues/667.

![image](https://user-images.githubusercontent.com/160104/59166342-fcc45e80-8b6b-11e9-86be-dbee4c69aaa8.png)
