### PR TITLE
Combined os test categories

### DIFF
--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -40,7 +40,7 @@ namespace Calamari.Tests.AWS
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void UploadPackage1()
         {
             var fileSelections = new List<S3FileSelectionProperties>
@@ -73,7 +73,7 @@ namespace Calamari.Tests.AWS
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void UploadPackage2()
         {
             var fileSelections = new List<S3FileSelectionProperties>
@@ -132,7 +132,7 @@ namespace Calamari.Tests.AWS
         };
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void UploadPackageWithMetadata()
         {
             var fileSelections = new List<S3FileSelectionProperties>

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -9,8 +9,7 @@ namespace Calamari.Tests.Fixtures.Bash
     public class BashFixture : CalamariFixture
     {
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldPrintEncodedVariable()
         {
             var (output, _) = RunScript("print-encoded-variable.sh");
@@ -20,8 +19,7 @@ namespace Calamari.Tests.Fixtures.Bash
         }
         
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldPrintSensitiveVariable()
         {
             var (output, _) = RunScript("print-sensitive-variable.sh");
@@ -31,8 +29,7 @@ namespace Calamari.Tests.Fixtures.Bash
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldCreateArtifact()
         {
             var (output, _) = RunScript("create-artifact.sh");
@@ -42,8 +39,7 @@ namespace Calamari.Tests.Fixtures.Bash
         }
         
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldUpdateProgress()
         {
             var (output, _) = RunScript("update-progress.sh");
@@ -53,8 +49,7 @@ namespace Calamari.Tests.Fixtures.Bash
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldConsumeParametersWithQuotes()
         {
             var (output, _) = RunScript("parameters.sh", new Dictionary<string, string>()
@@ -65,8 +60,7 @@ namespace Calamari.Tests.Fixtures.Bash
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldCallHello()
         {
             var (output, _) = RunScript("hello.sh", new Dictionary<string, string>()
@@ -84,8 +78,7 @@ namespace Calamari.Tests.Fixtures.Bash
 
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldCallHelloWithSensitiveVariable()
         {
             var (output, _) = RunScript("hello.sh", new Dictionary<string, string>()
@@ -97,8 +90,7 @@ namespace Calamari.Tests.Fixtures.Bash
 
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldCallHelloWithNullVariable()
         {
             var (output, _) = RunScript("hello.sh", new Dictionary<string, string>()
@@ -109,8 +101,7 @@ namespace Calamari.Tests.Fixtures.Bash
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldCallHelloWithNullSensitiveVariable()
         {
             var (output, _) = RunScript("hello.sh", new Dictionary<string, string>()
@@ -121,8 +112,7 @@ namespace Calamari.Tests.Fixtures.Bash
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldNotFailOnStdErr()
         {
             var (output, _) = RunScript("stderr.sh");
@@ -132,8 +122,7 @@ namespace Calamari.Tests.Fixtures.Bash
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShoulFailOnStdErrWithTreatScriptWarningsAsErrors()
         {
             var (output, _) = RunScript("stderr.sh", new Dictionary<string, string>()
@@ -144,7 +133,7 @@ namespace Calamari.Tests.Fixtures.Bash
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ThrowsExceptionOnWindows()
         {
             var (output, _) = RunScript("print-encoded-variable.sh");
@@ -153,8 +142,7 @@ namespace Calamari.Tests.Fixtures.Bash
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldSupportStrictVariableUnset()
         {
             var (output, _) = RunScript("strict-mode.sh");

--- a/source/Calamari.Tests/Fixtures/Bash/BashProxyFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashProxyFixture.cs
@@ -5,8 +5,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.Fixtures.Bash
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Nix)]
-    [Category(TestCategory.CompatibleOS.Mac)]
+    [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
     public class BashProxyFixture : ScriptProxyFixtureBase
     {
         protected override CalamariResult RunScript()

--- a/source/Calamari.Tests/Fixtures/Certificates/WindowsX509CertificateStoreFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Certificates/WindowsX509CertificateStoreFixture.cs
@@ -16,7 +16,7 @@ using Calamari.Tests.Helpers;
 namespace Calamari.Tests.Fixtures.Certificates
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class WindowsX509CertificateStoreFixture
     {
         [Test]

--- a/source/Calamari.Tests/Fixtures/Commands/ScriptRunningTest.cs
+++ b/source/Calamari.Tests/Fixtures/Commands/ScriptRunningTest.cs
@@ -71,7 +71,7 @@ namespace Calamari.Tests.Fixtures.Commands
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void RunScript()
         {
             Assert.IsTrue(File.Exists(Script), Script + " must exist as a file");

--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/TransformFileLocatorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/TransformFileLocatorFixture.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.Fixtures.ConfigurationTransforms
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class TransformFileLocatorFixture
     {
         [Test]

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
@@ -203,7 +203,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         [TestCase("bar.blah => *.Bar.Blah", "xyz.bar.blah", "bar.blah")]
         [TestCase("*.Bar.Blah => bar.blah", "bar.blah", "xyz.bar.blah")]
         [TestCase("foo.bar.config => Foo.Config", "foo.config", "foo.bar.config")]
@@ -218,7 +218,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
+        [Category(TestCategory.CompatibleOS.OnlyNix)]
         [TestCase("bar.blah => *.Bar.Blah", "xyz.bar.blah", "bar.blah")]
         [TestCase("*.Bar.Blah => bar.blah", "bar.blah", "xyz.bar.blah")]
         [TestCase("foo.bar.config => Foo.Config", "foo.config", "foo.bar.config")]
@@ -236,7 +236,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldOutputDiagnosticsLoggingIfEnabled()
         {
             var calamariFileSystem = Substitute.For<ICalamariFileSystem>();

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
@@ -218,13 +218,13 @@ namespace Calamari.Tests.Fixtures.Conventions
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.OnlyNix)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         [TestCase("bar.blah => *.Bar.Blah", "xyz.bar.blah", "bar.blah")]
         [TestCase("*.Bar.Blah => bar.blah", "bar.blah", "xyz.bar.blah")]
         [TestCase("foo.bar.config => Foo.Config", "foo.config", "foo.bar.config")]
         public void CaseSensitiveOnNix(string pattern, string from, string to)
         {
-            if (!CalamariEnvironment.IsRunningOnNix)
+            if (!CalamariEnvironment.IsRunningOnNix && !CalamariEnvironment.IsRunningOnMac)
                 Assert.Ignore("This test is designed to run on *nix");
 
             variables.Set(SpecialVariables.Package.AdditionalXmlConfigurationTransforms, pattern);

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
@@ -224,7 +224,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         [TestCase("foo.bar.config => Foo.Config", "foo.config", "foo.bar.config")]
         public void CaseSensitiveOnNix(string pattern, string from, string to)
         {
-            if (!CalamariEnvironment.IsRunningOnNix &&)
+            if (!CalamariEnvironment.IsRunningOnNix)
                 Assert.Ignore("This test is designed to run on *nix");
 
             variables.Set(SpecialVariables.Package.AdditionalXmlConfigurationTransforms, pattern);

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
@@ -218,13 +218,13 @@ namespace Calamari.Tests.Fixtures.Conventions
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
+        [Category(TestCategory.CompatibleOS.OnlyNix)]
         [TestCase("bar.blah => *.Bar.Blah", "xyz.bar.blah", "bar.blah")]
         [TestCase("*.Bar.Blah => bar.blah", "bar.blah", "xyz.bar.blah")]
         [TestCase("foo.bar.config => Foo.Config", "foo.config", "foo.bar.config")]
         public void CaseSensitiveOnNix(string pattern, string from, string to)
         {
-            if (!CalamariEnvironment.IsRunningOnNix && !CalamariEnvironment.IsRunningOnMac)
+            if (!CalamariEnvironment.IsRunningOnNix &&)
                 Assert.Ignore("This test is designed to run on *nix");
 
             variables.Set(SpecialVariables.Package.AdditionalXmlConfigurationTransforms, pattern);

--- a/source/Calamari.Tests/Fixtures/Conventions/ContributeEnvironmentVariablesFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ContributeEnvironmentVariablesFixture.cs
@@ -16,6 +16,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             if (!CalamariEnvironment.IsRunningOnWindows)
                 Assert.Ignore("This test is designed to run on windows");
+
             var variables = AddEnvironmentVariables();
             Assert.That(variables.Evaluate("My OS is #{env:OS}"), Does.StartWith("My OS is Windows"));
         }
@@ -40,6 +41,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             // http://askubuntu.com/a/394330
             if (!CalamariEnvironment.IsRunningOnMac)
                 Assert.Ignore("This test is designed to run on Mac");
+
             var variables = AddEnvironmentVariables();
             Assert.That(variables.Evaluate("My paths are #{env:PATH}"), Does.Contain("/usr/local/bin"));
         }

--- a/source/Calamari.Tests/Fixtures/Conventions/ContributeEnvironmentVariablesFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ContributeEnvironmentVariablesFixture.cs
@@ -11,7 +11,7 @@ namespace Calamari.Tests.Fixtures.Conventions
     public class ContributeEnvironmentVariablesConventionFixture
     {
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldAddWindowsEnvironmentVariables()
         {
             if (!CalamariEnvironment.IsRunningOnWindows)
@@ -21,7 +21,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
+        [Category(TestCategory.CompatibleOS.OnlyNix)]
         public void ShouldAddLinuxEnvironmentVariables()
         {
             if (!CalamariEnvironment.IsRunningOnNix)
@@ -32,7 +32,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyMac)]
         public void ShouldAddMacEnvironmentVariables()
         {
             // Mac running in TeamCity agent service does not contain $HOME variable

--- a/source/Calamari.Tests/Fixtures/Conventions/CopyPackageToCustomInstallationDirectoryConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/CopyPackageToCustomInstallationDirectoryConventionFixture.cs
@@ -112,8 +112,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         [ExpectedException(ExpectedMessage = "Access to the path /var/tmp/myCustomInstallDir was denied. Ensure that the application that uses this directory is not running.")]
         public void ShouldNotIncludeIISRelatedInfoInErrorMessageWhenAccessDeniedException()
         {
@@ -126,7 +125,7 @@ namespace Calamari.Tests.Fixtures.Conventions
 
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         [ExpectedException(ExpectedMessage = "Access to the path C:\\myCustomInstallDir was denied. Ensure that the application that uses this directory is not running. If this is an IIS website, stop the application pool or use an app_offline.htm file (see https://g.octopushq.com/TakingWebsiteOffline).")]
         public void ShouldIncludeIISRelatedInfoInErrorMessageWhenAccessDeniedException()
         {

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithScriptsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithScriptsFixture.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.Fixtures.Deployment
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class DeployPackageWithScriptsFixture : DeployPackageFixture
     {
         private const string ServiceName = "Acme.Package";

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployVhdFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployVhdFixture.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.Fixtures.Deployment
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class DeployVhdFixture : DeployPackageFixture
     {
         private const string ServiceName = "Acme.Vhd";

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -44,7 +44,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldDeployPackageOnWindows()
         {
             var result = DeployPackage();
@@ -57,8 +57,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldDeployPackageOnMacOrNix()
         {
             if (!CalamariEnvironment.IsRunningOnMac && !CalamariEnvironment.IsRunningOnNix)
@@ -191,7 +190,7 @@ namespace Calamari.Tests.Fixtures.Deployment
 
 #if IIS_SUPPORT
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldModifyIisWebsiteRoot()
         {
             // If the 'UpdateIisWebsite' variable is set, the website root will be updated

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageToIISFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageToIISFixture.cs
@@ -67,7 +67,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldDeployAsWebSite()
         {
             Variables["Octopus.Action.IISWebSite.DeploymentType"] = "webSite";
@@ -107,7 +107,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldDeployAsVirtualDirectory()
         {
             iis.CreateWebSiteOrVirtualDirectory(uniqueValue, null, ".", 1083);
@@ -136,7 +136,7 @@ namespace Calamari.Tests.Fixtures.Deployment
 
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldKeepExistingBindingsWhenExistingBindingsIsMerge()
         {
             // The variable we are testing
@@ -169,7 +169,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
         
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldRemoveExistingBindingsByDefault()
         {
             const int existingBindingPort = 1083;
@@ -199,7 +199,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
         
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldDeployNewVersion()
         {
             iis.CreateWebSiteOrVirtualDirectory(uniqueValue, null, ".", 1083);
@@ -226,7 +226,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldNotAllowMissingParentSegments()
         {
             iis.CreateWebSiteOrVirtualDirectory(uniqueValue, null, ".", 1084);
@@ -248,7 +248,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldNotAllowMissingWebSiteForVirtualFolders()
         {
             Variables["Octopus.Action.IISWebSite.DeploymentType"] = "virtualDirectory";
@@ -266,7 +266,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldDeployAsWebApplication()
         {
             iis.CreateWebSiteOrVirtualDirectory(uniqueValue, null, ".", 1085);
@@ -303,7 +303,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldDetectAttemptedConversionFromVirtualDirectoryToWebApplication()
         {
             iis.CreateWebSiteOrVirtualDirectory(uniqueValue, $"/{uniqueValue}", ".", 1086);
@@ -328,7 +328,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldDeployWhenVirtualPathAlreadyExistsAndPointsToPhysicalDirectory()
         {
             var webSitePhysicalPath = Path.Combine(Path.GetTempPath(), uniqueValue);
@@ -358,7 +358,7 @@ namespace Calamari.Tests.Fixtures.Deployment
 
 #if WINDOWS_CERTIFICATE_STORE_SUPPORT 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldCreateHttpsBindingUsingCertificatePassedAsVariable()
         {
             Variables["Octopus.Action.IISWebSite.DeploymentType"] = "webSite";
@@ -402,7 +402,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldFindAndUseExistingCertificateInStoreIfPresent()
         {
             Variables["Octopus.Action.IISWebSite.DeploymentType"] = "webSite";
@@ -445,7 +445,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldCreateHttpsBindingUsingCertificatePassedAsThumbprint()
         {
             Variables["Octopus.Action.IISWebSite.DeploymentType"] = "webSite";
@@ -482,7 +482,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test] // https://github.com/OctopusDeploy/Issues/issues/3378
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldNotFailIfDisabledBindingUsesUnavailableCertificateVariable()
         {
             Variables["Octopus.Action.IISWebSite.DeploymentType"] = "webSite";

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWindowsServiceArgumentsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWindowsServiceArgumentsFixture.cs
@@ -10,7 +10,7 @@ using Assent.Reporters.DiffPrograms;
 namespace Calamari.Tests.Fixtures.Deployment
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class DeployWindowsServiceArgumentsFixture : DeployWindowsServiceAbstractFixture
     {
         protected override string ServiceName => "DumpArgs";

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWindowsServiceFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWindowsServiceFixture.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.Fixtures.Deployment
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class DeployWindowsServiceFixture : DeployWindowsServiceAbstractFixture
     {
         protected override string ServiceName => "Acme.Service";

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWindowsServiceWithCustomServiceNameFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWindowsServiceWithCustomServiceNameFixture.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.Fixtures.Deployment
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class DeployWindowsServiceWithCustomServiceNameFixture : DeployWindowsServiceAbstractFixture
     {
         protected override string ServiceName => @"[f`o]o$b'[a]r";

--- a/source/Calamari.Tests/Fixtures/Iis/IisFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Iis/IisFixture.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.Fixtures.Iis
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class IisFixture
     {
         readonly WebServerSupport webServer = WebServerSupport.AutoDetect();

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSytemFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSytemFixture.cs
@@ -37,7 +37,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
 
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void WindowsUsesWindowsFileSystem()
         {
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
@@ -45,8 +45,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void NonWindowsUsesWindowsFileSystem()
         {
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
@@ -217,7 +216,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void LongFilePathsShouldWork()
         {
             var paths = new Stack<string>();

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/PathExtensionsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/PathExtensionsFixture.cs
@@ -23,7 +23,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         [TestCase(@"c:\foo\..\bar\baz", @"c:\foo", false)]
         [TestCase(@"c:\foo\..\bar\baz", @"c:\bar", true)]
         [TestCase(@"c:\foo\..\bar\baz", @"c:\barr", false)]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void IsChildOfTest(string child, string parent, bool result)
         {
             child.IsChildOf(parent).Should().Be(result);
@@ -33,7 +33,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         [TestCase(@"c:\foo\a.txt", @"c:\FOO", true)]
         [TestCase(@"c:\foo", @"c:", true)]
         [TestCase(@"c:\foo", @"c:\", true)]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void IsChildOfTestWindows(string child, string parent, bool result)
         {
             child.IsChildOf(parent).Should().Be(result);
@@ -44,8 +44,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         [TestCase(@"/", @"/", true)]
         [TestCase(@"/foo", @"/", true)]
         [TestCase(@"/", @"/foo", false)]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void IsChildOfTestUnix(string child, string parent, bool result)
         {
             child.IsChildOf(parent).Should().Be(result);

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/WindowsPhysicalFileSystemFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/WindowsPhysicalFileSystemFixture.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.Fixtures.Integration.FileSystem
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class WindowsPhysicalFileSystemFixture
     {
         [Test]

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/GitHubPackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/GitHubPackageDownloadFixture.cs
@@ -41,7 +41,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)] //Keeps rate limit low
+        [Category(TestCategory.CompatibleOS.OnlyWindows)] //Keeps rate limit low
         public void DownloadsPackageFromGitHub()
         {
             var downloader = new GitHubPackageDownloader();
@@ -55,7 +55,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)] //Keeps rate limit low
+        [Category(TestCategory.CompatibleOS.OnlyWindows)] //Keeps rate limit low
         public void WillReUseFileIfItExists()
         {
             var downloader = new GitHubPackageDownloader();
@@ -76,7 +76,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)] //Keeps rate limit low
+        [Category(TestCategory.CompatibleOS.OnlyWindows)] //Keeps rate limit low
         public void DownloadsPackageFromGitHubWithDifferentVersionFormat()
         {
             var downloader = new GitHubPackageDownloader();

--- a/source/Calamari.Tests/Fixtures/Integration/Process/Semaphores/SemaphoreFactoryFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Process/Semaphores/SemaphoreFactoryFixture.cs
@@ -19,7 +19,7 @@ namespace Calamari.Tests.Fixtures.Integration.Process.Semaphores
 
 #if NETFX
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ReturnsSystemSemaphoreManagerForWindows()
         {
             if (!CalamariEnvironment.IsRunningOnWindows)

--- a/source/Calamari.Tests/Fixtures/Integration/Process/Semaphores/SystemSemaphoreFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Process/Semaphores/SystemSemaphoreFixture.cs
@@ -8,14 +8,14 @@ namespace Calamari.Tests.Fixtures.Integration.Process.Semaphores
     public class SystemSemaphoreFixture : SemaphoreFixtureBase
     {
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void SystemSemaphoreWaitsUntilFirstSemaphoreIsReleased()
         {
             SecondSemaphoreWaitsUntilFirstSemaphoreIsReleased(new SystemSemaphoreManager());
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void SystemSemaphoreShouldIsolate()
         {
             ShouldIsolate(new SystemSemaphoreManager());

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
@@ -39,7 +39,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void Initialize_HasSystemProxy_NoProxy()
         {
             ProxyRoutines.SetProxy(proxyUrl).Should().BeTrue();
@@ -49,7 +49,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void Initialize_HasSystemProxy_UseSystemProxy()
         {
             ProxyRoutines.SetProxy(proxyUrl).Should().BeTrue();
@@ -59,7 +59,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void Initialize_HasSystemProxy_UseSystemProxyWithCredentials()
         {
             ProxyRoutines.SetProxy(proxyUrl).Should().BeTrue();
@@ -69,7 +69,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void Initialize_HasSystemProxy_CustomProxy()
         {
             ProxyRoutines.SetProxy(BadproxyUrl).Should().BeTrue();
@@ -79,7 +79,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void Initialize_HasSystemProxy_CustomProxyWithCredentials()
         {
             ProxyRoutines.SetProxy(BadproxyUrl).Should().BeTrue();

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/WebProxyInitializerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/WebProxyInitializerFixture.cs
@@ -9,7 +9,7 @@ using SetProxy;
 namespace Calamari.Tests.Fixtures.Integration.Proxies
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class ProxyInitializerFixture
     {
         const string BadproxyUrl = "http://proxy-initializer-fixture-bad-proxy:1234";

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/WindowsScriptProxyFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/WindowsScriptProxyFixtureBase.cs
@@ -18,7 +18,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public virtual void Initialize_HasSystemProxy_NoProxy()
         {
             ProxyRoutines.SetProxy(proxyUrl).Should().BeTrue();
@@ -28,7 +28,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public virtual void Initialize_HasSystemProxy_UseSystemProxy()
         {
             ProxyRoutines.SetProxy(proxyUrl).Should().BeTrue();
@@ -38,7 +38,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public virtual void Initialize_HasSystemProxy_UseSystemProxyWithCredentials()
         {
             ProxyRoutines.SetProxy(proxyUrl).Should().BeTrue();
@@ -48,7 +48,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public virtual void Initialize_HasSystemProxy_CustomProxy()
         {
             ProxyRoutines.SetProxy(BadproxyUrl).Should().BeTrue();
@@ -58,7 +58,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public virtual void Initialize_HasSystemProxy_CustomProxyWithCredentials()
         {
             ProxyRoutines.SetProxy(BadproxyUrl).Should().BeTrue();

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
@@ -15,7 +15,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
     public class ScriptEngineFixture
     {
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void PowershellDecryptsSensitiveVariables()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
@@ -39,8 +39,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void BashDecryptsSensitiveVariables()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "sh")))

--- a/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
@@ -16,7 +16,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.Fixtures.Nginx
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.OnlyNix)]
+    [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
     public class NginxFixture : CalamariFixture
     {
         readonly ICalamariFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();

--- a/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
@@ -16,7 +16,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.Fixtures.Nginx
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Nix)]
+    [Category(TestCategory.CompatibleOS.OnlyNix)]
     public class NginxFixture : CalamariFixture
     {
         readonly ICalamariFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
@@ -135,8 +135,7 @@ namespace Calamari.Tests.Fixtures.Nginx
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void SetupReverseProxyWithSslSite()
         {
             var locations =

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -16,7 +16,7 @@ using Octostache;
 namespace Calamari.Tests.Fixtures.PowerShell
 {    
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class WindowsPowerShellFixture : PowerShellFixture
     {
         [Test]
@@ -77,7 +77,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
     }
     
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Nix)]
+    [Category(TestCategory.CompatibleOS.OnlyNix)]
     public class WindowsPowerShellOnLinuxFixture : CalamariFixture
     {
         [Test]
@@ -111,7 +111,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
     }
 
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Mac)]
+    [Category(TestCategory.CompatibleOS.OnlyMac)]
     public class WindowsPowerShellOnMacFixture : CalamariFixture
     {
         [Test]

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixture.cs
@@ -77,11 +77,11 @@ namespace Calamari.Tests.Fixtures.PowerShell
     }
     
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.OnlyNix)]
-    public class WindowsPowerShellOnLinuxFixture : CalamariFixture
+    [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
+    public class WindowsPowerShellOnLinuxAndMacFixture : CalamariFixture
     {
         [Test]
-        public void PowerShellThrowsExceptionOnNix()
+        public void PowerShellThrowsExceptionOnNixAndMac()
         {
             var (output, _) = RunScript("Hello.ps1");
             output.AssertErrorOutput("PowerShell scripts are not supported on this platform");
@@ -110,40 +110,6 @@ namespace Calamari.Tests.Fixtures.PowerShell
         }
     }
 
-    [TestFixture]
-    [Category(TestCategory.CompatibleOS.OnlyMac)]
-    public class WindowsPowerShellOnMacFixture : CalamariFixture
-    {
-        [Test]
-        public void PowerShellThrowsExceptionOnMac()
-        {
-            var (output, _) = RunScript("Hello.ps1");
-            output.AssertErrorOutput("PowerShell scripts are not supported on this platform");
-        }
-
-        [Test]
-        public void ShouldRunBashInsteadOfPowerShell()
-        {
-            var variablesFile = Path.GetTempFileName();
-
-            var variables = new VariableDictionary();
-            variables.Set(SpecialVariables.Action.Script.ScriptBodyBySyntax(ScriptSyntax.PowerShell), "Write-Host Hello Powershell");
-            variables.Set(SpecialVariables.Action.Script.ScriptBodyBySyntax(ScriptSyntax.CSharp), "Write-Host Hello CSharp");
-            variables.Set(SpecialVariables.Action.Script.ScriptBodyBySyntax(ScriptSyntax.Bash), "echo Hello Bash");
-            variables.Save(variablesFile);
-
-            using (new TemporaryFile(variablesFile))
-            {
-                var output = Invoke(Calamari()
-                    .Action("run-script")
-                    .Argument("variables", variablesFile));
-
-                output.AssertSuccess();
-                output.AssertOutput("Hello Bash");
-            }
-        }
-    }
-    
     public abstract class PowerShellFixture : CalamariFixture
     {
         void AssertPSEdition(CalamariResult output)

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellProxyFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellProxyFixture.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.Fixtures.PowerShell
 {
     [TestFixture]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class PowerShellProxyFixture : WindowsScriptProxyFixtureBase
     {
         protected override CalamariResult RunScript()

--- a/source/Calamari.Tests/Fixtures/Python/PythonFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Python/PythonFixture.cs
@@ -61,7 +61,7 @@ namespace Calamari.Tests.Fixtures.Python
         }
         
         [Test, RequiresMinimumPython3Version(4)]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void ShouldWriteServiceMessageForArtifactsOnWindows()
         {
             var (output, _) = RunScript("createartifactwin.py");
@@ -70,8 +70,7 @@ namespace Calamari.Tests.Fixtures.Python
         }
 
         [Test, RequiresMinimumPython3Version(4)]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void ShouldWriteServiceMessageForArtifactsOnNix()
         {
             var (output, _) = RunScript("createartifactnix.py");

--- a/source/Calamari.Tests/Fixtures/Util/CrossPlatformFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/CrossPlatformFixture.cs
@@ -25,8 +25,7 @@ namespace Calamari.Tests.Fixtures.Util
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void TildePrefixReplacedWithHome()
         {
             var home = Environment.GetEnvironmentVariable("HOME");
@@ -42,8 +41,7 @@ namespace Calamari.Tests.Fixtures.Util
         [TestCase("$MARIO_BROTHERZZ/blah", "/blah", Description = "Variables terminate at last non alpha numeric character")]
         [TestCase("IMA$MARIO_BROTHER", "IMALUIGI", Description = "Variables begin from dollar character")]
         [TestCase("\\$MARIO_BROTHER/blah", "\\$MARIO_BROTHER/blah", Description = "Escaped dollar preserved")]
-        [Category(TestCategory.CompatibleOS.Nix)]
-        [Category(TestCategory.CompatibleOS.Mac)]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void NixEnvironmentVariableReplaced(string inputValue, string expectedResult)
         {
             var value = CrossPlatform.ExpandPathEnvironmentVariables(inputValue);
@@ -53,7 +51,7 @@ namespace Calamari.Tests.Fixtures.Util
         [Test]
         [TestCase("$MARIO_BROTHER/blah", "$MARIO_BROTHER/blah", Description = "Nix variable format ignored")]
         [TestCase("IMA%MARIO_BROTHER%PLUMBER", "IMALUIGIPLUMBER", Description = "Variables demarcated by percent character")]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void WindowsEnvironmentVariableReplaced(string inputValue, string expectedResult)
         {
             var value = CrossPlatform.ExpandPathEnvironmentVariables(inputValue);

--- a/source/Calamari.Tests/Helpers/TestCategory.cs
+++ b/source/Calamari.Tests/Helpers/TestCategory.cs
@@ -11,11 +11,13 @@ namespace Calamari.Tests.Helpers
 
         public static class CompatibleOS
         {
-            public const string Nix = "Nix";
+            public const string OnlyNix = "Nix";
 
-            public const string Windows = "Windows";
+            public const string OnlyWindows = "Windows";
 
-            public const string Mac = "macOS";
+            public const string OnlyMac = "macOS";
+
+            public const string OnlyNixOrMac = "nixMacOS";
         }
         
         public const string PlatformAgnostic = "PlatformAgnostic";

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -40,7 +40,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Windows)]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         [Ignore("Not yet ready for prime time. Tested via Helm tests atm anyway")]
         public void PowershellKubeCtlScripts()
         {
@@ -49,7 +49,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.Nix)]
+        [Category(TestCategory.CompatibleOS.OnlyNix)]
         [Ignore("Not yet ready for prime time. Tested via Helm tests atm anyway")]
         public void BashKubeCtlScripts()
         {

--- a/source/Calamari.Tests/Terraform/TerraformFixture.cs
+++ b/source/Calamari.Tests/Terraform/TerraformFixture.cs
@@ -26,7 +26,7 @@ namespace Calamari.Tests.Terraform
     [RequiresNon32BitWindows]
     [RequiresNonMac]
     [RequiresNonMono]
-    [Category(TestCategory.CompatibleOS.Windows)]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     public class TerraformFixture
     {
         private string customTerraformExecutable;


### PR DESCRIPTION
When we run Calamari unit tests, we exclude the categories that do not make sense for the agent the tests are running on.

For example: `/TestCaseFilter:"TestCategory != Windows & TestCategory != fsharp & TestCategory != scriptcs & TestCategory != PlatformAgnostic"`

We were assigning multiple OS categories to the same test, which would work if our test runs were inclusive rather than exclusive. Because they are exclusive, the test agents would skip tests where there were two OS categories but one was not applicable to the current build agent.

Give a category rule: `TestCategory != Nix`
The following test would not run on a Mac agent:
```
[Category("Nix")]
[Category("Mac")]
public void ATestThatCanRunOnLinuxOrMac
```

This PR adds a new category for tests that can run on Mac and Nix, and sets only a single category for all OS specific tests.