### PR TITLE
Fix Powershell $PSVersionTable log output on MaxOSX

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -14,7 +14,7 @@ $ErrorActionPreference = 'Stop'
 
 function Log-VersionTable
 {
-	Write-Verbose ($PSVersionTable | Out-String)
+	Write-Verbose ($PSVersionTable | Out-String -Width 200) # Calling Out-String without specify the width resulted in blank lines when running tests under MacOS 10.15 and Netcore 3.1 for some reason
 }
 
 function Log-EnvironmentInformation

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -65,7 +65,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [Ignore("Failing on < Mono 5 Need to fix ASAP", Until = "2019-12-11")]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldDownloadPackage()
         {
             var result = DownloadPackage(FeedzPackage.PackageId, FeedzPackage.Version.ToString(), FeedzPackage.Id, PublicFeedUri);
@@ -154,7 +154,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [Ignore("Failing on < Mono 5 Need to fix ASAP", Until = "2019-12-11")]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldUsePackageFromCache()
         {
             DownloadPackage(FeedzPackage.PackageId,
@@ -241,7 +241,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         }
 
         [Test]
-        [Ignore("Failing on < Mono 5 Need to fix ASAP", Until = "2019-12-11")]
+        [RequiresMonoVersion480OrAbove]
         public void ShouldByPassCacheAndDownloadPackage()
         {
             DownloadPackage(FeedzPackage.PackageId,


### PR DESCRIPTION
Merging from the `lts_2019.9` branch