### PR TITLE
Fix Powershell $PSVersionTable log output on MaxOSX

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -14,7 +14,7 @@ $ErrorActionPreference = 'Stop'
 
 function Log-VersionTable
 {
-	Write-Verbose ($PSVersionTable | Out-String)
+	Write-Verbose ($PSVersionTable | Out-String -Width 200) # Calling Out-String without specify the width resulted in blank lines when running tests under MacOS 10.15 and Netcore 3.1 for some reason
 }
 
 function Log-EnvironmentInformation


### PR DESCRIPTION
Merging from the `lts_2019.12` branch