### PR TITLE
Terraform Fallback

### DIFF
--- a/source/Calamari.Tests/Terraform/TerraformFixture.cs
+++ b/source/Calamari.Tests/Terraform/TerraformFixture.cs
@@ -18,6 +18,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using Octostache;
 using Newtonsoft.Json.Linq;
+using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Tests.Terraform
 {
@@ -51,12 +52,30 @@ namespace Calamari.Tests.Terraform
                             var downloadBaseUrl = parsedJson["current_download_url"].Value<string>();
                             var currentVersion = parsedJson["current_version"].Value<string>();
                             var fileName = $"terraform_{currentVersion}_windows_amd64.zip";
-
+                            
+                            try
+                            {
+                                var request = WebRequest.Create($"{downloadBaseUrl}{fileName}");
+                                using (var response = (HttpWebResponse)request.GetResponse())
+                                {
+                                    if (!response.IsSuccessStatusCode())
+                                    {
+                                        downloadBaseUrl = "https://releases.hashicorp.com/terraform/0.12.12/";
+                                        currentVersion = "0.12.12";
+                                        fileName = $"terraform_{currentVersion}_windows_amd64.zip";
+                                    }
+                                }
+                            }
+                            catch (WebException ex)
+                            {
+                                Log.Error($"There was an error accessing the terraform cli. The response {ex.Response} was returned");
+                            }
+                            
                             if (CalamariEnvironment.IsRunningOnNix)
                             {
                                 fileName = $"terraform_{currentVersion}_linux_amd64.zip";
                             }
-
+                            
                             var zipPath = Path.Combine(Path.GetTempPath(), fileName);
                             using (new TemporaryFile(zipPath))
                             {


### PR DESCRIPTION
Recently, we discovered that Terraform had an error in their API which causes a good chunk of our Terraform related tests to fail. To mitigate the risk of this happening again, this PR adds a fallback.