### PR TITLE
Nginx temp path fixes

### DIFF
--- a/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -349,7 +349,7 @@ namespace Calamari.Integration.FileSystem
 
         string GetTempBasePath()
         {
-            var path1 = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var path1 = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create);
             path1 = Path.Combine(path1, Assembly.GetEntryAssembly()?.GetName().Name ?? "Octopus.Calamari");
             path1 = Path.Combine(path1, "Temp");
             var path = path1;

--- a/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -357,7 +357,7 @@ namespace Calamari.Integration.FileSystem
             {
                 Directory.CreateDirectory(path);
             }
-            return path;
+            return Path.GetFullPath(path);
         }
 
         public string CreateTemporaryDirectory()

--- a/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
+++ b/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
@@ -1,27 +1,28 @@
 #!/bin/bash
 set -e
-
 nginxTempDir=$(get_octopusvariable "OctopusNginxFeatureTempDirectory")
-if [ -d "${nginxTempDir}" ]; then
-    nginxConfDir=$(get_octopusvariable "Octopus.Action.Nginx.ConfigurationsDirectory")
-    
-    # Always remove the temporary NGINX config folder
-    trap 'echo "Removing temporary folder ${nginxTempDir}..." && sudo rm -rf $nginxTempDir' exit
-    
-    nginxConfRoot=${nginxConfDir:-/etc/nginx/conf.d}
-    echo "Copying $nginxTempDir/conf/* to $nginxConfRoot..."
-    sudo cp -R $nginxTempDir/conf/* $nginxConfRoot -f
-    
-    if [ -d "$nginxTempDir/ssl" ]; then
-        nginxSslDir=$(get_octopusvariable "Octopus.Action.Nginx.CertificatesDirectory")
-        nginxSslDir=${nginxSslDir:-/etc/ssl}
-        echo "Copying $nginxTempDir/ssl/* to $nginxSslDir..."
-        sudo cp -R $nginxTempDir/ssl/* $nginxSslDir -f
-    fi
-    
-    echo "Validating nginx configuration"
-    sudo nginx -t
-    
-    echo "Reloading nginx configuration"
-    sudo nginx -s reload
+if [ ! -d "$nginxTempDir" ]; then
+    echo >&2 "Unable to find temporary folder '$nginxTempDir'."
+    exit 1
 fi
+nginxConfDir=$(get_octopusvariable "Octopus.Action.Nginx.ConfigurationsDirectory")
+
+# Always remove the temporary NGINX config folder
+trap 'echo "Removing temporary folder ${nginxTempDir}..." && sudo rm -rf $nginxTempDir' exit
+
+nginxConfRoot=${nginxConfDir:-/etc/nginx/conf.d}
+echo "Copying $nginxTempDir/conf/* to $nginxConfRoot..."
+sudo cp -R $nginxTempDir/conf/* $nginxConfRoot -f
+
+if [ -d "$nginxTempDir/ssl" ]; then
+    nginxSslDir=$(get_octopusvariable "Octopus.Action.Nginx.CertificatesDirectory")
+    nginxSslDir=${nginxSslDir:-/etc/ssl}
+    echo "Copying $nginxTempDir/ssl/* to $nginxSslDir..."
+    sudo cp -R $nginxTempDir/ssl/* $nginxSslDir -f
+fi
+
+echo "Validating nginx configuration"
+sudo nginx -t
+
+echo "Reloading nginx configuration"
+sudo nginx -s reload


### PR DESCRIPTION
This adds 3 related fixes to the handling of Nginx temp paths:

- Avoid a misleading success state when nginx scripts can't find their temp files; now raising an error instead.
- Automatically create `Environment.SpecialFolder.LocalApplicationData` as needed (instead of returning an empty string, which caused temporary files to land in the current working directory on my test system).
- Use an absolute path for the base temp directory, to avoid referencing different locations as it is passed between contexts.
