### PR TITLE
Cleanup of package extraction warnings

### DIFF
--- a/source/Calamari.Shared/Deployment/Conventions/ExtractPackageConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/ExtractPackageConvention.cs
@@ -30,8 +30,7 @@ namespace Calamari.Deployment.Conventions
 
                 Log.Verbose("Extracting package to: " + targetPath);
 
-                var filesExtracted = extractor.Extract(deployment.PackageFilePath, targetPath,
-                    deployment.Variables.GetFlag(SpecialVariables.Package.SuppressNestedScriptWarning, false));
+                var filesExtracted = extractor.Extract(deployment.PackageFilePath, targetPath);
 
                 Log.Verbose("Extracted " + filesExtracted + " files");
 

--- a/source/Calamari.Shared/Deployment/Conventions/StageScriptPackagesConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/StageScriptPackagesConvention.cs
@@ -92,7 +92,7 @@ namespace Calamari.Deployment.Conventions
             if (!File.Exists(packageFile))
                 throw new CommandException("Could not find package file: " + packageFile);
             
-            extractor.GetExtractor(packageFile).Extract(packageFile, extractionDirectory, true);
+            extractor.GetExtractor(packageFile).Extract(packageFile, extractionDirectory);
         }
     }
 }

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -145,7 +145,6 @@ namespace Calamari.Deployment
             public static readonly string SubstituteInFilesOutputEncoding = "Octopus.Action.SubstituteInFiles.OutputEncoding";
             public static readonly string SkipIfAlreadyInstalled = "Octopus.Action.Package.SkipIfAlreadyInstalled";
             public static readonly string IgnoreVariableReplacementErrors = "Octopus.Action.Package.IgnoreVariableReplacementErrors";
-            public static readonly string SuppressNestedScriptWarning = "OctopusSuppressNestedScriptWarning";
             public static readonly string RunPackageScripts = "Octopus.Action.Package.RunScripts";
 
             public class Output

--- a/source/Calamari.Shared/Integration/Packages/GenericPackageExtractor.cs
+++ b/source/Calamari.Shared/Integration/Packages/GenericPackageExtractor.cs
@@ -33,9 +33,9 @@ namespace Calamari.Integration.Packages
             get { return Extractors.SelectMany(e => e.Extensions).OrderBy(e => e).ToArray(); }
         }
 
-        public int Extract(string packageFile, string directory, bool suppressNestedScriptWarning)
+        public int Extract(string packageFile, string directory)
         {
-            return GetExtractor(packageFile).Extract(packageFile, directory, suppressNestedScriptWarning);
+            return GetExtractor(packageFile).Extract(packageFile, directory);
         }
 
         public IPackageExtractor GetExtractor(string packageFile)
@@ -61,31 +61,7 @@ namespace Calamari.Integration.Packages
                 $"The supplied package has the extension \"{file.Extension}\" which is not supported.",
                 "JAVA-DEPLOY-ERROR-0001"));
         }
