### PR TITLE
Removed IsSensitive from the variable dictionary

### DIFF
--- a/source/Calamari.Shared/Integration/Processes/CalamariVariableDictionary.cs
+++ b/source/Calamari.Shared/Integration/Processes/CalamariVariableDictionary.cs
@@ -13,8 +13,6 @@ namespace Calamari.Integration.Processes
 {
     public class CalamariVariableDictionary : VariableDictionary
     {
-        protected HashSet<string> SensitiveVariableNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
         public CalamariVariableDictionary() { }
 
         public CalamariVariableDictionary(string storageFilePath) : base(storageFilePath) { }
@@ -47,7 +45,7 @@ namespace Calamari.Integration.Processes
                         var sensitiveVariables = JsonConvert.DeserializeObject<Dictionary<string, string>>(rawVariables);
                         foreach (var variable in sensitiveVariables)
                         {
-                            SetSensitive(variable.Key, variable.Value);
+                            Set(variable.Key, variable.Value);
                         }
                     }
                     catch (JsonReaderException)
@@ -67,7 +65,6 @@ namespace Calamari.Integration.Processes
                     {
                         Set(variable.Key, variable.Value);
                     }
-
                 }
                 catch (JsonReaderException)
                 {
@@ -75,19 +72,7 @@ namespace Calamari.Integration.Processes
                 }
             }
         }
-
-        public void SetSensitive(string name, string value)
-        {
-            if (name == null) return;
-            Set(name, value);
-            SensitiveVariableNames.Add(name);
-        }
-
-        public bool IsSensitive(string name)
-        {
-            return name != null && SensitiveVariableNames.Contains(name);
-        }
-
+        
         static string Decrypt(byte[] encryptedVariables, string encryptionPassword)
         {
             try

--- a/source/Calamari.Shared/Integration/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Shared/Integration/Scripting/Bash/BashScriptBootstrapper.cs
@@ -55,10 +55,7 @@ namespace Calamari.Integration.Scripting.Bash
         {
             return variables.GetNames().Select(variable =>
             {
-                var variableValue = variables.IsSensitive(variable)
-                    ? DecryptValueCommand(variables.Get(variable))
-                    : string.Format("decode_servicemessagevalue \"{0}\"", EncodeValue(variables.Get(variable)));
-
+                var variableValue = DecryptValueCommand(variables.Get(variable));
                 return string.Format("    \"{1}\"){0}   {2}   ;;{0}", Environment.NewLine, EncodeValue(variable), variableValue);
             });
         }
@@ -66,10 +63,9 @@ namespace Calamari.Integration.Scripting.Bash
         static string DecryptValueCommand(string value)
         {
             var encrypted = VariableEncryptor.Encrypt(value ?? "");
-            byte[] iv;
-            var rawEncrypted = AesEncryption.ExtractIV(encrypted, out iv);
+            var rawEncrypted = AesEncryption.ExtractIV(encrypted, out var iv);
             
-            return string.Format("decrypt_variable \"{0}\" \"{1}\"", Convert.ToBase64String(rawEncrypted), ToHex(iv));
+            return $@"decrypt_variable ""{Convert.ToBase64String(rawEncrypted)}"" ""{ToHex(iv)}""";
         }
 
         static string ToHex(byte[] bytes)

--- a/source/Calamari.Shared/Integration/Scripting/FSharp/FSharpBootstrapper.cs
+++ b/source/Calamari.Shared/Integration/Scripting/FSharp/FSharpBootstrapper.cs
@@ -111,15 +111,10 @@ namespace Calamari.Integration.Scripting.FSharp
                 {
                     builder.AppendFormat("        | \"{0}\" -> Some null", EncodeValue(variableName));
                 }
-                else if (variables.IsSensitive(variableName))
+                else
                 {
                     builder.AppendFormat("        | \"{0}\" -> {1} |> Some", EncodeValue(variableName),
                                                                                         EncryptVariable(variableValue));                    
-                }
-                else
-                {
-                    builder.AppendFormat("        | \"{0}\" -> \"{1}\" |> decode |> Some", EncodeValue(variableName),
-                                                                                            EncodeValue(variableValue));
                 }
 
                 builder.Append(Environment.NewLine);
@@ -138,10 +133,9 @@ namespace Calamari.Integration.Scripting.FSharp
         static string EncryptVariable(string value)
         {
             var encrypted = VariableEncryptor.Encrypt(value);
-            byte[] iv;
-            var rawEncrypted = AesEncryption.ExtractIV(encrypted, out iv);
+            var rawEncrypted = AesEncryption.ExtractIV(encrypted, out var iv);
 
-            return string.Format("decryptString \"{0}\" \"{1}\"", Convert.ToBase64String(rawEncrypted), Convert.ToBase64String(iv));
+            return $@"decryptString ""{Convert.ToBase64String(rawEncrypted)}"" ""{Convert.ToBase64String(iv)}""";
         }
     }
 }

