### PR TITLE
Download helm chart direct instead of using helm executable

### DIFF
--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -51,6 +51,7 @@
     <PackageReference Include="Octostache" Version="2.7.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="YamlDotNet" Version="8.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Autofac" Version="4.8.0" />

--- a/source/Calamari.Shared/Extensions/HttpClientExtensions.cs
+++ b/source/Calamari.Shared/Extensions/HttpClientExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Calamari.Extensions
+{
+    public static class HttpClientExtensions
+    {
+        public static void AddAuthenticationHeader(this HttpRequestHeaders headers, string userName, string password)
+        {
+            if (!string.IsNullOrWhiteSpace(userName))
+            {
+                var byteArray = Encoding.ASCII.GetBytes($"{userName}:{password}");
+                headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
+            } 
+            else if (!string.IsNullOrWhiteSpace(password))
+            {
+                headers.Authorization = new AuthenticationHeaderValue("Token", password);
+            }
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/Packages/Download/Helm/HelmEndpointProxy.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/Helm/HelmEndpointProxy.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using Calamari.Extensions;
+using YamlDotNet.RepresentationModel;
+
+namespace Calamari.Integration.Packages.Download.Helm
+{
+    public interface IHelmEndpointProxy
+    {
+        YamlStream Get(CancellationToken cancellationToken);
+    }
+    
+     public class HelmEndpointProxy: IHelmEndpointProxy
+    {
+        readonly Uri endpoint;
+        readonly string username;
+        readonly string password;
+        static readonly string[] AcceptedContentType = {"application/x-yaml", "application/yaml"};
+        static string httpAccept = string.Join( ", ", AcceptedContentType);
+        
+        readonly HttpClient client;
+
+        public HelmEndpointProxy(HttpClient client, Uri endpoint, string username, string password)
+        {
+            this.endpoint = new Uri(endpoint, "index.yaml");
+            this.username = username;
+            this.password = password;
+            this.client = client;
+        }
+
+        public YamlStream Get(CancellationToken cancellationToken)
+        {
+            using (var response = PerformRequest(cancellationToken))
+            {
+                var stream = response.Content.ReadAsStreamAsync().Result;
+
+                using (var sr = new StreamReader(stream))
+                {
+                    var yaml = new YamlStream();
+                    yaml.Load(sr);
+                    return yaml;
+                }
+            }
+        }
+
+        HttpResponseMessage PerformRequest(CancellationToken cancellationToken)
+        {
+            HttpResponseMessage response;
+
+            using (var msg = new HttpRequestMessage(HttpMethod.Get, endpoint))
+            {
+                ApplyAuthorization(msg);
+                ApplyAccept(msg);
+                response = client.SendAsync(msg, cancellationToken).Result;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception($"Unable to read Helm index file at {endpoint}.\r\n\tStatus Code: {response.StatusCode}\r\n\tResponse: {response.Content.ReadAsStringAsync().Result}");
+            }
+
+            return response;
+        }
+        
+        void ApplyAuthorization(HttpRequestMessage msg)
+        {
+            msg.Headers.AddAuthenticationHeader(username, password);
+        }
+
+        void ApplyAccept(HttpRequestMessage msg)
+        {
+            msg.Headers.Add("Accept", httpAccept);
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/Packages/Download/Helm/HelmIndexYamlReader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/Helm/HelmIndexYamlReader.cs
@@ -7,7 +7,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace Calamari.Integration.Packages.Download.Helm
 {
-    public static class HelmYamlReader
+    public static class HelmIndexYamlReader
     {
         public static IEnumerable<(string PackageId, IEnumerable<ChartData> Versions)> Read(YamlStream yaml)
         {

--- a/source/Calamari.Shared/Integration/Packages/Download/Helm/HelmYamlReader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/Helm/HelmYamlReader.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Octopus.Versioning;
+using Octopus.Versioning.Semver;
+using YamlDotNet.RepresentationModel;
+
+namespace Calamari.Integration.Packages.Download.Helm
+{
+    public static class HelmYamlReader
+    {
+        public static IEnumerable<(string PackageId, IEnumerable<ChartData> Versions)> Read(YamlStream yaml)
+        {
+            var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
+                
+            var apiVersion = ((YamlScalarNode)mapping.Children[new YamlScalarNode("apiVersion")]).Value;
+            if (apiVersion != "v1")
+            {
+                throw new InvalidOperationException($"Octopus Deploy only supports the Helm repository api version 'v1'.\r\nThe version returned by this endpoint was '{apiVersion}'");
+            }
+                
+            var entries = (YamlMappingNode)mapping.Children[new YamlScalarNode("entries")];
+            foreach (var node in entries)
+            {
+                var packageId = (YamlScalarNode)node.Key;
+                yield return (packageId.Value, Foo((YamlSequenceNode)node.Value));
+            }
+        }
+        
+        static IEnumerable<ChartData> Foo(YamlSequenceNode packageVersions)
+        {
+            foreach (var yamlNode in packageVersions)
+            {
+                var node = ChartData.FromNode((YamlMappingNode)yamlNode);
+                if (node != null)
+                {
+                    yield return node;
+                }
+            }
+        }
+
+        public class ChartData
+        {
+            readonly YamlMappingNode yamlNode;
+
+            ChartData(YamlMappingNode yamlNode, IVersion version)
+            {
+                this.yamlNode = yamlNode;
+                Version = version;
+            }
+
+            public static ChartData FromNode(YamlMappingNode yamlNode)
+            {
+                if (!SemVerFactory.TryCreateVersion(((YamlScalarNode) yamlNode.Children[new YamlScalarNode("version")]).Value, out var version))
+                {
+                    return null;
+                }
+
+                if (yamlNode.Children.TryGetValue(new YamlScalarNode("deprecated"), out var deprecatedNode) &&
+                    bool.TryParse(((YamlScalarNode) deprecatedNode).Value, out var isDeprecated) &&
+                    isDeprecated)
+                {
+                    return null;
+                }
+                
+                return new ChartData(yamlNode, version);
+            }
+            
+            public IVersion Version { get; }
+
+            public string Description => yamlNode.Children.TryGetValue(new YamlScalarNode("description"), out var descriptionNode) ?
+                ((YamlScalarNode) descriptionNode).Value :
+                null;
+
+            public string Name => ((YamlScalarNode) yamlNode.Children[new YamlScalarNode("name")]).Value;
+
+            public DateTimeOffset? Published
+            {
+                get
+                {
+                    if (yamlNode.Children.TryGetValue(new YamlScalarNode("created"), out var createdNode) &&
+                        DateTimeOffset.TryParse(((YamlScalarNode) createdNode).Value, out var created))
+                    {
+                        return created;
+                    }
+
+                    return null;
+                }
+            }
+
+            public IEnumerable<string> Urls
+            {
+                get
+                {
+                    return ((YamlSequenceNode) yamlNode.Children[new YamlScalarNode("urls")]).Children.Select(t => ((YamlScalarNode) t).Value);
+                }
+            
+            }
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
@@ -1,10 +1,19 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
+using System.Net.Http;
+using System.Threading;
 using Calamari.Commands.Support;
+using Calamari.Extensions;
 using Calamari.Integration.FileSystem;
+using Calamari.Integration.Packages.Download.Helm;
+using Calamari.Util;
+using NuGet;
 using Octopus.Versioning;
+using HttpClient = System.Net.Http.HttpClient;
 #if SUPPORTS_POLLY
 using Polly;
 #endif
@@ -16,10 +25,14 @@ namespace Calamari.Integration.Packages.Download
         private static readonly IPackageDownloaderUtils PackageDownloaderUtils = new PackageDownloaderUtils();
         const string Extension = ".tgz";
         private readonly ICalamariFileSystem fileSystem;
+        readonly IHelmEndpointProxy endpointProxy;
+        readonly HttpClient client;
 
-        public HelmChartPackageDownloader(ICalamariFileSystem fileSystem)
+        public HelmChartPackageDownloader(ICalamariFileSystem fileSystem, IHelmEndpointProxy endpointProxy, HttpClient client)
         {
             this.fileSystem = fileSystem;
+            this.endpointProxy = endpointProxy;
+            this.client = client;
         }
         
         public PackagePhysicalFileMetadata DownloadPackage(string packageId, IVersion version, string feedId, Uri feedUri,
@@ -37,22 +50,40 @@ namespace Calamari.Integration.Packages.Download
                     return downloaded;
                 }
             }
+
+            var package = GetChartDetails(packageId, CancellationToken.None);
+
+            if (string.IsNullOrEmpty(package.PackageId))
+            {
+                throw new CommandException($"There was an error fetching the chart from the provided repository. The package id was not valid ({package.PackageId})");
+            }
             
-            return DownloadChart(packageId, version, feedUri, feedCredentials, cacheDirectory);
+            var packageVersion = package.Versions.FirstOrDefault(v => version.Equals(v.Version));
+            var foundUrl = packageVersion?.Urls.FirstOrDefault();
+                
+            if (foundUrl == null)
+            {
+                throw new CommandException("Could not determine download url from chart repository. Please check associated index.yaml is correct.");
+            }
+            
+            var packageUrl = foundUrl.IsValidUrl() ? new Uri(foundUrl, UriKind.Absolute) :  new Uri(feedUri, foundUrl);
+            return DownloadChart(packageUrl, packageId, version, feedCredentials, cacheDirectory);
         }
         
-        const string TempRepoName = "octopusfeed";
-
-        PackagePhysicalFileMetadata DownloadChart(string packageId, IVersion version, Uri feedUri,
-            ICredentials feedCredentials, string cacheDirectory)
+        (string PackageId, IEnumerable<HelmYamlReader.ChartData> Versions) GetChartDetails(string packageId, CancellationToken cancellationToken)
         {
-            var cred = feedCredentials.GetCredential(feedUri, "basic");
+            var yaml = endpointProxy.Get(cancellationToken);
+            var package = HelmYamlReader.Read(yaml).FirstOrDefault(p => p.PackageId.Equals(packageId, StringComparison.InvariantCultureIgnoreCase));
+            return package;
+        }
 
+        PackagePhysicalFileMetadata DownloadChart(Uri url, string packageId, IVersion version, ICredentials feedCredentials, string cacheDirectory)
+        {
+            var cred = feedCredentials.GetCredential(url, "basic");
             var tempDirectory = fileSystem.CreateTemporaryDirectory();
-
+            
             using (new TemporaryDirectory(tempDirectory))
             {
-                
                 var homeDir = Path.Combine(tempDirectory, "helm");
                 if (!Directory.Exists(homeDir))
                 {
@@ -64,15 +95,34 @@ namespace Calamari.Integration.Packages.Download
                     Directory.CreateDirectory(stagingDir);
                 }
 
-                var log = new LogWrapper();
-                InvokeWithRetry(() => Invoke($"init --home \"{homeDir}\" --client-only", tempDirectory, log, "initialise"));
-                InvokeWithRetry(() => Invoke($"repo add --home \"{homeDir}\" {(string.IsNullOrEmpty(cred.UserName) ? "" : $"--username \"{cred.UserName}\" --password \"{cred.Password}\"")} {TempRepoName} {feedUri.ToString()}", tempDirectory, log, "add the chart repository"));
-                InvokeWithRetry(() => Invoke($"fetch --home \"{homeDir}\"  --version \"{version}\" --destination \"{stagingDir}\" {TempRepoName}/{packageId}", tempDirectory, log, "download the chart"));
+                string cachedFileName = PackageName.ToCachedFileName(packageId, version, Extension);
+                var downloadPath = Path.Combine(Path.Combine(stagingDir, cachedFileName));
                 
-                var localDownloadName =
-                    Path.Combine(cacheDirectory, PackageName.ToCachedFileName(packageId, version, Extension));
+                InvokeWithRetry(() =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Headers.AddAuthenticationHeader(cred.UserName, cred.Password);
+                    
+                    using (var fileStream = fileSystem.OpenFile(downloadPath, FileAccess.Write))
+                    using (var response = client.SendAsync(request).Result)
+                    {
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            throw new CommandException(
+                                $"Helm failed to download the chart (Status Code {(int) response.StatusCode}). Reason: {response.ReasonPhrase}");
+                        }
+                        
+                        #if NET40
+                        response.Content.CopyToAsync(fileStream).Wait();
+                        #else
+                        response.Content.CopyToAsync(fileStream).GetAwaiter().GetResult();
+                        #endif
+                    }
+                });
 
-                fileSystem.MoveFile(Directory.GetFiles(stagingDir)[0], localDownloadName);
+                var localDownloadName = Path.Combine(cacheDirectory, cachedFileName);
+
+                fileSystem.MoveFile(downloadPath, localDownloadName);
                 return PackagePhysicalFileMetadata.Build(localDownloadName);
             }
         }
@@ -92,51 +142,6 @@ namespace Calamari.Integration.Packages.Download
         void InvokeWithRetry(Action action) => action();
 #endif
         
-        void Invoke(string args, string dir, ILog log, string specificAction)
-        {
-            var info = new ProcessStartInfo("helm", args)
-            {
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                WorkingDirectory = dir,
-                CreateNoWindow = true
-            };
-
-            var sw = Stopwatch.StartNew();
-            var timeout = TimeSpan.FromSeconds(30);
-            using (var server = Process.Start(info))
-            {
-                while (!server.WaitForExit(10000) && sw.Elapsed < timeout)
-                {
-                    log.Warn($"Still waiting for {info.FileName} {info.Arguments} [PID:{server.Id}] to exit after waiting {sw.Elapsed}...");
-                }
-
-                var stdout = server.StandardOutput.ReadToEnd();
-                if (!string.IsNullOrWhiteSpace(stdout))
-                {
-                    log.Verbose(stdout);
-                }
-
-                var stderr = server.StandardError.ReadToEnd();
-                if (!string.IsNullOrWhiteSpace(stderr))
-                {
-                    log.Error(stderr);
-                }
-
-                if (!server.HasExited)
-                {
-                    server.Kill();
-                    throw new CommandException($"Helm failed to {specificAction} in an appropriate period of time ({timeout.TotalSeconds} sec). Please try again or check your connection.");
-                }
-
-                if (server.ExitCode != 0)
-                {
-                    throw new CommandException($"Helm failed to {specificAction} (Exit code {server.ExitCode}). Error output: \r\n{stderr}");
-                }
-            }
-        }
-
         PackagePhysicalFileMetadata SourceFromCache(string packageId, IVersion version, string cacheDirectory)
         {
             Log.VerboseFormat("Checking package cache for package {0} v{1}", packageId, version.ToString());

--- a/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
@@ -22,9 +22,9 @@ namespace Calamari.Integration.Packages.Download
 {
     public class HelmChartPackageDownloader: IPackageDownloader
     {
-        private static readonly IPackageDownloaderUtils PackageDownloaderUtils = new PackageDownloaderUtils();
+        static readonly IPackageDownloaderUtils PackageDownloaderUtils = new PackageDownloaderUtils();
         const string Extension = ".tgz";
-        private readonly ICalamariFileSystem fileSystem;
+        readonly ICalamariFileSystem fileSystem;
         readonly IHelmEndpointProxy endpointProxy;
         readonly HttpClient client;
 

--- a/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Net;
+using System.Net.Http;
 using Calamari.Integration.FileSystem;
+using Calamari.Integration.Packages.Download.Helm;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;
 using Octopus.Versioning;
@@ -47,7 +49,8 @@ namespace Calamari.Integration.Packages.Download
                     downloader = new GitHubPackageDownloader();
                     break;
                 case FeedType.Helm :
-                    downloader = new HelmChartPackageDownloader(fileSystem);
+                    var cred = feedCredentials.GetCredential(feedUri, "basic");
+                    downloader = new HelmChartPackageDownloader(fileSystem, new HelmEndpointProxy(new HttpClient(), feedUri, cred.UserName, cred.Password), new HttpClient());
                     break;
                 case FeedType.Docker :
                 case FeedType.AwsElasticContainerRegistry :

--- a/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
@@ -49,8 +49,7 @@ namespace Calamari.Integration.Packages.Download
                     downloader = new GitHubPackageDownloader();
                     break;
                 case FeedType.Helm :
-                    var cred = feedCredentials.GetCredential(feedUri, "basic");
-                    downloader = new HelmChartPackageDownloader(fileSystem, new HelmEndpointProxy(new HttpClient(), feedUri, cred.UserName, cred.Password), new HttpClient());
+                    downloader = new HelmChartPackageDownloader(fileSystem);
                     break;
                 case FeedType.Docker :
                 case FeedType.AwsElasticContainerRegistry :

--- a/source/Calamari.Shared/Util/StringExtensions.cs
+++ b/source/Calamari.Shared/Util/StringExtensions.cs
@@ -50,5 +50,13 @@ namespace Calamari.Util
 
             return relativePath;
         }
+        
+        public static bool IsValidUrl(this string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            return Uri.TryCreate(value, UriKind.Absolute, out var _);
+        }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Net;
-using System.Net.Http;
-using Calamari.Commands.Support;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Packages.Download;
-using Calamari.Integration.Packages.Download.Helm;
 using FluentAssertions;
 using NUnit.Framework;
 using Octopus.Versioning.Semver;
@@ -36,7 +33,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [SetUp]
         public void Setup()
         {
-            downloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new HelmEndpointProxy(new HttpClient(),new Uri(AuthFeedUri), FeedUsername, FeedPassword), new HttpClient());
+            downloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem());
         }
         
         [Test]
@@ -54,7 +51,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         public void PackageWithInvalidUrl_Throws()
         {
             var badUrl = new Uri($"https://octopusdeploy.jfrog.io/gobbelygook/{Guid.NewGuid().ToString("N")}");
-            var badEndpointDownloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new HelmEndpointProxy(new HttpClient(), badUrl, FeedUsername, FeedPassword), new HttpClient());
+            var badEndpointDownloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem());
             Action action = () => badEndpointDownloader.DownloadPackage("something", new SemanticVersion("99.9.7"), "gobbely", new Uri(badUrl, "something.99.9.7"), new NetworkCredential(FeedUsername, FeedPassword), true, 1, TimeSpan.FromSeconds(3));
             action.Should().Throw<Exception>().And.Message.Should().Contain("Unable to read Helm index file").And.Contain("404");
         }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
@@ -38,9 +38,8 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             downloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new HelmEndpointProxy(new HttpClient(),new Uri(AuthFeedUri), FeedUsername, FeedPassword), new HttpClient());
         }
         
-        //TODO: Revisit this at a later point. Mono really doesn't want to play nice here.
         [Test]
-        [RequiresMonoVersion480OrAbove]
+        [RequiresMonoVersion480OrAbove(Description = "This test requires TLS 1.2, which doesn't work with mono prior to 4.8")]
         public void PackageWithCredentials_Loads()
         {
             var pkg = downloader.DownloadPackage("mychart", new SemanticVersion("0.3.7"), "helm-feed", new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, FeedPassword), true, 1,

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using Calamari.Commands.Support;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Packages.Download;
 using Calamari.Integration.Packages.Download.Helm;
@@ -46,6 +47,16 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                 TimeSpan.FromSeconds(3));
             pkg.PackageId.Should().Be("mychart");
             pkg.Version.Should().Be(new SemanticVersion("0.3.7"));
+        }
+        
+        [Test]
+        [RequiresMonoVersion480OrAbove(Description = "This test requires TLS 1.2, which doesn't work with mono prior to 4.8")]
+        public void PackageWithInvalidUrl_Throws()
+        {
+            var badUrl = new Uri($"https://octopusdeploy.jfrog.io/gobbelygook/{Guid.NewGuid().ToString("N")}");
+            var badEndpointDownloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new HelmEndpointProxy(new HttpClient(), badUrl, FeedUsername, FeedPassword), new HttpClient());
+            Action action = () => badEndpointDownloader.DownloadPackage("something", new SemanticVersion("99.9.7"), "gobbely", new Uri(badUrl, "something.99.9.7"), new NetworkCredential(FeedUsername, FeedPassword), true, 1, TimeSpan.FromSeconds(3));
+            action.Should().Throw<Exception>().And.Message.Should().Contain("Unable to read Helm index file").And.Contain("404");
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using Calamari.Commands.Support;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Packages.Download;
 using Calamari.Integration.Packages.Download.Helm;
@@ -39,23 +38,15 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             downloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new HelmEndpointProxy(new HttpClient(),new Uri(AuthFeedUri), FeedUsername, FeedPassword), new HttpClient());
         }
         
+        //TODO: Revisit this at a later point. Mono really doesn't want to play nice here.
         [Test]
+        [RequiresNonMono]
         public void PackageWithCredentials_Loads()
         {
             var pkg = downloader.DownloadPackage("mychart", new SemanticVersion("0.3.7"), "helm-feed", new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, FeedPassword), true, 1,
                 TimeSpan.FromSeconds(3));
             pkg.PackageId.Should().Be("mychart");
             pkg.Version.Should().Be(new SemanticVersion("0.3.7"));
-        }        
-        
-        [Test]
-        public void PackageWithWrongCredentials_Fails()
-        {
-            Action download = () => downloader.DownloadPackage("mychart", new SemanticVersion("0.3.7"), "helm-feed",
-                new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, "FAKE"), true, 1,
-                TimeSpan.FromSeconds(3));
-            download.Should().Throw<CommandException>()
-                .And.Message.Should().Contain("Helm failed to download the chart");
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
@@ -40,7 +40,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         }
         
         [Test]
