### PR TITLE
Use NormalizedFilename for s3 package upload

### DIFF
--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -246,9 +246,12 @@ namespace Calamari.Aws.Deployment.Conventions
             Guard.NotNull(deployment, "Deployment may not be null");
             Guard.NotNull(options, "Package options may not be null");
             Guard.NotNull(clientFactory, "Client factory must not be null");
-
+            
+            var directory = Path.GetDirectoryName(deployment.PackageFilePath) ?? "";
+            var packageName = deployment.Variables[SpecialVariables.Packages.NormalizedFilename(null)];
+            
             return CreateRequest(deployment.PackageFilePath,
-                    GetBucketKey(Path.GetDirectoryName(deployment.PackageFilePath), deployment.PackageFilePath, options), options)
+                    GetBucketKey(directory, Path.Combine(directory, packageName), options), options)
                 .Tee(x => LogPutObjectRequest("entire package", x))
                 .Map(x => HandleUploadRequest(clientFactory(), x, ThrowInvalidFileUpload));
         }

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -200,6 +200,11 @@ namespace Calamari.Deployment
             {
                 return $"Octopus.Action.Package[{key}].PackageFilePath";
             }
+
+            public static string NormalizedFilename(string key)
+            {
+                return $"Octopus.Action.Package[{key}].NormalizedFilename";
+            }
         }
 
         public static class Vhd

--- a/source/Calamari/Commands/DownloadPackageCommand.cs
+++ b/source/Calamari/Commands/DownloadPackageCommand.cs
@@ -98,6 +98,7 @@ namespace Calamari.Commands
                 Log.SetOutputVariable("StagedPackage.Hash", pkg.Hash);
                 Log.SetOutputVariable("StagedPackage.Size", pkg.Size.ToString(CultureInfo.InvariantCulture));
                 Log.SetOutputVariable("StagedPackage.FullPathOnRemoteMachine", pkg.FullFilePath);
+                Log.SetOutputVariable("StagedPackage.NormalizedFilename", $"{pkg.PackageId}-{pkg.Version}.{pkg.Extension}");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Use NormalizedFilename for s3 package upload since `deployment.PackageFilePath` or `OriginalFilename` may differ between built-in worker and external workers.