### PR TITLE
Nicer pipeline support for New-OctopusArtifact

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -335,6 +335,7 @@ function New-OctopusArtifact
         [Alias('fullname')]
         [Alias('path')]
         [string]$fullpath,
+        [Parameter(ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
         [string]$name=""""
     )
     process

--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/CanCreateArtifactPiped.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/CanCreateArtifactPiped.ps1
@@ -1,1 +1,1 @@
-﻿Get-ChildItem -Path $TempDirectory -Filter "CanCreateArtifactPipedTestFile.txt" | New-OctopusArtifact 
+﻿Get-ChildItem -Path $TempDirectory -Filter *.artifact | New-OctopusArtifact


### PR DESCRIPTION
The name of the artifact will now also come from the pipeline, rather than being the same for each artifact.

`Get-ChildItem . -Recurse -Include *.txt | New-OctopusArtifact`

Was yielding:
C:\Test1.txt Test1.txt
C:\Test2.txt **Test1.txt**

It will now result in:
C:\Test1.txt Test1.txt
C:\Test2.txt **Test2.txt**

When a function runs in a piepline, the `process` section acts like a loop around the output from the pipeline. Parameters and variables that are not assigned by the pipeline retain their value through the entire loop.

For example:
```
function Print-Value {
    param(
        [Parameter(ValueFromPipeline=$true)]
        [int] $value,
        [string]$name=""""
    )
    process
    {
	    if ($name -eq """")	{
		    $name =  $value
	    }
        Write-Host $value, $name
    }
}
(0..5) | Print-Value
```

Prints:
```
0 0
1 0
2 0
3 0
4 0
5 0
```