### PR TITLE
Tweak gitversion to respect our tags on master when calculating versions

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,7 @@
 mode: ContinuousDeployment
+branches:
+  release:
+    is-release-branch: false
 ignore:
   sha: [
     e823e5382ae16d433cbfda913f593f92aaaa462f,

--- a/build.cake
+++ b/build.cake
@@ -243,8 +243,10 @@ private void DoPackage(string project, string framework, string version, string 
 
 private void SignAndTimestampBinaries(string outputDirectory)
 {
+    // When building locally signing isn't really necessary and it could take up to 3-4 minutes to sign all the binaries 
+    // as we build for many, many different runtimes so disabling it locally means quicker turn around when doing local development.    
     if (BuildSystem.IsLocalBuild) return;
-    
+
     Information($"Signing binaries in {outputDirectory}");
 
     // check that any unsigned libraries, that Octopus Deploy authors, get signed to play nice with security scanning tools

--- a/build.cake
+++ b/build.cake
@@ -243,6 +243,8 @@ private void DoPackage(string project, string framework, string version, string 
 
 private void SignAndTimestampBinaries(string outputDirectory)
 {
+    if (BuildSystem.IsLocalBuild) return;
+    
     Information($"Signing binaries in {outputDirectory}");
 
     // check that any unsigned libraries, that Octopus Deploy authors, get signed to play nice with security scanning tools

--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////
 // TOOLS
 //////////////////////////////////////////////////////////////////////
-#tool "nuget:?package=GitVersion.CommandLine&version=4.0.0-beta0012"
+#tool "nuget:?package=GitVersion.CommandLine&version=5.2.0"
 #addin "nuget:?package=Cake.Incubator&version=5.0.1"
 
 using Path = System.IO.Path;

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.24.0" />
+    <package id="Cake" version="0.36.0" />
 </packages>


### PR DESCRIPTION
Because we have branch `release/2019.3` which has been merged into `master` GitVersion sometimes gets a little bit 😕 with which version it should use when building `master`. 

This PR "demotes" the `release` branch configuration from a _release_ branch which takes precedence when calculating versions.