### PR TITLE
Adds retry logic for package extraction

### DIFF
--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -56,6 +56,7 @@
     <PackageReference Include="System.IO.Packaging" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
+    <PackageReference Include="Polly" Version="5.4.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="BouncyCastle" Version="1.8.1-octopus" />
@@ -89,6 +90,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="Autofac" Version="4.8.0" />
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
+    <PackageReference Include="Polly" Version="5.4.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Integration\Packages\Download\Scripts\*.*" />

--- a/source/Calamari.Shared/Integration/Packages/ZipPackageExtractor.cs
+++ b/source/Calamari.Shared/Integration/Packages/ZipPackageExtractor.cs
@@ -38,14 +38,14 @@ namespace Calamari.Integration.Packages
             Policy.Handle<IOException>().WaitAndRetry(
                     retryCount: extractAttempts,
                     sleepDurationProvider: i => TimeSpan.FromMilliseconds(50),
-                    onRetry: (ex, i) => { Log.Verbose($"Attempt {i} of {extractAttempts}: {ex.Message}"); })
+                    onRetry: (ex, retry) => { Log.Verbose($"Failed to extract: {ex.Message}. Retry in {retry.Milliseconds} milliseconds."); })
                 .Execute(() =>
                 {
                     entry.WriteToDirectory(directory, new ExtractionOptions {ExtractFullPath = true, Overwrite = true, PreserveFileTime = true});
                 });
 #endif
         }
-
+        
         protected void ProcessEvent(ref int filesExtracted, IEntry entry, bool suppressNestedScriptWarning)
         {
             if (entry.IsDirectory) return;


### PR DESCRIPTION
Prevents unnecessary failures when some files are locked by A/V programs.

Fixes: https://github.com/OctopusDeploy/Issues/issues/5726

## Before

Before this change it is possible that antivirus programs might lock files at inconvenient times that involve package extraction.

## After

This change will give a little bit of time (~500ms) for A/V to do its thing. Uses Polly.NET

# How to review this PR

Try it out, make sure nothing weird happens when using packages against the server (run a script step for e.g.)