### PR TITLE
Dont cleanup temp bootstrapper files if DeleteScriptsOnCleanup set to…

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/ScriptEngine.cs
+++ b/source/Calamari.Shared/Integration/Scripting/ScriptEngine.cs
@@ -51,10 +51,13 @@ namespace Calamari.Integration.Scripting
                 }
                 finally
                 {
-                    foreach (var temporaryFile in execution.TemporaryFiles)
+                    if (variables.GetFlag(SpecialVariables.DeleteScriptsOnCleanup, true))
                     {
-                        var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-                        fileSystem.DeleteFile(temporaryFile, FailureOptions.IgnoreFailure);
+                        foreach (var temporaryFile in execution.TemporaryFiles)
+                        {
+                            var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+                            fileSystem.DeleteFile(temporaryFile, FailureOptions.IgnoreFailure);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
… false

We were cleaning up the bootstrapper files all the time, even if the `OctopusDeleteScriptsOnCleanup` variable was set to `false`.

@droyad - pinging you on this, as I believe you have context around this. Doesn't have to be you though.