### PR TITLE
Verbose stack trace and helpful message when java can't be run

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/Java/JavaRuntime.cs
+++ b/source/Calamari.Shared/Integration/Packages/Java/JavaRuntime.cs
@@ -20,17 +20,25 @@ namespace Calamari.Integration.Packages.Java
 
         public static void VerifyExists()
         {
-            var MinimumJavaVersion = "1.8";
+            const string minimumJavaVersion = "1.8";
             var jarFile = Path.Combine(ExecutingDirectory, "javatest.jar");
-            var silentProcessResult = SilentProcessRunner.ExecuteCommand(CmdPath,
-                $"-jar \"{jarFile}\" {MinimumJavaVersion}", ".", Console.WriteLine, (i) => Console.Error.WriteLine(i));
-
-            if (silentProcessResult.ExitCode != 0)
+            try
             {
-                throw new CommandException(
-                    $"You must have Java {MinimumJavaVersion} or later installed on the target machine, " +
-                    "and have the java executable on the path or have the JAVA_HOME environment variable defined");
+                var silentProcessResult = SilentProcessRunner.ExecuteCommand(CmdPath,
+                    $"-jar \"{jarFile}\" {minimumJavaVersion}", ".", Console.WriteLine, i => Console.Error.WriteLine(i));
+
+                if (silentProcessResult.ExitCode == 0)
+                {
+                    return;
+                }
             }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            throw new CommandException(
+                $"Failed to run {CmdPath}. You must have Java {minimumJavaVersion} or later installed on the target machine, " +
+                "and have the java executable on the path or have the JAVA_HOME environment variable defined");
         }
     }
 }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/171197/64396185-2f64f100-d0a0-11e9-9a2c-a08226282415.png)


After:
Stack trace is logged to verbose.

![image](https://user-images.githubusercontent.com/171197/64396212-41df2a80-d0a0-11e9-994f-adc95e2249a7.png)
