### PR TITLE
Allow usage of CompressPackage parameter during deployment to Azure ServiceFabric

### DIFF
--- a/source/Calamari.Azure/Scripts/DeployAzureServiceFabricApplication.ps1
+++ b/source/Calamari.Azure/Scripts/DeployAzureServiceFabricApplication.ps1
@@ -84,6 +84,7 @@ function Read-PublishProfile {
 
     $publishProfile.ClusterConnectionParameters = Read-XmlElementAsHashtable $publishProfileXml.PublishProfile.Item("ClusterConnectionParameters")
     $publishProfile.UpgradeDeployment = Read-XmlElementAsHashtable $publishProfileXml.PublishProfile.Item("UpgradeDeployment")
+	$publishProfile.CopyPackageParameters = Read-XmlElementAsHashtable $publishProfileXml.PublishProfile.Item("CopyPackageParameters")
 
     if ($publishProfileXml.PublishProfile.Item("UpgradeDeployment")) {
         $publishProfile.UpgradeDeployment.Parameters = Read-XmlElementAsHashtable $publishProfileXml.PublishProfile.Item("UpgradeDeployment").Item("Parameters")
@@ -142,6 +143,10 @@ $parameters = @{
     ApplicationParameterFilePath = $publishProfile.ApplicationParameterFile
     ApplicationParameter         = $ApplicationParameter
     ErrorAction                  = 'Stop'
+}
+
+if ($publishProfile.CopyPackageParameters.CompressPackage) {
+    $parameters.CompressPackage = $publishProfile.CopyPackageParameters.CompressPackage
 }
 
 if (-not $AppTypeAndVersionExists) {


### PR DESCRIPTION
This enables usage of `CopyPackageParameters/CompressPackage` parameter from application publish profile during deployment.
We needed in our organization to set this parameter `true` to solve problem when Octopus deployment occasionally got stuck during -
> Copying application package to image store...

As there is no possibility to specify this value in Octopus step parameters, I added it to the deployment script (similarly as it is in the original ServiceFabric deployment script).