### PR TITLE
Use ordinal instead of current/invariant culture for string comparisons

### DIFF
--- a/source/Calamari.Aws/Commands/ApplyCloudFormationChangesetCommand.cs
+++ b/source/Calamari.Aws/Commands/ApplyCloudFormationChangesetCommand.cs
@@ -33,7 +33,7 @@ namespace Calamari.Aws.Commands
                 v => sensitiveVariablesPassword = v);
             Options.Add("package=", "Path to the NuGet package to install.", v => packageFile = Path.GetFullPath(v));
             Options.Add("waitForCompletion=", "True if the deployment process should wait for the stack to complete, and False otherwise.", v => waitForComplete =  
-                !bool.FalseString.Equals(v, StringComparison.InvariantCultureIgnoreCase)); //True by default
+                !bool.FalseString.Equals(v, StringComparison.OrdinalIgnoreCase)); //True by default
         }
 
         public override int Execute(string[] commandLineArguments)

--- a/source/Calamari.Aws/Commands/DeleteCloudFormationCommand.cs
+++ b/source/Calamari.Aws/Commands/DeleteCloudFormationCommand.cs
@@ -34,7 +34,7 @@ namespace Calamari.Aws.Commands
                 v => sensitiveVariablesPassword = v);
             Options.Add("package=", "Path to the NuGet package to install.", v => packageFile = Path.GetFullPath(v));
             Options.Add("waitForCompletion=", "True if the deployment process should wait for the stack to complete, and False otherwise.", v => waitForComplete =  
-                !bool.FalseString.Equals(v, StringComparison.InvariantCultureIgnoreCase)); //True by default
+                !bool.FalseString.Equals(v, StringComparison.OrdinalIgnoreCase)); //True by default
         }
 
         public override int Execute(string[] commandLineArguments)

--- a/source/Calamari.Aws/Commands/DeployAwsCloudFormationCommand.cs
+++ b/source/Calamari.Aws/Commands/DeployAwsCloudFormationCommand.cs
@@ -47,10 +47,10 @@ namespace Calamari.Aws.Commands
             Options.Add("template=", "Path to the JSON template file.", v => templateFile = v);
             Options.Add("templateParameters=", "Path to the JSON template parameters file.", v => templateParameterFile = v);
             Options.Add("waitForCompletion=", "True if the deployment process should wait for the stack to complete, and False otherwise.", 
-                v => waitForComplete = !bool.FalseString.Equals(v, StringComparison.InvariantCultureIgnoreCase)); //True by default
+                v => waitForComplete = !bool.FalseString.Equals(v, StringComparison.OrdinalIgnoreCase)); //True by default
             Options.Add("stackName=", "The name of the CloudFormation stack.", v => stackName = v);
             Options.Add("disableRollback=", "True to disable the CloudFormation stack rollback on failure, and False otherwise.", 
-                v => disableRollback = bool.TrueString.Equals(v, StringComparison.InvariantCultureIgnoreCase)); //False by default
+                v => disableRollback = bool.TrueString.Equals(v, StringComparison.OrdinalIgnoreCase)); //False by default
         }
 
         public override int Execute(string[] commandLineArguments)

