### PR TITLE
Turn on AzureRM aliasing if the cmds are missing from the system

### DIFF
--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -67,6 +67,12 @@ Execute-WithRetry{
             $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
             $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
 
+            if (-Not (Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
+            {
+                # Turn only AzureRm aliasing
+                Enable-AzureRmAlias -Scope Process
+            }
+
             # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
             Disable-AzureRMContextAutosave -Scope Process
 

--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -69,7 +69,8 @@ Execute-WithRetry{
 
             if (-Not (Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
             {
-                # Turn only AzureRm aliasing
+                # Turn on AzureRm aliasing
+                # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
                 Enable-AzureRmAlias -Scope Process
             }
 


### PR DESCRIPTION
This fixes an issue with Azure commands not working if the environment has `az` instead of `AzureRm` modules installed.

Related to OctopusDeploy/Issues#5384

Fixes OctopusDeploy/Issues#5968