### PR TITLE
Support `Set-PSDebug -trace` to enable super detailed diagnostic traces

### DIFF
--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -360,6 +360,7 @@ namespace Calamari.Deployment
                 public static readonly string UserName = "Octopus.Action.PowerShell.UserName";
                 public static readonly string Password = "Octopus.Action.PowerShell.Password";
                 public static readonly string DebugMode = "Octopus.Action.PowerShell.DebugMode";
+                public static readonly string TraceMode = "Octopus.Action.PowerShell.TraceMode";
                 public static readonly string Edition = "Octopus.Action.PowerShell.Edition";
             }
 

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -360,8 +360,13 @@ namespace Calamari.Deployment
                 public static readonly string UserName = "Octopus.Action.PowerShell.UserName";
                 public static readonly string Password = "Octopus.Action.PowerShell.Password";
                 public static readonly string DebugMode = "Octopus.Action.PowerShell.DebugMode";
-                public static readonly string TraceMode = "Octopus.Action.PowerShell.TraceMode";
                 public static readonly string Edition = "Octopus.Action.PowerShell.Edition";
+
+                public static class PSDebug
+                {
+                    public static readonly string Trace = "Octopus.Action.PowerShell.PSDebug.Trace";
+                    public static readonly string Strict = "Octopus.Action.PowerShell.PSDebug.Strict";
+                }
             }
 
             public static class Certificate

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -179,9 +179,8 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
             var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword));
             var commandArguments = new StringBuilder();
             var executeWithoutProfile = variables[SpecialVariables.Action.PowerShell.ExecuteWithoutProfile];
-            var traceLevel = variables[SpecialVariables.Action.PowerShell.TraceMode];
-            var traceCommand = !string.IsNullOrEmpty(traceLevel) ? " Set-PSDebug -Trace 2; " : "";
-            
+            var traceCommand = GetPsDebugCommand(variables);
+
             foreach (var argument in ContributeCommandArguments(variables))
                 commandArguments.Append(argument);
             
@@ -200,6 +199,33 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
 
             commandArguments.AppendFormat("-Command \"{0}Try {{. {{. '{1}' -OctopusKey '{2}'; if ((test-path variable:global:lastexitcode)) {{ exit $LastExitCode }}}};}} catch {{ throw }}\"", traceCommand, fileToExecute, encryptionKey);
             return commandArguments.ToString();
+        }
+
+        static string GetPsDebugCommand(CalamariVariableDictionary variables)
+        {
+            //https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-psdebug?view=powershell-6
+            var traceArg = variables[SpecialVariables.Action.PowerShell.PSDebug.Trace];
+            var traceCommand = "-Trace 0";
+            if (int.TryParse(traceArg, out var traceArgAsInt))
+            {
+                Log.Warn($"{SpecialVariables.Action.PowerShell.PSDebug.Trace} is enabled,  This should only be used for debugging, and then disabled again for normal deployments.");
+                traceCommand = $"-Trace {traceArgAsInt}";
+            }
+            else if (bool.TryParse(traceArg, out var traceArgAsBool) && traceArgAsBool)
+            {
+                Log.Warn($"{SpecialVariables.Action.PowerShell.PSDebug.Trace} is enabled,  This should only be used for debugging, and then disabled again for normal deployments.");
+                traceCommand = "-Trace 2";
+            }
+            
+            var strictArg = variables[SpecialVariables.Action.PowerShell.PSDebug.Strict];
+            var strictCommand = "";
+            if (bool.TryParse(strictArg, out var strictArgAsBool) && strictArgAsBool)
+            {
+                Log.Info($"{SpecialVariables.Action.PowerShell.PSDebug.Trace} is enabled, putting PowerShell into strict mode where variables must be assigned a value before being referenced in a script. If a variable is referenced before a value is assigned, an exception will be thrown. This feature is experimental.");
+                strictCommand = " -Strict";
+            }
+            
+            return $"Set-PSDebug {traceCommand}{strictCommand};";
         }
 
         protected abstract IEnumerable<string> ContributeCommandArguments(CalamariVariableDictionary variables);

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -221,7 +221,7 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
             var strictCommand = "";
             if (bool.TryParse(strictArg, out var strictArgAsBool) && strictArgAsBool)
             {
-                Log.Info($"{SpecialVariables.Action.PowerShell.PSDebug.Trace} is enabled, putting PowerShell into strict mode where variables must be assigned a value before being referenced in a script. If a variable is referenced before a value is assigned, an exception will be thrown. This feature is experimental.");
+                Log.Info($"{SpecialVariables.Action.PowerShell.PSDebug.Strict} is enabled, putting PowerShell into strict mode where variables must be assigned a value before being referenced in a script. If a variable is referenced before a value is assigned, an exception will be thrown. This feature is experimental.");
                 strictCommand = " -Strict";
             }
             

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -179,6 +179,8 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
             var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword));
             var commandArguments = new StringBuilder();
             var executeWithoutProfile = variables[SpecialVariables.Action.PowerShell.ExecuteWithoutProfile];
