### PR TITLE
Pulled free space check out of CalamariPhysicalFileSystem and into a service

### DIFF
--- a/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
+++ b/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
@@ -50,8 +50,6 @@ namespace Calamari.Aws.Commands
             if (!fileSystem.FileExists(packageFile))
                 throw new CommandException("Could not find package file: " + packageFile);
 
-            fileSystem.FreeDiskSpaceOverrideInMegaBytes = variables.GetInt32(SpecialVariables.FreeDiskSpaceOverrideInMegaBytes);
-            fileSystem.SkipFreeDiskSpaceCheck = variables.GetFlag(SpecialVariables.SkipFreeDiskSpaceCheck);
             var environment = AwsEnvironmentGeneration.Create(variables).GetAwaiter().GetResult();
             var substituter = new FileSubstituter(fileSystem);
             var bucketKeyProvider = new BucketKeyProvider();

--- a/source/Calamari.Shared/Commands/ApplyDeltaCommand.cs
+++ b/source/Calamari.Shared/Commands/ApplyDeltaCommand.cs
@@ -21,6 +21,7 @@ namespace Calamari.Commands
         bool showProgress;
         bool skipVerification;
         readonly ICalamariFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+        readonly IFreeSpaceChecker freeSpaceChecker = new FreeSpaceChecker(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new CalamariVariableDictionary());
 
         public ApplyDeltaCommand()
         {
@@ -44,7 +45,7 @@ namespace Calamari.Commands
             try
             {
                 ValidateParameters(out basisFilePath, out deltaFilePath, out newFilePath);
-                fileSystem.EnsureDiskHasEnoughFreeSpace(PackageStore.GetPackagesDirectory());
+                freeSpaceChecker.EnsureDiskHasEnoughFreeSpace(PackageStore.GetPackagesDirectory());
 
                 var tempNewFilePath = newFilePath + ".partial";
 #if USE_OCTODIFF_EXE

--- a/source/Calamari.Shared/Deployment/ApplicationDirectory.cs
+++ b/source/Calamari.Shared/Deployment/ApplicationDirectory.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Packages;
+using Calamari.Integration.Processes;
 using Calamari.Integration.Processes.Semaphores;
 using Octostache;
 
@@ -15,7 +16,7 @@ namespace Calamari.Deployment
         /// Returns the directory where the package will be installed. 
         /// Also ensures the directory exists, and that there is free-space on the disk.
         /// </summary>
-        public static string GetApplicationDirectory(PackageFileNameMetadata packageFileNameMetadata, VariableDictionary variables, ICalamariFileSystem fileSystem)
+        public static string GetApplicationDirectory(PackageFileNameMetadata packageFileNameMetadata, CalamariVariableDictionary variables, ICalamariFileSystem fileSystem)
         {
             return EnsureTargetPathExistsAndIsEmpty(
                 Path.Combine(GetEnvironmentApplicationDirectory(fileSystem, variables),
@@ -25,14 +26,14 @@ namespace Calamari.Deployment
         }
 
         /// This will be specific to Tenant and/or Environment if these variables are available.
-        static string GetEnvironmentApplicationDirectory(ICalamariFileSystem fileSystem, VariableDictionary variables)
+        static string GetEnvironmentApplicationDirectory(ICalamariFileSystem fileSystem, CalamariVariableDictionary variables)
         {
             var root = GetApplicationDirectoryRoot(variables);
             root = AppendTenantNameIfProvided(fileSystem, variables, root);
             root = AppendEnvironmentNameIfProvided(fileSystem, variables, root);
 
             fileSystem.EnsureDirectoryExists(root);
-            fileSystem.EnsureDiskHasEnoughFreeSpace(root);
+            new FreeSpaceChecker(fileSystem, variables).EnsureDiskHasEnoughFreeSpace(root);
 
             return root;
         }

--- a/source/Calamari.Shared/Integration/FileSystem/FreeSpaceChecker.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/FreeSpaceChecker.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using Calamari.Commands.Support;
+using Calamari.Deployment;
+using Calamari.Integration.Processes;
+using Octostache;
+
+namespace Calamari.Integration.FileSystem
+{
+    public interface IFreeSpaceChecker
+    {
+        void EnsureDiskHasEnoughFreeSpace(string directoryPath);
+    }
+
+    public class FreeSpaceChecker : IFreeSpaceChecker
+    {
+        readonly ICalamariFileSystem fileSystem;
+        readonly CalamariVariableDictionary variables;
+
+        public FreeSpaceChecker(ICalamariFileSystem fileSystem, CalamariVariableDictionary variables)
+        {
+            this.fileSystem = fileSystem;
+            this.variables = variables;
+        }
+
+        public void EnsureDiskHasEnoughFreeSpace(string directoryPath)
+        {
+            if (CalamariEnvironment.IsRunningOnMono && CalamariEnvironment.IsRunningOnMac)
+            {
+                //After upgrading to macOS 10.15.2, and mono 5.14.0, drive.TotalFreeSpace and drive.AvailableFreeSpace both started returning 0.
+                //see https://github.com/mono/mono/issues/17151, which was fixed in mono 6.4.xx
+                //If we upgrade mono past 5.14.x, scriptcs stops working.
+                //Rock and a hard place.
+                Log.Verbose("Unable to determine disk free space under Mono on macOS. Assuming there's enough.");
+                return;
+            }
+
+            if (variables.GetFlag(SpecialVariables.SkipFreeDiskSpaceCheck))
+            {
+                Log.Verbose($"{SpecialVariables.SkipFreeDiskSpaceCheck} is enabled. The check to ensure that the drive containing the directory '{directoryPath}' on machine '{Environment.MachineName}' has enough free space will be skipped.");
+                return;
+            }
+
+            ulong requiredSpaceInBytes = 500L * 1024 * 1024;
+            var freeSpaceOverrideInMegaBytes = variables.GetInt32(SpecialVariables.FreeDiskSpaceOverrideInMegaBytes);
+
+            if (freeSpaceOverrideInMegaBytes.HasValue)
+            {
+                requiredSpaceInBytes = (ulong) freeSpaceOverrideInMegaBytes * 1024 * 1024;
+                Log.Verbose($"{SpecialVariables.FreeDiskSpaceOverrideInMegaBytes} has been specified. We will check and ensure that the drive containing the directory '{directoryPath}' on machine '{Environment.MachineName}' has {((ulong) requiredSpaceInBytes).ToFileSizeString()} free disk space.");
+            }
+
+            var success = fileSystem.GetDiskFreeSpace(directoryPath, out ulong totalNumberOfFreeBytes);
+            if (!success)
+                return;
+
+            if (totalNumberOfFreeBytes < requiredSpaceInBytes)
+                throw new CommandException($"The drive containing the directory '{directoryPath}' on machine '{Environment.MachineName}' does not have enough free disk space available for this operation to proceed. The disk only has {totalNumberOfFreeBytes.ToFileSizeString()} available; please free up at least {requiredSpaceInBytes.ToFileSizeString()}.");
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/FileSystem/ICalamariFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/ICalamariFileSystem.cs
@@ -37,8 +37,7 @@ namespace Calamari.Integration.FileSystem
         void PurgeDirectory(string targetDirectory, Predicate<FileSystemInfo> exclude, FailureOptions options);
         void PurgeDirectory(string targetDirectory, FailureOptions options, params string[] globs);
         void EnsureDirectoryExists(string directoryPath);
-        void EnsureDiskHasEnoughFreeSpace(string directoryPath);
-        void EnsureDiskHasEnoughFreeSpace(string directoryPath, long requiredSpaceInBytes);
+        bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes);
         string GetFullPath(string relativeOrAbsoluteFilePath);
         void OverwriteAndDelete(string originalFile, string temporaryReplacement);
         void WriteAllBytes(string filePath, byte[] data);

--- a/source/Calamari.Shared/Integration/FileSystem/NixPhysicalFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/NixPhysicalFileSystem.cs
@@ -4,7 +4,7 @@ namespace Calamari.Integration.FileSystem
 {
     public class NixCalamariPhysicalFileSystem : CalamariPhysicalFileSystem
     {
-        protected override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
+        public override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
         {
             // This method will not work for UNC paths on windows 
             // (hence WindowsPhysicalFileSystem) but should be sufficient for Linux mounts

--- a/source/Calamari.Shared/Integration/FileSystem/WindowsPhysicalFileSystem.cs
+++ b/source/Calamari.Shared/Integration/FileSystem/WindowsPhysicalFileSystem.cs
@@ -16,7 +16,7 @@ namespace Calamari.Integration.FileSystem
         [return: MarshalAs(UnmanagedType.Bool)]
         static extern bool GetDiskFreeSpaceEx(string lpDirectoryName, out ulong lpFreeBytesAvailable, out ulong lpTotalNumberOfBytes, out ulong lpTotalNumberOfFreeBytes);
 
-        protected override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
+        public override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
         {
             ulong freeBytesAvailable;
             ulong totalNumberOfBytes;

--- a/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
@@ -6,6 +6,7 @@ using System.Net.Cache;
 using System.Threading;
 using Calamari.Extensions;
 using Calamari.Integration.FileSystem;
+using Calamari.Integration.Processes;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Octopus.Versioning;
@@ -18,9 +19,18 @@ namespace Calamari.Integration.Packages.Download
 {
     public class GitHubPackageDownloader : IPackageDownloader
     {
+        readonly ICalamariFileSystem fileSystem;
+        readonly IFreeSpaceChecker freeSpaceChecker;
         private static readonly IPackageDownloaderUtils PackageDownloaderUtils = new PackageDownloaderUtils();
-        readonly CalamariPhysicalFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+
         public static readonly string DownloadingExtension = ".downloading";
+
+        public GitHubPackageDownloader(ICalamariFileSystem fileSystem, IFreeSpaceChecker freeSpaceChecker)
+        {
+            this.fileSystem = fileSystem;
+            this.freeSpaceChecker = freeSpaceChecker;
+        }
+
         const string Extension = ".zip";
         const char OwnerRepoSeperator = '/';
 
@@ -102,7 +112,7 @@ namespace Calamari.Integration.Packages.Download
             Log.Info("Downloading GitHub package {0} v{1} from feed: '{2}'", packageId, version, feedUri);
             Log.VerboseFormat("Downloaded package will be stored in: '{0}'", cacheDirectory);
             fileSystem.EnsureDirectoryExists(cacheDirectory);
-            fileSystem.EnsureDiskHasEnoughFreeSpace(cacheDirectory);
+            freeSpaceChecker.EnsureDiskHasEnoughFreeSpace(cacheDirectory);
 
             SplitPackageId(packageId, out string owner, out string repository);
             if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repository))

--- a/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
@@ -9,6 +9,7 @@ using System.Xml;
 using Calamari.Exceptions;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Packages.Java;
+using Calamari.Integration.Processes;
 using Octopus.CoreUtilities.Extensions;
 using Octopus.Versioning;
 using Octopus.Versioning.Maven;
@@ -20,13 +21,22 @@ namespace Calamari.Integration.Packages.Download
     /// </summary>
     public class MavenPackageDownloader : IPackageDownloader
     {
+   
         /// <summary>
         /// These are extensions that can be handled by extractors other than the Java one. We accept these
         /// because not all artifacts from Maven will be used by Java.
         /// </summary>
         public static readonly string[] AdditionalExtensions = {".nupkg", ".tar.bz2", ".tar.bz", ".tbz", ".tgz", ".tar.gz", ".tar.Z", ".tar"};
         static readonly IPackageDownloaderUtils PackageDownloaderUtils = new PackageDownloaderUtils();
-        readonly ICalamariFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+
+        readonly ICalamariFileSystem fileSystem;
+        readonly IFreeSpaceChecker freeSpaceChecker;
+
+        public MavenPackageDownloader(ICalamariFileSystem fileSystem, IFreeSpaceChecker freeSpaceChecker)
+        {
+            this.fileSystem = fileSystem;
+            this.freeSpaceChecker = freeSpaceChecker;
+        }
 
         public PackagePhysicalFileMetadata DownloadPackage(
             string packageId,
@@ -116,7 +126,7 @@ namespace Calamari.Integration.Packages.Download
 
             Log.Info("Downloading Maven package {0} v{1} from feed: '{2}'", packageId, version, feedUri);
             Log.VerboseFormat("Downloaded package will be stored in: '{0}'", cacheDirectory);
-            fileSystem.EnsureDiskHasEnoughFreeSpace(cacheDirectory);
+            freeSpaceChecker.EnsureDiskHasEnoughFreeSpace(cacheDirectory);
 
             var mavenPackageId = new MavenPackageID(packageId, version);
             

--- a/source/Calamari.Shared/Integration/Packages/Download/NuGetPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/NuGetPackageDownloader.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Packages.NuGet;
+using Calamari.Integration.Processes;
 using Octopus.Versioning;
 #if USE_NUGET_V2_LIBS
 using NuGet;
@@ -19,8 +20,18 @@ namespace Calamari.Integration.Packages.Download
     {
         private static readonly IPackageDownloaderUtils PackageDownloaderUtils = new PackageDownloaderUtils();
         const string WhyAmINotAllowedToUseDependencies = "http://octopusdeploy.com/documentation/packaging";
-        readonly CalamariPhysicalFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+
         public static readonly string DownloadingExtension = ".downloading";
+
+        
+        readonly ICalamariFileSystem fileSystem;
+        readonly IFreeSpaceChecker freeSpaceChecker;
+        
+        public NuGetPackageDownloader(ICalamariFileSystem fileSystem, IFreeSpaceChecker freeSpaceChecker)
+        {
+            this.fileSystem = fileSystem;
+            this.freeSpaceChecker = freeSpaceChecker;
+        }
 
         public PackagePhysicalFileMetadata DownloadPackage(
             string packageId,
@@ -85,7 +96,7 @@ namespace Calamari.Integration.Packages.Download
         {
             Log.Info("Downloading NuGet package {0} v{1} from feed: '{2}'", packageId, version, feedUri);
             Log.VerboseFormat("Downloaded package will be stored in: '{0}'", cacheDirectory);
-            fileSystem.EnsureDiskHasEnoughFreeSpace(cacheDirectory);
+            freeSpaceChecker.EnsureDiskHasEnoughFreeSpace(cacheDirectory);
 
             var fullPathToDownloadTo = Path.Combine(cacheDirectory, PackageName.ToCachedFileName(packageId, version, ".nupkg"));
 

--- a/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
@@ -15,16 +15,19 @@ namespace Calamari.Integration.Packages.Download
     /// </summary>
     public class PackageDownloaderStrategy
     {
-        private readonly IScriptEngine engine;
-        private readonly ICalamariFileSystem fileSystem;
-        private readonly ICommandLineRunner commandLineRunner;
+        readonly IScriptEngine engine;
+        readonly ICalamariFileSystem fileSystem;
+        readonly IFreeSpaceChecker freeSpaceChecker;
+        readonly ICommandLineRunner commandLineRunner;
 
-        public PackageDownloaderStrategy(IScriptEngine engine, ICalamariFileSystem fileSystem, ICommandLineRunner commandLineRunner)
+        public PackageDownloaderStrategy(IScriptEngine engine, ICalamariFileSystem fileSystem, IFreeSpaceChecker freeSpaceChecker, ICommandLineRunner commandLineRunner)
         {
             this.engine = engine;
             this.fileSystem = fileSystem;
+            this.freeSpaceChecker = freeSpaceChecker;
             this.commandLineRunner = commandLineRunner;
         }
+        
         public PackagePhysicalFileMetadata DownloadPackage(
             string packageId,
             IVersion version,
@@ -40,18 +43,18 @@ namespace Calamari.Integration.Packages.Download
             switch (feedType)
             {
                 case FeedType.Maven:
-                    downloader = new MavenPackageDownloader();
+                    downloader = new MavenPackageDownloader(fileSystem, freeSpaceChecker);
                     break;
                 case FeedType.NuGet:
-                    downloader = new NuGetPackageDownloader();
+                    downloader = new NuGetPackageDownloader(fileSystem, freeSpaceChecker);
                     break;
                 case FeedType.GitHub:
-                    downloader = new GitHubPackageDownloader();
+                    downloader = new GitHubPackageDownloader(fileSystem, freeSpaceChecker);
                     break;
-                case FeedType.Helm :
+                case FeedType.Helm:
                     downloader = new HelmChartPackageDownloader(fileSystem);
                     break;
-                case FeedType.Docker :
+                case FeedType.Docker:
                 case FeedType.AwsElasticContainerRegistry :
                     downloader = new DockerImagePackageDownloader(engine, fileSystem, commandLineRunner);
                     break;

--- a/source/Calamari.Shared/Modules/CommonModule.cs
+++ b/source/Calamari.Shared/Modules/CommonModule.cs
@@ -5,6 +5,7 @@ using Calamari.Integration.Processes;
 using System.IO;
 using System.Linq;
 using Calamari.Integration.Certificates;
+using Calamari.Integration.FileSystem;
 using Octostache;
 using Module = Autofac.Module;
 
@@ -66,6 +67,7 @@ namespace Calamari.Modules
                     .As<VariableDictionary>();
             }
 
+            builder.RegisterType<FreeSpaceChecker>().As<IFreeSpaceChecker>();
             builder.RegisterType<CalamariCertificateStore>().As<ICertificateStore>().InstancePerLifetimeScope();
             builder.RegisterType<LogWrapper>().As<ILog>().InstancePerLifetimeScope();
         }

--- a/source/Calamari.Terraform/TerraformCommand.cs
+++ b/source/Calamari.Terraform/TerraformCommand.cs
@@ -46,8 +46,6 @@ namespace Calamari.Terraform
                 }
             }
 
-            fileSystem.FreeDiskSpaceOverrideInMegaBytes = variables.GetInt32(SpecialVariables.FreeDiskSpaceOverrideInMegaBytes);
-            fileSystem.SkipFreeDiskSpaceCheck = variables.GetFlag(SpecialVariables.SkipFreeDiskSpaceCheck);
             var substituter = new FileSubstituter(fileSystem);
             var packageExtractor = new GenericPackageExtractorFactory().createStandardGenericPackageExtractor();
             var additionalFileSubstitution = variables.Get(TerraformSpecialVariables.Action.Terraform.FileSubstitution);

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/TestCalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/TestCalamariPhysicalFileSystem.cs
@@ -17,7 +17,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             return new TestWindowsPhysicalFileSystem();
         }
 
-        protected override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
+        public override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
         {
             throw new NotImplementedException("*testing* this is in TestCalamariPhysicalFileSystem");
         }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/GitHubPackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/GitHubPackageDownloadFixture.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Net;
+using Calamari.Integration.FileSystem;
 using Calamari.Integration.Packages.Download;
+using Calamari.Integration.Processes;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
 using Octopus.Versioning.Semver;
@@ -19,6 +21,9 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         static readonly string FeedUsername = ExternalVariables.Get(ExternalVariable.GitHubUsername);
         static readonly string FeedPassword = ExternalVariables.Get(ExternalVariable.GitHubPassword);
 
+        static readonly CalamariPhysicalFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+        static readonly FreeSpaceChecker freeSpaceChecker = new FreeSpaceChecker(fileSystem, new CalamariVariableDictionary());
+            
         private static string home = Path.GetTempPath();
         [OneTimeSetUp]
         public void TestFixtureSetUp()
@@ -44,7 +49,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [Category(TestCategory.CompatibleOS.OnlyWindows)] //Keeps rate limit low
         public void DownloadsPackageFromGitHub()
         {
-            var downloader = new GitHubPackageDownloader();
+            var downloader = new GitHubPackageDownloader(fileSystem, freeSpaceChecker);
 
             var file = downloader.DownloadPackage("OctopusDeploy/Octostache", new SemanticVersion("2.1.8"), "feed-github",
                 new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, FeedPassword), true, 3,
@@ -58,7 +63,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [Category(TestCategory.CompatibleOS.OnlyWindows)] //Keeps rate limit low
         public void WillReUseFileIfItExists()
         {
-            var downloader = new GitHubPackageDownloader();
+            var downloader = new GitHubPackageDownloader(fileSystem, freeSpaceChecker);
 
             var file1 = downloader.DownloadPackage("OctopusDeploy/Octostache", new SemanticVersion("2.1.7"), "feed-github",
                 new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, FeedPassword), true, 3,
@@ -79,7 +84,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [Category(TestCategory.CompatibleOS.OnlyWindows)] //Keeps rate limit low
         public void DownloadsPackageFromGitHubWithDifferentVersionFormat()
         {
-            var downloader = new GitHubPackageDownloader();
+            var downloader = new GitHubPackageDownloader(fileSystem, freeSpaceChecker);
 
             var file = downloader.DownloadPackage("octokit/octokit.net", new SemanticVersion("0.28.0"), "feed-github",
                 new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, FeedPassword), true, 3,

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/MavenPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/MavenPackageDownloaderFixture.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Net;
+using Calamari.Integration.FileSystem;
 using Calamari.Integration.Packages.Download;
+using Calamari.Integration.Processes;
+using Calamari.Tests.Fixtures.Integration.FileSystem;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
 using Octopus.Versioning;
@@ -29,7 +32,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [RequiresNonFreeBSDPlatform]
         public void DownloadMavenPackage()
         {
-            var downloader = new MavenPackageDownloader();
+            var downloader = new MavenPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new FreeSpaceChecker(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new CalamariVariableDictionary()));
             var pkg = downloader.DownloadPackage("com.google.guava:guava", VersionFactory.CreateMavenVersion("22.0"), "feed-maven",
                 new Uri("https://repo.maven.apache.org/maven2/"), new NetworkCredential("", ""), true, 3, TimeSpan.FromSeconds(3));
 

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -56,9 +56,6 @@ namespace Calamari.Commands
 
             var variables = new CalamariVariableDictionary(variablesFile, sensitiveVariableFiles, sensitiveVariablesPassword);
 
-            fileSystem.FreeDiskSpaceOverrideInMegaBytes = variables.GetInt32(SpecialVariables.FreeDiskSpaceOverrideInMegaBytes);
-            fileSystem.SkipFreeDiskSpaceCheck = variables.GetFlag(SpecialVariables.SkipFreeDiskSpaceCheck);
-
             var featureClasses = new List<IFeature>();
 
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));

--- a/source/Calamari/Commands/DownloadPackageCommand.cs
+++ b/source/Calamari/Commands/DownloadPackageCommand.cs
@@ -83,7 +83,10 @@ namespace Calamari.Commands
                     out var parsedAttemptBackoff);
 
                 var commandLineRunner = new CommandLineRunner(new ConsoleCommandOutput());
-                var pkg = new PackageDownloaderStrategy(scriptEngine, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), commandLineRunner).DownloadPackage(
+                ICalamariFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+                IFreeSpaceChecker freeSpaceChecker = new FreeSpaceChecker(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new CalamariVariableDictionary());
+
+                var pkg = new PackageDownloaderStrategy(scriptEngine, fileSystem, freeSpaceChecker, commandLineRunner).DownloadPackage(
                     packageId,
                     version,
                     feedId,

--- a/source/Calamari/Commands/TransferPackageCommand.cs
+++ b/source/Calamari/Commands/TransferPackageCommand.cs
@@ -43,9 +43,6 @@ namespace Calamari.Commands
             if (!fileSystem.FileExists(packageFile))
                 throw new CommandException("Could not find package file: " + packageFile);    
 
-            fileSystem.FreeDiskSpaceOverrideInMegaBytes = variables.GetInt32(SpecialVariables.FreeDiskSpaceOverrideInMegaBytes);
-            fileSystem.SkipFreeDiskSpaceCheck = variables.GetFlag(SpecialVariables.SkipFreeDiskSpaceCheck);
-            
             var journal = new DeploymentJournal(fileSystem, SemaphoreFactory.Get(), variables);
             
             var conventions = new List<IConvention>


### PR DESCRIPTION
The skip and override were being resolved in multiple places and being set long before they were used. This extracts the free space check as a service so the entry points can be seen.