### PR TITLE
Time has come for async commands in the new world

### DIFF
--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -15,7 +15,6 @@ using Calamari.Integration.Processes;
 using Calamari.Integration.Proxies;
 using Calamari.Integration.Substitutions;
 using Calamari.Plumbing;
-using Calamari.Util;
 using Calamari.Util.Environments;
 using Calamari.Variables;
 using NuGet;
@@ -123,7 +122,7 @@ namespace Calamari
             {
                 yield return programAssembly; // Calamari Flavour
             }
-            
+
             yield return typeof(CalamariFlavourProgram).Assembly; // Calamari.Common
         }
     }

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -1,0 +1,134 @@
+﻿#if !NET40
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Autofac;
+using Autofac.Core;
+using Autofac.Core.Registration;
+using Calamari.Commands.Support;
+using Calamari.Common.Features.Scripting;
+using Calamari.Common.Variables;
+using Calamari.Deployment.Conventions;
+using Calamari.Integration.FileSystem;
+using Calamari.Integration.Packages;
+using Calamari.Integration.Processes;
+using Calamari.Integration.Proxies;
+using Calamari.Integration.Substitutions;
+using Calamari.Plumbing;
+using Calamari.Util.Environments;
+using Calamari.Variables;
+
+namespace Calamari
+{
+    public abstract class CalamariFlavourProgramAsync
+    {
+        readonly ILog log;
+
+        protected CalamariFlavourProgramAsync(ILog log)
+        {
+            this.log = log;
+        }
+
+        protected virtual void ConfigureContainer(ContainerBuilder builder, CommonOptions options)
+        {
+            var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+            builder.RegisterInstance(fileSystem).As<ICalamariFileSystem>();
+            builder.RegisterType<VariablesFactory>().AsSelf();
+            builder.Register(c => c.Resolve<VariablesFactory>().Create(options)).As<IVariables>().SingleInstance();
+            builder.RegisterType<ScriptEngine>().As<IScriptEngine>();
+            builder.RegisterType<VariableLogger>().AsSelf();
+            builder.RegisterInstance(log).As<ILog>().SingleInstance();
+            builder.RegisterType<FreeSpaceChecker>().As<IFreeSpaceChecker>().SingleInstance();
+            builder.RegisterType<CommandLineRunner>().As<ICommandLineRunner>().SingleInstance();
+            builder.RegisterType<FileSubstituter>().As<IFileSubstituter>();
+            builder.RegisterType<SubstituteInFiles>().As<ISubstituteInFiles>();
+            builder.RegisterType<CombinedPackageExtractor>().As<ICombinedPackageExtractor>();
+            builder.RegisterType<ExtractPackage>().As<IExtractPackage>();
+
+            var assemblies = GetAllAssembliesToRegister().ToArray();
+
+            builder.RegisterAssemblyTypes(assemblies)
+                .AssignableTo<IScriptWrapper>()
+                .Except<TerminalScriptWrapper>()
+                .As<IScriptWrapper>()
+                .SingleInstance();
+
+            builder.RegisterAssemblyTypes(assemblies)
+                .AssignableTo<ICommandAsync>()
+                .Where(t => t.GetCustomAttribute<CommandAttribute>().Name
+                    .Equals(options.Command, StringComparison.OrdinalIgnoreCase))
+                .Named<ICommandAsync>(t => t.GetCustomAttribute<CommandAttribute>().Name);
+        }
+
+        Assembly GetProgramAssemblyToRegister()
+        {
+            return GetType().Assembly;
+        }
+
+        protected async Task<int> Run(string[] args)
+        {
+            try
+            {
+                SecurityProtocols.EnableAllSecurityProtocols();
+                var options = CommonOptions.Parse(args);
+
+                log.Verbose($"Calamari Version: {GetType().Assembly.GetInformationalVersion()}");
+
+                if (options.Command.Equals("version", StringComparison.OrdinalIgnoreCase))
+                {
+                    return 0;
+                }
+
+                var envInfo = string.Join($"{Environment.NewLine}  ",
+                    EnvironmentHelper.SafelyGetEnvironmentInformation());
+                log.Verbose($"Environment Information: {Environment.NewLine}  {envInfo}");
+
+                EnvironmentHelper.SetEnvironmentVariable("OctopusCalamariWorkingDirectory",
+                    Environment.CurrentDirectory);
+                ProxyInitializer.InitializeDefaultProxy();
+
+                var builder = new ContainerBuilder();
+                ConfigureContainer(builder, options);
+                using (var container = builder.Build())
+                {
+                    container.Resolve<VariableLogger>().LogVariables();
+
+                    await ResolveAndExecuteCommand(container, options);
+                    return 0;
+                }
+            }
+            catch (Exception ex)
+            {
+                return ConsoleFormatter.PrintError(ConsoleLog.Instance, ex);
+            }
+        }
+
+        IEnumerable<Assembly> GetAllAssembliesToRegister()
+        {
+            var programAssembly = GetProgramAssemblyToRegister();
+            if (programAssembly != null)
+            {
+                yield return programAssembly; // Calamari Flavour
+            }
+
+            yield return typeof(CalamariFlavourProgram).Assembly; // Calamari.Common
+        }
+
+        Task ResolveAndExecuteCommand(IContainer container, CommonOptions options)
+        {
+            try
+            {
+                var command = container.ResolveNamed<ICommandAsync>(options.Command);
+                return command.Execute();
+            }
+            catch (Exception e) when (e is ComponentNotRegisteredException ||
+                                      e is DependencyResolutionException)
+            {
+                throw new CommandException($"Could not find the command {options.Command}");
+            }
+        }
+    }
+}
+#endif

--- a/source/Calamari.Common/Commands/ICommand.cs
+++ b/source/Calamari.Common/Commands/ICommand.cs
@@ -1,12 +1,17 @@
-﻿using System.IO;
+﻿using System.Threading.Tasks;
 
 namespace Calamari.Commands.Support
 {
     /// <summary>
-    /// A command that requires the command line arguments passed to it. We are transitioning away from this interface  
+    /// A command that requires the command line arguments passed to it. We are transitioning away from this interface
     /// </summary>
     public interface ICommand
     {
         int Execute();
+    }
+
+    public interface ICommandAsync
+    {
+        Task Execute();
     }
 }


### PR DESCRIPTION
Added support for `ICommandAsync`.

This comes with a base class for Program.cs to support async Mains.

```c#
public class TestAsyncProgram : CalamariFlavourProgramAsync
{
    public TestAsyncProgram(ILog log) : base(log)
    {
    }

    public static Task<int> Main(string[] args)
    {
        return new TestAsyncProgram(ConsoleLog.Instance).Run(args);
    }
}

public class TestAsyncCommand : ICommandAsync
{
    public Task Execute()
    {
        ...
    }
}
```