### PR TITLE
Allow for variables to be read from additional JSON file.

### DIFF
--- a/source/Calamari.Shared/Commands/Support/CommandException.cs
+++ b/source/Calamari.Shared/Commands/Support/CommandException.cs
@@ -8,5 +8,11 @@ namespace Calamari.Commands.Support
             : base(message)
         {
         }
+
+        public CommandException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            
+        }
     }
 }

--- a/source/Calamari.Shared/Deployment/Conventions/ContributeVariablesFromJsonFileConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/ContributeVariablesFromJsonFileConvention.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.IO;
+using Calamari.Commands.Support;
+using Calamari.Integration.Processes;
+using Octostache;
+
+namespace Calamari.Deployment.Conventions
+{
+    /// <summary>
+    /// Attempts to read a file path from an environment variable and, if present,
+    /// reads that file as a VariableDictionary and copies the values into the
+    /// current RunningDeployment's VariableDictionary.
+    /// </summary>
+    public class ContributeVariablesFromJsonFileConvention : IInstallConvention
+    {
+        /// <summary>
+        /// The name of the environment variable that specifies the file path
+        /// from which to read the additional variables.
+        /// </summary>
+        public const string AdditionalVariablesKey = SpecialVariables.Environment.Prefix + "Octopus.AdditionalVariablesPath";
+
+        readonly Func<string, VariableDictionary> dictionaryReader;
+        
+        /// <summary>
+        /// Creates a default convention that attempts to read variable files
+        /// using Octostache's reading functionality.
+        /// </summary>
+        public ContributeVariablesFromJsonFileConvention()
+            : this(ReadDictionaryFromFilePath)
+        {
+        }
+        
+        /// <summary>
+        /// Creates a convention that uses the provided function to read a
+        /// variable dictionary from a filepath.
+        /// </summary>
+        public ContributeVariablesFromJsonFileConvention(Func<string, VariableDictionary> dictionaryReader)
+        {
+            this.dictionaryReader = dictionaryReader;
+        }
+        
+        public void Install(RunningDeployment deployment)
+        {
+            if (deployment == null)
+                throw new ArgumentNullException(nameof(deployment));
+            
+            var additionalVariablesPath = deployment.Variables.Get(AdditionalVariablesKey);
+
+            if (string.IsNullOrEmpty(additionalVariablesPath))
+                return;
+
+            var additionalVariables = dictionaryReader(additionalVariablesPath);
+            
+            CopyVariables(additionalVariables, deployment.Variables);
+        }
+
+        static VariableDictionary ReadDictionaryFromFilePath(string filePath)
+        {
+            if (!File.Exists(filePath))
+            {
+                throw BuildException(filePath, "File does not exist.");
+            }
+            
+            try
+            {
+                return new VariableDictionary(filePath);
+            }
+            catch (Exception e)
+            {
+                throw BuildException(filePath, "The file could not be read.", e);
+            }
+        }
+
+        private static CommandException BuildException(string path, string reason, Exception inner = null)
+        {
+            var msg = $"Could not read additional variables from JSON file at '{path}'. " +
+                      $"{reason} Make sure the file can be read or remove the " +
+                      $"'{AdditionalVariablesKey}' environment variable. " +
+                      $"See inner exception for details.";
+            
+            throw new CommandException(msg, inner);
+        }
+        
+        /// <summary>
+        /// Copies all of the variables from one variable dictionary into another.
+        /// </summary>
+        void CopyVariables(VariableDictionary copyFrom, CalamariVariableDictionary copyTo)
+        {
+            foreach (var variable in copyFrom)
+            {
+                copyTo.Add(variable.Key, variable.Value);
+            }
+        }
+    }
+}

