### PR TITLE
Updated Octostache to get the new UriPart filter

### DIFF
--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="Octopus.Versioning" Version="4.1.3" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
-    <PackageReference Include="Octostache" Version="2.6.0" />
+    <PackageReference Include="Octostache" Version="2.7.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>


### PR DESCRIPTION
Updating Octostache reference to obtain the changes in this PR: https://github.com/OctopusDeploy/Octostache/pull/36

This adds a new filter called UriPart which extracts information from a URI