### PR TITLE
Maven classifiers

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -51,7 +51,7 @@
 
     <ItemGroup>
       <PackageReference Include="Octopus.CoreUtilities" Version="1.1.2" />
-      <PackageReference Include="Octopus.Versioning" Version="4.1.7-ci0005" />
+      <PackageReference Include="Octopus.Versioning" Version="4.1.8" />
       <PackageReference Include="Octostache" Version="2.7.0" />
       <PackageReference Include="SharpCompress" Version="0.24.0" />
       <PackageReference Include="YamlDotNet" Version="8.1.0" />

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -51,7 +51,7 @@
 
     <ItemGroup>
       <PackageReference Include="Octopus.CoreUtilities" Version="1.1.2" />
-      <PackageReference Include="Octopus.Versioning" Version="4.1.4" />
+      <PackageReference Include="Octopus.Versioning" Version="4.1.7-ci0005" />
       <PackageReference Include="Octostache" Version="2.7.0" />
       <PackageReference Include="SharpCompress" Version="0.24.0" />
       <PackageReference Include="YamlDotNet" Version="8.1.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -47,7 +47,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Octodiff" Version="1.1.2" />
-    <PackageReference Include="Octopus.Versioning" Version="4.1.7-ci0005" />
+    <PackageReference Include="Octopus.Versioning" Version="4.1.8" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="Octostache" Version="2.7.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -47,7 +47,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Octodiff" Version="1.1.2" />
-    <PackageReference Include="Octopus.Versioning" Version="4.1.6" />
+    <PackageReference Include="Octopus.Versioning" Version="4.1.7-ci0005" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="Octostache" Version="2.7.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />

--- a/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
@@ -221,8 +221,12 @@ namespace Calamari.Integration.Packages.Download
                 .Where(e => string.IsNullOrEmpty(mavenPackageId.Packaging) || e == "." + mavenPackageId.Packaging)
                 .Select(extension =>
                 {
-                    var packageId = new MavenPackageID(mavenPackageId.Group, mavenPackageId.Artifact,
-                        mavenPackageId.Version, Regex.Replace(extension, "^\\.", ""));
+                    var packageId = new MavenPackageID(
+                        mavenPackageId.Group, 
+                        mavenPackageId.Artifact,
+                        mavenPackageId.Version, 
+                        Regex.Replace(extension, "^\\.", ""),
+                        mavenPackageId.Classifier);
                     var result = MavenPackageExists(packageId, feedUri, feedCredentials, snapshotMetadata);
                     errors.Add(result.ErrorMsg);
                     return new

--- a/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
@@ -174,8 +174,8 @@ namespace Calamari.Integration.Packages.Download
                                   : mavenGavFirst.SnapshotArtifactPath(GetLatestSnapshotRelease(
                                       snapshotMetadata,
                                       mavenGavFirst.Packaging,
-                                      mavenGavFirst.Version,
-                                      mavenGavFirst.Classifier)));
+                                      mavenGavFirst.Classifier,
+                                      mavenGavFirst.Version)));
 
             for (var retry = 0; retry < maxDownloadAttempts; ++retry)
             {

--- a/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
@@ -260,8 +260,8 @@ namespace Calamari.Integration.Packages.Download
                               GetLatestSnapshotRelease(
                                   snapshotMetadata,
                                   mavenGavParser.Packaging,
-                                  mavenGavParser.Version,
-                                  mavenGavParser.Classifier)));
+                                  mavenGavParser.Classifier,
+                                  mavenGavParser.Version)));
 
             try
             {
@@ -275,7 +275,7 @@ namespace Calamari.Integration.Packages.Download
             }
             catch(Exception ex)
             {
-                return (false, ex.Message);
+                return (false, $"Failed to download {uri}\n" + ex.Message);
             }
         }
 

