### PR TITLE
Power shell core bootstrapper tests

### DIFF
--- a/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -662,6 +662,11 @@ namespace Calamari.Integration.FileSystem
             return new FileInfo(filePath).Name;
         }
 
+        public string GetDirectoryName(string directoryPath)
+        {
+            return new DirectoryInfo(directoryPath).Name;
+        }
+
         public Stream OpenFileExclusively(string filePath, FileMode fileMode, FileAccess fileAccess)
         {
             return File.Open(filePath, fileMode, fileAccess, FileShare.None);

--- a/source/Calamari.Shared/Integration/FileSystem/ICalamariFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/ICalamariFileSystem.cs
@@ -48,5 +48,6 @@ namespace Calamari.Integration.FileSystem
         Stream OpenFileExclusively(string filePath, FileMode fileMode, FileAccess fileAccess);
         DateTime GetCreationTime(string filePath);
         string GetFileName(string filePath);
+        string GetDirectoryName(string directoryPath);
     }
 }

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -55,6 +55,12 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
     public class PowerShellCoreBootstrapper : PowerShellBootstrapper
     {
         const string EnvPowerShellPath = "pwsh.exe";
+        ICalamariFileSystem fileSystem;
+
+        public PowerShellCoreBootstrapper(ICalamariFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
 
         public override string PathToPowerShellExecutable(CalamariVariableDictionary variables)
         {
@@ -70,12 +76,11 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
                     .Where(p => p != null)
                     .Distinct()
                     .Select(pf => Path.Combine(pf, "PowerShell"))
-                    .Where(Directory.Exists)
-                    .SelectMany(Directory.EnumerateDirectories)
+                    .Where(fileSystem.DirectoryExists)
+                    .SelectMany(fileSystem.EnumerateDirectories) // use fs everywhere
                     .Select<string, (string path, string versionId, int? majorVersion, string remaining)>(d =>
                     {
-                        var directoryInfo = new DirectoryInfo(d);
-                        var directoryName = directoryInfo.Name;
+                        var directoryName = fileSystem.GetDirectoryName(d);
 
                         // Directories are typically versions like "6" or they might also have a prerelease component like "7-preview"
                         var splitString = directoryName.Split(new[] {'-'}, 2);
@@ -89,6 +94,7 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
                             return (d, directoryName, majorVersion, preRelease);
                         return (d, directoryName, null, preRelease);
                     }).ToList();
+                
                 var latestPowerShellVersionDirectory = availablePowerShellVersions
                     .Where(p => string.IsNullOrEmpty(customVersion) || p.versionId == customVersion)
                     .OrderByDescending(p => p.majorVersion)
@@ -103,7 +109,7 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
 
                 var pathToPwsh = Path.Combine(latestPowerShellVersionDirectory, EnvPowerShellPath);
 
-                return File.Exists(pathToPwsh) ? pathToPwsh : EnvPowerShellPath;
+                return fileSystem.FileExists(pathToPwsh) ? pathToPwsh : EnvPowerShellPath;
             }
             catch (PowerShellVersionNotFoundException)
             {

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -55,7 +55,7 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
     public class PowerShellCoreBootstrapper : PowerShellBootstrapper
     {
         const string EnvPowerShellPath = "pwsh.exe";
-        ICalamariFileSystem fileSystem;
+        readonly ICalamariFileSystem fileSystem;
 
         public PowerShellCoreBootstrapper(ICalamariFileSystem fileSystem)
         {
@@ -77,7 +77,7 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
                     .Distinct()
                     .Select(pf => Path.Combine(pf, "PowerShell"))
                     .Where(fileSystem.DirectoryExists)
-                    .SelectMany(fileSystem.EnumerateDirectories) // use fs everywhere
+                    .SelectMany(fileSystem.EnumerateDirectories)
                     .Select<string, (string path, string versionId, int? majorVersion, string remaining)>(d =>
                     {
                         var directoryName = fileSystem.GetDirectoryName(d);

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellScriptEngine.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security;
 using Calamari.Deployment;
+using Calamari.Integration.FileSystem;
 using Calamari.Integration.Processes;
 
 namespace Calamari.Integration.Scripting.WindowsPowerShell
@@ -50,7 +50,7 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
                 return new WindowsPowerShellBootstrapper();
             
             if (specifiedEdition.Equals("PowerShellCore", StringComparison.OrdinalIgnoreCase))
-                return new PowerShellCoreBootstrapper();
+                return new PowerShellCoreBootstrapper(CalamariPhysicalFileSystem.GetPhysicalFileSystem());
             
             // If it is an unrecognized value, fall back to Windows 
             return new WindowsPowerShellBootstrapper();

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellCoreBootstrapperFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellCoreBootstrapperFixture.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Linq;
+using Calamari.Deployment;
+using Calamari.Integration.FileSystem;
+using Calamari.Integration.Processes;
+using Calamari.Integration.Scripting.WindowsPowerShell;
+using Calamari.Tests.Helpers;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Integration.Scripting
+{
+    [TestFixture]
+    [Category(TestCategory.CompatibleOS.Windows)]
+    public class PowerShellCoreBootstrapperFixture
+    {
+        [Test]
+        public void ShouldReturnLatestPath()
+        {
+            var mockFileSystem = Substitute.For<ICalamariFileSystem>();
+            SetUpMockFileSystem(mockFileSystem);
+            
+            var pathToPowerShell = CreatePowerShellCoreBootstrapper(mockFileSystem).PathToPowerShellExecutable(new CalamariVariableDictionary());
+            pathToPowerShell.Should().Be("C:\\Program Files\\PowerShell\\8-preview\\pwsh.exe");
+        }
+
+        [Test]
+        public void SpecifyingVersionShouldReturnPath()
+        {
+            var mockFileSystem = Substitute.For<ICalamariFileSystem>();
+            SetUpMockFileSystem(mockFileSystem);
+
+            var variables = new CalamariVariableDictionary();
+            variables.Add(SpecialVariables.Action.PowerShell.CustomPowerShellVersion, "6");
+            
+            var pathToPowerShell = CreatePowerShellCoreBootstrapper(mockFileSystem).PathToPowerShellExecutable(variables);
+            pathToPowerShell.Should().Be("C:\\Program Files\\PowerShell\\6\\pwsh.exe");
+        }
+        
+        [Test]
+        public void IncorrectVersionShouldThrowException()
+        {
+            var mockFileSystem = Substitute.For<ICalamariFileSystem>();
+            SetUpMockFileSystem(mockFileSystem);
+
+            var variables = new CalamariVariableDictionary();
+            variables.Add(SpecialVariables.Action.PowerShell.CustomPowerShellVersion, "6-preview");
+            
+            Action act = () => CreatePowerShellCoreBootstrapper(mockFileSystem).PathToPowerShellExecutable(variables);
+            act.Should().Throw<PowerShellVersionNotFoundException>();
+        }
+        
+        [Test]
+        public void NoVersionInstalledShouldThrowException()
+        {
+            var mockFileSystem = Substitute.For<ICalamariFileSystem>();
+            SetUpMockFileSystem(mockFileSystem);
+
+            var variables = new CalamariVariableDictionary();
+            variables.Add(SpecialVariables.Action.PowerShell.CustomPowerShellVersion, "6-preview");
+            
+            Action act = () => CreatePowerShellCoreBootstrapper(mockFileSystem).PathToPowerShellExecutable(variables);
+            act.Should().Throw<PowerShellVersionNotFoundException>();
+        }
+        
+        static void SetUpMockFileSystem(ICalamariFileSystem mockFileSystem)
+        {
+            string parentDirectoryPath = "C:\\Program Files\\PowerShell";
+            var versions = new[] {"6", "7-preview", "7", "8-preview"};
+            
+            string[] powerShellPaths = versions.Select(version => $"{parentDirectoryPath}\\{version}").ToArray();
+               
+            mockFileSystem.EnumerateDirectories(parentDirectoryPath).Returns(powerShellPaths);
+            
+            mockFileSystem.DirectoryExists(parentDirectoryPath).Returns(true);
+            
+            for (int i = 0; i < powerShellPaths.Length; i++) 
+                mockFileSystem.GetDirectoryName(powerShellPaths[i]).Returns(versions[i]);
+
+            foreach (var t in powerShellPaths)
+                mockFileSystem.FileExists($"{t}\\pwsh.exe").Returns(true);
+        }
+
+        static PowerShellCoreBootstrapper CreatePowerShellCoreBootstrapper(ICalamariFileSystem mockFileSystem)
+        { 
+            return new PowerShellCoreBootstrapper(mockFileSystem);
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellCoreBootstrapperFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellCoreBootstrapperFixture.cs
@@ -52,22 +52,23 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
         }
         
         [Test]
-        public void NoVersionInstalledShouldThrowException()
+        public void CustommVersionSpecifiedButNoVersionInstalledShouldThrowException()
         {
             var mockFileSystem = Substitute.For<ICalamariFileSystem>();
-            SetUpMockFileSystem(mockFileSystem);
+            string[] installedPSVersions = new string[] { };
+            SetUpMockFileSystem(mockFileSystem, installedPSVersions);
 
             var variables = new CalamariVariableDictionary();
-            variables.Add(SpecialVariables.Action.PowerShell.CustomPowerShellVersion, "6-preview");
+            variables.Add(SpecialVariables.Action.PowerShell.CustomPowerShellVersion, "6");
             
             Action act = () => CreatePowerShellCoreBootstrapper(mockFileSystem).PathToPowerShellExecutable(variables);
             act.Should().Throw<PowerShellVersionNotFoundException>();
         }
         
-        static void SetUpMockFileSystem(ICalamariFileSystem mockFileSystem)
+        static void SetUpMockFileSystem(ICalamariFileSystem mockFileSystem, string[] powerShellVersions = null)
         {
             string parentDirectoryPath = "C:\\Program Files\\PowerShell";
-            var versions = new[] {"6", "7-preview", "7", "8-preview"};
+            var versions = powerShellVersions ?? new[] {"6", "7-preview", "7", "8-preview"};
             
             string[] powerShellPaths = versions.Select(version => $"{parentDirectoryPath}\\{version}").ToArray();
                


### PR DESCRIPTION
- Extend PhysicalFileSystem and ICalamariFileSystem to support GetDirectoryName
- Augment PowerShellCoreBootstrapper to use ICalamariFileSystem and it's functions
- Update ScriptEngine to enable changes to PowerShellCoreBootstrapper
- Add tests for PowerShellCoreBootstrapper