### PR TITLE
Rename PowerShell bootstrap variable from proxyUri to octopusProxyUri

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -514,6 +514,7 @@ function Decrypt-Variables($iv, $Encrypted)
 }
 
 function Initialize-ProxySettings() {
+	$octopusProxyUri = $null
 	$proxyUsername = $env:TentacleProxyUsername
 	$proxyPassword = $env:TentacleProxyPassword
 	$proxyHost = $env:TentacleProxyHost

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -519,7 +519,7 @@ function Initialize-ProxySettings() {
 	$proxyHost = $env:TentacleProxyHost
 	[int]$proxyPort = $env:TentacleProxyPort
 	if (![string]::IsNullOrEmpty($proxyHost)) {
-		$proxyUri = New-Object Uri("http://${proxyHost}:$proxyPort")
+		$octopusProxyUri = New-Object Uri("http://${proxyHost}:$proxyPort")
 	}
 
 	$useDefaultProxy = $true
@@ -536,14 +536,14 @@ function Initialize-ProxySettings() {
 	if ($useDefaultProxy -and [string]::IsNullOrEmpty($proxyHost)) {
 		# Calamari ensure both http_proxy and HTTP_PROXY are set, so we don't need to worry about casing
 		if (![string]::IsNullOrEmpty($env:HTTP_PROXY)) {
-			$proxyUri = New-Object System.Uri($env:HTTP_PROXY)
+			$octopusProxyUri = New-Object System.Uri($env:HTTP_PROXY)
             
 			# The HTTP_PROXY env variable may also contain credentials.
 			# This is a common enough pattern, but we need to extract the credentials in order to use them
             
 			# But if credentials were explicitly provided, use those ones instead
 			if (-not $hasCredentials) {
-				$credentialsArray = $proxyUri.UserInfo.Split(":")
+				$credentialsArray = $octopusProxyUri.UserInfo.Split(":")
 				$hasCredentials = $credentialsArray.length -gt 1;
 				if ($hasCredentials) {
 					$proxyUsername = $credentialsArray[0];
@@ -555,7 +555,7 @@ function Initialize-ProxySettings() {
 
 	#custom proxy		
 	if ($useCustomProxy) {
-		$proxy = New-Object System.Net.WebProxy($proxyUri)
+		$proxy = New-Object System.Net.WebProxy($octopusProxyUri)
 
 		if ($hasCredentials) {
 			$proxy.Credentials = New-Object System.Net.NetworkCredential($proxyUsername, $proxyPassword)			
@@ -568,8 +568,8 @@ function Initialize-ProxySettings() {
 		#system proxy		
 		if ($useDefaultProxy) {
 			# The system proxy should be provided through an environment variable, which has been used to initialize $proxyHost
-			if ($proxyUri -ne $null) {
-				$proxy = New-Object System.Net.WebProxy($proxyUri)
+			if ($octopusProxyUri -ne $null) {
+				$proxy = New-Object System.Net.WebProxy($octopusProxyUri)
 			}
 			else {
 				# If Tentacle is configured to use a System proxy, but there is no system proxy configured then we should configure this as if there was no proxy
@@ -606,9 +606,9 @@ function Initialize-ProxySettings() {
 			# We don't use default parameter values in Windows PowerShell because this simplifies things, 
 			# and means that users could change this value globally by modifying just a single property
 			if ($useDefaultProxy -or $useCustomProxy) {
-				if ($proxyUri -ne $null) {
-					$PSDefaultParameterValues.Add("Invoke-WebRequest:Proxy", $proxyUri.ToString())
-					$PSDefaultParameterValues.Add("Invoke-RestMethod:Proxy", $proxyUri.ToString())
+				if ($octopusProxyUri -ne $null) {
+					$PSDefaultParameterValues.Add("Invoke-WebRequest:Proxy", $octopusProxyUri.ToString())
+					$PSDefaultParameterValues.Add("Invoke-RestMethod:Proxy", $octopusProxyUri.ToString())
 					if ($hasCredentials) {
 						$securePassword = ConvertTo-SecureString $proxyPassword -AsPlainText -Force
 						$credentials = New-Object System.Management.Automation.PSCredential -ArgumentList $proxyUsername, $securePassword

--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/Proxy.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/Proxy.ps1
@@ -3,10 +3,10 @@ Write-Host "HTTPS_PROXY:$env:HTTPS_PROXY"
 Write-Host "NO_PROXY:$env:NO_PROXY"
 
 $testUri = New-Object Uri("http://octopustesturl.com")
-$proxyUri = [System.Net.WebRequest]::DefaultWebProxy.GetProxy($testUri)
-if ($proxyUri.Host -ne "octopustesturl.com")
+$octopusProxyUri = [System.Net.WebRequest]::DefaultWebProxy.GetProxy($testUri)
+if ($octopusProxyUri.Host -ne "octopustesturl.com")
 {
-    Write-Host "WebRequest.DefaultProxy:$proxyUri"
+    Write-Host "WebRequest.DefaultProxy:$octopusProxyUri"
 }
 else
 {

--- a/source/Calamari.Tests/Fixtures/ScriptCS/Scripts/Proxy.csx
+++ b/source/Calamari.Tests/Fixtures/ScriptCS/Scripts/Proxy.csx
@@ -7,10 +7,10 @@ Console.WriteLine("NO_PROXY:"+Environment.GetEnvironmentVariable("NO_PROXY"));
 if (Environment.OSVersion.Platform == PlatformID.Win32NT)
 {
     var testUri = new Uri("http://octopustesturl.com");
-    var proxyUri = System.Net.WebRequest.DefaultWebProxy.GetProxy(testUri);
-    if (proxyUri.Host != "octopustesturl.com")
+    var octopusProxyUri = System.Net.WebRequest.DefaultWebProxy.GetProxy(testUri);
+    if (octopusProxyUri.Host != "octopustesturl.com")
     {
-        Console.WriteLine("WebRequest.DefaultProxy:" + proxyUri);
+        Console.WriteLine("WebRequest.DefaultProxy:" + octopusProxyUri);
     }
     else
     {


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/6204

One of our customers has encountered an issue where their variable template named `ProxyURI` is interfering with our `proxyUri` variable in the bootstrap script. to avoid this I have simple renamed this variable to `ocotpusProxyUri`
Our usage of this variable is only local to the Initialize-ProxySettings cmdlet.