### PR TITLE
Upgraded YamlDotNet to fix license URL issue

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -45,7 +45,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="YamlDotNet" Version="4.2.1" />
+    <PackageReference Include="YamlDotNet" Version="6.1.2" />
     <ProjectReference Include="..\Calamari.Shared\Calamari.Shared.csproj" />
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
@@ -91,7 +91,7 @@
     Unfortunately, RunResolvePackageDependencies doesn't exist for the full fat framework, so we 
     define a new empty target if it's not already defined to keep it happy.
   -->
-  <Target Name="RunResolvePackageDependencies" Condition="'$(RunResolvePackageDependencies)' != ''"/>
+  <Target Name="RunResolvePackageDependencies" Condition="'$(RunResolvePackageDependencies)' != ''" />
   <Target Name="GetToolFiles" DependsOnTargets="RunResolvePackageDependencies">
     <CreateItem Include="@(PackageDefinitions)" Condition="'%(Name)' == 'FSharp.Compiler.Tools'">
       <Output TaskParameter="Include" ItemName="FSharpCompilerToolsRef" />


### PR DESCRIPTION
# Background

The versions of `YamlDotNet` we were using had an invalid license URL which broke our tests and our license attribution for external libraries. The author has since updated their packaging and fixed the problem. This PR updates the references in Octopus Server and Calamari.

See this conversation for more context: https://octopusdeploy.slack.com/archives/C9TUPEJ8K/p1563409987155800

Relates to https://github.com/OctopusDeploy/OctopusDeploy/pull/4105

# How to review this PR

@matt-richardson FYI
@mcasperson I couldn't see anything which would break, but this is a major version update of the library. Perhaps something will jump out at you? Otherwise, I'm relying on 💚 tests.