--- a/source/Calamari.Aws/Integration/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.Aws/Integration/AwsEnvironmentGeneration.cs
@@ -179,7 +179,7 @@ namespace Calamari.Aws.Integration
         /// </summary>
         async Task AssumeRole()
         {
-            if ("True".Equals(assumeRole, StringComparison.InvariantCultureIgnoreCase))
+            if ("True".Equals(assumeRole, StringComparison.OrdinalIgnoreCase))
             {
                var client = new AmazonSecurityTokenServiceClient(AwsCredentials);
                var credentials = (await client.AssumeRoleAsync(new AssumeRoleRequest

--- a/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
@@ -16,7 +16,7 @@ namespace Calamari.Aws.Integration.CloudFormation
 {
     public static class CloudFormationObjectExtensions
     {
-        private static readonly HashSet<string> RecognisedCapabilities = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
+        private static readonly HashSet<string> RecognisedCapabilities = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"
         };
@@ -24,7 +24,7 @@ namespace Calamari.Aws.Integration.CloudFormation
         // These status indicate that an update or create was not successful.
         // http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html#w2ab2c15c15c17c11
         private static HashSet<string> UnsuccessfulStackEvents =
-            new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "CREATE_ROLLBACK_COMPLETE",
                 "CREATE_ROLLBACK_FAILED",
@@ -60,7 +60,7 @@ namespace Calamari.Aws.Integration.CloudFormation
         /// 
         /// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html#w2ab2c15c15c17c11
         private static HashSet<string> UnrecoverableStackStatuses =
-            new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "CREATE_FAILED", "ROLLBACK_COMPLETE", "ROLLBACK_FAILED", "DELETE_FAILED",
                 "UPDATE_ROLLBACK_FAILED"

--- a/source/Calamari.Aws/Integration/CloudFormation/StackEventLogger.cs
+++ b/source/Calamari.Aws/Integration/CloudFormation/StackEventLogger.cs
@@ -10,7 +10,7 @@ namespace Calamari.Aws.Integration.CloudFormation
     {
         private readonly ILog log;
         private string lastMessage;
-        private HashSet<string> warnings = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+        private HashSet<string> warnings = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         public StackEventLogger(ILog log)
         {

--- a/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
@@ -16,7 +16,7 @@ namespace Calamari.Aws.Integration.S3
     {
         //Special headers as per AWS docs - https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
         private static readonly IDictionary<string, Func<HeadersCollection, string>> SupportedSpecialHeaders =
-            new Dictionary<string, Func<HeadersCollection, string>>(StringComparer.InvariantCultureIgnoreCase)
+            new Dictionary<string, Func<HeadersCollection, string>>(StringComparer.OrdinalIgnoreCase)
                 .WithHeaderFrom("Cache-Control", headers => headers.CacheControl)
                 .WithHeaderFrom("Content-Disposition", headers => headers.ContentDisposition)
                 .WithHeaderFrom("Content-Encoding", headers => headers.ContentEncoding)
@@ -49,7 +49,7 @@ namespace Calamari.Aws.Integration.S3
             var allKeys = next.Keys.Union(current.Keys).Distinct().ToList();
             var keysInBoth = allKeys.Where(key => next.ContainsKey(key) && current.ContainsKey(key)).ToList();
             var missingKeys = allKeys.Except(keysInBoth).ToList();
-            var differentValues = keysInBoth.Where(key => string.Compare(next[key], current[key], StringComparison.CurrentCultureIgnoreCase) != 0).ToList();
+            var differentValues = keysInBoth.Where(key => !string.Equals(next[key], current[key], StringComparison.OrdinalIgnoreCase)).ToList();
 
             return missingKeys.Count == 0 && differentValues.Count == 0;
         }
@@ -154,7 +154,7 @@ namespace Calamari.Aws.Integration.S3
 
         public static bool IsSameAsRequestMd5Digest(this ETag etag, PutObjectRequest request)
         {
-            return string.Compare(etag.Hash, request.Md5DigestToHexString(), StringComparison.InvariantCultureIgnoreCase) == 0;
+            return string.Compare(etag.Hash, request.Md5DigestToHexString(), StringComparison.OrdinalIgnoreCase) == 0;
         }
     }
 }

--- a/source/Calamari.Azure/HealthChecks/WebAppHealthChecker.cs
+++ b/source/Calamari.Azure/HealthChecks/WebAppHealthChecker.cs
@@ -69,7 +69,7 @@ namespace Calamari.Azure.HealthChecks
                         if (webAppsResponse.StatusCode != HttpStatusCode.OK)
                             throw new Exception($"Azure returned HTTP status-code getting WebApps for the WebSpace '{webSpace}': {webAppsResponse.StatusCode}");
                         return webAppsResponse.WebSites.Where(
-                            x => string.Equals(x.Name, siteName, StringComparison.CurrentCultureIgnoreCase)
+                            x => string.Equals(x.Name, siteName, StringComparison.OrdinalIgnoreCase)
                             && x.WebSpace.ToLower().Contains(resourceGroupName.ToLower())
                         );
                     }).FirstOrDefault();
@@ -85,7 +85,7 @@ namespace Calamari.Azure.HealthChecks
                 var matchingSite = webSiteClient.WebApps
                     .ListByResourceGroup(resourceGroupName, true)
                     .ToList()
-                    .FirstOrDefault(x => string.Equals(x.Name, siteAndSlotName, StringComparison.CurrentCultureIgnoreCase));
+                    .FirstOrDefault(x => string.Equals(x.Name, siteAndSlotName, StringComparison.OrdinalIgnoreCase));
                 if (matchingSite == null)
                     throw new Exception($"Could not find site {siteAndSlotName} in resource group {resourceGroupName}, using Service Principal with subscription {servicePrincipalAccount.SubscriptionNumber}");
             }

--- a/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
+++ b/source/Calamari.Azure/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
@@ -110,7 +110,7 @@ namespace Calamari.Azure.Integration.Websites.Publishing
             {
                 var sites = webSiteClient.WebApps.List();
                 var matchingSites = sites.Where(webApp =>
-                    string.Equals(webApp.Name, azureTargetSite.Site, StringComparison.CurrentCultureIgnoreCase)).ToList();
+                    string.Equals(webApp.Name, azureTargetSite.Site, StringComparison.OrdinalIgnoreCase)).ToList();
 
                 LogFoundSites(sites.ToList());
 

--- a/source/Calamari.Shared/Integration/Packages/Download/FixedFilePathResolver.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/FixedFilePathResolver.cs
@@ -51,7 +51,7 @@ namespace Calamari.Integration.Packages.Download
 
         void EnsureRightPackage(string packageId)
         {
-            var samePackage = string.Equals(packageId, packageName, StringComparison.InvariantCultureIgnoreCase);
+            var samePackage = string.Equals(packageId, packageName, StringComparison.OrdinalIgnoreCase);
 
             if (!samePackage)
             {

--- a/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
@@ -75,7 +75,7 @@ namespace Calamari.Integration.Packages.Download
             var cred = credentials.GetCredential(feedUri, "basic");
             
             var yaml = endpointProxy.Get(feedUri, cred.UserName, cred.Password, cancellationToken);
-            var package = HelmIndexYamlReader.Read(yaml).FirstOrDefault(p => p.PackageId.Equals(packageId, StringComparison.InvariantCultureIgnoreCase));
+            var package = HelmIndexYamlReader.Read(yaml).FirstOrDefault(p => p.PackageId.Equals(packageId, StringComparison.OrdinalIgnoreCase));
             return package;
         }
 

--- a/source/Calamari.Shared/Integration/Packages/PackageName.cs
+++ b/source/Calamari.Shared/Integration/Packages/PackageName.cs
@@ -135,7 +135,7 @@ namespace Calamari.Integration.Packages
             }
 
             //TODO: Extract... Obviously _could_ be an issue for .net core
-            if (extension.Equals(".nupkg", StringComparison.InvariantCultureIgnoreCase) && File.Exists(path))
+            if (extension.Equals(".nupkg", StringComparison.OrdinalIgnoreCase) && File.Exists(path))
             {
 //                var metaData = new FileSystemNuGetPackage(path);
 //                version = metaData.Version;

--- a/source/Calamari.Shared/Integration/Proxies/ProxyEnvironmentVariablesGenerator.cs
+++ b/source/Calamari.Shared/Integration/Proxies/ProxyEnvironmentVariablesGenerator.cs
@@ -22,7 +22,7 @@ namespace Calamari.Integration.Proxies
         public static IEnumerable<EnvironmentVariable> GenerateProxyEnvironmentVariables()
         {
             var environmentVariables = Environment.GetEnvironmentVariables();
-            var existingProxyEnvironmentVariables = ProxyEnvironmentVariableNames.Where(environmentVariables.Contains).ToHashSet(StringComparer.InvariantCulture);
+            var existingProxyEnvironmentVariables = ProxyEnvironmentVariableNames.Where(environmentVariables.Contains).ToHashSet(StringComparer.Ordinal);
             if (existingProxyEnvironmentVariables.Any())
             {
                 Log.Verbose("Proxy related environment variables already exist. Calamari will not overwrite any proxy environment variables.");

--- a/source/Calamari.Shared/Util/StringExtensions.cs
+++ b/source/Calamari.Shared/Util/StringExtensions.cs
@@ -9,7 +9,7 @@ namespace Calamari.Util
     {
         public static bool ContainsIgnoreCase(this string originalString, string value)
         {
-            return originalString.IndexOf(value, StringComparison.InvariantCultureIgnoreCase) != -1;
+            return originalString.IndexOf(value, StringComparison.OrdinalIgnoreCase) != -1;
         }
 
         public static string EscapeSingleQuotedString(this string str) =>

--- a/source/Calamari/Deployment/Features/NginxFeature.cs
+++ b/source/Calamari/Deployment/Features/NginxFeature.cs
@@ -56,7 +56,7 @@ namespace Calamari.Deployment.Features
         {
             var sslCertsForEnabledBindings = new Dictionary<string, (string, string, string)>();
             foreach (var httpsBinding in enabledBindings.Where(b =>
-                string.Equals("https", b.Protocol, StringComparison.InvariantCultureIgnoreCase) &&
+                string.Equals("https", b.Protocol, StringComparison.OrdinalIgnoreCase) &&
                 !string.IsNullOrEmpty(b.CertificateVariable)
             ))
             {

--- a/source/Calamari/Integration/Iis/WebServerSevenSupport.cs
+++ b/source/Calamari/Integration/Iis/WebServerSevenSupport.cs
@@ -16,7 +16,7 @@ namespace Calamari.Integration.Iis
 
             Execute(serverManager =>
             {
-                var existing = serverManager.Sites.FirstOrDefault(x => String.Equals(x.Name, webSiteName, StringComparison.InvariantCultureIgnoreCase));
+                var existing = serverManager.Sites.FirstOrDefault(x => String.Equals(x.Name, webSiteName, StringComparison.OrdinalIgnoreCase));
                 if (existing == null)
                 {
                     existing = serverManager.Sites.Add(webSiteName, webRootPath, port);                    
@@ -52,7 +52,7 @@ namespace Calamari.Integration.Iis
         {
             Execute(serverManager =>
             {
-                var existing = serverManager.Sites.FirstOrDefault(x => String.Equals(x.Name, webSiteName, StringComparison.InvariantCultureIgnoreCase));
+                var existing = serverManager.Sites.FirstOrDefault(x => String.Equals(x.Name, webSiteName, StringComparison.OrdinalIgnoreCase));
                 if (existing == null)
                 {
                     throw new Exception($"The site '{webSiteName}'  does not exist.");
@@ -67,7 +67,7 @@ namespace Calamari.Integration.Iis
         {
             Execute(serverManager =>
             {
-                var existing = serverManager.ApplicationPools.FirstOrDefault(x => String.Equals(x.Name, applicationPoolName, StringComparison.InvariantCultureIgnoreCase));
+                var existing = serverManager.ApplicationPools.FirstOrDefault(x => String.Equals(x.Name, applicationPoolName, StringComparison.OrdinalIgnoreCase));
                 if (existing == null)
                 {
                     throw new Exception($"The application pool '{applicationPoolName}' does not exist");
@@ -102,7 +102,7 @@ namespace Calamari.Integration.Iis
                 var virtuals = ListVirtualDirectories("", site);
                 foreach (var vdir in virtuals)
                 {
-                    if (!string.Equals(Normalize(vdir.FullVirtualPath), Normalize(virtualDirectoryPath), StringComparison.InvariantCultureIgnoreCase)) 
+                    if (!string.Equals(Normalize(vdir.FullVirtualPath), Normalize(virtualDirectoryPath), StringComparison.OrdinalIgnoreCase)) 
                         continue;
 
                     found(vdir.VirtualDirectory);
@@ -174,7 +174,7 @@ namespace Calamari.Integration.Iis
 
         public Site FindWebSite(string webSiteName)
         {
-            return Execute(serverManager => serverManager.Sites.FirstOrDefault(x => String.Equals(x.Name, webSiteName, StringComparison.InvariantCultureIgnoreCase)));
+            return Execute(serverManager => serverManager.Sites.FirstOrDefault(x => String.Equals(x.Name, webSiteName, StringComparison.OrdinalIgnoreCase)));
         }
 
         public bool WebSiteExists(string webSiteName)
@@ -195,7 +195,7 @@ namespace Calamari.Integration.Iis
 
         public ApplicationPool FindApplicationPool(string applicationPoolName)
         {
-            return Execute(serverManager => serverManager.ApplicationPools.FirstOrDefault(x => String.Equals(x.Name, applicationPoolName, StringComparison.InvariantCultureIgnoreCase)));              
+            return Execute(serverManager => serverManager.ApplicationPools.FirstOrDefault(x => String.Equals(x.Name, applicationPoolName, StringComparison.OrdinalIgnoreCase)));              
         }
 
         public bool ApplicationPoolExists(string applicationPool)

--- a/source/Calamari/Integration/Nginx/NginxServer.cs
+++ b/source/Calamari/Integration/Nginx/NginxServer.cs
@@ -51,7 +51,7 @@ namespace Calamari.Integration.Nginx
         {
             foreach (var binding in bindings)
             {
-                if (string.Equals("http", binding.Protocol, StringComparison.InvariantCultureIgnoreCase))
+                if (string.Equals("http", binding.Protocol, StringComparison.OrdinalIgnoreCase))
                 {
                     AddServerBindingDirective(NginxDirectives.Server.Listen,
                         GetListenValue(binding.IpAddress, binding.Port));


### PR DESCRIPTION
Merging https://github.com/OctopusDeploy/Calamari/pull/487 to master.

We should default to using ordinal unless we actually want to deal with culture

https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1309?view=vs-2019

Our Ubuntu18 agent exposed this because its InvariantCulture + CurrentCulture behaved differently.