--- a/source/Calamari.Shared/Integration/Scripting/Python/PythonBootstrapper.cs
+++ b/source/Calamari.Shared/Integration/Scripting/Python/PythonBootstrapper.cs
@@ -59,10 +59,7 @@ namespace Calamari.Integration.Scripting.Python
         {
             return variables.GetNames().Select(variable =>
             {
-                var variableValue = variables.IsSensitive(variable)
-                    ? DecryptValueCommand(variables.Get(variable))
-                    : $"decode(\"{EncodeValue(variables.Get(variable))}\")";
-
+                var variableValue = DecryptValueCommand(variables.Get(variable));
                 return $"decode(\"{EncodeValue(variable)}\") : {variableValue}";
             });
         }
@@ -70,10 +67,9 @@ namespace Calamari.Integration.Scripting.Python
         static string DecryptValueCommand(string value)
         {
             var encrypted = VariableEncryptor.Encrypt(value ?? "");
-            byte[] iv;
-            var rawEncrypted = AesEncryption.ExtractIV(encrypted, out iv);
+            var rawEncrypted = AesEncryption.ExtractIV(encrypted, out var iv);
             
-            return $"decrypt(\"{Convert.ToBase64String(rawEncrypted)}\",\"{ToHex(iv)}\")";
+            return $@"decrypt(""{Convert.ToBase64String(rawEncrypted)}"",""{ToHex(iv)}"")";
         }
 
         static string ToHex(byte[] bytes)

--- a/source/Calamari.Shared/Integration/Scripting/ScriptCS/ScriptCSBootstrapper.cs
+++ b/source/Calamari.Shared/Integration/Scripting/ScriptCS/ScriptCSBootstrapper.cs
@@ -113,9 +113,7 @@ namespace Calamari.Integration.Scripting.ScriptCS
             var builder = new StringBuilder();
             foreach (var variable in variables.GetNames())
             {
-                var variableValue = variables.IsSensitive(variable)
-                    ? EncryptVariable(variables.Get(variable))
-                    : EncodeValue(variables.Get(variable));
+                var variableValue = EncryptVariable(variables.Get(variable));
                 builder.Append("\t\t\tthis[").Append(EncodeValue(variable)).Append("] = ").Append(variableValue).AppendLine(";");
             }
             return builder.ToString();
@@ -139,10 +137,9 @@ namespace Calamari.Integration.Scripting.ScriptCS
                 return "null;";
 
             var encrypted = VariableEncryptor.Encrypt(value);
-            byte[] iv;
-            var rawEncrypted = AesEncryption.ExtractIV(encrypted, out iv);
+            var rawEncrypted = AesEncryption.ExtractIV(encrypted, out var iv);
 
