### PR TITLE
Fix bug where multiple directives in NGINX step where getting overridden

### DIFF
--- a/source/Calamari.Tests/Fixtures/Nginx/Approved/NginxFixture.SetupReverseProxyWithSslUsingCertificateVariableSite.approved.txt
+++ b/source/Calamari.Tests/Fixtures/Nginx/Approved/NginxFixture.SetupReverseProxyWithSslUsingCertificateVariableSite.approved.txt
@@ -1,8 +1,8 @@
 server {
     listen 80;
     listen 443 ssl;
-    ssl_certificate /etc/ssl\www.nginxsamplewebapp.com\www.nginxsamplewebapp.com.crt;
-    ssl_certificate_key /etc/ssl\www.nginxsamplewebapp.com\www.nginxsamplewebapp.com.key;
+    ssl_certificate /etc/ssl/www.nginxsamplewebapp.com/www.nginxsamplewebapp.com.crt;
+    ssl_certificate_key /etc/ssl/www.nginxsamplewebapp.com/www.nginxsamplewebapp.com.key;
     location / {
         proxy_pass http://localhost:5000;
         proxy_http_version 1.1;

--- a/source/Calamari.Tests/Fixtures/Nginx/Approved/NginxFixture.SetupReverseProxyWithSslUsingCertificateVariableSite.approved.txt
+++ b/source/Calamari.Tests/Fixtures/Nginx/Approved/NginxFixture.SetupReverseProxyWithSslUsingCertificateVariableSite.approved.txt
@@ -1,8 +1,8 @@
 server {
     listen 80;
     listen 443 ssl;
-    ssl_certificate /etc/ssl/www.nginxsamplewebapp.com/www.nginxsamplewebapp.com.crt;
-    ssl_certificate_key /etc/ssl/www.nginxsamplewebapp.com/www.nginxsamplewebapp.com.key;
+    ssl_certificate /etc/ssl\www.nginxsamplewebapp.com\www.nginxsamplewebapp.com.crt;
+    ssl_certificate_key /etc/ssl\www.nginxsamplewebapp.com\www.nginxsamplewebapp.com.key;
     location / {
         proxy_pass http://localhost:5000;
         proxy_http_version 1.1;

--- a/source/Calamari.Tests/Fixtures/Nginx/Approved/NginxFixture.SetupStaticContentSiteWithMultipleIncludeDirectives.approved.txt
+++ b/source/Calamari.Tests/Fixtures/Nginx/Approved/NginxFixture.SetupStaticContentSiteWithMultipleIncludeDirectives.approved.txt
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    location / {
+        root #{Octopus.Action.Package.InstallationDirectoryPath}/wwwroot;
+        try_files $uri $uri/ /index.html;
+        include fastcgi_params;
+        include /etc/nginx/api_proxy.conf;
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
@@ -29,7 +29,7 @@ namespace Calamari.Tests.Fixtures.Nginx
         readonly string httpAndHttpsBindings = "[{\"protocol\":\"http\",\"port\":\"80\",\"ipAddress\":\"*\",\"certificateLocation\":null,\"certificateKeyLocation\":null,\"securityProtocols\":null,\"enabled\":true},{\"protocol\":\"https\",\"port\":\"443\",\"ipAddress\":\"*\",\"certificateLocation\":\"/etc/ssl/nginxsample/certificate.crt\",\"certificateKeyLocation\":\"/etc/ssl/nginxsample/certificate.key\",\"securityProtocols\":null,\"enabled\":true}]";
         readonly string httpAndHttpsBindingWithCertificateVariable = "[{\"protocol\":\"http\",\"port\":\"80\",\"ipAddress\":\"*\",\"certificateLocation\":null,\"certificateKeyLocation\":null,\"securityProtocols\":null,\"enabled\":true},{\"protocol\":\"https\",\"port\":\"443\",\"ipAddress\":\"*\",\"certificateLocation\":null,\"certificateKeyLocation\":null,\"securityProtocols\":null,\"enabled\":true,\"thumbprint\":null,\"certificateVariable\":\"NginxSampleWebAppCertificate\"}]";
 
-        readonly string staticContentAndReverseProxyLocations = "[{\"path\":\"/\",\"directives\":\"{\\\"root\\\":\\\"#{Octopus.Action.Package.InstallationDirectoryPath}/wwwroot\\\",\\\"try_files\\\":\\\"$uri $uri/ /index.html\\\"}\",\"headers\":\"\",\"reverseProxy\":false,\"reverseProxyUrl\":\"\",\"reverseProxyHeaders\":\"\",\"reverseProxyDirectives\":\"\"},{\"path\":\"/api/\",\"directives\":\"\",\"headers\":\"\",\"reverseProxy\":\"True\",\"reverseProxyUrl\":\"http://localhost:5000\",\"reverseProxyHeaders\":\"{\\\"Upgrade\\\":\\\"$http_upgrade\\\",\\\"Connection\\\":\\\"keep-alive\\\",\\\"Host\\\":\\\"$host\\\",\\\"X-Forwarded-For\\\":\\\"$proxy_add_x_forwarded_for\\\",\\\"X-Forwarded-Proto\\\":\\\"$scheme\\\"}\",\"reverseProxyDirectives\":\"{\\\"proxy_http_version\\\":\\\"1.1\\\",\\\"proxy_cache_bypass\\\":\\\"$http_upgrade\\\"}\"}]";
+        readonly string staticContentAndReverseProxyLocations = "[{\"path\":\"/\",\"directives\":\"[{\\\"root\\\":\\\"#{Octopus.Action.Package.InstallationDirectoryPath}/wwwroot\\\"},{\\\"try_files\\\":\\\"$uri $uri/ /index.html\\\"}]\",\"headers\":\"\",\"reverseProxy\":false,\"reverseProxyUrl\":\"\",\"reverseProxyHeaders\":\"\",\"reverseProxyDirectives\":\"\"},{\"path\":\"/api/\",\"directives\":\"\",\"headers\":\"\",\"reverseProxy\":\"True\",\"reverseProxyUrl\":\"http://localhost:5000\",\"reverseProxyHeaders\":\"{\\\"Upgrade\\\":\\\"$http_upgrade\\\",\\\"Connection\\\":\\\"keep-alive\\\",\\\"Host\\\":\\\"$host\\\",\\\"X-Forwarded-For\\\":\\\"$proxy_add_x_forwarded_for\\\",\\\"X-Forwarded-Proto\\\":\\\"$scheme\\\"}\",\"reverseProxyDirectives\":\"{\\\"proxy_http_version\\\":\\\"1.1\\\",\\\"proxy_cache_bypass\\\":\\\"$http_upgrade\\\"}\"}]";
 
         [SetUp]
         public void SetUp()
@@ -52,8 +52,30 @@ namespace Calamari.Tests.Fixtures.Nginx
         {
             var locations =
                 JsonConvert.DeserializeObject<IEnumerable<Location>>(
-                    "[{\"path\":\"/\",\"directives\":\"{\\\"root\\\":\\\"#{Octopus.Action.Package.InstallationDirectoryPath}/wwwroot\\\",\\\"try_files\\\":\\\"$uri $uri/ /index.html\\\"}\",\"headers\":\"\",\"reverseProxy\":false,\"reverseProxyUrl\":\"\",\"reverseProxyHeaders\":\"\",\"reverseProxyDirectives\":\"\"}]");
+                    "[{\"path\":\"/\",\"directives\":\"[{\\\"root\\\":\\\"#{Octopus.Action.Package.InstallationDirectoryPath}/wwwroot\\\"},{\\\"try_files\\\":\\\"$uri $uri/ /index.html\\\"}]\",\"headers\":\"\",\"reverseProxy\":false,\"reverseProxyUrl\":\"\",\"reverseProxyHeaders\":\"\",\"reverseProxyDirectives\":\"\"}]");
             
+            var virtualServerName = "StaticContent";
+
+            nginxServer
+                .WithVirtualServerName(virtualServerName)
+                .WithServerBindings(JsonConvert.DeserializeObject<IEnumerable<Binding>>(httpOnlyBinding),
+                    new Dictionary<string, (string, string, string)>())
+                .WithRootLocation(locations.First());
+
+            nginxServer.BuildConfiguration();
+            nginxServer.SaveConfiguration(tempDirectory);
+            
+            var nginxConfigFilePath = Path.Combine(tempDirectory, "conf", $"{virtualServerName}.conf");
+            this.Assent(File.ReadAllText(nginxConfigFilePath), TestEnvironment.AssentConfiguration);
+        }
+
+        [Test]
+        public void SetupStaticContentSiteWithMultipleIncludeDirectives()
+        {
+            var locations =
+                JsonConvert.DeserializeObject<IEnumerable<Location>>(
+                    "[{\"path\":\"/\",\"directives\":\"[{\\\"root\\\":\\\"#{Octopus.Action.Package.InstallationDirectoryPath}/wwwroot\\\"},{\\\"try_files\\\":\\\"$uri $uri/ /index.html\\\"},{\\\"include\\\":\\\"fastcgi_params\\\"},{\\\"include\\\":\\\"/etc/nginx/api_proxy.conf\\\"}]\",\"headers\":\"\",\"reverseProxy\":false,\"reverseProxyUrl\":\"\",\"reverseProxyHeaders\":\"\",\"reverseProxyDirectives\":\"\"}]");
+
             var virtualServerName = "StaticContent";
 
             nginxServer

--- a/source/Calamari/Integration/Nginx/NginxServer.cs
+++ b/source/Calamari/Integration/Nginx/NginxServer.cs
@@ -237,7 +237,7 @@ server {{
         {
             if (string.IsNullOrEmpty(directivesString) && string.IsNullOrEmpty(reverseProxyDirectivesString)) return string.Empty;
 
-            var directives = ParseJson(directivesString);
+            var directives = ParseJsonArray(directivesString);
             var reverseProxyDirectives = ParseJson(reverseProxyDirectivesString);
             var allDirectives = CombineItems(directives.ToList(), reverseProxyDirectives.ToList());
             return !allDirectives.Any()
@@ -277,7 +277,30 @@ server {{
 
             return items1;
         }
-        
+
+        static IEnumerable<dynamic> ParseJsonArray(string json)
+        {
+            try
+            {
+                var result = new List<dynamic>();
+                var array = JArray.Parse(json);
+                foreach (var o in array.Children<JObject>())
+                {
+                    foreach (var p in o.Properties())
+                    {
+                        result.Add(new { p.Name, Value = (string)p.Value });
+                    }
+                }
+
+                return result;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                return new List<dynamic>();
+            }
+        }
+
         static IEnumerable<dynamic> ParseJson(string json)
         {
             try


### PR DESCRIPTION
Calamari side fix for: https://github.com/OctopusDeploy/Issues/issues/6142
There is a bug in the NGINX step where we don't allow for multiple directives with the same name
We serialize the directives as a JSON object and duplicates with the same name/key get overridden.
example:
```
server {
    listen 80;
    location / {
        include fastcgi_params;
        include /etc/nginx/api_proxy.conf;
    }
}
``` 
would end up as 
```
server {
    listen 80;
    location / {
        include /etc/nginx/api_proxy.conf;
    }
}
```

We have made a change on the Server to serialize the directives as an array, and this change is for Calamari to handle that change.