### PR TITLE
Additional logging during package extraction

### DIFF
--- a/source/Calamari.Shared/Deployment/Conventions/StageScriptPackagesConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/StageScriptPackagesConvention.cs
@@ -45,6 +45,7 @@ namespace Calamari.Deployment.Conventions
 
             foreach (var packageReferenceName in packageReferenceNames)
             {
+                Log.Verbose($"Considering '{packageReferenceName}' for extraction");
                 var sanitizedPackageReferenceName = fileSystem.RemoveInvalidFileNameChars(packageReferenceName);
                 
                 var packageOriginalPath = variables.Get(SpecialVariables.Packages.OriginalPath(packageReferenceName));
@@ -59,7 +60,10 @@ namespace Calamari.Deployment.Conventions
 
                 // In the case of container images, the original path is not a file-path.  We won't try and extract or move it.
                 if (!fileSystem.FileExists(packageOriginalPath))
+                {
+                    Log.Verbose($"Package '{packageReferenceName}' was not found at '{packageOriginalPath}', skipping extraction");
                     continue;
+                }
 
                 var shouldExtract = variables.GetFlag(SpecialVariables.Packages.Extract(packageReferenceName));
 


### PR DESCRIPTION
Sometimes it can be difficult to diagnose why a package was not extracted. Before this change, package extraction could bail out without indicating that a package extraction was even attempted. This PR add a couple of log lines to make it easier to troubleshoot.
These changes have been used in the wild to successfully diagnose an issue.