### PR TITLE
Update CalamariPhysicalFileSystem.cs

### DIFF
--- a/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -457,7 +457,7 @@ namespace Calamari.Integration.FileSystem
                 File.Copy(temporaryReplacement, originalFile, true);
             else
             {
-                System.IO.File.Replace(temporaryReplacement, originalFile, backup);
+                System.IO.File.Replace(temporaryReplacement, originalFile, backup, true);
             }
 
             File.Delete(temporaryReplacement);


### PR DESCRIPTION
Handle writing to NAS devices that the process has generic write permissions, but not write_dac permissions.

See https://stackoverflow.com/questions/59062659/file-replace-doesnt-work-on-shared-driver for reference.