### PR TITLE
Flag mac/nix test as inconclusive when run on windows

### DIFF
--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -61,6 +61,9 @@ namespace Calamari.Tests.Fixtures.Deployment
         [Category(TestCategory.CompatibleOS.Mac)]
         public void ShouldDeployPackageOnMacOrNix()
         {
+            if (!CalamariEnvironment.IsRunningOnMac && !CalamariEnvironment.IsRunningOnNix)
+                Assert.Inconclusive("This test is designed to run on *Nix or Mac.");
+        
             var result = DeployPackage();
             result.AssertSuccess();
 


### PR DESCRIPTION
I ran all the tests from my windows box, and this one failed (It's excluded on the build server by category).

This PR marks the test as inconclusive when its executed on windows.