### PR TITLE
Enclose condition in bracket to evaluate correctly

### DIFF
--- a/source/Calamari.Azure/Scripts/DeployAzureServiceFabricApplication.ps1
+++ b/source/Calamari.Azure/Scripts/DeployAzureServiceFabricApplication.ps1
@@ -123,7 +123,7 @@ $AppTypeAndNameExists = $null -ne (Get-ServiceFabricApplication | ? { $_.Applica
 $AppTypeAndNameAndVersionExists = $null -ne (Get-ServiceFabricApplication | ? { $_.ApplicationTypeName -eq $AppTypeName -and $_.ApplicationName -eq $AppName -and $_.ApplicationTypeVersion -eq $AppTypeVersion})
 $AppTypeAndVersionExists = $null -ne (Get-ServiceFabricApplicationType -ApplicationTypeName $AppTypeName | Where-Object { $_.ApplicationTypeVersion -eq $AppTypeVersion })
 $UpgradeEnabledInProfile = $publishProfile.UpgradeDeployment -and $publishProfile.UpgradeDeployment.Enabled
-$UpgradeEnabled = $UpgradeEnabledInProfile -and -not $OverrideUpgradeBehavior -eq 'VetoUpgrade'
+$UpgradeEnabled = $UpgradeEnabledInProfile -and -not ($OverrideUpgradeBehavior -eq 'VetoUpgrade')
 $ForceUpgrade = $OverrideUpgradeBehavior -eq 'ForceUpgrade'
 $requiresRegister = $false
 


### PR DESCRIPTION
Relates to OctopusDeploy/Issues#5657

This was intended to evaluate to `true` but evaluated to `false`:
```
$UpgradeEnabledInProfile = $true
$OverrideUpgradeBehavior = ‘None’
$UpgradeEnabledInProfile -and -not $OverrideUpgradeBehavior -eq ‘VetoUpgrade’
```