### PR TITLE
Make proxies work with PowerShell Core

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -565,28 +565,28 @@ function Initialize-ProxySettings()
     # In some versions of PowerShell Core, if a script uses HttpClient 
     # it won't be automatically configured with the right proxy. This is essentially unavoidable
     # For those versions, we expose a $OctopusProxy variable that can be used to manually configure their HttpClients
-	$global:OctopusProxy = $proxy
-	[System.Net.WebRequest]::DefaultWebProxy = $proxy
+    $global:OctopusProxy = $proxy
+    [System.Net.WebRequest]::DefaultWebProxy = $proxy
 	
-	if ($PSVersionTable.PSEdition -eq "Core") {
+    if ($PSVersionTable.PSEdition -eq "Core") {
         # HttpClient is used to implement built in cmdlets like Invoke-WebRequest.
         # Because some versions of PowerShell Core don't allow us to set a default proxy for HttpClient,
         # the cmdlets also don't get a default proxy set either
         # Fortunately, for these cmdlets we can use $PSDefaultParameterValues to provide the right defaults
-	    # We don't use default parameter values in Windows PowerShell because this simplifies things, 
-	    # and means that users could change this value globally by modifying just a single property
-	    if (![string]::IsNullOrEmpty($env:HTTP_PROXY)) {
-	        $PSDefaultParameterValues.Add("Invoke-WebRequest:Proxy", $env:HTTP_PROXY)
+        # We don't use default parameter values in Windows PowerShell because this simplifies things, 
+        # and means that users could change this value globally by modifying just a single property
+        if (![string]::IsNullOrEmpty($env:HTTP_PROXY)) {
+            $PSDefaultParameterValues.Add("Invoke-WebRequest:Proxy", $env:HTTP_PROXY)
             $PSDefaultParameterValues.Add("Invoke-RestMethod:Proxy", $env:HTTP_PROXY)
             if ($hasCredentials) {
                 $securePassword = ConvertTo-SecureString $proxyPassword -AsPlainText -Force
-                $credentials = New-Object System.Management.Automation.PSCredential -ArgumentList $proxyUsername,$securePassword
+                $credentials = New-Object System.Management.Automation.PSCredential -ArgumentList $proxyUsername, $securePassword
                         
                 $PSDefaultParameterValues.Add("Invoke-WebRequest:ProxyCredential", $credentials)
                 $PSDefaultParameterValues.Add("Invoke-RestMethod:ProxyCredential", $credentials)
             }
-	    }
-	}
+        }
+    }
 }
 
 function Execute-WithRetry([ScriptBlock] $command, [int] $maxFailures = 3, [int] $sleepBetweenFailures = 1) {

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -541,13 +541,18 @@ function Initialize-ProxySettings()
 	else
 	{
 		#system proxy		
-		if ($useDefaultProxy)
-		{
-		    $proxyUri = New-Object Uri($env:HTTP_PROXY)
-            $proxy = New-Object System.Net.WebProxy($proxyUri)
+		if ($useDefaultProxy) {
+			# If a system proxy is defined, then this env variable should have been configured by Calamari
+			if (![string]::IsNullOrEmpty($env:HTTP_PROXY)) {
+				$proxyUri = New-Object System.Uri($env:HTTP_PROXY)
+				$proxy = New-Object System.Net.WebProxy($proxyUri)
+			}
+			else {
+				# If Tentacle is configured to use a System proxy, but there is no system proxy configured then we should configure this as if there was no proxy
+				$proxy = New-Object System.Net.WebProxy
+			}
 
-			if ($hasCredentials)
-			{
+			if ($hasCredentials) {
 				$proxy.Credentials = New-Object System.Net.NetworkCredential($proxyUsername, $proxyPassword)
 			}
 			else

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -562,6 +562,19 @@ function Initialize-ProxySettings()
 	}
 	
 	[System.Net.WebRequest]::DefaultWebProxy = $proxy
+	if ($PSVersionTable.PSEdition -eq "Core") {
+	    # In some versions of PowerShell Core, if a script uses HttpClient 
+	    # it won't be automatically configured with the right proxy. This is essentially unavoidable
+	    
+	    # The best way can do is make some APIs (like WebClient) continue to work with the proxy, 
+	    # and also use the default parameter values feature with built in cmdlets like Invoke-WebRequest
+	    # We don't use default parameter values in Windows PowerShell because this simplifies things, 
+	    # and means that users could change this value globally by modifying just a single property
+	    $global:PSDefaultParameterValues = @{
+            "Invoke-WebRequest:Proxy" = $env:HTTP_PROXY;
+            "Invoke-RestMethod:Proxy" = $env:HTTP_PROXY
+        }
+	}
 }
 
 function Execute-WithRetry([ScriptBlock] $command, [int] $maxFailures = 3, [int] $sleepBetweenFailures = 1) {

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/ScriptProxyFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/ScriptProxyFixtureBase.cs
@@ -24,7 +24,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         protected const int proxyPort = 8888;
 
         protected string proxyUrl = $"http://{proxyHost}:{proxyPort}";
-        string authenticatedProxyUrl = $"http://{UrlEncodedProxyUserName}:{UrlEncodedProxyPassword}@{proxyHost}:{proxyPort}";
+        protected string authenticatedProxyUrl = $"http://{UrlEncodedProxyUserName}:{UrlEncodedProxyPassword}@{proxyHost}:{proxyPort}";
 
         protected static bool IsRunningOnWindows = CalamariEnvironment.IsRunningOnWindows;
         

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/WindowsScriptProxyFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/WindowsScriptProxyFixtureBase.cs
@@ -71,14 +71,16 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         {
             base.AssertAuthenticatedProxyUsed(output);
             if (IsRunningOnWindows && TestWebRequestDefaultProxy)
-                output.AssertPropertyValue("WebRequest.DefaultProxy", proxyUrl + "/");
+                // This can be either the authenticated or unauthenticated URL. The authentication part should be ignored
+                output.AssertPropertyValue("WebRequest.DefaultProxy", proxyUrl + "/", authenticatedProxyUrl + "/");
         }
 
         protected override void AssertUnauthenticatedProxyUsed(CalamariResult output)
         {
             base.AssertUnauthenticatedProxyUsed(output);
             if (IsRunningOnWindows && TestWebRequestDefaultProxy)
-                output.AssertPropertyValue("WebRequest.DefaultProxy", proxyUrl + "/");
+                // This can be either the authenticated or unauthenticated URL. The authentication part should be ignored
+                output.AssertPropertyValue("WebRequest.DefaultProxy", proxyUrl + "/", authenticatedProxyUrl + "/");
         }
 
         protected override void AssertNoProxyChanges(CalamariResult output)

--- a/source/Calamari.Tests/Helpers/CalamariResult.cs
+++ b/source/Calamari.Tests/Helpers/CalamariResult.cs
@@ -184,12 +184,12 @@ namespace Calamari.Tests.Helpers
 
         //Assuming we print properties like:
         //"name: expectedValue"
-        public void AssertPropertyValue(string name, string expectedValue)
+        public void AssertPropertyValue(string name, params string[] expectedValues)
         {
             var title = name + ":";
             string line = GetOutputForLineContaining(title);
 
-            line.Replace(title, "").Should().Be(expectedValue);
+            line.Replace(title, "").Should().BeOneOf(expectedValues);
         }
     }
 }


### PR DESCRIPTION
Our existing proxy setup for windows powershell didn't work for powershell core

There are a few ways I'm aware of that you can do web requests in powershell
1. Using the powershell cmdlets `Invoke-WebRequest` and `Invoke-RestMethod`
2. Using `WebRequest`
3. Using `WebClient`
4. Using `HttpClient`

There are 5 interesting ways to configure your proxy
1. No proxy
2. Custom proxy (no auth)
3. Custom proxy (with auth)
4. System proxy (no auth)
5. System proxy (with auth)

The previous way we were configuring the proxy (for windows powershell) was `[System.Net.WebRequest]::DefaultWebProxy = $proxy`

This worked in all 4 of the ways you can do web requests in windows powershell, but does not work in all cases for powershell core. For 2 and 3 `WebRequest` and `WebClient`, it works well for powershell core.

For case 4 (`HttpClient`), PowerShell Core does not have a way of configuring a static default proxy in the current version of powershell (pre version 7.0.0), so there is no way for us to set this up globally for customers scripts. This has changed significantly from powershell vs powershell core.

For case 1, `Invoke-WebRequest` and `Invoke-RestMethod` use `HttpClient` under the hood, so they also suffer from the same problem. However, because these are cmdlets there is another option available, which is using [$PSDefaultParameterValues](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parameters_default_values?view=powershell-6) to set a default proxy whenever these cmdlets are invoked.

So in summary, for PowerShell Core v6.x scripts
1. Using the powershell cmdlets `Invoke-WebRequest` and `Invoke-RestMethod` will work (through the magic of `$PSDefaultParameterValues`)
2. Using `WebRequest` works
3. Using `WebClient` works
4. Using `HttpClient` does not work. Customers will have to configure their `HttpClient` instances manually. This PR adds a new preconfigured `$OctopusProxy` parameter which customers can use in their scripts to configure `HttpClient`.

However, for PowerShell Core v7.0.0 and beyond, there exists a new mechanism for setting the Default Proxy for httpclient, which solves all of the above issues. See [this Issue](https://github.com/dotnet/corefx/issues/36553) and [this PR](https://github.com/dotnet/corefx/pull/37333) for more information. So this PR also uses this new feature if the detected version of powershell core is v7 or later, which means this PR becomes "future proof" and we won't need to come back and add more proxy support in a months time when PSCore v7 ships :)

I have manually tested this PR on windows powershell, powershell core v6, and powershell core v7, for the 5 proxy configuration scenarios described above, across the 4 different ways we can perform web request.

It would be nice to add automated tests but there's a bunch of work involved there. For now, I think we should just get by with manual testing until we have time to set up proxies on our test agents.