### PR TITLE
Allowed packaging to be specified in maven coordinates

### DIFF
--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -47,7 +47,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Octodiff" Version="1.1.2" />
-    <PackageReference Include="Octopus.Versioning" Version="4.1.4" />
+    <PackageReference Include="Octopus.Versioning" Version="4.1.5-relaxed-validati0004" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="Octostache" Version="2.7.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -47,7 +47,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Octodiff" Version="1.1.2" />
-    <PackageReference Include="Octopus.Versioning" Version="4.1.5-relaxed-validati0004" />
+    <PackageReference Include="Octopus.Versioning" Version="4.1.6" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="Octostache" Version="2.7.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />

--- a/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
@@ -218,7 +218,7 @@ namespace Calamari.Integration.Packages.Download
             var fileChecks = JarPackageExtractor.SupportedExtensions
                 .Union(AdditionalExtensions)
                 // Either consider all supported extensions, or select only the specified extension
-                .Where(e => string.IsNullOrEmpty(mavenPackageId.Packaging) || e == mavenPackageId.Packaging)
+                .Where(e => string.IsNullOrEmpty(mavenPackageId.Packaging) || e == "." + mavenPackageId.Packaging)
                 .Select(extension =>
                 {
                     var packageId = new MavenPackageID(mavenPackageId.Group, mavenPackageId.Artifact,

--- a/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
@@ -128,7 +128,7 @@ namespace Calamari.Integration.Packages.Download
             Log.VerboseFormat("Downloaded package will be stored in: '{0}'", cacheDirectory);
             freeSpaceChecker.EnsureDiskHasEnoughFreeSpace(cacheDirectory);
 
-            var mavenPackageId = new MavenPackageID(packageId, version);
+            var mavenPackageId = MavenPackageID.CreatePackageIDFromUIInput(packageId, version);
             
             var snapshotMetadata = GetSnapshotMetadata(mavenPackageId,  feedUri,  feedCredentials,  maxDownloadAttempts, downloadAttemptBackoff);
 
@@ -217,7 +217,8 @@ namespace Calamari.Integration.Packages.Download
             var errors = new ConcurrentBag<string>();
             var fileChecks = JarPackageExtractor.SupportedExtensions
                 .Union(AdditionalExtensions)
-                .AsParallel()
+                // Either consider all supported extensions, or select only the specified extension
+                .Where(e => string.IsNullOrEmpty(mavenPackageId.Packaging) || e == mavenPackageId.Packaging)
                 .Select(extension =>
                 {
                     var packageId = new MavenPackageID(mavenPackageId.Group, mavenPackageId.Artifact,

--- a/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
@@ -128,7 +128,7 @@ namespace Calamari.Integration.Packages.Download
             Log.VerboseFormat("Downloaded package will be stored in: '{0}'", cacheDirectory);
             freeSpaceChecker.EnsureDiskHasEnoughFreeSpace(cacheDirectory);
 
-            var mavenPackageId = MavenPackageID.CreatePackageIDFromUIInput(packageId, version);
+            var mavenPackageId = MavenPackageID.CreatePackageIdFromOctopusInput(packageId, version);
             
             var snapshotMetadata = GetSnapshotMetadata(mavenPackageId,  feedUri,  feedCredentials,  maxDownloadAttempts, downloadAttemptBackoff);
 

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -57,7 +57,7 @@
     <ProjectReference Include="..\Calamari.Shared\Calamari.Shared.csproj" />
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
-    <PackageReference Include="Octopus.Versioning" Version="4.1.5-relaxed-validati0004" />
+    <PackageReference Include="Octopus.Versioning" Version="4.1.6" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -57,7 +57,7 @@
     <ProjectReference Include="..\Calamari.Shared\Calamari.Shared.csproj" />
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
-    <PackageReference Include="Octopus.Versioning" Version="4.1.4" />
+    <PackageReference Include="Octopus.Versioning" Version="4.1.5-relaxed-validati0004" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />


### PR DESCRIPTION
This update allows maven package types to be specified where a repo contains multiple files with different extensions e.g. `org.example:myapp:jar` and `org.example:myapp:zip`.