### PR TITLE
Fix Powershell $PSVersionTable log output on MaxOSX

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -14,7 +14,7 @@ $ErrorActionPreference = 'Stop'
 
 function Log-VersionTable
 {
-	Write-Verbose ($PSVersionTable | Out-String)
+	Write-Verbose ($PSVersionTable | Out-String -Width 200) # Calling Out-String without specify the width resulted in blank lines when running tests under MacOS for some reason
 }
 
 function Log-EnvironmentInformation

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -14,7 +14,7 @@ $ErrorActionPreference = 'Stop'
 
 function Log-VersionTable
 {
-	Write-Verbose ($PSVersionTable | Out-String -Width 200) # Calling Out-String without specify the width resulted in blank lines when running tests under MacOS for some reason
+	Write-Verbose ($PSVersionTable | Out-String -Width 200) # Calling Out-String without specify the width resulted in blank lines when running tests under MacOS 10.15 and Netcore 3.1 for some reason
 }
 
 function Log-EnvironmentInformation

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -65,6 +65,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldDownloadPackage()
         {
             var result = DownloadPackage(FeedzPackage.PackageId, FeedzPackage.Version.ToString(), FeedzPackage.Id, PublicFeedUri);
@@ -153,6 +154,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldUsePackageFromCache()
         {
             DownloadPackage(FeedzPackage.PackageId,
@@ -239,6 +241,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldByPassCacheAndDownloadPackage()
         {
             DownloadPackage(FeedzPackage.PackageId,


### PR DESCRIPTION
After the Mac test agent was upgraded (OSX 10.12 to 10.15, Netcore to 3.1), the tests started failing.

`$PSVersionTable | Out-String` started resulting in blank lines for some reason, but only when running in the test. Invoking this in the `pwsh` terminal gives the right results.

Specifying the width manually fixed the problem, and shouldn't hurt other platforms, so I'm going with that.