-            return string.Format("DecryptString(\"{0}\", \"{1}\")", Convert.ToBase64String(rawEncrypted), Convert.ToBase64String(iv));
+            return $@"DecryptString(""{Convert.ToBase64String(rawEncrypted)}"", ""{Convert.ToBase64String(iv)}"")";
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/BashScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/BashScriptEngineFixture.cs
@@ -11,12 +11,12 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
     {
         [Test]
         [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
-        public void BashDecryptsSensitiveVariables()
+        public void BashDecryptsVariables()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "sh")))
             {
                 File.WriteAllText(scriptFile.FilePath, "#!/bin/bash\necho $(get_octopusvariable \"mysecrect\")");
-                var result = ExecuteScript(new BashScriptEngine(), scriptFile.FilePath, GetDictionaryWithSecret());
+                var result = ExecuteScript(new BashScriptEngine(), scriptFile.FilePath, GetVariables());
                 result.AssertOutput("KingKong");
             }
         }

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/CSharpScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/CSharpScriptEngineFixture.cs
@@ -11,12 +11,12 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
     {
         [Category(TestCategory.ScriptingSupport.ScriptCS)]
         [Test, RequiresMonoVersion400OrAbove, RequiresDotNet45]
-        public void CSharpDecryptsSensitiveVariables()
+        public void CSharpDecryptsVariables()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "cs")))
             {
                 File.WriteAllText(scriptFile.FilePath, "System.Console.WriteLine(Octopus.Parameters[\"mysecrect\"]);");
-                var result = ExecuteScript(new ScriptCSScriptEngine(), scriptFile.FilePath, GetDictionaryWithSecret());
+                var result = ExecuteScript(new ScriptCSScriptEngine(), scriptFile.FilePath, GetVariables());
                 result.AssertOutput("KingKong");
             }
         }

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellScriptEngineFixture.cs
@@ -12,12 +12,12 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
     {
         [Test]
         [RequiresNonFreeBSDPlatform]
-        public void PowerShellDecryptsSensitiveVariables()
+        public void PowerShellDecryptsVariables()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
             {
                 File.WriteAllText(scriptFile.FilePath, "Write-Host $mysecrect");
-                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, GetDictionaryWithSecret());
+                var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, GetVariables());
                 result.AssertOutput("KingKong");
             }
         }
@@ -34,7 +34,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
             {
                 File.WriteAllText(scriptFile.FilePath, "Write-Host $mysecrect");
-                var calamariVariableDictionary = GetDictionaryWithSecret();
+                var calamariVariableDictionary = GetVariables();
                 calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Trace", variableValue);
 
                 var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath,
@@ -72,7 +72,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
             {
                 File.WriteAllText(scriptFile.FilePath, "Write-Host $mysecrect");
-                var calamariVariableDictionary = GetDictionaryWithSecret();
+                var calamariVariableDictionary = GetVariables();
                 calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Trace", variableValue);
 
                 var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath, calamariVariableDictionary);
@@ -93,7 +93,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
             {
                 File.WriteAllText(scriptFile.FilePath, "Write-Host $mysecrect");
-                var calamariVariableDictionary = GetDictionaryWithSecret();
+                var calamariVariableDictionary = GetVariables();
                 if (!string.IsNullOrEmpty(variableValue))
                     calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Trace", variableValue);
 
@@ -113,7 +113,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
             {
                 File.WriteAllText(scriptFile.FilePath,
                     "$newVar = $nonExistentVar" + Environment.NewLine + "write-host \"newVar = '$newVar'\"");
-                var calamariVariableDictionary = GetDictionaryWithSecret();
+                var calamariVariableDictionary = GetVariables();
                 calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Strict", "true");
 
                 var result = ExecuteScript(new PowerShellScriptEngine(), scriptFile.FilePath,
@@ -134,7 +134,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
             {
                 File.WriteAllText(scriptFile.FilePath,
                     "$newVar = $nonExistentVar" + Environment.NewLine + "write-host \"newVar = '$newVar'\"");
-                var calamariVariableDictionary = GetDictionaryWithSecret();
+                var calamariVariableDictionary = GetVariables();
                 if (!string.IsNullOrEmpty(variableValue))
                     calamariVariableDictionary.Set("Octopus.Action.PowerShell.PSDebug.Strict", variableValue);
 

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixtureBase.cs
@@ -6,11 +6,11 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
 {
     public abstract class ScriptEngineFixtureBase
     {
-        protected CalamariVariableDictionary GetDictionaryWithSecret()
+        protected CalamariVariableDictionary GetVariables()
         {
             var cd = new CalamariVariableDictionary();
             cd.Set("foo", "bar");
-            cd.SetSensitive("mysecrect", "KingKong");
+            cd.Set("mysecrect", "KingKong");
             return cd;
         }
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1687639/74901624-20c08b00-53ef-11ea-9caf-dfdc493aa4ee.png)

This code no longer sparked joy. Since the server no longer sends down non-sensitive variable files, most variables will come into Calamari as "sensitive". The only time variables are not sensitive is if a offline drop does not have a password set, or it's an output variable passed from a previous offline step. 

This change removes the distinction between non-sensitive and sensitive variables and always treat the variable as sensitive. This means all variables will now be encrypted at in the bootstrapper file (at rest). 

Due to https://github.com/OctopusDeploy/Issues/issues/4840 sensitive output variables in offline drops were never included.