+            var traceLevel = variables[SpecialVariables.Action.PowerShell.TraceMode];
+            var traceCommand = !string.IsNullOrEmpty(traceLevel) ? " Set-PSDebug -Trace 2; " : "";
             
             foreach (var argument in ContributeCommandArguments(variables))
                 commandArguments.Append(argument);
@@ -192,11 +194,11 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
             commandArguments.Append("-NonInteractive ");
             commandArguments.Append("-ExecutionPolicy Unrestricted ");
 
-            var filetoExecute = IsDebuggingEnabled(variables)
+            var fileToExecute = IsDebuggingEnabled(variables)
                 ? debuggingBootstrapFile.EscapeSingleQuotedString()
                 : bootstrapFile.EscapeSingleQuotedString();
 
-            commandArguments.AppendFormat("-Command \"Try {{. {{. '{0}' -OctopusKey '{1}'; if ((test-path variable:global:lastexitcode)) {{ exit $LastExitCode }}}};}} catch {{ throw }}\"", filetoExecute, encryptionKey);
+            commandArguments.AppendFormat("-Command \"{0}Try {{. {{. '{1}' -OctopusKey '{2}'; if ((test-path variable:global:lastexitcode)) {{ exit $LastExitCode }}}};}} catch {{ throw }}\"", traceCommand, fileToExecute, encryptionKey);
             return commandArguments.ToString();
         }
 

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/BashScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/BashScriptEngineFixture.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using Calamari.Integration.FileSystem;
+using Calamari.Integration.Scripting.Bash;
+using Calamari.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Integration.Scripting
+{
+    [TestFixture]
+    public class BashScriptEngineFixture : ScriptEngineFixtureBase
+    {
+        [Test]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
+        public void BashDecryptsSensitiveVariables()
+        {
+            using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "sh")))
+            {
+                File.WriteAllText(scriptFile.FilePath, "#!/bin/bash\necho $(get_octopusvariable \"mysecrect\")");
+                var result = ExecuteScript(new BashScriptEngine(), scriptFile.FilePath, GetDictionaryWithSecret());
+                result.AssertOutput("KingKong");
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/CSharpScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/CSharpScriptEngineFixture.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using Calamari.Integration.FileSystem;
+using Calamari.Integration.Scripting.ScriptCS;
+using Calamari.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Integration.Scripting
+{
+    [TestFixture]
+    public class CSharpScriptEngineFixture : ScriptEngineFixtureBase
+    {
+        [Category(TestCategory.ScriptingSupport.ScriptCS)]
+        [Test, RequiresMonoVersion400OrAbove, RequiresDotNet45]
+        public void CSharpDecryptsSensitiveVariables()
+        {
+            using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "cs")))
+            {
+                File.WriteAllText(scriptFile.FilePath, "System.Console.WriteLine(Octopus.Parameters[\"mysecrect\"]);");
+                var result = ExecuteScript(new ScriptCSScriptEngine(), scriptFile.FilePath, GetDictionaryWithSecret());
+                result.AssertOutput("KingKong");
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellScriptEngineFixture.cs
@@ -1,21 +1,17 @@
 ﻿using System;
 using System.IO;
 using Calamari.Integration.FileSystem;
-using Calamari.Integration.Processes;
-using Calamari.Integration.Scripting;
-using Calamari.Integration.Scripting.Bash;
-using Calamari.Integration.Scripting.ScriptCS;
 using Calamari.Integration.Scripting.WindowsPowerShell;
 using Calamari.Tests.Fixtures.ScriptCS;
-using Calamari.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures.Integration.Scripting
 {
     [TestFixture]
-    public class ScriptEngineFixture
+    public class PowerShellScriptEngineFixture : ScriptEngineFixtureBase
     {
         [Test]
+        [RequiresNonFreeBSDPlatform]
         public void PowerShellDecryptsSensitiveVariables()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
@@ -25,12 +21,13 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
                 result.AssertOutput("KingKong");
             }
         }
-        
+
         [Test]
         [TestCase("true")]
         [TestCase("True")]
         [TestCase("1")]
         [TestCase("2")]
+        [RequiresNonFreeBSDPlatform]
         public void PowerShellCanSetTraceMode(string variableValue)
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
@@ -39,8 +36,9 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
                 var calamariVariableDictionary = GetDictionaryWithSecret();
                 calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Trace", variableValue);
 
-                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, calamariVariableDictionary);
-                
+                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath,
+                    calamariVariableDictionary);
+
                 result.AssertOutput("KingKong");
                 result.AssertOutput("DEBUG:    1+  >>>> Write-Host $mysecrect");
 