--- a/source/Calamari.Shared/Deployment/Conventions/ContributeVariablesFromJsonFileConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/ContributeVariablesFromJsonFileConvention.cs
@@ -6,34 +6,15 @@ using Octostache;
 
 namespace Calamari.Deployment.Conventions
 {
-    /// <summary>
-    /// Attempts to read a file path from an environment variable and, if present,
-    /// reads that file as a VariableDictionary and copies the values into the
-    /// current RunningDeployment's VariableDictionary.
-    /// </summary>
     public class ContributeVariablesFromJsonFileConvention : IInstallConvention
     {
-        /// <summary>
-        /// The name of the environment variable that specifies the file path
-        /// from which to read the additional variables.
-        /// </summary>
-        public const string AdditionalVariablesKey = SpecialVariables.Environment.Prefix + "Octopus.AdditionalVariablesPath";
-
         readonly Func<string, VariableDictionary> dictionaryReader;
         
-        /// <summary>
-        /// Creates a default convention that attempts to read variable files
-        /// using Octostache's reading functionality.
-        /// </summary>
         public ContributeVariablesFromJsonFileConvention()
             : this(ReadDictionaryFromFilePath)
         {
         }
         
-        /// <summary>
-        /// Creates a convention that uses the provided function to read a
-        /// variable dictionary from a filepath.
-        /// </summary>
         public ContributeVariablesFromJsonFileConvention(Func<string, VariableDictionary> dictionaryReader)
         {
             this.dictionaryReader = dictionaryReader;
@@ -44,7 +25,7 @@ namespace Calamari.Deployment.Conventions
             if (deployment == null)
                 throw new ArgumentNullException(nameof(deployment));
             
-            var additionalVariablesPath = deployment.Variables.Get(AdditionalVariablesKey);
+            var additionalVariablesPath = deployment.Variables.Get(SpecialVariables.AdditionalVariablesPath);
 
             if (string.IsNullOrEmpty(additionalVariablesPath))
                 return;
@@ -75,15 +56,12 @@ namespace Calamari.Deployment.Conventions
         {
             var msg = $"Could not read additional variables from JSON file at '{path}'. " +
                       $"{reason} Make sure the file can be read or remove the " +
-                      $"'{AdditionalVariablesKey}' environment variable. " +
+                      $"'{SpecialVariables.AdditionalVariablesPath}' environment variable. " +
                       $"See inner exception for details.";
             
             throw new CommandException(msg, inner);
         }
         
-        /// <summary>
-        /// Copies all of the variables from one variable dictionary into another.
-        /// </summary>
         void CopyVariables(VariableDictionary copyFrom, CalamariVariableDictionary copyTo)
         {
             foreach (var variable in copyFrom)

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -64,6 +64,8 @@ namespace Calamari.Deployment
         public static readonly string CopyWorkingDirectoryIncludingKeyTo = "Octopus.Calamari.CopyWorkingDirectoryIncludingKeyTo";
         public static readonly string CalamariWorkingDirectory = "OctopusCalamariWorkingDirectory";
 
+        public const string AdditionalVariablesPath = Environment.Prefix + "Octopus.AdditionalVariablesPath";
+        
         public static class Bootstrapper
         {
             public static string ModulePaths = "Octopus.Calamari.Bootstrapper.ModulePaths";

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -209,6 +209,7 @@ namespace Calamari.Deployment
 
         public static class Environment
         {
+            public const string Prefix = "env:";
             public static readonly string Id = "Octopus.Environment.Id";
             public static readonly string Name = "Octopus.Environment.Name";
         }

--- a/source/Calamari.Tests/Fixtures/Conventions/ContributeVariablesFromJsonFileConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ContributeVariablesFromJsonFileConventionFixture.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using Calamari.Commands.Support;
+using Calamari.Deployment;
+using Calamari.Deployment.Conventions;
+using Calamari.Integration.Processes;
+using FluentAssertions;
+using NUnit.Framework;
+using Octostache;
+
+namespace Calamari.Tests.Fixtures.Conventions
+{
+    [TestFixture]
+    public class ContributeVariablesFromJsonFileConventionFixture
+    {
+        void RunTest(
+            IEnumerable<(string Key, string Value)> existingVariables,
+            IEnumerable<(string Key, string Value)> newVariables,
+            Action<CalamariVariableDictionary> assertions
+        )
+        {
+            var deploymentVariables = new CalamariVariableDictionary();
+
+            foreach (var variable in existingVariables)
+            {
+                deploymentVariables.Add(variable.Key, variable.Value);
+            }
+            
+            var deployment = new RunningDeployment(null, deploymentVariables);
+            
+            var fileVariables = new VariableDictionary();
+
+            foreach (var variable in newVariables)
+            {
+                fileVariables.Add(variable.Key, variable.Value);
+            }
+            
+            var convention = new ContributeVariablesFromJsonFileConvention(path => fileVariables);
+            
+            convention.Install(deployment);
+
+            var actual = deployment.Variables;
+
+            assertions(actual);
+        }
+
+        [Test]
+        public void VariablesAreNotContributedIfEnvVarIsNotFound()
+        {
+            RunTest(
+                new (string, string)[0],
+                new[]
+                {
+                    ("new.key", "new.value")
+                },
+                actual => actual.Should().BeEmpty()
+            );
+        }
+
+        [Test]
+        public void VariablesAreContributedIfEnvVarIsFound()
+        {
+            RunTest(
+                new[]
+                {
+                    (ContributeVariablesFromJsonFileConvention.AdditionalVariablesKey, "ignored_by_this_test"),
+                    ("existing.key", "existing.value")
+                },
+                new[]
+                {
+                    ("new.key", "new.value")
+                },
+                actual =>
+                {
+                    actual.Should().HaveCount(3);
+                    actual.Should().ContainSingle(pair => 
+                        pair.Key == ContributeVariablesFromJsonFileConvention.AdditionalVariablesKey &&
+                        pair.Value == "ignored_by_this_test");
+                    actual.Should().ContainSingle(pair => 
+                        pair.Key == "existing.key" &&
+                        pair.Value == "existing.value");
+                    actual.Should().ContainSingle(pair => 
+                        pair.Key == "new.key" &&
+                        pair.Value == "new.value");
+                }
+            );
+        }
+
+        [Test]
+        public void ThrowsExceptionIfFileNotFound()
+        {
+            const string filePath = "c:/assuming/that/this/file/doesnt/exist.json";
+            
+            var deployment = new RunningDeployment(
+                null,
+                new CalamariVariableDictionary
+                {
+                    { ContributeVariablesFromJsonFileConvention.AdditionalVariablesKey, filePath }
+                }
+            );
+
+            var convention = new ContributeVariablesFromJsonFileConvention();
+
+            convention
+                .Invoking(c => c.Install(deployment))
+                .Should()
+                .Throw<CommandException>()
+                // Make sure that the message says how to turn this feature off.
+                .Where(e => e.Message.Contains(ContributeVariablesFromJsonFileConvention.AdditionalVariablesKey))
+                // Make sure that the message says where it looked for the file.
+                .Where(e => e.Message.Contains(filePath));
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Conventions/ContributeVariablesFromJsonFileConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ContributeVariablesFromJsonFileConventionFixture.cs
@@ -63,7 +63,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             RunTest(
                 new[]
                 {
-                    (ContributeVariablesFromJsonFileConvention.AdditionalVariablesKey, "ignored_by_this_test"),
+                    (SpecialVariables.AdditionalVariablesPath, "ignored_by_this_test"),
                     ("existing.key", "existing.value")
                 },
                 new[]
@@ -74,7 +74,7 @@ namespace Calamari.Tests.Fixtures.Conventions
                 {
                     actual.Should().HaveCount(3);
                     actual.Should().ContainSingle(pair => 
-                        pair.Key == ContributeVariablesFromJsonFileConvention.AdditionalVariablesKey &&
+                        pair.Key == SpecialVariables.AdditionalVariablesPath &&
                         pair.Value == "ignored_by_this_test");
                     actual.Should().ContainSingle(pair => 
                         pair.Key == "existing.key" &&
@@ -95,7 +95,7 @@ namespace Calamari.Tests.Fixtures.Conventions
                 null,
                 new CalamariVariableDictionary
                 {
-                    { ContributeVariablesFromJsonFileConvention.AdditionalVariablesKey, filePath }
+                    { SpecialVariables.AdditionalVariablesPath, filePath }
                 }
             );
 
@@ -106,7 +106,7 @@ namespace Calamari.Tests.Fixtures.Conventions
                 .Should()
                 .Throw<CommandException>()
                 // Make sure that the message says how to turn this feature off.
-                .Where(e => e.Message.Contains(ContributeVariablesFromJsonFileConvention.AdditionalVariablesKey))
+                .Where(e => e.Message.Contains(SpecialVariables.AdditionalVariablesPath))
                 // Make sure that the message says where it looked for the file.
                 .Where(e => e.Message.Contains(filePath));
         }

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -69,6 +69,7 @@ namespace Calamari.Commands
             var conventions = new List<IConvention>
             {
                 new ContributeEnvironmentVariablesConvention(),
+                new ContributeVariablesFromJsonFileConvention(),
                 new LogVariablesConvention(),
                 new StageScriptPackagesConvention(packageFile, fileSystem, extractor),
                 // Substitute the script source file


### PR DESCRIPTION
# Background
Health checks on tentacles currently don't have any way of supplying variables. If something goes wrong during a health check it can be difficult to debug what has happened. This PR allows for the `run-script` command to check an environment variable (`Octopus.AdditionalVariablesPath`) for a path to a JSON file of additional variables. Those variables are then merged into the variables that have been provided to the command.

# Results
Relates to https://github.com/OctopusDeploy/Issues/issues/6012

# How to review this PR
Some things to consider:

- Is the name of the environment variable okay?
- The variables from the additional JSON file will override other variables if they are defined with the same name.
- These additional variables only apply to the `run-script` command.

# Pre-requisites
- [x] I have considered whether this should be a patch or wait for a minor.
- [x] I have considered appropriate testing for my change.