### PR TITLE
Allow for multiple sensitive variable files

### DIFF
--- a/source/Calamari.Aws/Commands/ApplyCloudFormationChangesetCommand.cs
+++ b/source/Calamari.Aws/Commands/ApplyCloudFormationChangesetCommand.cs
@@ -19,7 +19,7 @@ namespace Calamari.Aws.Commands
     {
         private string packageFile;
         private string variablesFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
         private bool waitForComplete;
         
@@ -28,7 +28,7 @@ namespace Calamari.Aws.Commands
             Options.Add("variables=", "Path to a JSON file containing variables.",
                 v => variablesFile = Path.GetFullPath(v));
             Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.",
-                v => sensitiveVariablesFile = v);
+                v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.",
                 v => sensitiveVariablesPassword = v);
             Options.Add("package=", "Path to the NuGet package to install.", v => packageFile = Path.GetFullPath(v));
@@ -43,7 +43,7 @@ namespace Calamari.Aws.Commands
             if (variablesFile != null && !File.Exists(variablesFile))
                 throw new CommandException("Could not find variables file: " + variablesFile);
             
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
             var environment = AwsEnvironmentGeneration.Create(variables).GetAwaiter().GetResult();
             var stackEventLogger = new StackEventLogger(new LogWrapper());
 

--- a/source/Calamari.Aws/Commands/DeleteCloudFormationCommand.cs
+++ b/source/Calamari.Aws/Commands/DeleteCloudFormationCommand.cs
@@ -20,7 +20,7 @@ namespace Calamari.Aws.Commands
     {
         private string packageFile;
         private string variablesFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
         private bool waitForComplete;
         
@@ -29,7 +29,7 @@ namespace Calamari.Aws.Commands
             Options.Add("variables=", "Path to a JSON file containing variables.",
                 v => variablesFile = Path.GetFullPath(v));
             Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.",
-                v => sensitiveVariablesFile = v);
+                v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.",
                 v => sensitiveVariablesPassword = v);
             Options.Add("package=", "Path to the NuGet package to install.", v => packageFile = Path.GetFullPath(v));
@@ -44,7 +44,7 @@ namespace Calamari.Aws.Commands
             if (variablesFile != null && !File.Exists(variablesFile))
                 throw new CommandException("Could not find variables file: " + variablesFile);
             
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
             var environment = AwsEnvironmentGeneration.Create(variables).GetAwaiter().GetResult();;
             var stackEventLogger = new StackEventLogger(new LogWrapper());
          

--- a/source/Calamari.Aws/Commands/DeployAwsCloudFormationCommand.cs
+++ b/source/Calamari.Aws/Commands/DeployAwsCloudFormationCommand.cs
@@ -27,7 +27,7 @@ namespace Calamari.Aws.Commands
     {
         private string packageFile;
         private string variablesFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
         private string templateFile;
         private string templateParameterFile;
@@ -40,7 +40,7 @@ namespace Calamari.Aws.Commands
             Options.Add("variables=", "Path to a JSON file containing variables.",
                 v => variablesFile = Path.GetFullPath(v));
             Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.",
-                v => sensitiveVariablesFile = v);
+                v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.",
                 v => sensitiveVariablesPassword = v);
             Options.Add("package=", "Path to the NuGet package to install.", v => packageFile = Path.GetFullPath(v));
@@ -59,7 +59,7 @@ namespace Calamari.Aws.Commands
             if (variablesFile != null && !File.Exists(variablesFile))
                 throw new CommandException("Could not find variables file: " + variablesFile);
             
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile,
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles,
                 sensitiveVariablesPassword);
 
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();

