### PR TITLE
Redirect stderr to stdout during docker pull

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/Download/Scripts/DockerPull.ps1
+++ b/source/Calamari.Shared/Integration/Packages/Download/Scripts/DockerPull.ps1
@@ -11,9 +11,9 @@ if (-not ([string]::IsNullOrEmpty($dockerUsername))) {
     $parsedVersion = [Version]($dockerVersion -split '-')[0]
     $dockerNeedsPasswordViaStdIn = (($parsedVersion.Major -gt 17) -or (($parsedVersion.Major -eq 17) -and ($parsedVersion.Minor -gt 6)))
     if ($dockerNeedsPasswordViaStdIn) {
-        echo $dockerPassword | docker login --username $dockerUsername --password-stdin $feedUri 2>&1
+        echo $dockerPassword | cmd /c "docker login --username $dockerUsername --password-stdin $feedUri 2>&1"
     } else {
-        docker login --username $dockerUsername --password $dockerPassword $feedUri 2>&1
+        cmd /c "docker login --username $dockerUsername --password $dockerPassword $feedUri 2>&1"
     }
     
     if(!$?)

--- a/source/Calamari.Shared/Integration/Packages/Download/Scripts/DockerPull.ps1
+++ b/source/Calamari.Shared/Integration/Packages/Download/Scripts/DockerPull.ps1
@@ -11,9 +11,9 @@ if (-not ([string]::IsNullOrEmpty($dockerUsername))) {
     $parsedVersion = [Version]($dockerVersion -split '-')[0]
     $dockerNeedsPasswordViaStdIn = (($parsedVersion.Major -gt 17) -or (($parsedVersion.Major -eq 17) -and ($parsedVersion.Minor -gt 6)))
     if ($dockerNeedsPasswordViaStdIn) {
-        echo $dockerPassword | docker login --username $dockerUsername --password-stdin $feedUri
+        echo $dockerPassword | docker login --username $dockerUsername --password-stdin $feedUri 2>&1
     } else {
-        docker login --username $dockerUsername --password $dockerPassword $feedUri
+        docker login --username $dockerUsername --password $dockerPassword $feedUri 2>&1
     }
     
     if(!$?)


### PR DESCRIPTION
When attempting to deploy to a windows target using the Run a docker container step template, and pulling the container from a registry that requires authentication, the deployment will fail due to the windows docker cli writing a warning to stderr on Docker versions >= 17.7.

We use stream redirection on the linux shell script version of this calamari script, but the windows version does not.

This PR wraps the calls in `cmd /c "..."` to get the redirection to work correctly.

Relates to OctopusDeploy/Issues#6360
Supercedes https://github.com/OctopusDeploy/Calamari/pull/556