### PR TITLE
Catch powershell exceptions and write out a nicer error message

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -734,7 +734,8 @@ try
 }
 catch
 {
-	[System.Console]::Error.WriteLine($error[0].Exception.Message)
+	
+	[System.Console]::Error.WriteLine("$($error[0].CategoryInfo.Category): $($error[0].Exception.Message)")
 	[System.Console]::Error.WriteLine($error[0].InvocationInfo.PositionMessage)
 	[System.Console]::Error.WriteLine($error[0].ScriptStackTrace)
 	if ($null -ne $error[0].ErrorDetails) {

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -121,8 +121,14 @@ function Import-ScriptModule([string]$moduleName, [string]$moduleFilePath)
 	}
 	Catch
 	{
-		Write-Warning "Failed to import Script Module '$moduleName'"
-		Throw
+		[System.Console]::Error.WriteLine("Failed to import Script Module '$moduleName' from '$moduleFilePath'")
+		[System.Console]::Error.WriteLine("$($error[0].CategoryInfo.Category): $($error[0].Exception.Message)")
+		[System.Console]::Error.WriteLine($error[0].InvocationInfo.PositionMessage)
+		[System.Console]::Error.WriteLine($error[0].ScriptStackTrace)
+		if ($null -ne $error[0].ErrorDetails) {
+			[System.Console]::Error.WriteLine($error[0].ErrorDetails.Message)
+		}
+		exit 1
 	}
 }
 

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -728,7 +728,21 @@ Import-CalamariModules
 # Invoke target script
 # -----------------------------------------------------------------
 {{BeforeLaunchingUserScriptDebugLocation}}
-. '{{TargetScriptFile}}' {{ScriptParameters}}
+try
+{
+	. '{{TargetScriptFile}}' { { ScriptParameters } }
+}
+catch
+{
+	[System.Console]::Error.WriteLine($error[0].Exception.Message)
+	[System.Console]::Error.WriteLine($error[0].InvocationInfo.PositionMessage)
+	[System.Console]::Error.WriteLine($error[0].ScriptStackTrace)
+	if ($null -ne $error[0].ErrorDetails) {
+		[System.Console]::Error.WriteLine($error[0].ErrorDetails.Message)
+	}
+
+	exit 1
+}
 
 # -----------------------------------------------------------------
 # Ensure we exit with whatever exit code the last exe used

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -730,7 +730,7 @@ Import-CalamariModules
 {{BeforeLaunchingUserScriptDebugLocation}}
 try
 {
-	. '{{TargetScriptFile}}' { { ScriptParameters } }
+	. '{{TargetScriptFile}}' {{ScriptParameters}}
 }
 catch
 {

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
@@ -327,8 +327,19 @@ namespace Calamari.Tests.Fixtures.PowerShell
         public void ShouldFailOnInvalidSyntax()
         {
             var (output, _) = RunPowerShellScript("InvalidSyntax.ps1");
+
             output.AssertFailure();
-            output.AssertErrorOutput("ParserError");
+            //ensure it logs the type of error
+            output.AssertErrorOutput("ParserError:");
+            //ensure it logs the error line in question
+            output.AssertErrorOutput("+ $#FC(@UCJ@(#U");
+            //ensure it logs each of the errors
+            output.AssertErrorOutput("Unexpected token '@(' in expression or statement.");
+            output.AssertErrorOutput("Missing closing ')' in expression.");
+            output.AssertErrorOutput("The splatting operator '@' cannot be used to reference variables in an expression. '@UCJ' can be used only as an argument to a command. To reference variables in an expression use '$UCJ'.");
+            //ensure it logs the stack trace
+            output.AssertErrorOutput("at <ScriptBlock>, ");
+            
             AssertPowerShellEdition(output);
         }
 
@@ -378,9 +389,18 @@ namespace Calamari.Tests.Fixtures.PowerShell
             { ["Octopus.Script.Module[Foo]"] = "function SayHello() { Write-Host \"Hello from module! }" });
 
             output.AssertFailure();
-            output.AssertOutput("Failed to import Script Module 'Foo'");
-            output.AssertErrorOutput("Write-Host \"Hello from module!");
+            //ensure it logs the script module name
+            output.AssertErrorOutput("Failed to import Script Module 'Foo' from '");
+            //ensure it logs the type of error
+            output.AssertErrorOutput("ParserError:");
+            //ensure it logs the error line in question
+            output.AssertErrorOutput("+ function SayHello() { Write-Host \"Hello from module! }");
+            //ensure it logs each of the errors
             output.AssertErrorOutput("The string is missing the terminator: \".");
+            output.AssertErrorOutput("Missing closing '}' in statement block or type definition.");
+            //ensure it logs the stack trace
+            output.AssertErrorOutput("at Import-ScriptModule, ");
+            output.AssertErrorOutput("at <ScriptBlock>, ");
             AssertPowerShellEdition(output);
         }
 

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
@@ -397,7 +397,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
             output.AssertErrorOutput("+ function SayHello() { Write-Host \"Hello from module! }");
             //ensure it logs each of the errors
             output.AssertErrorOutput("The string is missing the terminator: \".");
-            output.AssertErrorOutput("Missing closing '}' in statement block or type definition.");
+            output.AssertErrorOutput("Missing closing '}' in statement block");
             //ensure it logs the stack trace
             output.AssertErrorOutput("at Import-ScriptModule, ");
             output.AssertErrorOutput("at <ScriptBlock>, ");


### PR DESCRIPTION
After dealing with many tickets with insufficient error information, this PR improves how powershell error messages are printed.

It _should_ prevent powershell from being helpful and truncating the error message too.

# old
![image](https://user-images.githubusercontent.com/373389/69697807-b96ca500-1137-11ea-81cc-bcd59230f587.png)

# new
![image](https://user-images.githubusercontent.com/373389/69697815-bd98c280-1137-11ea-923a-74821f07ed6b.png)

# Thoughts
* this [issue on the powershell repo](https://github.com/PowerShell/PowerShell/issues/3647) issue has a lot of detail and ideas
* should we try and dig into [Resolve-ErrorRecord](https://github.com/PowerShell/PowerShell/issues/4674#issuecomment-325029851) 
* [pcsx](https://github.com/Pscx/Pscx/) has a more detailed implementation of [Resolve-ErrorRecord](https://github.com/Pscx/Pscx/blob/eeceb96a9ad4111bbfb6c815fc26ae055e8c7ba7/Src/Pscx/Modules/Utility/Pscx.Utility.psm1#L552-L600) that we might want to consider