### PR TITLE
Handle two-part extensions like "tar.gz" when parsing file names

### DIFF
--- a/source/Calamari.Tests/Fixtures/Integration/Packages/GenericPackageExtractorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/GenericPackageExtractorFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Calamari.Integration.Packages;
 using Calamari.Integration.Packages.NuGet;
@@ -20,16 +21,41 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         }
 
         [Test]
-        [TestCase("tar.gz", typeof(TarGzipPackageExtractor))]
-        [TestCase("tar.bz2", typeof(TarBzipPackageExtractor))]
-        [TestCase("tar", typeof(TarPackageExtractor))]
-        [TestCase("zip", typeof(ZipPackageExtractor))]
-        [TestCase("nupkg", typeof(NupkgExtractor))]
-        public void GettingFileByExtension(string extension, Type expectedType)
+        [TestCaseSource(nameof(PackageNameTestCases))]
+        public void GettingFileByExtension(string filename, Type expectedType)
         {
-            var extractor = this.extractor.GetExtractor("foo.1.0.0."+ extension);
+            var extractor = this.extractor.GetExtractor(filename);
 
             Assert.AreEqual(expectedType, extractor.GetType());
+        }
+
+        static IEnumerable<object> PackageNameTestCases()
+        {
+            var fileNames = new[]
+            {
+                "foo.1.0.0",
+                "foo.1.0.0-tag",
+                "foo.1.0.0-tag-release.tag",
+                "foo.1.0.0+buildmeta",
+                "foo.1.0.0-tag-release.tag+buildmeta",
+            };
+
+            var extractorMapping = new (string extension, Type extractor)[]
+            {
+                ("zip", typeof(ZipPackageExtractor)),
+                ("nupkg", typeof(NupkgExtractor)),
+                ("tar", typeof(TarPackageExtractor)),
+                ("tar.gz", typeof(TarGzipPackageExtractor)),
+                ("tar.bz2", typeof(TarBzipPackageExtractor)),
+            };
+
+            foreach (var filename in fileNames)
+            {
+                foreach (var (extension, type) in extractorMapping)
+                {
+                    yield return new TestCaseData($"{filename}.{extension}", type);
+                }
+            }
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/PackageNameFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/PackageNameFixture.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Calamari.Integration.Packages;
 using NUnit.Framework;
 using Octopus.Versioning;
-using Octopus.Versioning.Maven;
 using Octopus.Versioning.Semver;
 
 namespace Calamari.Tests.Fixtures.Integration.Packages
@@ -72,6 +68,16 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         }
 
         [Test]
+        [TestCaseSource(nameof(PackageNameTestCases))]
+        public void FromFile(string filename, string extension, string packageId, IVersion version)
+        {
+            var details = PackageName.FromFile($"blah/{filename}");
+            Assert.AreEqual(packageId, details.PackageId);
+            Assert.AreEqual(version, details.Version);
+            Assert.AreEqual(extension, details.Extension);
+        }
+
+        [Test]
         public void FromFile_InvalidVersionType()
         {
             Assert.Throws<Exception>(() => PackageName.FromFile("blah/pkg@1.0.0%2BCAT@XXXYYYZZZ.jar"));
@@ -88,7 +94,35 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         public void FromFile_UnknownInvalidVersionType()
         {
             Assert.Throws<Exception>(() => PackageName.FromFile("blah/pkg@1.0.0%2BCAT@XXXYYYZZZ.jar"));
-            
+        }
+
+        static IEnumerable<object> PackageNameTestCases()
+        {
+            var files = new (string filename, string version, string packageId)[]
+            {
+                ("foo.1.0.0", "1.0.0", "foo"),
+                ("foo.1.0.0-tag", "1.0.0-tag", "foo"),
+                ("foo.1.0.0-tag-release.tag", "1.0.0-tag-release.tag", "foo"),
+                ("foo.1.0.0+buildmeta", "1.0.0+buildmeta", "foo"),
+                ("foo.1.0.0-tag-release.tag+buildmeta", "1.0.0-tag-release.tag+buildmeta", "foo"),
+            };
+
+            var extensions = new []
+            {
+                ".zip", 
+                ".nupkg",
+                ".tar",
+                ".tar.gz",
+                ".tar.bz2", 
+            };
+
+            foreach (var file in files)
+            {
+                foreach (var extension in extensions)
+                {
+                    yield return new TestCaseData($"{file.filename}{extension}", extension, file.packageId, VersionFactory.CreateSemanticVersion(file.version));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes OctopusDeploy/Issues/issues/6199

.tar archives with a two-part extension aren't being parsed correctly when a package name includes release tags and/or build metadata.

This came up internally with a package named `helm-v2.9.1-windows-amd64.tar.gz`

## Before 

package name | .zip  .tar  .nupkg | .tar.gz  .tar.bz2 .tar.xyz | .abc.xyx 
--- | --- | --- | ---
foo.1.0.0  | ✔️ | ✔️  | ✔️ 
foo.1.0.0-tag   | ✔️ | ❌  | ❌ 
foo.1.0.0-tag-release.tag   | ✔️ | ❌  | ❌ 
foo.1.0.0+buildmeta   | ✔️ | ❌  | ❌
foo.1.0.0-tag-release.tag+buildmeta   | ✔️ | ❌  | ❌ 

## After

package name | .zip  .tar  .nupkg | .tar.gz  .tar.bz2 .tar.xyz | .abc.xyx 
--- | --- | --- | ---
foo.1.0.0  | ✔️ | ✔️  | ✔️ 
foo.1.0.0-tag   | ✔️ | ✔️ | ❌ 
foo.1.0.0-tag-release.tag   | ✔️ | ✔️ | ❌ 
foo.1.0.0+buildmeta   | ✔️ | ✔️ | ❌
foo.1.0.0-tag-release.tag+buildmeta   | ✔️ | ✔️ | ❌ 
