### PR TITLE
Fix bug where Calamari's referencing legacy variable names - 2019.12 LTS

### DIFF
--- a/source/Calamari.Azure/Deployment/Conventions/UploadAzureCloudServicePackageConvention.cs
+++ b/source/Calamari.Azure/Deployment/Conventions/UploadAzureCloudServicePackageConvention.cs
@@ -27,7 +27,7 @@ namespace Calamari.Azure.Deployment.Conventions
             var package = deployment.Variables.Get(SpecialVariables.Action.Azure.CloudServicePackagePath); 
             Log.Info("Uploading package to Azure blob storage: '{0}'", package);
             var packageHash = HashCalculator.Hash(package);
-            var nugetPackageVersion = deployment.Variables.Get(SpecialVariables.Package.NuGetPackageVersion);
+            var nugetPackageVersion = deployment.Variables.Get(SpecialVariables.Package.PackageVersion);
             var uploadedFileName = Path.ChangeExtension(Path.GetFileName(package), "." + nugetPackageVersion + "_" + packageHash + ".cspkg");
 
             var credentials = credentialsFactory.GetCredentials(deployment.Variables);

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -119,10 +119,9 @@ namespace Calamari.Deployment
         public static class Package
         {
             public static readonly string TransferPath = "Octopus.Action.Package.TransferPath";
-            public static readonly string NuGetPackageId = "Octopus.Action.Package.NuGetPackageId";
-            public static readonly string NuGetPackageVersion = "Octopus.Action.Package.NuGetPackageVersion";
+            public static readonly string PackageId = "Octopus.Action.Package.PackageId";
+            public static readonly string PackageVersion = "Octopus.Action.Package.PackageVersion";
             public static readonly string ShouldDownloadOnTentacle = "Octopus.Action.Package.DownloadOnTentacle";
-            public static readonly string NuGetFeedId = "Octopus.Action.Package.NuGetFeedId";
             public static readonly string OriginalFileName = "Octopus.Action.Package.OriginalFileName";
             public static readonly string EnabledFeatures = "Octopus.Action.EnabledFeatures";
             public static readonly string UpdateIisWebsite = "Octopus.Action.Package.UpdateIisWebsite";

--- a/source/Calamari.Tests/Fixtures/Conventions/LegacyIisWebSiteConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/LegacyIisWebSiteConventionFixture.cs
@@ -49,7 +49,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             const string packageId = "Acme.1.1.1";
             variables.Set(SpecialVariables.Package.UpdateIisWebsite, true.ToString());
-            variables.Set(SpecialVariables.Package.NuGetPackageId, packageId);
+            variables.Set(SpecialVariables.Package.PackageId, packageId);
             fileSystem.FileExists(Path.Combine(stagingDirectory, "Web.config")).Returns(true);
             iis.OverwriteHomeDirectory(packageId, stagingDirectory, false).Returns(true);
 

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -274,8 +274,8 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             Variables.Set(SpecialVariables.Package.SkipIfAlreadyInstalled, true.ToString());
             Variables.Set(SpecialVariables.RetentionPolicySet, "a/b/c/d");
-            Variables.Set(SpecialVariables.Package.NuGetPackageId, "Acme.Web");
-            Variables.Set(SpecialVariables.Package.NuGetPackageVersion, "1.0.0");
+            Variables.Set(SpecialVariables.Package.PackageId, "Acme.Web");
+            Variables.Set(SpecialVariables.Package.PackageVersion, "1.0.0");
 
             var result = DeployPackage(deploymentType);
             result.AssertSuccess();
@@ -291,8 +291,8 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             Variables.Set(SpecialVariables.Package.SkipIfAlreadyInstalled, true.ToString());
             Variables.Set(SpecialVariables.RetentionPolicySet, "a/b/c/d");
-            Variables.Set(SpecialVariables.Package.NuGetPackageId, "Acme.Web");
-            Variables.Set(SpecialVariables.Package.NuGetPackageVersion, "1.0.0");
+            Variables.Set(SpecialVariables.Package.PackageId, "Acme.Web");
+            Variables.Set(SpecialVariables.Package.PackageVersion, "1.0.0");
 
             var result = DeployPackage(DeploymentType.Tar);
             result.AssertSuccess();

--- a/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
@@ -191,7 +191,7 @@ namespace Calamari.Tests.Fixtures.Nginx
             var confDirectory = "conf";
             
             var deployment = new RunningDeployment($"C:\\{packageId}.zip", new CalamariVariableDictionary());
-            deployment.Variables.Set(SpecialVariables.Package.NuGetPackageId, packageId);
+            deployment.Variables.Set(SpecialVariables.Package.PackageId, packageId);
             deployment.Variables.Set(SpecialVariables.Package.Output.InstallationDirectoryPath, $"/var/www/{packageId}");
             deployment.Variables.Set(SpecialVariables.Action.Nginx.Server.Bindings, httpOnlyBinding);
             deployment.Variables.Set(SpecialVariables.Action.Nginx.Server.Locations, staticContentAndReverseProxyLocations);

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -88,10 +88,10 @@ namespace Calamari.Tests.KubernetesFixtures
             Variables.Set(SpecialVariables.Tentacle.Agent.ApplicationDirectoryPath, StagingDirectory);
 
             //Chart Pckage
-            Variables.Set(SpecialVariables.Package.NuGetPackageId, "mychart");
-            Variables.Set(SpecialVariables.Package.NuGetPackageVersion, "0.3.7");
-            Variables.Set(SpecialVariables.Packages.PackageId(""), $"#{{{SpecialVariables.Package.NuGetPackageId}}}");
-            Variables.Set(SpecialVariables.Packages.PackageVersion(""), $"#{{{SpecialVariables.Package.NuGetPackageVersion}}}");
+            Variables.Set(SpecialVariables.Package.PackageId, "mychart");
+            Variables.Set(SpecialVariables.Package.PackageVersion, "0.3.7");
+            Variables.Set(SpecialVariables.Packages.PackageId(""), $"#{{{SpecialVariables.Package.PackageId}}}");
+            Variables.Set(SpecialVariables.Packages.PackageVersion(""), $"#{{{SpecialVariables.Package.PackageVersion}}}");
             
             //Helm Options
             Variables.Set(Kubernetes.SpecialVariables.Helm.ReleaseName, ReleaseName);

--- a/source/Calamari/Deployment/Conventions/AlreadyInstalledConvention.cs
+++ b/source/Calamari/Deployment/Conventions/AlreadyInstalledConvention.cs
@@ -20,8 +20,8 @@ namespace Calamari.Deployment.Conventions
                 return;
             }
 
