### PR TITLE
Support more AWS S3 headers like Content-Type

### DIFF
--- a/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
@@ -20,10 +20,13 @@ namespace Calamari.Aws.Integration.S3
                 .WithHeaderFrom("Cache-Control", headers => headers.CacheControl)
                 .WithHeaderFrom("Content-Disposition", headers => headers.ContentDisposition)
                 .WithHeaderFrom("Content-Encoding", headers => headers.ContentEncoding)
+                .WithHeaderFrom("Content-Type", headers => headers.ContentType)
                 .WithHeaderFrom("Expires")
-                .WithHeaderFrom("x-amz-website​-redirect-location")
+                .WithHeaderFrom("x-amz-website-redirect-location")
+                .WithHeaderFrom("x-amz-object-lock-retain-until-date")
+                .WithHeaderFrom("x-amz-object-lock-legal-hold")
                 .WithHeaderFrom("x-amz-object-lock-mode");
-
+        
         private static T WithHeaderFrom<T>(this T values, string key) where T : IDictionary<string, Func<HeadersCollection, string>>
         {
             values.Add(key, (headers) => headers[key]);

--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -213,7 +213,6 @@ namespace Calamari.Tests.AWS
                 }
             });
 
-
             var variablesFile = Path.GetTempFileName();
             var variables = new VariableDictionary();
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");


### PR DESCRIPTION
Added support for these headers:
- `Content-Type`
- `x-amz-object-lock-retain-until-date`
- `x-amz-object-lock-legal-hold`

Fixed spelling of 
- `x-amz-website​-redirect-location`


Fixes: https://github.com/OctopusDeploy/Issues/issues/5709