### PR TITLE
Enh cleaner failed python script output

### DIFF
--- a/source/Calamari.Shared/Integration/Processes/CommandLineRunner.cs
+++ b/source/Calamari.Shared/Integration/Processes/CommandLineRunner.cs
@@ -34,16 +34,12 @@ namespace Calamari.Integration.Processes
             }       
             catch (Exception ex)
             {
-                if (ex.InnerException is Win32Exception &&
-                     string.Equals(ex.InnerException.Message,"The system cannot find the file specified", StringComparison.Ordinal))
+                if (ex.InnerException is Win32Exception )
                 {
-                    commandOutput.WriteError($"{invocation.Executable} was not found, please ensure that {invocation.Executable} is installed and is in the PATH");
+                    commandOutput.WriteError(ConstructWin32ExceptionMessage(invocation.Executable));
                 }
-                else
-                {
-                    commandOutput.WriteError(ex.ToString());
-                }
-                                
+                
+                commandOutput.WriteError(ex.ToString());
                 commandOutput.WriteError("The command that caused the exception was: " + invocation);
 
                 return new CommandResult(
@@ -52,6 +48,12 @@ namespace Calamari.Integration.Processes
                     ex.ToString(),
                     invocation.WorkingDirectory);
             }
+        }
+
+        public static string ConstructWin32ExceptionMessage(string executable)
+        {
+            return
+                $"Unable to execute {executable}, please ensure that {executable} is installed and is in the PATH.{Environment.NewLine}";
         }
     }
 }

--- a/source/Calamari.Shared/Integration/Processes/CommandLineRunner.cs
+++ b/source/Calamari.Shared/Integration/Processes/CommandLineRunner.cs
@@ -35,16 +35,16 @@ namespace Calamari.Integration.Processes
             catch (Exception ex)
             {
                 if (ex.InnerException is Win32Exception &&
-                    ex.InnerException.Message == "The system cannot find the file specified")
+                     string.Equals(ex.InnerException.Message,"The system cannot find the file specified", StringComparison.Ordinal))
                 {
-                    Console.Error.WriteLine($"{invocation.Executable} was not found, please ensure that this executable is a supported - https://octopus.com/docs/deployment-examples/custom-scripts and is installed");
+                    commandOutput.WriteError($"{invocation.Executable} was not found, please ensure that {invocation.Executable} is installed and is in the PATH");
                 }
                 else
                 {
-                    Console.Error.WriteLine(ex);
+                    commandOutput.WriteError(ex.ToString());
                 }
                                 
-                Console.Error.WriteLine("The command that caused the exception was: " + invocation);
+                commandOutput.WriteError("The command that caused the exception was: " + invocation);
 
                 return new CommandResult(
                     invocation.ToString(), 

--- a/source/Calamari.Shared/Integration/Processes/CommandLineRunner.cs
+++ b/source/Calamari.Shared/Integration/Processes/CommandLineRunner.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Reflection;
+using System.ComponentModel;
 
 namespace Calamari.Integration.Processes
 {
@@ -17,9 +17,9 @@ namespace Calamari.Integration.Processes
             try
             {
                 var exitCode = SilentProcessRunner.ExecuteCommand(
-                    invocation.Executable, 
+                    invocation.Executable,
                     invocation.Arguments,
-                    invocation.WorkingDirectory,      
+                    invocation.WorkingDirectory,
                     invocation.EnvironmentVars,
                     invocation.UserName,
                     invocation.Password,
@@ -27,15 +27,25 @@ namespace Calamari.Integration.Processes
                     commandOutput.WriteError);
 
                 return new CommandResult(
-                    invocation.ToString(), 
+                    invocation.ToString(),
                     exitCode.ExitCode,
-                    exitCode.ErrorOutput, 
+                    exitCode.ErrorOutput,
                     invocation.WorkingDirectory);
-            }
+            }       
             catch (Exception ex)
             {
-                Console.Error.WriteLine(ex);
+                if (ex.InnerException is Win32Exception &&
+                    ex.InnerException.Message == "The system cannot find the file specified")
+                {
+                    Console.Error.WriteLine($"{invocation.Executable} was not found, please ensure that this executable is a supported - https://octopus.com/docs/deployment-examples/custom-scripts and is installed");
+                }
+                else
+                {
+                    Console.Error.WriteLine(ex);
+                }
+                                
                 Console.Error.WriteLine("The command that caused the exception was: " + invocation);
+
                 return new CommandResult(
                     invocation.ToString(), 
                     -1, 

--- a/source/Calamari.Tests/Fixtures/Integration/Process/CommandLineRunnerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Process/CommandLineRunnerFixture.cs
@@ -13,8 +13,9 @@ namespace Calamari.Tests.Fixtures.Integration.Process
         {
             var output = new CaptureCommandOutput();
             var subject = new CommandLineRunner(output);
-            var result = subject.Execute(new CommandLineInvocation(executable: "random", arguments:"--version"));
+            var result = subject.Execute(new CommandLineInvocation(executable: "TestingCalamariThisExecutableShouldNeverExist", arguments:"--version"));
             result.HasErrors.Should().BeTrue();
+            output.Errors.Should().Contain("TestingCalamariThisExecutableShouldNeverExist was not found, please ensure that TestingCalamariThisExecutableShouldNeverExist is installed and is in the PATH");
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Process/CommandLineRunnerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Process/CommandLineRunnerFixture.cs
@@ -11,11 +11,12 @@ namespace Calamari.Tests.Fixtures.Integration.Process
         [Test]
         public void ScriptShouldFailIfExecutableDoesNotExist()
         {
+            const string executable = "TestingCalamariThisExecutableShouldNeverExist";
             var output = new CaptureCommandOutput();
             var subject = new CommandLineRunner(output);
-            var result = subject.Execute(new CommandLineInvocation(executable: "TestingCalamariThisExecutableShouldNeverExist", arguments:"--version"));
+            var result = subject.Execute(new CommandLineInvocation(executable: executable, arguments:"--version"));
             result.HasErrors.Should().BeTrue();
-            output.Errors.Should().Contain("TestingCalamariThisExecutableShouldNeverExist was not found, please ensure that TestingCalamariThisExecutableShouldNeverExist is installed and is in the PATH");
+            output.Errors.Should().Contain(CommandLineRunner.ConstructWin32ExceptionMessage(executable));
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Process/CommandLineRunnerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Process/CommandLineRunnerFixture.cs
@@ -1,0 +1,20 @@
+using Calamari.Integration.Processes;
+using Calamari.Tests.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Integration.Process
+{
+    [TestFixture]
+    public class CommandLineRunnerFixture
+    {
+        [Test]
+        public void ScriptShouldFailIfExecutableDoesNotExist()
+        {
+            var output = new CaptureCommandOutput();
+            var subject = new CommandLineRunner(output);
+            var result = subject.Execute(new CommandLineInvocation(executable: "random", arguments:"--version"));
+            result.HasErrors.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
Cleaner message when an executable is missing.

fixes https://github.com/OctopusDeploy/Issues/issues/5851