### PR TITLE
Package IDs with slashes break Nginx

### DIFF
--- a/source/Calamari/Integration/Nginx/NginxServer.cs
+++ b/source/Calamari/Integration/Nginx/NginxServer.cs
@@ -37,6 +37,10 @@ namespace Calamari.Integration.Nginx
 
         public NginxServer WithVirtualServerName(string name)
         {
+            /*
+             * Ensure package ids with chars that are invalid for file names (for example, a GitHub package is in the format
+             * "owner/repository") do not generate unexpected file names.
+             */
             VirtualServerName = String.Join("_", name.Split(
                 System.IO.Path.GetInvalidFileNameChars(),
                 StringSplitOptions.RemoveEmptyEntries));


### PR DESCRIPTION
When a package ID includes a slash (for example, a GitHub release package), the NGINX step places the conf files in a subdirectory not scanned by NGINX. This PR removes any invalid characters from the package ID when generating a filename.