### PR TITLE
Feedz.io now needs mono 4.8 or higher to work

### DIFF
--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -65,7 +65,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [Ignore("Failing on < Mono 5 Need to fix ASAP", Until = "2019-12-11")]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldDownloadPackage()
         {
             var result = DownloadPackage(FeedzPackage.PackageId, FeedzPackage.Version.ToString(), FeedzPackage.Id, PublicFeedUri);
@@ -154,7 +154,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [Ignore("Failing on < Mono 5 Need to fix ASAP", Until = "2019-12-11")]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldUsePackageFromCache()
         {
             DownloadPackage(FeedzPackage.PackageId,
@@ -241,7 +241,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [Ignore("Failing on < Mono 5 Need to fix ASAP", Until = "2019-12-11")]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldByPassCacheAndDownloadPackage()
         {
             DownloadPackage(FeedzPackage.PackageId,


### PR DESCRIPTION
Feedz.io changed it's ssl certs, which is causing older versions of Mono to fail. The usual guidance here is to upgrade mono, so that's what we'll do.