### PR TITLE
Add ICommand that does not take arguments and look package from the variables

### DIFF
--- a/source/Calamari.Shared/Commands/Support/Command.cs
+++ b/source/Calamari.Shared/Commands/Support/Command.cs
@@ -2,7 +2,7 @@
 
 namespace Calamari.Commands.Support
 {
-    public abstract class Command : ICommand
+    public abstract class Command : ICommandWithArguments
     {
         protected Command()
         {

--- a/source/Calamari.Shared/Commands/Support/ICommand.cs
+++ b/source/Calamari.Shared/Commands/Support/ICommand.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Calamari.Deployment.Conventions;
+
+namespace Calamari.Commands.Support
+{
+    public interface ICommand
+    {
+        string PrimaryPackagePath { get; }
+        IEnumerable<IConvention> GetConventions();
+    }
+}

--- a/source/Calamari.Shared/Commands/Support/ICommand.cs
+++ b/source/Calamari.Shared/Commands/Support/ICommand.cs
@@ -1,9 +1,0 @@
-﻿using System.IO;
-
-namespace Calamari.Commands.Support
-{
-    public interface ICommand
-    {
-        int Execute(string[] commandLineArguments);
-    }
-}

--- a/source/Calamari.Shared/Commands/Support/ICommandWithArguments.cs
+++ b/source/Calamari.Shared/Commands/Support/ICommandWithArguments.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using Calamari.Deployment.Conventions;
+﻿using System.IO;
 
 namespace Calamari.Commands.Support
 {
@@ -10,11 +8,5 @@ namespace Calamari.Commands.Support
     public interface ICommandWithArguments
     {
         int Execute(string[] commandLineArguments);
-    }
-
-    public interface ICommand
-    {
-        string PrimaryPackagePath { get; }
-        IEnumerable<IConvention> GetConventions();
     }
 }

--- a/source/Calamari.Shared/Commands/Support/ICommandWithArguments.cs
+++ b/source/Calamari.Shared/Commands/Support/ICommandWithArguments.cs
@@ -1,0 +1,17 @@
+﻿using System.IO;
+
+namespace Calamari.Commands.Support
+{
+    /// <summary>
+    /// A command that requires the command line arguments passed to it. We are transitioning away from this interface  
+    /// </summary>
+    public interface ICommandWithArguments
+    {
+        int Execute(string[] commandLineArguments);
+    }
+
+    public interface ICommand
+    {
+        int Execute();
+    }
+}

--- a/source/Calamari.Shared/Commands/Support/ICommandWithArguments.cs
+++ b/source/Calamari.Shared/Commands/Support/ICommandWithArguments.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
+using Calamari.Deployment.Conventions;
 
 namespace Calamari.Commands.Support
 {
@@ -12,6 +14,7 @@ namespace Calamari.Commands.Support
 
     public interface ICommand
     {
-        int Execute();
+        string PrimaryPackagePath { get; }
+        IEnumerable<IConvention> GetConventions();
     }
 }

--- a/source/Calamari.Shared/Extensions/VariableExtensions.cs
+++ b/source/Calamari.Shared/Extensions/VariableExtensions.cs
@@ -1,0 +1,27 @@
+using Calamari.Commands.Support;
+using Calamari.Deployment;
+using Calamari.Integration.FileSystem;
+using Calamari.Util;
+
+namespace Calamari.Extensions
+{
+    public static class VariableExtensions
+    {
+        public static string GetPrimaryPackagePath(this IVariables variables, ICalamariFileSystem fileSystem, bool required)
+        {
+            var path = variables.Get(SpecialVariables.Tentacle.CurrentDeployment.PackageFilePath);
+
+            if(string.IsNullOrEmpty(path))
+                if (required)
+                    throw new CommandException($"The `{SpecialVariables.Tentacle.CurrentDeployment.PackageFilePath}` was not specified or blank. This is likely a bug in Octopus, please contact Octopus support.");
+                else
+                    return null;
+            
+            path = CrossPlatform.ExpandPathEnvironmentVariables(path);
+            if (!fileSystem.FileExists(path))
+                throw new CommandException("Could not find package file: " + path);
+
+            return path;
+        }
+    }
+}

--- a/source/Calamari.Shared/Extensions/VariableExtensions.cs
+++ b/source/Calamari.Shared/Extensions/VariableExtensions.cs
@@ -7,7 +7,7 @@ namespace Calamari.Extensions
 {
     public static class VariableExtensions
     {
-        public static string GetPrimaryPackagePath(this IVariables variables, ICalamariFileSystem fileSystem, bool required)
+        public static string GetPathToPrimaryPackage(this IVariables variables, ICalamariFileSystem fileSystem, bool required)
         {
             var path = variables.Get(SpecialVariables.Tentacle.CurrentDeployment.PackageFilePath);
 

--- a/source/Calamari.Shared/IVariables.cs
+++ b/source/Calamari.Shared/IVariables.cs
@@ -4,7 +4,6 @@ namespace Calamari
 {
     public interface IVariables : IEnumerable<KeyValuePair<string, string>>
     {
-        string GetEnvironmentExpandedPath(string variableName, string defaultValue = null);
         bool IsSet(string name);
         void Set(string name, string value);
         void SetStrings(string variableName, IEnumerable<string> values, string separator);

--- a/source/Calamari.Terraform/TerraformCommand.cs
+++ b/source/Calamari.Terraform/TerraformCommand.cs
@@ -28,7 +28,7 @@ namespace Calamari.Terraform
             this.fileSystem = fileSystem;
         }
 
-        public string PrimaryPackagePath => variables.GetPrimaryPackagePath(fileSystem, false);
+        public string PrimaryPackagePath => variables.GetPathToPrimaryPackage(fileSystem, false);
 
         public IEnumerable<IConvention> GetConventions()
         {

--- a/source/Calamari.Tests/Helpers/TestProgram.cs
+++ b/source/Calamari.Tests/Helpers/TestProgram.cs
@@ -9,7 +9,7 @@ namespace Calamari.Tests.Helpers
     class TestProgram : Program
     {
         public InMemoryLog Log { get; } = new InMemoryLog();
-        public ICommand CommandOverride { get; set; }
+        public ICommandWithArguments CommandOverride { get; set; }
         public bool StubWasCalled { get; set; }
         public IVariables VariablesOverride { get; set; }
 
@@ -25,7 +25,7 @@ namespace Calamari.Tests.Helpers
             var builder = base.BuildContainer(options);
             builder.RegisterInstance(Log).As<ILog>();
             if (CommandOverride != null)
-                builder.RegisterInstance(CommandOverride).As<ICommand>();
+                builder.RegisterInstance(CommandOverride).As<ICommandWithArguments>();
             if (VariablesOverride != null)
                 builder.RegisterInstance(VariablesOverride).As<IVariables>();
             return builder;
@@ -33,7 +33,7 @@ namespace Calamari.Tests.Helpers
     }
 
     [Command("stub")]
-    class StubCommand : ICommand
+    class StubCommand : ICommandWithArguments
     {
         readonly Action callback;
 

--- a/source/Calamari.Tests/Terraform/TerraformFixture.cs
+++ b/source/Calamari.Tests/Terraform/TerraformFixture.cs
@@ -394,7 +394,7 @@ namespace Calamari.Tests.Terraform
                     Log.StdOut = new IndentedTextWriter(new StringWriter(sb));
 
                     var command = (ICommand) Activator.CreateInstance(commandType, variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new CommandLineRunner(new LogWrapper(), variables));
-                    var result = command.Execute(new string[0]);
+                    var result = command.Execute();
 
                     result.Should().Be(0);
 

--- a/source/Calamari.Tests/Terraform/TerraformFixture.cs
+++ b/source/Calamari.Tests/Terraform/TerraformFixture.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Calamari.Commands;
 using Calamari.Commands.Support;
 using Calamari.Deployment;
 using Calamari.Integration.FileSystem;
@@ -394,7 +395,7 @@ namespace Calamari.Tests.Terraform
                     Log.StdOut = new IndentedTextWriter(new StringWriter(sb));
 
                     var command = (ICommand) Activator.CreateInstance(commandType, variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new CommandLineRunner(new LogWrapper(), variables));
-                    var result = command.Execute();
+                    var result = new CommandAdapter(command, variables).Execute(new string[0]);
 
                     result.Should().Be(0);
 

--- a/source/Calamari/Commands/CommandAdapter.cs
+++ b/source/Calamari/Commands/CommandAdapter.cs
@@ -1,0 +1,23 @@
+using Calamari.Commands.Support;
+
+namespace Calamari.Commands
+{
+    /// <summary>
+    /// Adapts a ICommand to the ICommandWithArguments interface
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class CommandAdapter<T> 
+        : ICommandWithArguments
+        where T : ICommand
+    {
+        readonly ICommand command;
+
+        public CommandAdapter(ICommand command)
+        {
+            this.command = command;
+        }
+
+        public int Execute(string[] commandLineArguments)
+            => command.Execute();
+    }
+}

--- a/source/Calamari/Commands/TransferPackageCommand.cs
+++ b/source/Calamari/Commands/TransferPackageCommand.cs
@@ -5,6 +5,7 @@ using Calamari.Commands.Support;
 using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
 using Calamari.Deployment.Journal;
+using Calamari.Extensions;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Processes.Semaphores;
@@ -28,15 +29,8 @@ namespace Calamari.Commands
 
         public override int Execute(string[] commandLineArguments)
         {
-            var packageFile = variables.GetEnvironmentExpandedPath(SpecialVariables.Tentacle.CurrentDeployment.PackageFilePath);
-            if(string.IsNullOrEmpty(packageFile))
-            {
-                throw new CommandException($"No package file was specified. Please provide `{SpecialVariables.Tentacle.CurrentDeployment.PackageFilePath}` variable");
-            }
-
-            if (!fileSystem.FileExists(packageFile))
-                throw new CommandException("Could not find package file: " + packageFile);    
-
+            var packageFile = variables.GetPrimaryPackagePath(fileSystem, true);
+            
             var journal = new DeploymentJournal(fileSystem, SemaphoreFactory.Get(), variables);
             
             var conventions = new List<IConvention>

--- a/source/Calamari/Commands/TransferPackageCommand.cs
+++ b/source/Calamari/Commands/TransferPackageCommand.cs
@@ -29,7 +29,7 @@ namespace Calamari.Commands
 
         public override int Execute(string[] commandLineArguments)
         {
-            var packageFile = variables.GetPrimaryPackagePath(fileSystem, true);
+            var packageFile = variables.GetPathToPrimaryPackage(fileSystem, true);
             
             var journal = new DeploymentJournal(fileSystem, SemaphoreFactory.Get(), variables);
             

--- a/source/Calamari/Deployment/Conventions/TransferPackageConvention.cs
+++ b/source/Calamari/Deployment/Conventions/TransferPackageConvention.cs
@@ -15,7 +15,7 @@ namespace Calamari.Deployment.Conventions
 
         public void Install(RunningDeployment deployment)
         {
-            var transferPath = deployment.Variables.GetEnvironmentExpandedPath(SpecialVariables.Package.TransferPath);
+            var transferPath = CrossPlatform.ExpandPathEnvironmentVariables(deployment.Variables.Get(SpecialVariables.Package.TransferPath));
             fileSystem.EnsureDirectoryExists(transferPath);
             var fileName = deployment.Variables.Get(SpecialVariables.Package.OriginalFileName) ?? Path.GetFileName(deployment.PackageFilePath);
             var filePath = Path.Combine(transferPath, fileName);

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -106,7 +106,10 @@ namespace Calamari
                 .Where(t => !t.IsAbstract && t.IsAssignableTo<ICommand>())
                 .Where(t => t.GetCustomAttribute<CommandAttribute>().Name.Equals(options.Command, StringComparison.OrdinalIgnoreCase));
             foreach (var iCommandType in iCommandTypes)
-                builder.RegisterType(typeof(CommandAdapter<>).MakeGenericType(iCommandType)).As<ICommandWithArguments>();
+            {
+                builder.RegisterType(iCommandType).AsSelf();
+                builder.Register<ICommandWithArguments>(c => new CommandAdapter((ICommand) c.Resolve(iCommandType), c.Resolve<IVariables>()));
+            }
 
             return builder;
         }

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -98,6 +98,7 @@ namespace Calamari
 
             builder.RegisterAssemblyTypes(assemblies)
                 .AssignableTo<ICommandWithArguments>()
+                .Except<CommandAdapter>()
                 .Where(t => t.GetCustomAttribute<CommandAttribute>().Name.Equals(options.Command, StringComparison.OrdinalIgnoreCase))
                 .As<ICommandWithArguments>();
 

--- a/source/Calamari/Variables/CalamariVariables.cs
+++ b/source/Calamari/Variables/CalamariVariables.cs
@@ -7,11 +7,6 @@ namespace Calamari.Variables
 {
     public class CalamariVariables : VariableDictionary, IVariables
     {
-        public string GetEnvironmentExpandedPath(string variableName, string defaultValue = null)
-        {
-            return CrossPlatform.ExpandPathEnvironmentVariables(Get(variableName, defaultValue));
-        }
-
         public bool IsSet(string name)
         {
             return this[name] != null;


### PR DESCRIPTION
Each command parsing it's own variables seems unnecessary and adds extra code. For packages at least the path is already in the variables (https://github.com/OctopusDeploy/OctopusDeploy/blob/5c109575cd99157868b871acda6d517aeb78b640/source/Octopus.Core/Model/Projects/AcquiredPackageMap.cs#L72). Also with the advent of multiple packages per step, passing it at the command line no longer seems appropriate.

The setup of RunningDeployment and executing the conventions themselves seems to be repeated often, so this pulls that out of the command itself. If we do need a richer experience, we can add a Command type that allows that, but I think this simple interface makes it really easy to implement.

The Terraform step does it the "new" way, and if we agree to go down that path, we'll refactor it throughout the code base.

I haven't looked at other options yet, but if passing at the command line (instead of variables) is better for some reason we'd extend `ICommand` (`ICommandWithOptions<T>`?) to handle that.

There is an adapter for `ICommand` to `ICommandWithArguments` to keep the code simpler in `Program`.