### PR TITLE
Improve recursive variable exception message

### DIFF
--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="Octopus.Versioning" Version="4.1.3" />
     <PackageReference Include="ScriptCS" Version="0.17.1" />
-    <PackageReference Include="Octostache" Version="2.4.1" />
+    <PackageReference Include="Octostache" Version="2.4.2-enh-improvedrecursi1" />
     <PackageReference Include="SharpCompress" Version="0.15.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="Octopus.Versioning" Version="4.1.3" />
     <PackageReference Include="ScriptCS" Version="0.17.1" />
-    <PackageReference Include="Octostache" Version="2.4.2-enh-improvedrecursi1" />
+    <PackageReference Include="Octostache" Version="2.5.0" />
     <PackageReference Include="SharpCompress" Version="0.15.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>

--- a/source/Calamari.Shared/Commands/Support/ConsoleFormatter.cs
+++ b/source/Calamari.Shared/Commands/Support/ConsoleFormatter.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Reflection;
 using Calamari.Util;
+using Octostache.Templates;
 
 namespace Calamari.Commands.Support
 {
@@ -9,7 +10,7 @@ namespace Calamari.Commands.Support
     {
         public static int PrintError(Exception ex)
         {
-            if (ex is CommandException)
+            if (ex is CommandException || ex is RecursiveDefinitionException)
             {
                 Log.Error(ex.Message);
                 return 1;

--- a/source/Calamari.Shared/Commands/Support/ConsoleFormatter.cs
+++ b/source/Calamari.Shared/Commands/Support/ConsoleFormatter.cs
@@ -10,10 +10,15 @@ namespace Calamari.Commands.Support
     {
         public static int PrintError(Exception ex)
         {
-            if (ex is CommandException || ex is RecursiveDefinitionException)
+            if (ex is CommandException)
             {
-                Log.Error(ex.Message);
+                Log.Error("X6: " + ex.Message);
                 return 1;
+            }
+            if (ex is RecursiveDefinitionException)
+            {
+                Log.Error("X7: " + ex.Message);
+                return 100;
             }
             if (ex is ReflectionTypeLoadException)
             {

--- a/source/Calamari.Shared/Commands/Support/ConsoleFormatter.cs
+++ b/source/Calamari.Shared/Commands/Support/ConsoleFormatter.cs
@@ -12,13 +12,13 @@ namespace Calamari.Commands.Support
         {
             if (ex is CommandException)
             {
-                Log.Error("X6: " + ex.Message);
+                Log.Error(ex.Message);
                 return 1;
             }
             if (ex is RecursiveDefinitionException)
             {
-                Log.Error("X7: " + ex.Message);
-                return 100;
+                //dont log these - they have already been logged earlier
+                return 101;
             }
             if (ex is ReflectionTypeLoadException)
             {

--- a/source/Calamari.Shared/Deployment/ConventionProcessor.cs
+++ b/source/Calamari.Shared/Deployment/ConventionProcessor.cs
@@ -33,9 +33,9 @@ namespace Calamari.Deployment
             {
                 Debugger.Break();
                 if (installException is CommandException || installException is RecursiveDefinitionException)
-                    Console.Error.WriteLine(installException.Message);
+                    Console.Error.WriteLine("X1: " + installException.Message);
                 else
-                    Console.Error.WriteLine(installException);
+                    Console.Error.WriteLine("X2: " + installException);
 
                 Console.Error.WriteLine("Running rollback conventions...");
 
@@ -52,12 +52,12 @@ namespace Calamari.Deployment
                 catch (Exception rollbackException)
                 {
                     if (rollbackException is CommandException)
-                        Console.Error.WriteLine(rollbackException.Message);
+                        Console.Error.WriteLine("X3: " + rollbackException.Message);
                     else if (rollbackException is RecursiveDefinitionException && rollbackException.Message != installException.Message)
                         //dont duplicate error messages
-                        Console.Error.WriteLine(rollbackException.Message);
+                        Console.Error.WriteLine("X4: " + rollbackException.Message);
                     else if (!(rollbackException is RecursiveDefinitionException))
-                        Console.Error.WriteLine(rollbackException);
+                        Console.Error.WriteLine("X5: " + rollbackException);
                 }
                 throw;
             }

--- a/source/Calamari.Shared/Deployment/ConventionProcessor.cs
+++ b/source/Calamari.Shared/Deployment/ConventionProcessor.cs
@@ -31,11 +31,10 @@ namespace Calamari.Deployment
             }
             catch (Exception installException)
             {
-                Debugger.Break();
                 if (installException is CommandException || installException is RecursiveDefinitionException)
-                    Console.Error.WriteLine("X1: " + installException.Message);
+                    Console.Error.WriteLine(installException.Message);
                 else
-                    Console.Error.WriteLine("X2: " + installException);
+                    Console.Error.WriteLine(installException);
 
                 Console.Error.WriteLine("Running rollback conventions...");
 
@@ -52,12 +51,12 @@ namespace Calamari.Deployment
                 catch (Exception rollbackException)
                 {
                     if (rollbackException is CommandException)
-                        Console.Error.WriteLine("X3: " + rollbackException.Message);
+                        Console.Error.WriteLine(rollbackException.Message);
                     else if (rollbackException is RecursiveDefinitionException && rollbackException.Message != installException.Message)
-                        //dont duplicate error messages
-                        Console.Error.WriteLine("X4: " + rollbackException.Message);
+                        //dont duplicate these error messages
+                        Console.Error.WriteLine(rollbackException.Message);
                     else if (!(rollbackException is RecursiveDefinitionException))
-                        Console.Error.WriteLine("X5: " + rollbackException);
+                        Console.Error.WriteLine(rollbackException);
                 }
                 throw;
             }

--- a/source/Calamari.Shared/Deployment/ConventionProcessor.cs
+++ b/source/Calamari.Shared/Deployment/ConventionProcessor.cs
@@ -38,19 +38,31 @@ namespace Calamari.Deployment
                 {
                     Console.Error.WriteLine(ex);
                 }
+
                 Console.Error.WriteLine("Running rollback conventions...");
 
                 deployment.Error(ex);
 
-                // Rollback conventions include tasks like DeployFailed.ps1
-                RunRollbackConventions();
+                try
+                {
 
-                // Run cleanup for rollback conventions, for example: delete DeployFailed.ps1 script
-                RunRollbackCleanup();
+                    // Rollback conventions include tasks like DeployFailed.ps1
+                    RunRollbackConventions();
 
+                    // Run cleanup for rollback conventions, for example: delete DeployFailed.ps1 script
+                    RunRollbackCleanup();
+                }
+                catch (Exception ex2)
+                {
+                    if (ex2 is CommandException || ex2 is RecursiveDefinitionException)
+                        Console.Error.WriteLine(ex2.Message);
+                    else
+                        Console.Error.WriteLine(ex2);
+                }
                 throw;
             }
         }
+        
 
         void RunInstallConventions()
         {

--- a/source/Calamari.Shared/Deployment/ConventionProcessor.cs
+++ b/source/Calamari.Shared/Deployment/ConventionProcessor.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Calamari.Commands.Support;
 using Calamari.Deployment.Conventions;
 using Octostache.Templates;
-using Org.BouncyCastle.Bcpg;
 
 namespace Calamari.Deployment
 {
@@ -31,6 +31,7 @@ namespace Calamari.Deployment
             }
             catch (Exception installException)
             {
+                Debugger.Break();
                 if (installException is CommandException || installException is RecursiveDefinitionException)
                     Console.Error.WriteLine(installException.Message);
                 else
@@ -53,8 +54,9 @@ namespace Calamari.Deployment
                     if (rollbackException is CommandException)
                         Console.Error.WriteLine(rollbackException.Message);
                     else if (rollbackException is RecursiveDefinitionException && rollbackException.Message != installException.Message)
+                        //dont duplicate error messages
                         Console.Error.WriteLine(rollbackException.Message);
-                    else if (!(rollbackException is RecursiveDefinitionException)) //dont duplicate error messages
+                    else if (!(rollbackException is RecursiveDefinitionException))
                         Console.Error.WriteLine(rollbackException);
                 }
                 throw;

--- a/source/Calamari.Shared/Deployment/ConventionProcessor.cs
+++ b/source/Calamari.Shared/Deployment/ConventionProcessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Calamari.Commands.Support;
 using Calamari.Deployment.Conventions;
+using Octostache.Templates;
 
 namespace Calamari.Deployment
 {
@@ -29,7 +30,7 @@ namespace Calamari.Deployment
             }
             catch (Exception ex)
             {
-                if (ex is CommandException)
+                if (ex is CommandException || ex is RecursiveDefinitionException)
                 {
                     Console.Error.WriteLine(ex.Message);
                 }


### PR DESCRIPTION
## Why

The current error message shown when a recursive variable is encountered is big, ugly and scary. It leads you to think that something really bad has gone wrong in Octopus:

![image](https://user-images.githubusercontent.com/373389/59985929-9b29e700-9677-11e9-836d-62b8b683e845.png)

## Result

Lets make the exception message nice and clear, and drop that stack trace.

## Screenshot

![image](https://user-images.githubusercontent.com/373389/59986039-34f19400-9678-11e9-90a9-cba49f8bc5fe.png)

Relies on https://github.com/OctopusDeploy/Octostache/pull/34