### PR TITLE
Ignore disk free space check on macOS under Mono

### DIFF
--- a/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/CalamariPhysicalFileSystem.cs
@@ -577,6 +577,16 @@ namespace Calamari.Integration.FileSystem
 
         public void EnsureDiskHasEnoughFreeSpace(string directoryPath)
         {
+            if (CalamariEnvironment.IsRunningOnMono && CalamariEnvironment.IsRunningOnMac)
+            {
+                //After upgrading to macOS 10.15.2, and mono 5.14.0, drive.TotalFreeSpace and drive.AvailableFreeSpace both started returning 0.
+                //see https://github.com/mono/mono/issues/17151, which was fixed in mono 6.4.xx
+                //If we upgrade mono past 5.14.x, scriptcs stops working.
+                //Rock and a hard place.
+                Log.Verbose("Unable to determine disk free space under Mono on macOS. Assuming there's enough.");
+                return;
+            }
+            
             if (SkipFreeDiskSpaceCheck)
             {
                 Log.Verbose($"{SpecialVariables.SkipFreeDiskSpaceCheck} is enabled. The check to ensure that the drive containing the directory '{directoryPath}' on machine '{Environment.MachineName}' has enough free space will be skipped.");

--- a/source/Calamari.Tests/Helpers/CalamariResult.cs
+++ b/source/Calamari.Tests/Helpers/CalamariResult.cs
@@ -194,8 +194,8 @@ namespace Calamari.Tests.Helpers
 
         public void AssertProcessNameAndId(string processName)
         {
-            AssertOutputMatches(@"HostProcess: (Calamari|dotnet|mono-sgen32|mono-sgen) \([0-9]+\)", "Calamari process name and id are printed");
-            AssertOutputMatches($@"HostProcess: ({processName}|mono-sgen32|mono-sgen) \([0-9]+\)", $"{processName} process name and id are printed");
+            AssertOutputMatches(@"HostProcess: (Calamari|dotnet|mono-sgen32|mono-sgen64|mono-sgen) \([0-9]+\)", "Calamari process name and id are printed");
+            AssertOutputMatches($@"HostProcess: ({processName}|mono-sgen32|mono-sgen64|mono-sgen) \([0-9]+\)", $"{processName} process name and id are printed");
         }
     }
 }


### PR DESCRIPTION
After upgrading to macOS 10.15.2, and mono 5.14.0, `drive.TotalFreeSpace` and `drive.AvailableFreeSpace` both started returning 0.
See https://github.com/mono/mono/issues/17151, which was fixed in mono 6.4.xx
If we upgrade mono past 5.14.x, scriptcs stops working.
Rock and a hard place.

[slack conversation](https://octopusdeploy.slack.com/archives/C033W4273/p1580357106054500) about how much we care about mono and mac now