@@ -54,12 +52,13 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
                 }
             }
         }
-        
+
         [Test]
         [TestCase("0")]
         [TestCase("False")]
         [TestCase("false")]
         [TestCase("")]
+        [RequiresNonFreeBSDPlatform]
         public void PowerShellDoesntForceTraceMode(string variableValue)
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
@@ -69,86 +68,53 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
                 if (!string.IsNullOrEmpty(variableValue))
                     calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Trace", variableValue);
 
-                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, calamariVariableDictionary);
-                
+                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath,
+                    calamariVariableDictionary);
+
                 result.AssertOutput("KingKong");
                 result.AssertNoOutput("DEBUG:    1+  >>>> Write-Host $mysecrect");
             }
         }
-        
+
         [Test]
+        [RequiresNonFreeBSDPlatform]
         public void PowerShellWorksWithStrictMode()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
             {
-                File.WriteAllText(scriptFile.FilePath, "$newVar = $nonExistentVar" + Environment.NewLine + "write-host \"newVar = '$newVar'\"");
+                File.WriteAllText(scriptFile.FilePath,
+                    "$newVar = $nonExistentVar" + Environment.NewLine + "write-host \"newVar = '$newVar'\"");
                 var calamariVariableDictionary = GetDictionaryWithSecret();
                 calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Strict", "true");
 
-                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, calamariVariableDictionary);
-                
+                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath,
+                    calamariVariableDictionary);
+
                 result.AssertErrorOutput(" cannot be retrieved because it has not been set.");
                 result.AssertFailure();
             }
         }
-        
+
         [Test]
         [TestCase("false")]
         [TestCase("")]
+        [RequiresNonFreeBSDPlatform]
         public void PowerShellDoesntForceStrictMode(string variableValue)
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
             {
-                File.WriteAllText(scriptFile.FilePath, "$newVar = $nonExistentVar" + Environment.NewLine + "write-host \"newVar = '$newVar'\"");
+                File.WriteAllText(scriptFile.FilePath,
+                    "$newVar = $nonExistentVar" + Environment.NewLine + "write-host \"newVar = '$newVar'\"");
                 var calamariVariableDictionary = GetDictionaryWithSecret();
                 if (!string.IsNullOrEmpty(variableValue))
                     calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Strict", variableValue);
 
-                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, calamariVariableDictionary);
-                
+                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath,
+                    calamariVariableDictionary);
+
                 result.AssertOutput("newVar = ''");
                 result.AssertNoOutput(" cannot be retrieved because it has not been set.");
             }
-        }
-
-        [Category(TestCategory.ScriptingSupport.ScriptCS)]
-        [Test, RequiresMonoVersion400OrAbove, RequiresDotNet45]
-        public void CSharpDecryptsSensitiveVariables()
-        {
-            using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "cs")))
-            {
-                File.WriteAllText(scriptFile.FilePath, "System.Console.WriteLine(Octopus.Parameters[\"mysecrect\"]);");
-                var result = ExecuteScript(new ScriptCSScriptEngine(), scriptFile.FilePath, GetDictionaryWithSecret());
-                result.AssertOutput("KingKong");
-            }
-        }
-
-        [Test]
-        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
-        public void BashDecryptsSensitiveVariables()
-        {
-            using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "sh")))
-            {
-                File.WriteAllText(scriptFile.FilePath, "#!/bin/bash\necho $(get_octopusvariable \"mysecrect\")");
-                var result = ExecuteScript(new BashScriptEngine(), scriptFile.FilePath, GetDictionaryWithSecret());
-                result.AssertOutput("KingKong");
-            }
-        }
-
-        private CalamariVariableDictionary GetDictionaryWithSecret()
-        {
-            var cd = new CalamariVariableDictionary();
-            cd.Set("foo", "bar");
-            cd.SetSensitive("mysecrect", "KingKong");
-            return cd;
-        }
-
-        private CalamariResult ExecuteScript(IScriptEngine psse, string scriptName, CalamariVariableDictionary variables)
-        {
-            var capture = new CaptureCommandOutput();
-            var runner = new CommandLineRunner(capture);
-            var result = psse.Execute(new Script(scriptName), variables, runner);
-            return new CalamariResult(result.ExitCode, capture);
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
@@ -16,8 +16,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
     public class ScriptEngineFixture
     {
         [Test]
-        [Category(TestCategory.CompatibleOS.OnlyWindows)]
-        public void PowershellDecryptsSensitiveVariables()
+        public void PowerShellDecryptsSensitiveVariables()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
             {
@@ -28,7 +27,6 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
         }
         
         [Test]
-        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         [TestCase("true")]
         [TestCase("True")]
         [TestCase("1")]
@@ -58,7 +56,6 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
         }
         
         [Test]
-        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         [TestCase("0")]
         [TestCase("False")]
         [TestCase("false")]
@@ -80,7 +77,6 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
         }
         
         [Test]
