### PR TITLE
Use sudo path when checking nginx is installed

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.Nginx_BeforePreDeploy.sh
+++ b/source/Calamari/Scripts/Octopus.Features.Nginx_BeforePreDeploy.sh
@@ -32,14 +32,15 @@ function check_user_has_sudo_access_without_password_to_required_commands {
     fi
 }
 
-function check_app_exists {
-	command -v $1 > /dev/null 2>&1
+function check_nginx_exists {
+	sudo -n bash -c 'command -v nginx' > /dev/null 2>&1
 	if [[ $? -ne 0 ]]; then
-		echo >&2 "The executable $1 does not exist, or is not on the path"
-        echo >&2 "See https://g.octopushq.com/NginxInstall from more information"
+		echo >&2 "The executable 'nginx' does not exist, or is not on the sudo path,"
+		echo >&2 "or the user does not have 'sudo' access to it without a password."
+		echo >&2 "See https://g.octopushq.com/NginxInstall from more information."
 		exit 1
 	fi
 }
 
-check_app_exists nginx
+check_nginx_exists
 check_user_has_sudo_access_without_password_to_required_commands

--- a/source/Calamari/Scripts/Octopus.Features.Nginx_BeforePreDeploy.sh
+++ b/source/Calamari/Scripts/Octopus.Features.Nginx_BeforePreDeploy.sh
@@ -35,9 +35,12 @@ function check_user_has_sudo_access_without_password_to_required_commands {
 function check_nginx_exists {
 	sudo -n bash -c 'command -v nginx' > /dev/null 2>&1
 	if [[ $? -ne 0 ]]; then
-		echo >&2 "The executable 'nginx' does not exist, or is not on the sudo path,"
-		echo >&2 "or the user does not have 'sudo' access to it without a password."
-		echo >&2 "See https://g.octopushq.com/NginxInstall from more information."
+		echo >&2 "The executable 'nginx' does not exist, or cannot be located using the PATH in"
+		echo >&2 "the 'sudo' environment, or the user does not have the required 'sudo' access"
+		echo >&2 "without a password."
+		echo >&2 "For more on installing nginx, see https://g.octopushq.com/NginxInstall."
+		echo >&2 "For more on sudo settings see https://g.octopushq.com/NginxUserPermissions,"
+		echo >&2 "and the 'secure_path' and 'NOPASSWD' options in 'man sudoers'."
 		exit 1
 	fi
 }


### PR DESCRIPTION
This check was requiring nginx to be on the non-sudo `PATH`, which is a bit atypical and unnecessary, since our invocations of nginx use sudo. This adjustment checks the sudo `PATH` instead.