### PR TITLE
Adds logging when exceptions occur acquiring semaphores or mutexes

### DIFF
--- a/source/Calamari.Shared/Integration/Processes/Semaphores/SystemSemaphoreManager.cs
+++ b/source/Calamari.Shared/Integration/Processes/Semaphores/SystemSemaphoreManager.cs
@@ -2,6 +2,7 @@
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Threading;
+using Calamari.Util;
 
 namespace Calamari.Integration.Processes.Semaphores
 {
@@ -37,8 +38,10 @@ namespace Calamari.Integration.Processes.Semaphores
             {
                 semaphore = CreateGlobalSemaphoreAccessibleToEveryone(globalName);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                log.Verbose($"Acquiring semaphore failed: {ex.PrettyPrint()}");
+                log.Verbose("Retrying without setting access controls...");
                 semaphore = new Semaphore(1, 1, globalName);
             }
 
@@ -73,8 +76,10 @@ namespace Calamari.Integration.Processes.Semaphores
             {
                 mutex = CreateGlobalMutexAccessibleToEveryone(globalName);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                log.Verbose($"Acquiring mutex failed: {ex.PrettyPrint()}");
+                log.Verbose("Retrying without setting access controls...");
                 mutex = new Mutex(false, globalName);
             }
 
@@ -109,7 +114,7 @@ namespace Calamari.Integration.Processes.Semaphores
             semaphoreSecurity.AddAccessRule(rule);
 
             bool createdNew;
-            
+
             var semaphore = new Semaphore(1, 1, name, out createdNew);
             semaphore.SetAccessControl(semaphoreSecurity);
             return semaphore;


### PR DESCRIPTION
Adds logging to Calamari's `SystemSemaphoreManager` so we can attempt to diagnose an issue intermittently occurring during attempting to acquire semaphores.

https://trello.com/c/U5KSylrj/3181-intermittent-semaphore-error-during-octopus-server-shipping