### PR TITLE
Remove use of File.Replace

### DIFF
--- a/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -453,18 +453,18 @@ namespace Calamari.Integration.FileSystem
         {
             var backup = originalFile + ".backup" + Guid.NewGuid();
 
-            if (!File.Exists(originalFile))
-                File.Copy(temporaryReplacement, originalFile, true);
-            else
+            if (File.Exists(originalFile))
             {
-                System.IO.File.Replace(temporaryReplacement, originalFile, backup);
+                File.Copy(originalFile, backup, true);
             }
+
+            File.Copy(temporaryReplacement, originalFile, true);
 
             File.Delete(temporaryReplacement);
             if (File.Exists(backup))
                 File.Delete(backup);
         }
-
+        
         public void WriteAllBytes(string filePath, byte[] data)
         {
             File.WriteAllBytes(filePath, data);


### PR DESCRIPTION
Allow file operations to work on network drives that don't have full admin access (write_dec), and just the 'normal' write/modify file permission set