### PR TITLE
Implemented proxy support for powershell core on linux

### DIFF
--- a/source/Calamari.Shared/Integration/Proxies/ProxyEnvironmentVariablesGenerator.cs
+++ b/source/Calamari.Shared/Integration/Proxies/ProxyEnvironmentVariablesGenerator.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using Octopus.CoreUtilities;
+using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Integration.Proxies
 {
@@ -12,19 +14,36 @@ namespace Calamari.Integration.Proxies
         const string HttpsProxyVariableName = "HTTPS_PROXY";
         const string NoProxyVariableName = "NO_PROXY";
 
-        static IEnumerable<string> ProxyEnvironmentVariableNames => new[] {HttpProxyVariableName, HttpsProxyVariableName, NoProxyVariableName};
+        static IEnumerable<string> ProxyEnvironmentVariableNames => 
+            new[] {HttpProxyVariableName, HttpsProxyVariableName, NoProxyVariableName}
+            .SelectMany(v => new[] { v.ToUpperInvariant(), v.ToLowerInvariant()})
+            .ToArray();
         
         public static IEnumerable<EnvironmentVariable> GenerateProxyEnvironmentVariables()
         {
-            var environmentVariables = new HashSet<string>(Environment.GetEnvironmentVariables().Keys.Cast<string>(), StringComparer.OrdinalIgnoreCase);
-            if (ProxyEnvironmentVariableNames.Any(environmentVariables.Contains))
+            var environmentVariables = Environment.GetEnvironmentVariables();
+            var existingProxyEnvironmentVariables = ProxyEnvironmentVariableNames.Where(environmentVariables.Contains).ToHashSet(StringComparer.InvariantCulture);
+            if (existingProxyEnvironmentVariables.Any())
             {
                 Log.Verbose("Proxy related environment variables already exist. Calamari will not overwrite any proxy environment variables.");
-                return Enumerable.Empty<EnvironmentVariable>();
+                return DuplicateVariablesWithUpperAndLowerCasing(existingProxyEnvironmentVariables, environmentVariables);
             }
 
             Log.Verbose("Setting Proxy Environment Variables");
             return GenerateProxyEnvironmentVariables(ProxySettingsInitializer.GetProxySettingsFromEnvironment());
+        }
+
+        static IEnumerable<EnvironmentVariable> DuplicateVariablesWithUpperAndLowerCasing(ISet<string> existingProxyEnvironmentVariableNames, IDictionary environmentVariables)
+        {
+            foreach (var existingVariableName in existingProxyEnvironmentVariableNames)
+            {
+                var requiredVariables = new[] { existingVariableName.ToUpperInvariant(), existingVariableName.ToLowerInvariant() };
+
+                foreach (var requiredVariableName in requiredVariables.Where(v => !existingProxyEnvironmentVariableNames.Contains(v)))
+                {
+                    yield return new EnvironmentVariable(requiredVariableName, (string)environmentVariables[existingVariableName]);
+                }
+            }
         }
 
         static IEnumerable<EnvironmentVariable> GenerateProxyEnvironmentVariables(ProxySettings proxySettings)
@@ -89,8 +108,11 @@ namespace Calamari.Integration.Proxies
                 }
 
                 yield return new EnvironmentVariable(HttpProxyVariableName, proxyUri);
+                yield return new EnvironmentVariable(HttpProxyVariableName.ToLowerInvariant(), proxyUri);
                 yield return new EnvironmentVariable(HttpsProxyVariableName, proxyUri);
+                yield return new EnvironmentVariable(HttpsProxyVariableName.ToLowerInvariant(), proxyUri);
                 yield return new EnvironmentVariable(NoProxyVariableName, "127.0.0.1,localhost,169.254.169.254");