--- a/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
+++ b/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
@@ -19,7 +19,7 @@ namespace Calamari.Aws.Commands
     public class UploadAwsS3Command : Command
     {
         private string variablesFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
         private string packageFile;
         private string bucket;
@@ -29,7 +29,7 @@ namespace Calamari.Aws.Commands
         {
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
             Options.Add("package=", "Path to the package to extract that contains the package.", v => packageFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
             Options.Add("bucket=", "The bucket to use", v => bucket = v);
             Options.Add("targetMode=", "Whether the entire package or files within the package should be uploaded to the s3 bucket", v => targetMode = v);
@@ -40,7 +40,7 @@ namespace Calamari.Aws.Commands
             Options.Parse(commandLineArguments);
 
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
 
             if (string.IsNullOrEmpty(packageFile))
             {

--- a/source/Calamari.Azure/Commands/DeployAzureCloudServiceCommand.cs
+++ b/source/Calamari.Azure/Commands/DeployAzureCloudServiceCommand.cs
@@ -25,7 +25,7 @@ namespace Calamari.Azure.Commands
     {
         private string variablesFile;
         private string packageFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
         private readonly CombinedScriptEngine scriptEngine;
 
@@ -33,7 +33,7 @@ namespace Calamari.Azure.Commands
         {
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
             Options.Add("package=", "Path to the NuGet package to install.", v => packageFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
 
             this.scriptEngine = scriptEngine;
@@ -52,7 +52,7 @@ namespace Calamari.Azure.Commands
                 throw new CommandException("Could not find variables file: " + variablesFile);
 
             Log.Info("Deploying package:    " + packageFile);
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
 
             var account = (AzureAccount)AccountFactory.Create(variables);
             

--- a/source/Calamari.Azure/Commands/DeployAzureResourceGroupCommand.cs
+++ b/source/Calamari.Azure/Commands/DeployAzureResourceGroupCommand.cs
@@ -23,7 +23,7 @@ namespace Calamari.Azure.Commands
         private readonly CombinedScriptEngine scriptEngine;
         private string variablesFile;
         private string packageFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
         private string templateFile;
         private string templateParameterFile;
@@ -33,7 +33,7 @@ namespace Calamari.Azure.Commands
             this.scriptEngine = scriptEngine;
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
             Options.Add("package=", "Path to the deployment package to install.", v => packageFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
             Options.Add("template=", "Path to the JSON template file.", v => templateFile = v);
             Options.Add("templateParameters=", "Path to the JSON template parameters file.", v => templateParameterFile = v);
@@ -46,7 +46,7 @@ namespace Calamari.Azure.Commands
             if (variablesFile != null && !File.Exists(variablesFile))
                 throw new CommandException("Could not find variables file: " + variablesFile);
 
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
             variables.Set(SpecialVariables.OriginalPackageDirectoryPath, Environment.CurrentDirectory);
             var commandLineRunner = new CommandLineRunner(new SplitCommandOutput(new ConsoleCommandOutput(), new ServiceMessageCommandOutput(variables)));
             var fileSystem = new WindowsPhysicalFileSystem();

--- a/source/Calamari.Azure/Commands/DeployAzureServiceFabricAppCommand.cs
+++ b/source/Calamari.Azure/Commands/DeployAzureServiceFabricAppCommand.cs
@@ -24,7 +24,7 @@ namespace Calamari.Azure.Commands
     {
         private string variablesFile;
         private string packageFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
         private readonly CombinedScriptEngine scriptEngine;
         private readonly ICertificateStore certificateStore;
@@ -33,7 +33,7 @@ namespace Calamari.Azure.Commands
         {
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
             Options.Add("package=", "Path to the NuGet package to install.", v => packageFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
 
             this.scriptEngine = scriptEngine;
@@ -57,7 +57,7 @@ namespace Calamari.Azure.Commands
                 throw new CommandException("Could not find variables file: " + variablesFile);
 
             Log.Info("Deploying package:    " + packageFile);
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
 
             var fileSystem = new WindowsPhysicalFileSystem();
             var embeddedResources = new AssemblyEmbeddedResources();

--- a/source/Calamari.Azure/Commands/DeployAzureWebCommand.cs
+++ b/source/Calamari.Azure/Commands/DeployAzureWebCommand.cs
@@ -21,7 +21,7 @@ namespace Calamari.Azure.Commands
     {
         private string variablesFile;
         private string packageFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
         private readonly CombinedScriptEngine scriptEngine;
 
@@ -29,7 +29,7 @@ namespace Calamari.Azure.Commands
         {
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
             Options.Add("package=", "Path to the deployment package to install.", v => packageFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
 
             this.scriptEngine = scriptEngine;
@@ -49,7 +49,7 @@ namespace Calamari.Azure.Commands
                 throw new CommandException("Could not find variables file: " + variablesFile);
 
             Log.Info("Deploying package:    " + packageFile);
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
 
             var fileSystem = new WindowsPhysicalFileSystem();
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));

--- a/source/Calamari.Shared/Integration/Processes/CalamariVariableDictionary.cs
+++ b/source/Calamari.Shared/Integration/Processes/CalamariVariableDictionary.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Calamari.Commands.Support;
@@ -18,7 +19,9 @@ namespace Calamari.Integration.Processes
 
         public CalamariVariableDictionary(string storageFilePath) : base(storageFilePath) { }
 
-        public CalamariVariableDictionary(string storageFilePath, string sensitiveFilePath, string sensitiveFilePassword, string outputVariablesFilePath = null, string outputVariablesFilePassword = null)
+        public CalamariVariableDictionary(string storageFilePath, string sensitiveFilePath, string sensitiveFilePassword, string outputVariablesFilePath = null, string outputVariablesFilePassword = null) : this(storageFilePath, new List<string>(){ sensitiveFilePath }, sensitiveFilePassword, outputVariablesFilePath, outputVariablesFilePassword) { }
+
+        public CalamariVariableDictionary(string storageFilePath, List<string> sensitiveFilePaths, string sensitiveFilePassword, string outputVariablesFilePath = null, string outputVariablesFilePassword = null)
         {
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
@@ -31,23 +34,28 @@ namespace Calamari.Integration.Processes
                 nonSensitiveVariables.GetNames().ForEach(name => Set(name, nonSensitiveVariables.GetRaw(name)));
             }
 
-            if (!string.IsNullOrEmpty(sensitiveFilePath))
+            if (sensitiveFilePaths.Any())
             {
-                var rawVariables = string.IsNullOrWhiteSpace(sensitiveFilePassword)
-                    ? fileSystem.ReadFile(sensitiveFilePath)
-                    : Decrypt(fileSystem.ReadAllBytes(sensitiveFilePath), sensitiveFilePassword);
+                foreach (var sensitiveFilePath in sensitiveFilePaths)
+                {
+                    if (string.IsNullOrEmpty(sensitiveFilePath)) continue;
 
-                try
-                {
-                    var sensitiveVariables = JsonConvert.DeserializeObject<Dictionary<string, string>>(rawVariables);
-                    foreach (var variable in sensitiveVariables)
+                    var rawVariables = string.IsNullOrWhiteSpace(sensitiveFilePassword)
+                        ? fileSystem.ReadFile(sensitiveFilePath)
+                        : Decrypt(fileSystem.ReadAllBytes(sensitiveFilePath), sensitiveFilePassword);
+
+                    try
                     {
-                        SetSensitive(variable.Key, variable.Value);
+                        var sensitiveVariables = JsonConvert.DeserializeObject<Dictionary<string, string>>(rawVariables);
+                        foreach (var variable in sensitiveVariables)
+                        {
+                            SetSensitive(variable.Key, variable.Value);
+                        }
                     }
-                }
-                catch (JsonReaderException)
-                {
-                    throw new CommandException("Unable to parse sensitive-variables as valid JSON.");
+                    catch (JsonReaderException)
+                    {
+                        throw new CommandException("Unable to parse sensitive-variables as valid JSON.");
+                    }
                 }
             }
 

--- a/source/Calamari.Shared/Integration/Processes/CalamariVariableDictionary.cs
+++ b/source/Calamari.Shared/Integration/Processes/CalamariVariableDictionary.cs
@@ -19,8 +19,6 @@ namespace Calamari.Integration.Processes
 
         public CalamariVariableDictionary(string storageFilePath) : base(storageFilePath) { }
 
-        public CalamariVariableDictionary(string storageFilePath, string sensitiveFilePath, string sensitiveFilePassword, string outputVariablesFilePath = null, string outputVariablesFilePassword = null) : this(storageFilePath, new List<string>(){ sensitiveFilePath }, sensitiveFilePassword, outputVariablesFilePath, outputVariablesFilePassword) { }
-
         public CalamariVariableDictionary(string storageFilePath, List<string> sensitiveFilePaths, string sensitiveFilePassword, string outputVariablesFilePath = null, string outputVariablesFilePassword = null)
         {
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();

--- a/source/Calamari.Shared/Integration/Processes/CalamariVariableDictionary.cs
+++ b/source/Calamari.Shared/Integration/Processes/CalamariVariableDictionary.cs
@@ -19,7 +19,7 @@ namespace Calamari.Integration.Processes
 
         public CalamariVariableDictionary(string storageFilePath) : base(storageFilePath) { }
 
-        public CalamariVariableDictionary(string storageFilePath, List<string> sensitiveFilePaths, string sensitiveFilePassword, string outputVariablesFilePath = null, string outputVariablesFilePassword = null)
+        public CalamariVariableDictionary(string storageFilePath, IEnumerable<string> sensitiveFilePaths, string sensitiveFilePassword, string outputVariablesFilePath = null, string outputVariablesFilePassword = null)
         {
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 

--- a/source/Calamari.Shared/Integration/Processes/CalamariVariableDictionary.cs
+++ b/source/Calamari.Shared/Integration/Processes/CalamariVariableDictionary.cs
@@ -19,7 +19,7 @@ namespace Calamari.Integration.Processes
 
         public CalamariVariableDictionary(string storageFilePath) : base(storageFilePath) { }
 
-        public CalamariVariableDictionary(string storageFilePath, IEnumerable<string> sensitiveFilePaths, string sensitiveFilePassword, string outputVariablesFilePath = null, string outputVariablesFilePassword = null)
+        public CalamariVariableDictionary(string storageFilePath, List<string> sensitiveFilePaths, string sensitiveFilePassword, string outputVariablesFilePath = null, string outputVariablesFilePassword = null)
         {
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 

--- a/source/Calamari.Shared/Modules/CommonModule.cs
+++ b/source/Calamari.Shared/Modules/CommonModule.cs
@@ -20,7 +20,7 @@ namespace Calamari.Modules
         private string variablesFile;
         private string outputVariablesFile;
         private string outputVariablesPassword;
-        private List<string> sensitiveVariablesFiles = new List<string>();
+        private List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
 
         public CommonModule(string[] args)
@@ -30,7 +30,7 @@ namespace Calamari.Modules
                 v => variablesFile = Path.GetFullPath(v),
                 v => outputVariablesFile = v,
                 v => outputVariablesPassword = v,
-                v => sensitiveVariablesFiles.Add(v),
+                v => sensitiveVariableFiles.Add(v),
                 v => sensitiveVariablesPassword = v);
             optionSet.Parse(args);
         }
@@ -39,7 +39,7 @@ namespace Calamari.Modules
         {
             return !string.IsNullOrWhiteSpace(variablesFile) ||
                 !string.IsNullOrWhiteSpace(outputVariablesFile) ||
-                sensitiveVariablesFiles.Any(sensitiveVariablesFile => !string.IsNullOrWhiteSpace(sensitiveVariablesFile)) ||
+                sensitiveVariableFiles.Any(sensitiveVariablesFile => !string.IsNullOrWhiteSpace(sensitiveVariablesFile)) ||
                 !string.IsNullOrWhiteSpace(sensitiveVariablesPassword);
         }
 
@@ -50,7 +50,7 @@ namespace Calamari.Modules
             {
                 builder.RegisterInstance(new CalamariVariableDictionary(
                     variablesFile,
-                    sensitiveVariablesFiles,
+                    sensitiveVariableFiles,
                     sensitiveVariablesPassword,
                     outputVariablesFile,
                     outputVariablesPassword))

--- a/source/Calamari.Shared/Modules/CommonModule.cs
+++ b/source/Calamari.Shared/Modules/CommonModule.cs
@@ -1,7 +1,9 @@
-﻿using Autofac;
+﻿using System.Collections.Generic;
+using Autofac;
 using Calamari.Commands.Support;
 using Calamari.Integration.Processes;
 using System.IO;
+using System.Linq;
 using Calamari.Integration.Certificates;
 using Octostache;
 using Module = Autofac.Module;
@@ -18,7 +20,7 @@ namespace Calamari.Modules
         private string variablesFile;
         private string outputVariablesFile;
         private string outputVariablesPassword;
-        private string sensitiveVariablesFile;
+        private List<string> sensitiveVariablesFiles = new List<string>();
         private string sensitiveVariablesPassword;
 
         public CommonModule(string[] args)
@@ -28,7 +30,7 @@ namespace Calamari.Modules
                 v => variablesFile = Path.GetFullPath(v),
                 v => outputVariablesFile = v,
                 v => outputVariablesPassword = v,
-                v => sensitiveVariablesFile = v,
+                v => sensitiveVariablesFiles.Add(v),
                 v => sensitiveVariablesPassword = v);
             optionSet.Parse(args);
         }
@@ -37,7 +39,7 @@ namespace Calamari.Modules
         {
             return !string.IsNullOrWhiteSpace(variablesFile) ||
                 !string.IsNullOrWhiteSpace(outputVariablesFile) ||
-                !string.IsNullOrWhiteSpace(sensitiveVariablesFile) ||
+                sensitiveVariablesFiles.Any(sensitiveVariablesFile => !string.IsNullOrWhiteSpace(sensitiveVariablesFile)) ||
                 !string.IsNullOrWhiteSpace(sensitiveVariablesPassword);
         }
 
@@ -48,7 +50,7 @@ namespace Calamari.Modules
             {
                 builder.RegisterInstance(new CalamariVariableDictionary(
                     variablesFile,
-                    sensitiveVariablesFile,
+                    sensitiveVariablesFiles,
                     sensitiveVariablesPassword,
                     outputVariablesFile,
                     outputVariablesPassword))

--- a/source/Calamari.Terraform/TerraformCommand.cs
+++ b/source/Calamari.Terraform/TerraformCommand.cs
@@ -17,7 +17,7 @@ namespace Calamari.Terraform
 
         private readonly Func<ICalamariFileSystem, IConvention> step;
         private string variablesFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
         private string packageFile;
 
@@ -27,7 +27,7 @@ namespace Calamari.Terraform
             this.step = step;
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
             Options.Add("package=", "Path to the package to extract that contains the package.", v => packageFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
         }
 
@@ -36,7 +36,7 @@ namespace Calamari.Terraform
             Options.Parse(commandLineArguments);
 
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
             
             if (!string.IsNullOrEmpty(packageFile))
             {

--- a/source/Calamari.Tests/Fixtures/Integration/Process/CalamariVariableDictionaryFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Process/CalamariVariableDictionaryFixture.cs
@@ -44,7 +44,7 @@ namespace Calamari.Tests.Fixtures.Integration.Process
         [Test]
         public void ShouldIncludeEncryptedSensitiveVariables()
         {
-            var result = new CalamariVariableDictionary(insensitiveVariablesFileName, sensitiveVariablesFileName, encryptionPassword);
+            var result = new CalamariVariableDictionary(insensitiveVariablesFileName, new List<string>() { sensitiveVariablesFileName }, encryptionPassword);
 
             Assert.AreEqual("sensitiveVariableValue", result.Get("sensitiveVariableName"));
             Assert.AreEqual("insensitiveVariableValue", result.Get("insensitiveVariableName"));
@@ -56,7 +56,7 @@ namespace Calamari.Tests.Fixtures.Integration.Process
             var sensitiveVariables = new Dictionary<string, string> { {"sensitiveVariableName", "sensitiveVariableValue"} };
             File.WriteAllText(sensitiveVariablesFileName, JsonConvert.SerializeObject(sensitiveVariables));
 
-            var result = new CalamariVariableDictionary(insensitiveVariablesFileName, sensitiveVariablesFileName, null);
+            var result = new CalamariVariableDictionary(insensitiveVariablesFileName, new List<string>() { sensitiveVariablesFileName }, null);
 
             Assert.AreEqual("sensitiveVariableValue", result.Get("sensitiveVariableName"));
             Assert.AreEqual("insensitiveVariableValue", result.Get("insensitiveVariableName"));
@@ -66,7 +66,7 @@ namespace Calamari.Tests.Fixtures.Integration.Process
         [ExpectedException(typeof(CommandException), ExpectedMessage = "Cannot decrypt sensitive-variables. Check your password is correct.")]
         public void ThrowsCommandExceptionIfUnableToDecrypt()
         {
-            new CalamariVariableDictionary(insensitiveVariablesFileName, sensitiveVariablesFileName, "FakePassword");
+            new CalamariVariableDictionary(insensitiveVariablesFileName, new List<string>() { sensitiveVariablesFileName }, "FakePassword");
         }
 
         [Test]
@@ -74,7 +74,7 @@ namespace Calamari.Tests.Fixtures.Integration.Process
         public void ThrowsCommandExceptionIfUnableToParseAsJson()
         {
             File.WriteAllText(sensitiveVariablesFileName, "I Am Not JSON");
-            new CalamariVariableDictionary(insensitiveVariablesFileName, sensitiveVariablesFileName, null);
+            new CalamariVariableDictionary(insensitiveVariablesFileName, new List<string>() { sensitiveVariablesFileName }, null);
         }
 
         private void CreateInSensitiveVariableFile()
@@ -96,7 +96,7 @@ namespace Calamari.Tests.Fixtures.Integration.Process
         [Test]
         public void ShouldCheckVariableIsSet()
         {
-            var variables = new CalamariVariableDictionary(insensitiveVariablesFileName, sensitiveVariablesFileName, encryptionPassword);
+            var variables = new CalamariVariableDictionary(insensitiveVariablesFileName, new List<string>(){ sensitiveVariablesFileName }, encryptionPassword);
 
             Assert.That(variables.IsSet("thisIsBogus"), Is.False);
             Assert.That(variables.IsSet("sensitiveVariableName"), Is.True);

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -27,7 +27,7 @@ namespace Calamari.Commands
     {
         private string variablesFile;
         private string packageFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
         private readonly CombinedScriptEngine scriptEngine;
 
@@ -35,7 +35,7 @@ namespace Calamari.Commands
         {
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
             Options.Add("package=", "Path to the deployment package to install.", v => packageFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
 
             this.scriptEngine = scriptEngine;
@@ -54,7 +54,7 @@ namespace Calamari.Commands
             
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
 
             fileSystem.FreeDiskSpaceOverrideInMegaBytes = variables.GetInt32(SpecialVariables.FreeDiskSpaceOverrideInMegaBytes);
             fileSystem.SkipFreeDiskSpaceCheck = variables.GetFlag(SpecialVariables.SkipFreeDiskSpaceCheck);

--- a/source/Calamari/Commands/ExtractPackageToStagingCommand.cs
+++ b/source/Calamari/Commands/ExtractPackageToStagingCommand.cs
@@ -14,7 +14,7 @@ namespace Calamari.Commands
     {
         string packageFile;
         string variablesFile;
-        string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         string sensitiveVariablesPassword;
 
         public ExtractToStagingCommand()
@@ -26,7 +26,7 @@ namespace Calamari.Commands
             Options.Add(
                 "sensitiveVariables=",
                 "Password protected JSON file containing sensitive-variables.",
-                v => sensitiveVariablesFile = v);
+                v => sensitiveVariableFiles.Add(v));
             Options.Add(
                 "sensitiveVariablesPassword=",
                 "Password used to decrypt sensitive-variables.",
@@ -46,7 +46,7 @@ namespace Calamari.Commands
 
             var variables = new CalamariVariableDictionary(
                 variablesFile,
-                sensitiveVariablesFile,
+                sensitiveVariableFiles,
                 sensitiveVariablesPassword);
 
             var fileSystem = new WindowsPhysicalFileSystem();

--- a/source/Calamari/Commands/HealthCheckCommand.cs
+++ b/source/Calamari/Commands/HealthCheckCommand.cs
@@ -14,7 +14,7 @@ namespace Calamari.Commands
     {
         private readonly IEnumerable<IDoesDeploymentTargetTypeHealthChecks> deploymentTargetTypeHealthCheckers;
         private string variablesFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
 
         public HealthCheckCommand(IEnumerable<IDoesDeploymentTargetTypeHealthChecks> deploymentTargetTypeHealthCheckers)
@@ -22,14 +22,14 @@ namespace Calamari.Commands
             this.deploymentTargetTypeHealthCheckers = deploymentTargetTypeHealthCheckers;
 
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
         }
 
         public override int Execute(string[] commandLineArguments)
         {
             Options.Parse(commandLineArguments);
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
 
             var deploymentTargetTypeName = variables.Get(SpecialVariables.Machine.DeploymentTargetType);
 

--- a/source/Calamari/Commands/ImportCertificateCommand.cs
+++ b/source/Calamari/Commands/ImportCertificateCommand.cs
@@ -17,13 +17,13 @@ namespace Calamari.Commands
     public class ImportCertificateCommand : Command
     {
         private string variablesFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
 
         public ImportCertificateCommand()
         {
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
         }
 
@@ -31,7 +31,7 @@ namespace Calamari.Commands
         {
             Options.Parse(commandLineArguments);
 
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
             variables.EnrichWithEnvironmentVariables();
             variables.LogVariables();
 

--- a/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
+++ b/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
@@ -25,7 +25,7 @@ namespace Calamari.Commands.Java
     {
         string variablesFile;
         string archiveFile;
-        string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         string sensitiveVariablesPassword;
         private readonly CombinedScriptEngine scriptEngine;
 
@@ -33,7 +33,7 @@ namespace Calamari.Commands.Java
         {
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
             Options.Add("archive=", "Path to the Java archive to deploy.", v => archiveFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
 
             this.scriptEngine = scriptEngine;
@@ -53,7 +53,7 @@ namespace Calamari.Commands.Java
             
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
             var semaphore = SemaphoreFactory.Get();
             var journal = new DeploymentJournal(fileSystem, semaphore, variables);
             var substituter = new FileSubstituter(fileSystem);

--- a/source/Calamari/Commands/Java/JavaLibraryCommand.cs
+++ b/source/Calamari/Commands/Java/JavaLibraryCommand.cs
@@ -17,7 +17,7 @@ namespace Calamari.Commands.Java
     public class JavaLibraryCommand : Command
     {
         string variablesFile;
-        string sensitiveVariablesFile;
+        readonly List<string> sensitiveVariableFiles = new List<string>();
         string sensitiveVariablesPassword;
         string actionType;
         readonly CombinedScriptEngine scriptEngine;
@@ -27,7 +27,7 @@ namespace Calamari.Commands.Java
             Options.Add("variables=", "Path to a JSON file containing variables.",
                 v => variablesFile = Path.GetFullPath(v));
             Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.",
-                v => sensitiveVariablesFile = v);
+                v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.",
                 v => sensitiveVariablesPassword = v);
             Options.Add("actionType=", "The step type being invoked.", v => actionType = v);
@@ -41,7 +41,7 @@ namespace Calamari.Commands.Java
             
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
             var variables =
-                new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+                new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
 
             var commandOutput =
                 new SplitCommandOutput(new ConsoleCommandOutput(), new ServiceMessageCommandOutput(variables));

--- a/source/Calamari/Commands/TransferPackageCommand.cs
+++ b/source/Calamari/Commands/TransferPackageCommand.cs
@@ -16,14 +16,14 @@ namespace Calamari.Commands
     {
         private readonly IDeploymentJournalWriter deploymentJournalWriter;
         private string variablesFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
 
         public TransferPackageCommand(IDeploymentJournalWriter deploymentJournalWriter)
         {
             this.deploymentJournalWriter = deploymentJournalWriter;
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
         }
 
@@ -33,7 +33,7 @@ namespace Calamari.Commands
 
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
             var packageFile = variables.GetEnvironmentExpandedPath(SpecialVariables.Tentacle.CurrentDeployment.PackageFilePath);
             if(string.IsNullOrEmpty(packageFile))
             {

--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -27,7 +27,7 @@ namespace Calamari.Kubernetes.Commands
     {
         private string variablesFile;
         private string packageFile;
-        private string sensitiveVariablesFile;
+        private readonly List<string> sensitiveVariableFiles = new List<string>();
         private string sensitiveVariablesPassword;
         private readonly CombinedScriptEngine scriptEngine;
         private readonly IDeploymentJournalWriter deploymentJournalWriter;
@@ -37,7 +37,7 @@ namespace Calamari.Kubernetes.Commands
         {
             Options.Add("package=", "Path to the NuGet package to install.", v => packageFile = Path.GetFullPath(v));
             Options.Add("variables=", "Path to a JSON file containing variables.", v => variablesFile = Path.GetFullPath(v));
-            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariablesFile = v);
+            Options.Add("sensitiveVariables=", "Password protected JSON file containing sensitive-variables.", v => sensitiveVariableFiles.Add(v));
             Options.Add("sensitiveVariablesPassword=", "Password used to decrypt sensitive-variables.", v => sensitiveVariablesPassword = v);
             this.scriptEngine = scriptEngine;
             this.deploymentJournalWriter = deploymentJournalWriter;
@@ -53,7 +53,7 @@ namespace Calamari.Kubernetes.Commands
             if (variablesFile != null && !File.Exists(variablesFile))
                 throw new CommandException("Could not find variables file: " + variablesFile);
 
-            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariablesFile, sensitiveVariablesPassword);
+            var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
             var commandLineRunner = new CommandLineRunner(new SplitCommandOutput(new ConsoleCommandOutput(), new ServiceMessageCommandOutput(variables)));
             var substituter = new FileSubstituter(fileSystem);
             var extractor = new GenericPackageExtractorFactory().createStandardGenericPackageExtractor();


### PR DESCRIPTION
Due to the deployment pipeline change in Octopus Server, we can now send down multiple sensitive variable files.
This change to Calamari allows us to read multiple files