### PR TITLE
Allowed NGINX config file paths to be overwritten

### DIFF
--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -485,6 +485,7 @@ namespace Calamari.Deployment
                     public static readonly string HostName = "Octopus.Action.Nginx.Server.HostName";
                     public static readonly string Bindings = "Octopus.Action.Nginx.Server.Bindings";
                     public static readonly string Locations = "Octopus.Action.Nginx.Server.Locations";
+                    public static readonly string ConfigName = "Octopus.Action.Nginx.Server.ConfigName";
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/6216

See https://github.com/OctopusDeploy/OctopusDeploy/pull/5363 for the UI changes.

The end result of these changes are a directory structure like this:

```
mcasperson@DESKTOP-3E4K4R8:/etc/nginx/conf.d$ ls -la
total 20
drwxr-xr-x 2 root root 4096 Mar  3 07:50 .
drwxr-xr-x 8 root root 4096 Mar  3 07:41 ..
-rw-r--r-- 1 root root   48 Mar  3 07:45 Dev.Octopus.TeamCity.conf
-rw-r--r-- 1 root root   48 Mar  3 07:42 Octopus.TeamCity.conf
-rw-r--r-- 1 root root   48 Mar  3 07:47 Test.Dev.Octopus.TeamCity.conf
```