+                yield return new EnvironmentVariable(NoProxyVariableName.ToLowerInvariant(), "127.0.0.1,localhost,169.254.169.254");
             }
         }
     }

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -526,6 +526,8 @@ function Initialize-ProxySettings()
 	$hasCredentials = ![string]::IsNullOrEmpty($proxyUsername)
 
     # This means we should use the HTTP_PROXY variable if it exists, otherwise treat the proxy as not defined
+    # TODO: It would probably be better if Calamari was responsible for setting TentacleProxyHost, TentacleProxyUsername etc. based on HTTP_PROXY,
+    # but this probably involves resolving https://github.com/OctopusDeploy/Issues/issues/5865 first
     if ($useDefaultProxy -and [string]::IsNullOrEmpty($proxyHost))
     {
         # Calamari ensure both http_proxy and HTTP_PROXY are set, so we don't need to worry about casing

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using Calamari.Integration.Proxies;
 using Calamari.Tests.Helpers;
@@ -128,19 +129,34 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
             AssertAuthenticatedProxyUsed(result);
         }
 
-        [TestCase("HTTP_PROXY")]
         [TestCase("http_proxy")]
-        [TestCase("HTTPS_PROXY")]
         [TestCase("https_proxy")]
-        [TestCase("NO_PROXY")]
         [TestCase("no_proxy")]
-        public void Initialize_OneEnvironmentVariableExists_NoneReturned(string existingVariableName)
+        public void Initialize_OneLowerCaseEnvironmentVariableExists_UpperCaseVariantReturned(string existingVariableName)
         {
             var existingValue = "blahblahblah";
             Environment.SetEnvironmentVariable(existingVariableName, existingValue);
-            var result = RunWith(false, proxyHost, proxyPort, ProxyUserName, ProxyPassword);
+            var result = RunWith(false, proxyHost, proxyPort, ProxyUserName, ProxyPassword).ToList();
 
-            result.Should().BeEmpty();
+            result.Should().ContainSingle("The existing variable should be duplicated as an upper case variable");
+            var variable = result.Single();
+            variable.Key.Should().Be(existingVariableName.ToUpperInvariant());
+            variable.Value.Should().Be(existingValue);
+        }
+        
+        [TestCase("HTTP_PROXY")]
+        [TestCase("HTTPS_PROXY")]
+        [TestCase("NO_PROXY")]
+        public void Initialize_OneUpperCaseEnvironmentVariableExists_LowerCaseVariantReturned(string existingVariableName)
+        {
+            var existingValue = "blahblahblah";
+            Environment.SetEnvironmentVariable(existingVariableName, existingValue);
+            var result = RunWith(false, proxyHost, proxyPort, ProxyUserName, ProxyPassword).ToList();
+
+            result.Should().ContainSingle("The existing variable should be duplicated as a lower case variable");
+            var variable = result.Single();
+            variable.Key.Should().Be(existingVariableName.ToLowerInvariant());
+            variable.Value.Should().Be(existingValue);
         }
         
         IEnumerable<EnvironmentVariable> RunWith(


### PR DESCRIPTION
In linux, the system proxy is often configured with an environment variable, usually `http_proxy`.

For windows deployments, Calamari would deconstruct the system proxy and put it into a bunch of environment variables (like `TentacleProxyHost`). For linux deployments where the system proxy is provided through `http_proxy`, Calamari seems to go out of its way to avoid tweaking any of the environment variables and instead tries to keep them the same way that they were provided by the user.

Whether this is the right behavior is questionable and there is a bug for this: https://github.com/OctopusDeploy/Issues/issues/5865

I have tried to avoid changing this behavior right now, and instead the powershell bootstrapper script is able to extract the required information from the provided `http_proxy` environment variable if other variables like `TentacleProxyHost` is not provided.

Additionally, there is no reliable convention about the casing of the http_proxy (and related) environment variables, so the new implementation ensures both upper case and lower case variants of these environment variables are provided.

I've tested these changes manually across linux (powershell core) and windows (powershell core and windows powershell). I've tested all variations I can think of (system proxy / no proxy / custom proxy / with and without credentials / etc.)