-        [RequiresMonoVersion480OrAbove(Description = "This test requires TLS 1.2, which doesn't work with mono prior to 4.8")]
+        [RequiresMonoVersion480OrAboveForTls12(Description = "This test requires TLS 1.2, which doesn't work with mono prior to 4.8")]
         public void PackageWithCredentials_Loads()
         {
             var pkg = downloader.DownloadPackage("mychart", new SemanticVersion("0.3.7"), "helm-feed", new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, FeedPassword), true, 1,
@@ -50,7 +50,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         }
         
         [Test]
-        [RequiresMonoVersion480OrAbove(Description = "This test requires TLS 1.2, which doesn't work with mono prior to 4.8")]
+        [RequiresMonoVersion480OrAboveForTls12(Description = "This test requires TLS 1.2, which doesn't work with mono prior to 4.8")]
         public void PackageWithInvalidUrl_Throws()
         {
             var badUrl = new Uri($"https://octopusdeploy.jfrog.io/gobbelygook/{Guid.NewGuid().ToString("N")}");

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
@@ -40,7 +40,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         
         //TODO: Revisit this at a later point. Mono really doesn't want to play nice here.
         [Test]
-        [RequiresNonMono]
+        [RequiresMonoVersion480OrAbove]
         public void PackageWithCredentials_Loads()
         {
             var pkg = downloader.DownloadPackage("mychart", new SemanticVersion("0.3.7"), "helm-feed", new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, FeedPassword), true, 1,

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/MavenPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/MavenPackageDownloaderFixture.cs
@@ -25,7 +25,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         }
 
         [Test]
-        [RequiresMonoVersion480OrAbove]
+        [RequiresMonoVersion480OrAboveForTls12]
         [RequiresNonFreeBSDPlatform]
         public void DownloadMavenPackage()
         {

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -65,7 +65,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [RequiresMonoVersion480OrAbove]
+        [RequiresMonoVersion480OrAboveForTls12]
         public void ShouldDownloadPackage()
         {
             var result = DownloadPackage(FeedzPackage.PackageId, FeedzPackage.Version.ToString(), FeedzPackage.Id, PublicFeedUri);
@@ -81,7 +81,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [RequiresMonoVersion480OrAbove]
+        [RequiresMonoVersion480OrAboveForTls12]
         [RequiresNonFreeBSDPlatform]
         public void ShouldDownloadMavenPackage()
         {
@@ -110,7 +110,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [RequiresMonoVersion480OrAbove]
+        [RequiresMonoVersion480OrAboveForTls12]
         [RequiresNonFreeBSDPlatform]
         public void ShouldDownloadMavenSnapshotPackage()
         {
@@ -154,7 +154,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [RequiresMonoVersion480OrAbove]
+        [RequiresMonoVersion480OrAboveForTls12]
         public void ShouldUsePackageFromCache()
         {
             DownloadPackage(FeedzPackage.PackageId,
@@ -178,7 +178,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [RequiresMonoVersion480OrAbove]
+        [RequiresMonoVersion480OrAboveForTls12]
         [RequiresNonFreeBSDPlatform]
         public void ShouldUseMavenPackageFromCache()
         {
@@ -210,7 +210,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [RequiresMonoVersion480OrAbove]
+        [RequiresMonoVersion480OrAboveForTls12]
         [RequiresNonFreeBSDPlatform]
         public void ShouldUseMavenSnapshotPackageFromCache()
         {
@@ -241,7 +241,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [RequiresMonoVersion480OrAbove]
+        [RequiresMonoVersion480OrAboveForTls12]
         public void ShouldByPassCacheAndDownloadPackage()
         {
             DownloadPackage(FeedzPackage.PackageId,
@@ -264,7 +264,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [RequiresMonoVersion480OrAbove]
+        [RequiresMonoVersion480OrAboveForTls12]
         [RequiresNonFreeBSDPlatform]
         public void ShouldByPassCacheAndDownloadMavenPackage()
         {
@@ -302,7 +302,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [RequiresMonoVersion480OrAbove]
+        [RequiresMonoVersion480OrAboveForTls12]
         [RequiresNonFreeBSDPlatform]
         public void ShouldByPassCacheAndDownloadMavenSnapshotPackage()
         {

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -65,7 +65,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [Ignore("Failing on < Mono 5 Need to fix ASAP", Until = "2019-12-11")]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldDownloadPackage()
         {
             var result = DownloadPackage(FeedzPackage.PackageId, FeedzPackage.Version.ToString(), FeedzPackage.Id, PublicFeedUri);
@@ -154,7 +154,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [Ignore("Failing on < Mono 5 Need to fix ASAP", Until = "2019-12-11")]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldUsePackageFromCache()
         {
             DownloadPackage(FeedzPackage.PackageId,
@@ -241,7 +241,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [Ignore("Failing on < Mono 5 Need to fix ASAP", Until = "2019-12-11")]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldByPassCacheAndDownloadPackage()
         {
             DownloadPackage(FeedzPackage.PackageId,

--- a/source/Calamari.Tests/Fixtures/RequiresMonoVersion480OrAboveForTls12Attribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresMonoVersion480OrAboveForTls12Attribute.cs
@@ -1,11 +1,11 @@
 ﻿namespace Calamari.Tests.Fixtures
 {
-    public class RequiresMonoVersion480OrAboveAttribute : RequiresMinimumMonoVersionAttribute
+    public class RequiresMonoVersion480OrAboveForTls12Attribute : RequiresMinimumMonoVersionAttribute
     {
         /// <summary>
         /// TLSv1.2 was only provided from Mono 4.8.0. Running 
         /// </summary>
-        public RequiresMonoVersion480OrAboveAttribute()
+        public RequiresMonoVersion480OrAboveForTls12Attribute()
             : base(4, 8, 0)
         {
 

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -50,7 +50,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="YamlDotNet" Version="6.1.2" />
     <ProjectReference Include="..\Calamari.Shared\Calamari.Shared.csproj" />
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />


### PR DESCRIPTION
This PR modifies our helm chart feed to download charts directly from an associated repository. This avoids issues with some external feeds such as bitbucket pages which has been returning the wrong headers for years now causing errors such as bad GZIP header errors.

Please note, this only deals with package references as the upgrade helm chart step pushes the chart from server to the tentacle.