### PR TITLE
Warning about Management Certificate use for Web Apps

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
@@ -24,7 +24,7 @@ namespace Calamari.Azure.Deployment.Conventions
             
             if (variables.Get(SpecialVariables.Account.AccountType) == "AzureSubscription")
             {
-                Log.Warn("Use of Management Certificates to deploy Azure Web App services has been deprecated by Microsoft and they are progressively disabling them, please update to using a Service Principal. If you receive an error about the app not being found in the subscription then this account type is the most likely cause.");
+                Log.Warn("Use of Management Certificates to deploy Azure Web App services has been deprecated by Microsoft and they are progressively disabling them, please update to using a Service Principal. If you receive an error about the app not being found in the subscription then this account type is the most likely cause. See [our documentation](https://g.octopushq.com/AzureTargets#azure-management-certificate) for more details.");
             }
 
             var subscriptionId = variables.Get(SpecialVariables.Action.Azure.SubscriptionId);

--- a/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/AzureWebAppConvention.cs
@@ -21,6 +21,12 @@ namespace Calamari.Azure.Deployment.Conventions
         public void Install(RunningDeployment deployment)
         {
             var variables = deployment.Variables;
+            
+            if (variables.Get(SpecialVariables.Account.AccountType) == "AzureSubscription")
+            {
+                Log.Warn("Use of Management Certificates to deploy Azure Web App services has been deprecated by Microsoft and they are progressively disabling them, please update to using a Service Principal. If you receive an error about the app not being found in the subscription then this account type is the most likely cause.");
+            }
+
             var subscriptionId = variables.Get(SpecialVariables.Action.Azure.SubscriptionId);
             var resourceGroupName = variables.Get(SpecialVariables.Action.Azure.ResourceGroupName, string.Empty);
             var siteAndSlotName = variables.Get(SpecialVariables.Action.Azure.WebAppName);

--- a/source/Calamari.Tests/AzureFixtures/AzureWebAppConventionFixture.cs
+++ b/source/Calamari.Tests/AzureFixtures/AzureWebAppConventionFixture.cs
@@ -1,0 +1,64 @@
+#if AZURE
+
+using System;
+using Calamari.Azure.Deployment.Conventions;
+using Calamari.Deployment;
+using Calamari.Integration.Processes;
+using Calamari.Tests.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.AzureFixtures
+{
+    [TestFixture]
+    public class AzureWebAppConventionFixture
+    {
+        [Test]
+        public void UsingAManagementCertificateCausesAWarning()
+        {
+            using (var logs = new ProxyLog())
+            {
+                var convention = new AzureWebAppConvention();
+
+                var vars = new CalamariVariableDictionary();
+                vars.Set(SpecialVariables.Account.AccountType, "AzureSubscription");
+
+                var deployment = new RunningDeployment("", vars);
+
+                // ignore the incomplete setup, we just want to know about whether the warning is logged
+                try
+                {
+                    convention.Install(deployment);
+                }
+                catch(Exception){}
+
+                logs.StdOut.Contains("Use of Management Certificates to deploy Azure Web App services has been deprecated").Should().BeTrue();
+            }
+        }
+        
+        [Test]
+        public void UsingAServicePrincipalDoesNotCauseAWarning()
+        {
+            using (var logs = new ProxyLog())
+            {
+                var convention = new AzureWebAppConvention();
+
+                var vars = new CalamariVariableDictionary();
+                vars.Set(SpecialVariables.Account.AccountType, "AzureServicePrincipal");
+
+                var deployment = new RunningDeployment("", vars);
+
+                // ignore the incomplete setup, we just want to know about whether the warning is logged
+                try
+                {
+                    convention.Install(deployment);
+                }
+                catch(Exception){}
+
+                logs.StdOut.Contains("Use of Management Certificates to deploy Azure Web App services has been deprecated").Should().BeFalse();
+            }
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Updated the AzureWebAppConvention to emit a warning when it detects a Management Certificate is being used.

Relates to OctopusDeploy/Issues#5950