### PR TITLE
Log Terraform version when executing terraform steps

### DIFF
--- a/source/Calamari.Terraform/TerraformCliExecutor.cs
+++ b/source/Calamari.Terraform/TerraformCliExecutor.cs
@@ -56,6 +56,8 @@ namespace Calamari.Terraform
 
             InitializeTerraformEnvironmentVariables();
 
+            LogVersion();
+
             InitializePlugins();
 
             InitializeWorkspace();
@@ -133,6 +135,12 @@ namespace Calamari.Terraform
         {
             ExecuteCommandInternal(
                 $"init -no-color -get-plugins={AllowPluginDownloads.ToString().ToLower()} {InitParams}", out _).VerifySuccess();
+        }
+        
+        void LogVersion()
+        {
+            ExecuteCommandInternal($"--version", out _)
+                .VerifySuccess();
         }
 
         void InitializeWorkspace()


### PR DESCRIPTION
To help customers who are finding differences between terraform 0.11 and 0.12 (where they changed the HCL format)

![image](https://user-images.githubusercontent.com/373389/62751579-94302a00-baa7-11e9-8a88-a087f58cef69.png)

## links
in theory, this would've helped with these tickets: [one](https://help.octopus.com/t/using-terraform-step-template/23660), [two](https://help.octopus.com/t/terraform-apply-step-pem-variable-set-to-unix-lf-ucs-2-le-bom/23659)