### PR TITLE
Skip inaccessible stores when retrieving certificate for IIS HTTPS bindings

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -481,8 +481,9 @@ if ($deployAsWebSite)
 		}
 
 		Write-Host "Finding SSL certificate with thumbprint $sslCertificateThumbprint"
-	
-		$certificate = Get-ChildItem Cert:\LocalMachine -Recurse | Where-Object { $_.Thumbprint -eq $sslCertificateThumbprint -and $_.HasPrivateKey -eq $true } | Select-Object -first 1
+
+		$accessibleCertificates = Get-ChildItem Cert:\LocalMachine | Foreach-Object { Get-ChildItem "Cert:\LocalMachine\$($_.Name)" -ErrorAction Ignore }
+		$certificate = $accessibleCertificates | Where-Object { $_.Thumbprint -eq $sslCertificateThumbprint -and $_.HasPrivateKey -eq $true } | Select-Object -first 1
 		if (! $certificate) 
 		{
 			throw "Could not find certificate under Cert:\LocalMachine with thumbprint $sslCertificateThumbprint. Make sure that the certificate is installed to the Local Machine context and that the private key is available."


### PR DESCRIPTION
In some environments, while retrieving a certificate for use in an IIS website's HTTPS bindings, an inaccessible certificate store (e.g. UserDS) causes the deployment to fail. 

This PR aims to change the behavior so that an individual inaccessible certificate store is _skipped_, rather than causing the search for certificates to be terminated.

See https://help.octopus.com/t/userds-certificate-store-causing-deployment-with-a-certificate-to-fail/24852/4.

Relates to https://github.com/OctopusDeploy/Issues/issues/6376.

- [ ] Merge this to Calamari 2020.2 and master branches
- [ ] Bump Calamari versions in OctopusDeploy (2020.2 and master)