### PR TITLE
Ensured NGINX location files are processed in the correct order

### DIFF
--- a/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
@@ -147,7 +147,7 @@ namespace Calamari.Tests.Fixtures.Nginx
                 tempDirectory, 
                 "conf", 
                 $"{virtualServerName}.conf.d",
-                $"location.{apiLocation.Path.Trim('/')}.conf"
+                $"location.0{apiLocation.Path.Trim('/')}.conf"
             );
             
             this.Assent(

--- a/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
@@ -234,10 +234,10 @@ namespace Calamari.Tests.Fixtures.Nginx
             var exactRootConf = Path.Combine(tempConfPath, $"{packageId}.conf");
             Assert.IsTrue(File.Exists(exactRootConf));
 
-            var rootConf = Path.Combine(tempConfPath, $"{packageId}.conf.d", $"location.0.conf");
+            var rootConf = Path.Combine(tempConfPath, $"{packageId}.conf.d", "location.0.conf");
             Assert.IsTrue(File.Exists(rootConf));
 
-            var apiConf = Path.Combine(tempConfPath, $"{packageId}.conf.d", $"location.api.conf");
+            var apiConf = Path.Combine(tempConfPath, $"{packageId}.conf.d", "location.1api.conf");
             Assert.IsTrue(File.Exists(apiConf));
             
             this.Assent(File.ReadAllText(exactRootConf), TestEnvironment.AssentConfiguration, $"{nameof(ExecuteWorks)}.rootLocation");

--- a/source/Calamari/Integration/Nginx/NginxServer.cs
+++ b/source/Calamari/Integration/Nginx/NginxServer.cs
@@ -214,6 +214,8 @@ server {{
             }
 
             var virtualServerConfPath = Path.Combine(tempDirectory, TempConfigRootDirectory, $"{VirtualServerName}.conf");
+            // Remove any existing location config files to ensure only those defined in the UI are present. 
+            fileSystem.DeleteDirectory(virtualServerConfPath, FailureOptions.IgnoreFailure);
             fileSystem.EnsureDirectoryExists(Path.GetDirectoryName(virtualServerConfPath));
             fileSystem.OverwriteFile(virtualServerConfPath, RemoveEmptyLines(virtualServerConfig));
         }

--- a/source/Calamari/Integration/Nginx/NginxServer.cs
+++ b/source/Calamari/Integration/Nginx/NginxServer.cs
@@ -133,7 +133,7 @@ namespace Calamari.Integration.Nginx
             foreach (var location in locations)
             {
                 var locationConfig = GetLocationConfig(location);
-                var sanitizedLocationName = SanitizeLocationName(location.Path, locationIndex.ToString());
+                var sanitizedLocationName = SanitizeLocationName(location.Path, locationIndex);
                 var locationConfFile = Path.Combine(TempConfigRootDirectory, $"{VirtualServerName}.conf.d",
                     $"location.{sanitizedLocationName}.conf");
                 var defaultLocationConfFile = Path.Combine(TempConfigRootDirectory, $"{VirtualServerName}.conf.d",
@@ -149,19 +149,32 @@ namespace Calamari.Integration.Nginx
             return this;
         }
 
-        private string SanitizeLocationName(string locationPath, string defaultValue)
+        private string SanitizeLocationName(string locationPath, int index)
         {
-            var match = Regex.Match(locationPath, "[a-zA-Z0-9/]+");
-            if (match.Success)
-            {
-                // Watch out for cases where multiple locations both match a string like "/". Both
-                // of these will be sanitized down to an empty string.
-                var sanitizedResult = match.Value.Replace("/", "_").Trim('_');
-                // If we did not get an empty string, use the result. Otherwise fall back to the default.
-                if (!string.IsNullOrWhiteSpace(sanitizedResult)) return sanitizedResult;
-            }
-
-            return defaultValue;
+            /*
+             * The names of the files holding locations are significant as Nginx will process regular express
+             * locations in the order they are defined or imported. This is from the documentation at
+             * http://nginx.org/en/docs/http/request_processing.html:
+             *
+             * nginx first searches for the most specific prefix location given by literal strings regardless of the
+             * listed order. In the configuration above the only prefix location is “/” and since it matches any request
+             * it will be used as a last resort.
+             *
+             * [THIS IS THE IMPORTANT BIT]
+             * Then nginx checks locations given by regular expression in the order listed in the configuration file.
+             * The first matching expression stops the search and nginx will use this location.
+             *
+             * If no regular expression matches a request, then nginx uses the most specific prefix location
+             * found earlier.
+             *
+             * To accomodate this ordering, we prefix all location paths with the index of the location as it appeared
+             * in the UI. This ensures location file names are unique and processed in the order they were defined.
+             */
+            
+            var match = Regex.Match(index + locationPath, "[a-zA-Z0-9/]+");
+            // match must be a success, if only for the prefixed index
+            // Remove slashes, as these are not valid for a file name
+            return match.Value.Replace("/", "_").Trim('_');
         }
 
         public NginxServer WithRootLocation(Location location)

--- a/source/Calamari/Integration/Nginx/NginxServer.cs
+++ b/source/Calamari/Integration/Nginx/NginxServer.cs
@@ -214,8 +214,6 @@ server {{
             }
 
             var virtualServerConfPath = Path.Combine(tempDirectory, TempConfigRootDirectory, $"{VirtualServerName}.conf");
-            // Remove any existing location config files to ensure only those defined in the UI are present. 
-            fileSystem.DeleteDirectory(virtualServerConfPath, FailureOptions.IgnoreFailure);
             fileSystem.EnsureDirectoryExists(Path.GetDirectoryName(virtualServerConfPath));
             fileSystem.OverwriteFile(virtualServerConfPath, RemoveEmptyLines(virtualServerConfig));
         }

--- a/source/Calamari/Integration/Nginx/NginxServer.cs
+++ b/source/Calamari/Integration/Nginx/NginxServer.cs
@@ -152,7 +152,7 @@ namespace Calamari.Integration.Nginx
         private string SanitizeLocationName(string locationPath, int index)
         {
             /*
-             * The names of the files holding locations are significant as Nginx will process regular express
+             * The names of the files holding locations are significant as Nginx will process regular expression
              * locations in the order they are defined or imported. This is from the documentation at
              * http://nginx.org/en/docs/http/request_processing.html:
              *
@@ -171,10 +171,15 @@ namespace Calamari.Integration.Nginx
              * in the UI. This ensures location file names are unique and processed in the order they were defined.
              */
             
-            var match = Regex.Match(index + locationPath, "[a-zA-Z0-9/]+");
-            // match must be a success, if only for the prefixed index
-            // Remove slashes, as these are not valid for a file name
-            return match.Value.Replace("/", "_").Trim('_');
+            var match = Regex.Match(locationPath, "[a-zA-Z0-9/]+");
+            if (match.Success)
+            {
+                // Remove slashes, as these are not valid for a file name
+                return index + match.Value.Replace("/", "_").Trim('_');
+            }
+
+            // Fall back to the index as a file name
+            return index.ToString();
         }
 
         public NginxServer WithRootLocation(Location location)

--- a/source/Calamari/Integration/Nginx/NginxServer.cs
+++ b/source/Calamari/Integration/Nginx/NginxServer.cs
@@ -136,13 +136,8 @@ namespace Calamari.Integration.Nginx
                 var sanitizedLocationName = SanitizeLocationName(location.Path, locationIndex);
                 var locationConfFile = Path.Combine(TempConfigRootDirectory, $"{VirtualServerName}.conf.d",
                     $"location.{sanitizedLocationName}.conf");
-                var defaultLocationConfFile = Path.Combine(TempConfigRootDirectory, $"{VirtualServerName}.conf.d",
-                    $"location.{locationIndex}.conf");
 
-                AdditionalLocations.Add(
-                    // Don't assume sanitized means unique. If the filename is already used, fall back to the indexed filename.
-                    AdditionalLocations.ContainsKey(locationConfFile) ? defaultLocationConfFile : locationConfFile, 
-                    locationConfig);
+                AdditionalLocations.Add(locationConfFile, locationConfig);
                 locationIndex++;
             }
 

--- a/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
+++ b/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
@@ -13,7 +13,14 @@ trap 'echo "Removing temporary folder ${nginxTempDir}..." && sudo rm -rf $nginxT
 nginxConfRoot=${nginxConfDir:-/etc/nginx/conf.d}
 
 echo "Clearing the existing locations dir"
-for dir in $nginxTempDir/conf/*; do if [[ -d "$dir" && ! -L "$dir" ]]; then fixedDir=${dir##*/}; rm -rf $nginxConfRoot/$fixedDir; fi; done
+for dir in $nginxTempDir/conf/* 
+do 
+    fixedDir=${dir##*/}
+    if [[ -d "$dir" && ! -L "$dir" && -d "$nginxConfRoot/$fixedDir" ]]
+    then         
+        rm -rf $nginxConfRoot/$fixedDir
+    fi
+done
 
 echo "Copying $nginxTempDir/conf/* to $nginxConfRoot..."
 sudo cp -R $nginxTempDir/conf/* $nginxConfRoot -f

--- a/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
+++ b/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
@@ -18,7 +18,7 @@ do
     fixedDir=${dir##*/}
     if [[ -d "$dir" && ! -L "$dir" && -d "$nginxConfRoot/$fixedDir" ]]
     then         
