### PR TITLE
Do not return a remote path when pulling docker images

### DIFF
--- a/source/Calamari.Shared/Deployment/Conventions/StageScriptPackagesConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/StageScriptPackagesConvention.cs
@@ -52,7 +52,7 @@ namespace Calamari.Deployment.Conventions
                 
                 if (string.IsNullOrWhiteSpace(packageOriginalPath))
                 {
-                    Log.Info($"Package '{packageReferenceName}' was not acquired");
+                    Log.Info($"Package '{packageReferenceName}' was not acquired or does not require staging");
                     continue;
                 }
                 

--- a/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
@@ -47,7 +47,7 @@ namespace Calamari.Integration.Packages.Download
             var feedHost = GetFeedHost(feedUri);
             PerformPull(username, password, fullImageName, feedHost);
             var (hash, size) = GetImageDetails(fullImageName);
-            return new PackagePhysicalFileMetadata(new PackageFileNameMetadata(packageId, version, ""), fullImageName, hash, size);
+            return new PackagePhysicalFileMetadata(new PackageFileNameMetadata(packageId, version, ""), string.Empty, hash, size);
         }
 
         static string GetFullImageName(string packageId, IVersion version, Uri feedUri)

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using Calamari.Commands.Support;
 using Calamari.Hooks;
 using Calamari.Integration.FileSystem;
-using Calamari.Integration.Packages;
 using Calamari.Integration.Packages.Download;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;
@@ -22,8 +20,8 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         static readonly string AuthFeedUri =   "https://octopusdeploy-docker.jfrog.io";
         static readonly string FeedUsername = "e2e-reader";
         static readonly string FeedPassword = ExternalVariables.Get(ExternalVariable.HelmPassword);
-        static string home = Path.GetTempPath();
-        
+        static readonly string Home = Path.GetTempPath();
+
         static readonly string DockerHubFeedUri = "https://index.docker.io";
         static readonly string DockerTestUsername = "octopustestaccount";
         static readonly string DockerTestPassword = ExternalVariables.Get(ExternalVariable.DockerReaderPassword);
@@ -31,7 +29,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [OneTimeSetUp]
         public void TestFixtureSetUp()
         {
-            Environment.SetEnvironmentVariable("TentacleHome", home);
+            Environment.SetEnvironmentVariable("TentacleHome", Home);
         }
 
         [OneTimeTearDown]
@@ -39,7 +37,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         {
             Environment.SetEnvironmentVariable("TentacleHome", null);
         }
-                   
+
         [Test]
         [RequiresDockerInstalledAttribute]
         public void PackageWithoutCredentials_Loads()
@@ -49,16 +47,17 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                 new SemanticVersion("3.6.5"), "docker-feed", 
                 new Uri(DockerHubFeedUri), null, true, 1,
                 TimeSpan.FromSeconds(3));
-            
+
             Assert.AreEqual("alpine", pkg.PackageId);
             Assert.AreEqual(new SemanticVersion("3.6.5"), pkg.Version);
+            Assert.AreEqual(string.Empty, pkg.FullFilePath);
         }
-        
+
         [Test]
         [RequiresDockerInstalledAttribute]
         public void DockerHubWithCredentials_Loads()
         {
-            var privateImage = "octopusdeploy/private-alpine";
+            const string privateImage = "octopusdeploy/private-alpine";
             var version =  new SemanticVersion("1.0.0");
 
             var downloader = GetDownloader();
@@ -70,11 +69,12 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                 true, 
                 1,
                 TimeSpan.FromSeconds(3));
-            
+
             Assert.AreEqual(privateImage, pkg.PackageId);
             Assert.AreEqual(version, pkg.Version);
+            Assert.AreEqual(string.Empty, pkg.FullFilePath);
         }
-        
+
         [Test]
         [RequiresDockerInstalledAttribute]
         public void PackageWithCredentials_Loads()
@@ -86,11 +86,12 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                 new Uri(AuthFeedUri), 
                 new NetworkCredential(FeedUsername, FeedPassword), true, 1,
                 TimeSpan.FromSeconds(3));
-            
+
             Assert.AreEqual("octopus-echo", pkg.PackageId);
             Assert.AreEqual(new SemanticVersion("1.1"), pkg.Version);
+            Assert.AreEqual(string.Empty, pkg.FullFilePath);
         }
-        
+
         [Test]
         [RequiresDockerInstalledAttribute]
         public void PackageWithWrongCredentials_Fails()
@@ -101,7 +102,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                 new Uri(AuthFeedUri), 
                 new NetworkCredential(FeedUsername, "SuperDooper"), true, 1,
                 TimeSpan.FromSeconds(3)));
-            
+
             StringAssert.Contains("Unable to pull Docker image", exception.Message);
         }
 
@@ -110,6 +111,5 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var runner = new CommandLineRunner(new ConsoleCommandOutput());
             return new DockerImagePackageDownloader(new CombinedScriptEngine(Enumerable.Empty<IScriptWrapper>()), CalamariPhysicalFileSystem.GetPhysicalFileSystem(), runner, new CalamariVariables());
         }
-        
     }
 }


### PR DESCRIPTION
There isn't really a remote path when a docker image is pulled. On the server we will not attempt to stage packages without a remote path, so this will make the docker package pull compatible with referencing docker packages from steps other than docker. Enables package pull during acqusition for action container images.