--- a/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
@@ -174,7 +174,8 @@ namespace Calamari.Integration.Packages.Download
                                   : mavenGavFirst.SnapshotArtifactPath(GetLatestSnapshotRelease(
                                       snapshotMetadata,
                                       mavenGavFirst.Packaging,
-                                      mavenGavFirst.Version)));
+                                      mavenGavFirst.Version,
+                                      mavenGavFirst.Classifier)));
 
             for (var retry = 0; retry < maxDownloadAttempts; ++retry)
             {
@@ -259,7 +260,8 @@ namespace Calamari.Integration.Packages.Download
                               GetLatestSnapshotRelease(
                                   snapshotMetadata,
                                   mavenGavParser.Packaging,
-                                  mavenGavParser.Version)));
+                                  mavenGavParser.Version,
+                                  mavenGavParser.Classifier)));
 
             try
             {
@@ -330,7 +332,7 @@ namespace Calamari.Integration.Packages.Download
         }
 
         //Shared code with Server. Should live in Common Location
-        public string GetLatestSnapshotRelease(XmlDocument snapshotMetadata, string extension, string defaultVersion = "")
+        public string GetLatestSnapshotRelease(XmlDocument snapshotMetadata, string extension, string classifier, string defaultVersion = "")
         {
             return snapshotMetadata.ToEnumerable()
                        .Select(doc => doc.DocumentElement?.SelectSingleNode("./*[local-name()='versioning']"))
@@ -338,6 +340,8 @@ namespace Calamari.Integration.Packages.Download
                        .Where(nodes => nodes != null)
                        .SelectMany(nodes => nodes.Cast<XmlNode>())
                        .Where(node => (node.SelectSingleNode("./*[local-name()='extension']")?.InnerText.Trim() ?? "").Equals(extension.Trim(), StringComparison.OrdinalIgnoreCase))
+                       // Classifier is optional, and the XML element does not exists if the artifact has no classifier
+                       .Where(node => classifier == null || (node.SelectSingleNode("./*[local-name()='classifier']")?.InnerText.Trim() ?? "").Equals(classifier.Trim(), StringComparison.OrdinalIgnoreCase))
                        .OrderByDescending(node => node.SelectSingleNode("./*[local-name()='updated']")?.InnerText)
                        .Select(node => node.SelectSingleNode("./*[local-name()='value']")?.InnerText)
                        .FirstOrDefault() ?? defaultVersion;

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/MavenPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/MavenPackageDownloaderFixture.cs
@@ -39,5 +39,17 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
 
             Assert.AreEqual("com.google.guava:guava", pkg.PackageId);
         }
+        
+        [Test]
+        [RequiresMonoVersion480OrAboveForTls12]
+        [RequiresNonFreeBSDPlatform]
+        public void DownloadMavenSourcePackage()
+        {
+            var downloader = new MavenPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new FreeSpaceChecker(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new CalamariVariables()));
+            var pkg = downloader.DownloadPackage("com.google.guava:guava:jar:sources", VersionFactory.CreateMavenVersion("22.0"), "feed-maven",
+                new Uri("https://repo.maven.apache.org/maven2/"), new NetworkCredential("", ""), true, 3, TimeSpan.FromSeconds(3));
+
+            Assert.AreEqual("com.google.guava:guava:jar:sources", pkg.PackageId);
+        }
     }
 }

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -53,7 +53,7 @@
     <ProjectReference Include="..\Calamari.Shared\Calamari.Shared.csproj" />
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
-    <PackageReference Include="Octopus.Versioning" Version="4.1.7-ci0005" />
+    <PackageReference Include="Octopus.Versioning" Version="4.1.8" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -53,7 +53,7 @@
     <ProjectReference Include="..\Calamari.Shared\Calamari.Shared.csproj" />
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
-    <PackageReference Include="Octopus.Versioning" Version="4.1.6" />
+    <PackageReference Include="Octopus.Versioning" Version="4.1.7-ci0005" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />


### PR DESCRIPTION
This PR adds support for specifying Maven classifiers e.g. `com.google.guava:guava:jar:sources`.