-        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void PowerShellWorksWithStrictMode()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
@@ -97,7 +93,6 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
         }
         
         [Test]
-        [Category(TestCategory.CompatibleOS.OnlyWindows)]
         [TestCase("false")]
         [TestCase("")]
         public void PowerShellDoesntForceStrictMode(string variableValue)

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;
@@ -23,6 +24,95 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
                 File.WriteAllText(scriptFile.FilePath, "Write-Host $mysecrect");
                 var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, GetDictionaryWithSecret());
                 result.AssertOutput("KingKong");
+            }
+        }
+        
+        [Test]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
+        [TestCase("true")]
+        [TestCase("True")]
+        [TestCase("1")]
+        [TestCase("2")]
+        public void PowerShellCanSetTraceMode(string variableValue)
+        {
+            using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
+            {
+                File.WriteAllText(scriptFile.FilePath, "Write-Host $mysecrect");
+                var calamariVariableDictionary = GetDictionaryWithSecret();
+                calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Trace", variableValue);
+
+                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, calamariVariableDictionary);
+                
+                result.AssertOutput("KingKong");
+                result.AssertOutput("DEBUG:    1+  >>>> Write-Host $mysecrect");
+
+                if (variableValue != "1")
+                {
+                    //see https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-psdebug?view=powershell-6#description
+                    //When the Trace parameter has a value of 1, each line of script is traced as it runs.
+                    //When the parameter has a value of 2, variable assignments, function calls, and script calls are also traced
+                    //we translate "true" to "2"
+                    result.AssertOutput("! CALL function 'Import-CalamariModules'");
+                }
+            }
+        }
+        
+        [Test]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
+        [TestCase("0")]
+        [TestCase("False")]
+        [TestCase("false")]
+        [TestCase("")]
+        public void PowerShellDoesntForceTraceMode(string variableValue)
+        {
+            using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
+            {
+                File.WriteAllText(scriptFile.FilePath, "Write-Host $mysecrect");
+                var calamariVariableDictionary = GetDictionaryWithSecret();
+                if (!string.IsNullOrEmpty(variableValue))
+                    calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Trace", variableValue);
+
+                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, calamariVariableDictionary);
+                
+                result.AssertOutput("KingKong");
+                result.AssertNoOutput("DEBUG:    1+  >>>> Write-Host $mysecrect");
+            }
+        }
+        
+        [Test]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
+        public void PowerShellWorksWithStrictMode()
+        {
+            using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
+            {
+                File.WriteAllText(scriptFile.FilePath, "$newVar = $nonExistentVar" + Environment.NewLine + "write-host \"newVar = '$newVar'\"");
+                var calamariVariableDictionary = GetDictionaryWithSecret();
+                calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Strict", "true");
+
+                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, calamariVariableDictionary);
+                
+                result.AssertErrorOutput(" cannot be retrieved because it has not been set.");
+                result.AssertFailure();
+            }
+        }
+        
+        [Test]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
+        [TestCase("false")]
+        [TestCase("")]
+        public void PowerShellDoesntForceStrictMode(string variableValue)
+        {
+            using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
+            {
+                File.WriteAllText(scriptFile.FilePath, "$newVar = $nonExistentVar" + Environment.NewLine + "write-host \"newVar = '$newVar'\"");
+                var calamariVariableDictionary = GetDictionaryWithSecret();
+                if (!string.IsNullOrEmpty(variableValue))
+                    calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Strict", variableValue);
+
+                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, calamariVariableDictionary);
+                
+                result.AssertOutput("newVar = ''");
+                result.AssertNoOutput(" cannot be retrieved because it has not been set.");
             }
         }
 

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixtureBase.cs
@@ -1,0 +1,25 @@
+using Calamari.Integration.Processes;
+using Calamari.Integration.Scripting;
+using Calamari.Tests.Helpers;
+
+namespace Calamari.Tests.Fixtures.Integration.Scripting
+{
+    public abstract class ScriptEngineFixtureBase
+    {
+        protected CalamariVariableDictionary GetDictionaryWithSecret()
+        {
+            var cd = new CalamariVariableDictionary();
+            cd.Set("foo", "bar");
+            cd.SetSensitive("mysecrect", "KingKong");
+            return cd;
+        }
+
+        protected CalamariResult ExecuteScript(IScriptEngine psse, string scriptName, CalamariVariableDictionary variables)
+        {
+            var capture = new CaptureCommandOutput();
+            var runner = new CommandLineRunner(capture);
+            var result = psse.Execute(new Script(scriptName), variables, runner);
+            return new CalamariResult(result.ExitCode, capture);
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/RequiresPowerShell4Attribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresPowerShell4Attribute.cs
@@ -1,0 +1,19 @@
+using Calamari.Integration.Scripting;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace Calamari.Tests.Fixtures
+{
+    public class RequiresPowerShell4Attribute : NUnitAttribute, IApplyToTest
+    {
+        public void ApplyToTest(Test test)
+        {
+            if (ScriptingEnvironment.SafelyGetPowerShellVersion().Major == 4)
+            {
+                test.RunState = RunState.Skipped;
+                test.Properties.Set(PropertyNames.SkipReason, "This test requires PowerShell 4.");
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/RequiresPowerShell5OrAboveAttribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresPowerShell5OrAboveAttribute.cs
@@ -1,0 +1,19 @@
+using Calamari.Integration.Scripting;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace Calamari.Tests.Fixtures
+{
+    public class RequiresPowerShell5OrAboveAttribute : NUnitAttribute, IApplyToTest
+    {
+        public void ApplyToTest(Test test)
+        {
+            if (ScriptingEnvironment.SafelyGetPowerShellVersion().Major < 5)
+            {
+                test.RunState = RunState.Skipped;
+                test.Properties.Set(PropertyNames.SkipReason, "This test requires PowerShell 5 or newer.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# background
I've been dealing with a few tickets lately where we've really had trouble understand whats going wrong.

# results 
This PR adds support for two new variables, `Octopus.Action.PowerShell.PSDebug.Trace` and `Octopus.Action.PowerShell.PSDebug.Strict`, allowing better diagnostics.

`Octopus.Action.PowerShell.PSDebug.Trace` allows both `int` values and `bool` values:
1. If the value is `0`, `1`, or `2` pass that directly through to the cmdlet, giving "power under the hood"
1. If the value is `false`(or `False`) make it `0`
1. If the value is `true` (or `True`) make it a default of `2`

This gives an uber detailed output of what powershell is doing:
![image](https://user-images.githubusercontent.com/373389/69683680-c4a8dc00-1109-11ea-9409-11eb014df2b6.png)

`Octopus.Action.PowerShell.PSDebug.Strict` can be set to `true` (or `True`), and puts powershell into a stricter parsing mode where 
> variables must be assigned a value before being referenced in a script. If a variable is referenced before a value is assigned, an exception is thrown.

with the following code:
![image](https://user-images.githubusercontent.com/373389/69684600-56feaf00-110d-11ea-9395-d8c3fddf4d25.png)

We get this:
![image](https://user-images.githubusercontent.com/373389/69684584-49e1c000-110d-11ea-866e-4ed02edb90d3.png)

# powershell compatibility

I've checked, and this is supported back to PS2.0, according to [this blog post[(https://www.jonathanmedd.net/2010/06/powershell-2-0-one-cmdlet-at-a-time-105-set-strictmode.html).

# first class support?

If we decide we like this - we could promote this, and powershell debugging up to be full on features like [powershell core is](https://octopus.com/docs/deployment-examples/custom-scripts/powershell-core).

# links

[internal discussion thread](https://octopusdeploy.slack.com/archives/CLQNM80U9/p1574748811032300)