-        rm -rf $nginxConfRoot/$fixedDir
+        sudo rm -rf $nginxConfRoot/$fixedDir
     fi
 done
 

--- a/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
+++ b/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
@@ -11,6 +11,10 @@ nginxConfDir=$(get_octopusvariable "Octopus.Action.Nginx.ConfigurationsDirectory
 trap 'echo "Removing temporary folder ${nginxTempDir}..." && sudo rm -rf $nginxTempDir' exit
 
 nginxConfRoot=${nginxConfDir:-/etc/nginx/conf.d}
+
+echo "Clearing the existing locations dir"
+for dir in $nginxTempDir/conf/*; do if [[ -d "$dir" && ! -L "$dir" ]]; then fixedDir=${dir##*/}; rm -rf $nginxConfRoot/$fixedDir; fi; done
+
 echo "Copying $nginxTempDir/conf/* to $nginxConfRoot..."
 sudo cp -R $nginxTempDir/conf/* $nginxConfRoot -f
 


### PR DESCRIPTION
The order in which location files in NGINX are defined has significance. In particular any regular expression based location is processed from top to bottm. This is from the docs at http://nginx.org/en/docs/http/request_processing.html:

> Then nginx checks locations given by regular expression in the order listed in the configuration file.

Currently, location files are based on the location path, meaning locations will be imported in alphabetical order. This PR ensures the location configuration files have an index matching the order they were defined in the UI.