### PR TITLE
Merge forward to `master`: Skip inaccessible stores when retrieving certificate for IIS HTTPS bindings (#560)

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/Download/Scripts/DockerPull.ps1
+++ b/source/Calamari.Shared/Integration/Packages/Download/Scripts/DockerPull.ps1
@@ -11,9 +11,9 @@ if (-not ([string]::IsNullOrEmpty($dockerUsername))) {
     $parsedVersion = [Version]($dockerVersion -split '-')[0]
     $dockerNeedsPasswordViaStdIn = (($parsedVersion.Major -gt 17) -or (($parsedVersion.Major -eq 17) -and ($parsedVersion.Minor -gt 6)))
     if ($dockerNeedsPasswordViaStdIn) {
-        echo $dockerPassword | docker login --username $dockerUsername --password-stdin $feedUri
+        echo $dockerPassword | cmd /c "docker login --username $dockerUsername --password-stdin $feedUri 2>&1"
     } else {
-        docker login --username $dockerUsername --password $dockerPassword $feedUri
+        cmd /c "docker login --username $dockerUsername --password $dockerPassword $feedUri 2>&1"
     }
     
     if(!$?)

--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -481,8 +481,17 @@ if ($deployAsWebSite)
 		}
 
 		Write-Host "Finding SSL certificate with thumbprint $sslCertificateThumbprint"
-	
-		$certificate = Get-ChildItem Cert:\LocalMachine -Recurse | Where-Object { $_.Thumbprint -eq $sslCertificateThumbprint -and $_.HasPrivateKey -eq $true } | Select-Object -first 1
+		foreach ($certStore in (Get-ChildItem Cert:\LocalMachine)) {
+			try {
+				$certs = Get-ChildItem "Cert:\LocalMachine\$($certStore.Name)" -ErrorAction Stop
+				$certificate = $certs | Where-Object { $_.Thumbprint -eq $sslCertificateThumbprint -and $_.HasPrivateKey -eq $true } | Select-Object -first 1
+				if ($certificate) {
+					break
+				}
+			} catch {
+				Write-Host "Skipping inaccessible certificate store '$($certStore.Name)': $_"
+			}
+		}
 		if (! $certificate) 
 		{
 			throw "Could not find certificate under Cert:\LocalMachine with thumbprint $sslCertificateThumbprint. Make sure that the certificate is installed to the Local Machine context and that the private key is available."


### PR DESCRIPTION
- Merge https://github.com/OctopusDeploy/Calamari/pull/560 forward from `release/2020.2` to `master`
- [ ] Merge, don't squash