-
-        internal static void WarnUnsupportedSymlinkExtraction(string path)
-        {
-            Log.WarnFormat("Cannot create symbolic link: {0}, Calamari does not currently support the extraction of symbolic links", path);
-        }
-
-        internal static void WarnIfScriptInSubFolder(string path)
-        {
-            var fileName = Path.GetFileName(path);
-
-            if (string.Equals(fileName, "Deploy.ps1", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fileName, "PreDeploy.ps1", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fileName, "PostDeploy.ps1", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fileName, "DeployFailed.ps1", StringComparison.OrdinalIgnoreCase))
-            {
-                var directoryName = Path.GetDirectoryName(path);
-                if (!string.IsNullOrWhiteSpace(directoryName))
-                {
-                    Log.WarnFormat(
-                        "The script file \"{0}\" contained within the package will not be executed because it is contained within a child folder. As of Octopus Deploy 2.4, scripts in sub folders will not be executed.",
-                        path);
-                }
-            }
-        }
-
+        
         /// Order is important here since .tar.gz should be checked for before .gz
         protected virtual IList<IPackageExtractor> Extractors => new List<IPackageExtractor>
         {

--- a/source/Calamari.Shared/Integration/Packages/IPackageExtractor.cs
+++ b/source/Calamari.Shared/Integration/Packages/IPackageExtractor.cs
@@ -3,7 +3,7 @@ namespace Calamari.Integration.Packages
 {
     public interface IPackageExtractor
     {
-        int Extract(string packageFile, string directory, bool suppressNestedScriptWarning);
+        int Extract(string packageFile, string directory);
 
         string[] Extensions { get; }
     }

--- a/source/Calamari.Shared/Integration/Packages/Java/JarExtractor.cs
+++ b/source/Calamari.Shared/Integration/Packages/Java/JarExtractor.cs
@@ -16,7 +16,7 @@ namespace Calamari.Integration.Packages.Java
 
         public override string[] Extensions => EXTENSIONS;
 
-        public override int Extract(string packageFile, string directory, bool suppressNestedScriptWarning)
+        public override int Extract(string packageFile, string directory)
         {
             return jarTool.ExtractJar(packageFile, directory);
         }

--- a/source/Calamari.Shared/Integration/Packages/NuGet/NupkgExtractor.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NupkgExtractor.cs
@@ -41,7 +41,7 @@ namespace Calamari.Integration.Packages.NuGet
                         continue;
 
                     var targetFile = Path.Combine(targetDirectory, Path.GetFileName(unescapedKey));
-                    entry.WriteToFile(targetFile, new PackageExtractionOptions { ExtractFullPath = false });
+                    entry.WriteToFile(targetFile, new PackageExtractionOptions { ExtractFullPath = false, PreserveFileTime = false });
 
                     SetFileLastModifiedTime(entry, targetFile);
 

--- a/source/Calamari.Shared/Integration/Packages/NuGet/NupkgExtractor.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NupkgExtractor.cs
@@ -16,7 +16,7 @@ namespace Calamari.Integration.Packages.NuGet
     {
         public string[] Extensions => new[] {".nupkg"};
 
-        public int Extract(string packageFile, string directory, bool suppressNestedScriptWarning)
+        public int Extract(string packageFile, string directory)
         {
             var filesExtracted = 0;
 
@@ -41,23 +41,15 @@ namespace Calamari.Integration.Packages.NuGet
                         continue;
 
                     var targetFile = Path.Combine(targetDirectory, Path.GetFileName(unescapedKey));
-                    entry.WriteToFile(targetFile, new ExtractionOptions { Overwrite = true, WriteSymbolicLink = WriteSymbolicLink });
+                    entry.WriteToFile(targetFile, new PackageExtractionOptions { ExtractFullPath = false });
 
                     SetFileLastModifiedTime(entry, targetFile);
 
                     filesExtracted++;
-
-                    if (!suppressNestedScriptWarning)
-                        GenericPackageExtractor.WarnIfScriptInSubFolder(unescapedKey);
                 }
 
                 return filesExtracted;
             }
-        }
-
-        static void WriteSymbolicLink(string sourcepath, string targetpath)
-        {
-            GenericPackageExtractor.WarnUnsupportedSymlinkExtraction(sourcepath);
         }
 
         static void SetFileLastModifiedTime(IEntry entry, string targetFile)

--- a/source/Calamari.Shared/Integration/Packages/PackageExtractionOptions.cs
+++ b/source/Calamari.Shared/Integration/Packages/PackageExtractionOptions.cs
@@ -1,0 +1,18 @@
+using SharpCompress.Common;
+
+namespace Calamari.Integration.Packages
+{
+    public class PackageExtractionOptions : ExtractionOptions
+    {
+        public PackageExtractionOptions()
+        {
+            ExtractFullPath = true;
+            Overwrite = true;
+            PreserveFileTime = true;
+            WriteSymbolicLink = WarnThatSymbolicLinksAreNotSupported;
+        }
+
+        static void WarnThatSymbolicLinksAreNotSupported(string sourcepath, string targetpath)
+            => Log.WarnFormat("Cannot create symbolic link: {0}, Calamari does not currently support the extraction of symbolic links", sourcepath);
+    }
+}

--- a/source/Calamari.Shared/Integration/Packages/SimplePackageExtractor.cs
+++ b/source/Calamari.Shared/Integration/Packages/SimplePackageExtractor.cs
@@ -2,7 +2,7 @@ namespace Calamari.Integration.Packages
 {
     public abstract class SimplePackageExtractor : IPackageExtractor
     {
-        public abstract int Extract(string packageFile, string directory, bool suppressNestedScriptWarning);
+        public abstract int Extract(string packageFile, string directory);
         public abstract string[] Extensions { get; }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/PackageExtractorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/PackageExtractorFixture.cs
@@ -27,7 +27,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var extractor = (IPackageExtractor)Activator.CreateInstance(extractorType);
             var targetDir = GetTargetDir(extractorType, fileName);
 
-            var filesExtracted = extractor.Extract(fileName, targetDir, true);
+            var filesExtracted = extractor.Extract(fileName, targetDir);
             var textFileName = Path.Combine(targetDir, "my resource.txt");
             var text = File.ReadAllText(textFileName);
             var fileInfo = new FileInfo(textFileName);
@@ -53,7 +53,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var extractor = (IPackageExtractor)Activator.CreateInstance(extractorType);
             var targetDir = GetTargetDir(extractorType, fileName);
 
-            extractor.Extract(fileName, targetDir, true);
+            extractor.Extract(fileName, targetDir);
             var textFileName = Path.Combine(targetDir, "file-from-child-archive.txt");
             Assert.That(File.Exists(textFileName), Is.False, $"The file '{Path.GetFileName(textFileName)}' should not have been extracted.");
             var childArchiveName = Path.Combine(targetDir, "child-archive." + extension);
@@ -73,7 +73,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var extractor = (IPackageExtractor)Activator.CreateInstance(extractorType);
             var targetDir = GetTargetDir(extractorType, fileName);
 
-            extractor.Extract(fileName, targetDir, true);
+            extractor.Extract(fileName, targetDir);
             var textFileName = Path.Combine(targetDir, "ChildFolder", "file-in-child-folder.txt");
             Assert.That(File.Exists(textFileName), Is.True, $"The file '{Path.GetFileName(textFileName)}' should have been extracted.");
 
@@ -91,7 +91,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var extractor = (IPackageExtractor)Activator.CreateInstance(extractorType);
             var targetDir = GetTargetDir(extractorType, fileName);
 
-            extractor.Extract(fileName, targetDir, true);
+            extractor.Extract(fileName, targetDir);
             var textFileName = Path.Combine(targetDir, "package", "services", "metadata", "core-properties", "8e89f0a759d94c1aaab0626891f7b81f.psmdcp");
             Assert.That(File.Exists(textFileName), Is.False, $"The file '{Path.GetFileName(textFileName)}' should not have been extracted.");
         }
@@ -109,7 +109,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var extractor = (IPackageExtractor)Activator.CreateInstance(extractorType);
             var targetDir = GetTargetDir(extractorType, fileName);
 
-            extractor.Extract(fileName, targetDir, true);
+            extractor.Extract(fileName, targetDir);
             var folderName = Path.Combine(targetDir, "EmptyFolder");
             Assert.That(Directory.Exists(folderName), Is.True, $"The empty folder '{Path.GetFileName(folderName)}' should have been extracted.");
         }
@@ -125,7 +125,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                 var extractor = new TarGzipPackageExtractor();
                 var targetDir = GetTargetDir(typeof(TarGzipPackageExtractor), fileName);
 
-                extractor.Extract(fileName, targetDir, true);
+                extractor.Extract(fileName, targetDir);
 
                 //If we get this far and an exception hasn't been thrown, the test has served it's purpose'
 

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -61,7 +61,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 {
                     DownloadHelmPackage(ExplicitExeVersion, fileName);
 
-                    new TarGzipPackageExtractor().Extract(fileName, explicitVersionTempDirectory.DirectoryPath, false);
+                    new TarGzipPackageExtractor().Extract(fileName, explicitVersionTempDirectory.DirectoryPath);
                 }
             }
         }


### PR DESCRIPTION
Removed `SuppressNestedScriptWarning` as it's no longer relevant. (see https://octopusdeploy.slack.com/archives/C3KT1DFSM/p1585190441003100)
Created `PackageExtractionOptions` so we don't need to repeat the exact same `ExtractionOptions` all over the place