### PR TITLE
Log failed get encrypted variables string in calamari verbose output

### DIFF
--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -363,14 +363,14 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
             {
                 string value = null;
 
-                Log.Verbose($"Getting ecnrypted variabes string for {variableName}");
+                Log.Verbose($"Getting ecnrypted variables string for {variableName}");
                 try
                 {
                     value = variables.Get(variableName);
                 }
                 catch (Exception ex)
                 {
-                    Log.Error($"Error getting ecnrypted variabes string for {variableName}");
+                    Log.Error($"Error getting ecnrypted variables string for {variableName}");
                     throw ex;
                 }
 

--- a/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari.Shared/Integration/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -361,7 +361,19 @@ namespace Calamari.Integration.Scripting.WindowsPowerShell
             var sb = new StringBuilder();
             foreach (var variableName in variables.GetNames().Where(name => !SpecialVariables.IsLibraryScriptModule(name)))
             {
-                var value = variables.Get(variableName);
+                string value = null;
+
+                Log.Verbose($"Getting ecnrypted variabes string for {variableName}");
+                try
+                {
+                    value = variables.Get(variableName);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"Error getting ecnrypted variabes string for {variableName}");
+                    throw ex;
+                }
+
                 var encryptedValue = value == null ? "nul" : EncodeAsBase64(value); // "nul" is not a valid Base64 string
                 sb.Append(EncodeAsBase64(variableName)).Append("$").AppendLine(encryptedValue);
             }


### PR DESCRIPTION
Add log entries to find variables that fail call Calamari.Integration.Scripting.WindowsPowerShell.PowerShellBootstrapper.GetEncryptedVariablesString(IVariables variables), as described in forum post  https://help.octopus.com/t/calamari-tentacle-throws-index-was-out-of-range-argumentoutofrangeexception-on-variables-parsing/24963