### PR TITLE
Default to AzureCloud if Azure environment hasn't been set

### DIFF
--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -35,6 +35,9 @@ $OctopusAzureADTenantId = $OctopusParameters["Octopus.Action.Azure.TenantId"]
 $OctopusAzureADClientId = $OctopusParameters["Octopus.Action.Azure.ClientId"]
 $OctopusAzureADPassword = $OctopusParameters["Octopus.Action.Azure.Password"]
 $OctopusAzureEnvironment = $OctopusParameters["Octopus.Action.Azure.Environment"]
+if ($null -eq $OctopusAzureEnvironment) {
+	$OctopusAzureEnvironment = "AzureCloud"
+}
 $OctopusDisableAzureCLI = $OctopusParameters["OctopusDisableAzureCLI"]
 
 function EnsureDirectoryExists([string] $path)


### PR DESCRIPTION
`Octopus.Action.Azure.Environment` is unset unless you've configured the Azure cloud environment on the target, we handle this in `Calamari.Azure` by setting the variable to `AzureCloud` if the variable isn't set. This was missed when we moved the authentication into the k8s context scripts.

### Before
![image](https://user-images.githubusercontent.com/1035315/76369197-806ede00-637e-11ea-9183-c4bbf7518583.png)

### After
![image](https://user-images.githubusercontent.com/1035315/76369209-8c5aa000-637e-11ea-8b30-88cfa7d615fd.png)
