### PR TITLE
Add retry support for helm downloads

### DIFF
--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -23,12 +23,16 @@
     <StartupObject />
     <RootNamespace>Calamari</RootNamespace>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <DefineConstants>$(DefineConstants);USE_NUGET_V2_LIBS;IIS_SUPPORT;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT;USE_ALPHAFS_FOR_LONG_FILE_PATH_SUPPORT</DefineConstants>
     <PlatformTarget>anycpu</PlatformTarget>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <DefineConstants>$(DefineConstants);USE_NUGET_V2_LIBS;IIS_SUPPORT;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT;USE_ALPHAFS_FOR_LONG_FILE_PATH_SUPPORT;SUPPORTS_POLLY</DefineConstants>
+    <PlatformTarget>anycpu</PlatformTarget>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);USE_OCTOPUS_XMLT;USE_SYSTEM_IO_DIRECTORY;USE_NUGET_V3_LIBS;WORKAROUND_FOR_EMPTY_STRING_BUG</DefineConstants>
+    <DefineConstants>$(DefineConstants);USE_OCTOPUS_XMLT;USE_SYSTEM_IO_DIRECTORY;USE_NUGET_V3_LIBS;WORKAROUND_FOR_EMPTY_STRING_BUG;SUPPORTS_POLLY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />

--- a/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
@@ -65,7 +65,7 @@ namespace Calamari.Integration.Packages.Download
                 }
 
                 var log = new LogWrapper();
-                InvokeWithRetry(() => Invoke($"init --home \"{homeDir}\" --client-only", tempDirectory, log, "initialise helm"));
+                InvokeWithRetry(() => Invoke($"init --home \"{homeDir}\" --client-only", tempDirectory, log, "initialise"));
                 InvokeWithRetry(() => Invoke($"repo add --home \"{homeDir}\" {(string.IsNullOrEmpty(cred.UserName) ? "" : $"--username \"{cred.UserName}\" --password \"{cred.Password}\"")} {TempRepoName} {feedUri.ToString()}", tempDirectory, log, "add the chart repository"));
                 InvokeWithRetry(() => Invoke($"fetch --home \"{homeDir}\"  --version \"{version}\" --destination \"{stagingDir}\" {TempRepoName}/{packageId}", tempDirectory, log, "download the chart"));
                 

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
@@ -53,7 +53,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var exception = Assert.Throws<CommandException>(() => downloader.DownloadPackage("mychart", new SemanticVersion("0.3.7"), "helm-feed", new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, "FAKE"), true, 1,
                 TimeSpan.FromSeconds(3)));
             
-            StringAssert.Contains("Helm failed to download the chart", exception.Message);
+            StringAssert.Contains("Helm failed to add the chart repository", exception.Message);
             //StringAssert.Contains("401 Unauthorized", exception.Message);
         }
     }


### PR DESCRIPTION
Adds Polly retry on exception to helm downloads, as we were getting flaky tests:

from https://build.octopushq.com/viewLog.html?buildId=1029839&tab=buildResultsDiv&buildTypeId=OctopusDeploy_CalamariNetCore_NetcoreTesting_TestUbuntu1604ltsDotNet

```
Error: Looks like "https://octopusdeploy.jfrog.io/octopusdeploy/helm-testing/" is not a valid chart repository or cannot be reached: Failed to fetch https://octopusdeploy.jfrog.io/octopusdeploy/helm-testing/index.yaml : 403 Forbidden
```