### PR TITLE
Create an empty kubeconfig to suppress kubectl errors about the file missing

### DIFF
--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -167,6 +167,8 @@ function SetupContext {
 function ConfigureKubeCtlPath {
     $env:KUBECONFIG=$OctopusParameters["Octopus.Action.Kubernetes.KubectlConfig"]
     Write-Host "Temporary kubectl config set to $env:KUBECONFIG"
+	# create an empty file, to suppress kubectl errors about the file missing
+	Set-Content -Path $env:KUBECONFIG -Value ""
 }
 
 function CreateNamespace {


### PR DESCRIPTION
This was causing issues with powershell 5.1 on windows 2019 with net framework 4.8 where anything writing to stderr was causing powershell to crash.

Relates to https://github.com/OctopusDeploy/Issues/issues/6050