### PR TITLE
Added `Octopus.Action.IISWebSite.ExistingBindings` option

### DIFF
--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -245,6 +245,7 @@ namespace Calamari.Deployment
                 public static readonly string ApplicationPoolName = "Octopus.Action.IISWebSite.ApplicationPoolName";
                 public static readonly string ApplicationPoolUserName = "Octopus.Action.IISWebSite.ApplicationPoolUsername";
                 public static readonly string Bindings = "Octopus.Action.IISWebSite.Bindings";
+                public static readonly string ExistingBindings = "Octopus.Action.IISWebSite.ExistingBindings";
                 public static readonly string ApplicationPoolIdentityType = "Octopus.Action.IISWebSite.ApplicationPoolIdentityType";
 
                 public static class Output

--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -394,6 +394,7 @@ if ($deployAsWebSite)
 	$webSiteName = $OctopusParameters["Octopus.Action.IISWebSite.WebSiteName"]
 	$applicationPoolName = $OctopusParameters["Octopus.Action.IISWebSite.ApplicationPoolName"]
 	$bindingString = $OctopusParameters["Octopus.Action.IISWebSite.Bindings"]
+	$existingBindings = $OctopusParameters["Octopus.Action.IISWebSite.ExistingBindings"]
 	$webRoot =  Determine-Path $OctopusParameters["Octopus.Action.IISWebSite.WebRoot"]
 	$enableWindows = $OctopusParameters["Octopus.Action.IISWebSite.EnableWindowsAuthentication"]
 	$enableBasic = $OctopusParameters["Octopus.Action.IISWebSite.EnableBasicAuthentication"]
@@ -609,6 +610,13 @@ if ($deployAsWebSite)
 	function Get-BindingKey($binding) {
 		return $binding.protocol + "|" + $binding.bindingInformation + "|" + $binding.sslFlags
 	}
+
+    if($existingBindings -eq "Merge") {
+        # Merge existing bindings into the configured collection. This allows the following code to be the same regardless of this options
+        $configuredBindingsLookup = Convert-ToHashTable $wsbindings
+        $existingBindings = Get-ItemProperty $sitePath -name bindings
+        $bindingsToMerge = $existingBindings.Collection | where { $configuredBindingsLookup[(Get-BindingKey $_)] -eq $null } | ForEach-Object { $wsbindings.Add($_) }
+    }
 
 	# Returns $true if existing IIS bindings are as specified in configuration, otherwise $false
 	function Bindings-AreCorrect($existingBindings, $configuredBindings, [System.Collections.ArrayList] $bindingsToRemove) {


### PR DESCRIPTION
Related to https://github.com/OctopusDeploy/Issues/issues/5474

This adds the existing bindings into the configured binding collection so that the end result is the existing bindings are preserved. This is a lot easier than re-writing the following code to not clear the bindings when the option is on.