### PR TITLE
Use full password argument because of Azure bug

### DIFF
--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -131,7 +131,8 @@ Execute-WithRetry{
 
                     $loginArgs = @();
                     $loginArgs += @("-u", (ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADClientId))));
-                    $loginArgs += @("-p", (ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADPassword))));
+                    # Use the full argument because of https://github.com/Azure/azure-cli/issues/12105
+                    $loginArgs += @("--password", (ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADPassword))));
                     $loginArgs += @("--tenant", (ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADTenantId))));
                     az login --service-principal $loginArgs
 

--- a/source/Calamari.Azure/Scripts/AzureContext.sh
+++ b/source/Calamari.Azure/Scripts/AzureContext.sh
@@ -25,7 +25,8 @@ function setup_context {
         echo "Azure CLI: Authenticating with Service Principal"
         loginArgs=()
         loginArgs+=("-u $Octopus_Azure_ADClientId")
-        loginArgs+=("-p $Octopus_Azure_ADPassword")
+        # Use the full argument because of https://github.com/Azure/azure-cli/issues/12105
+        loginArgs+=("-password $Octopus_Azure_ADPassword")
         loginArgs+=("--tenant $Octopus_Azure_ADTenantId")
         echo az login --service-principal ${loginArgs[@]}
         az login --service-principal ${loginArgs[@]}

--- a/source/Calamari.Azure/Scripts/AzureContext.sh
+++ b/source/Calamari.Azure/Scripts/AzureContext.sh
@@ -26,7 +26,7 @@ function setup_context {
         loginArgs=()
         loginArgs+=("-u $Octopus_Azure_ADClientId")
         # Use the full argument because of https://github.com/Azure/azure-cli/issues/12105
-        loginArgs+=("-password $Octopus_Azure_ADPassword")
+        loginArgs+=("--password $Octopus_Azure_ADPassword")
         loginArgs+=("--tenant $Octopus_Azure_ADTenantId")
         echo az login --service-principal ${loginArgs[@]}
         az login --service-principal ${loginArgs[@]}


### PR DESCRIPTION
The Azure CLI bug at https://github.com/Azure/azure-cli/issues/12105 means that passwords starting with a dash are not processed correctly. This PR uses the full `--password` option to fix the issue.