-            var id = deployment.Variables.Get(SpecialVariables.Package.NuGetPackageId);
-            var version = deployment.Variables.Get(SpecialVariables.Package.NuGetPackageVersion);
+            var id = deployment.Variables.Get(SpecialVariables.Package.PackageId);
+            var version = deployment.Variables.Get(SpecialVariables.Package.PackageVersion);
             var policySet = deployment.Variables.Get(SpecialVariables.RetentionPolicySet);
 
             var previous = journal.GetLatestInstallation(policySet, id, version);

--- a/source/Calamari/Deployment/Conventions/LegacyIisWebSiteConvention.cs
+++ b/source/Calamari/Deployment/Conventions/LegacyIisWebSiteConvention.cs
@@ -25,7 +25,7 @@ namespace Calamari.Deployment.Conventions
             var iisSiteName = deployment.Variables.Get(SpecialVariables.Package.UpdateIisWebsiteName);
             if (string.IsNullOrWhiteSpace(iisSiteName))
             {
-                iisSiteName = deployment.Variables.Get(SpecialVariables.Package.NuGetPackageId);
+                iisSiteName = deployment.Variables.Get(SpecialVariables.Package.PackageId);
             }
 
             var webRoot = GetRootMostDirectoryContainingWebConfig(deployment);

--- a/source/Calamari/Deployment/Features/NginxFeature.cs
+++ b/source/Calamari/Deployment/Features/NginxFeature.cs
@@ -36,7 +36,7 @@ namespace Calamari.Deployment.Features
             var customNginxSslRoot = variables.Get(SpecialVariables.Action.Nginx.SslRoot);
             
             nginxServer
-                .WithVirtualServerName(variables.Get(SpecialVariables.Package.NuGetPackageId))
+                .WithVirtualServerName(variables.Get(SpecialVariables.Package.PackageId))
                 .WithHostName(variables.Get(SpecialVariables.Action.Nginx.Server.HostName))
                 .WithServerBindings(enabledBindings, sslCertificates, customNginxSslRoot)
                 .WithRootLocation(rootLocation)

--- a/source/Calamari/Deployment/Journal/DeployedPackage.cs
+++ b/source/Calamari/Deployment/Journal/DeployedPackage.cs
@@ -43,18 +43,18 @@ namespace Calamari.Deployment.Journal
         {
             var variables = deployment.Variables;
 
-            if (!string.IsNullOrWhiteSpace(variables.Get(SpecialVariables.Package.NuGetPackageId)))
+            if (!string.IsNullOrWhiteSpace(variables.Get(SpecialVariables.Package.PackageId)))
             {
                 yield return new DeployedPackage(
-                    variables.Get(SpecialVariables.Package.NuGetPackageId),
-                    variables.Get(SpecialVariables.Package.NuGetPackageVersion),
+                    variables.Get(SpecialVariables.Package.PackageId),
+                    variables.Get(SpecialVariables.Package.PackageVersion),
                     deployment.PackageFilePath
                 );
             }
 
             foreach (var packageReferenceName in variables.GetIndexes(SpecialVariables.Packages.PackageCollection))
             {
-                if (string.IsNullOrEmpty(packageReferenceName) && variables.IsSet(SpecialVariables.Package.NuGetPackageId))
+                if (string.IsNullOrEmpty(packageReferenceName) && variables.IsSet(SpecialVariables.Package.PackageId))
                 {
                     continue;
                 }

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -275,7 +275,7 @@ namespace Calamari.Kubernetes.Conventions
         {
             var packagePath = deployment.Variables.Get(Deployment.SpecialVariables.Package.Output.InstallationDirectoryPath);
             
-            var packageId = deployment.Variables.Get(Deployment.SpecialVariables.Package.NuGetPackageId);
+            var packageId = deployment.Variables.Get(Deployment.SpecialVariables.Package.PackageId);
 
             if (fileSystem.FileExists(Path.Combine(packagePath, "Chart.yaml")))
             {


### PR DESCRIPTION
This is breaking any runbooks with packages because runbooks don't polyfill legacy variable names like deployments