### PR TITLE
Setting Azure CLI Extensions Folder to default or variable and test

### DIFF
--- a/source/Calamari.Azure/Integration/AzurePowershellContext.cs
+++ b/source/Calamari.Azure/Integration/AzurePowershellContext.cs
@@ -68,6 +68,9 @@ namespace Calamari.Azure.Integration
                 Log.Info("Using Azure Environment override - {0}", azureEnvironment);
             }
             SetOutputVariable("OctopusAzureEnvironment", azureEnvironment, variables);
+            
+            SetOutputVariable("OctopusAzureExtensionsDirectory",
+                variables.Get(SpecialVariables.Action.Azure.ExtensionsDirectory), variables);
 
             using (new TemporaryFile(Path.Combine(workingDirectory, "AzureProfile.json")))
             using (var contextScriptFile = new TemporaryFile(CreateContextScriptFile(workingDirectory, scriptSyntax)))

--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -124,9 +124,9 @@ Execute-WithRetry{
                     $env:AZURE_CONFIG_DIR = [System.IO.Path]::Combine($env:OctopusCalamariWorkingDirectory, "azure-cli") 
                     EnsureDirectoryExists($env:AZURE_CONFIG_DIR) 
  
-                    # Set the azure extensions directory to $HOME\.azure\cliextension as that's the default, but it's getting 
-                    # overridden above when we set the azure config dir. By defining $env:AZURE_EXTENSION_DIR we can override the 
-                    # directory again back to the default 
+                    # The azure extensions directory is getting overridden above when we set the azure config dir (undocumented behavior). 
+                    # Set the azure extensions directory to the value of $OctopusAzureExtensionsDirectory if specified, 
+                    # otherwise, back to the default value of $HOME\.azure\cliextension.
                     if($OctopusAzureExtensionsDirectory) 
                     { 
                         Write-Host "Setting Azure CLI extensions directory to $OctopusAzureExtensionsDirectory" 
@@ -210,4 +210,3 @@ try {
         }
     }
 }
-

--- a/source/Calamari.Azure/Scripts/AzureContext.ps1
+++ b/source/Calamari.Azure/Scripts/AzureContext.ps1
@@ -17,6 +17,7 @@
 ##   $OctopusAzureADPassword = "..."
 ##   $OctopusAzureEnvironment = "..."
 ##   $OctopusDisableAzureCLI = "..."
+##   $OctopusAzureExtensionsDirectory = "..." 
 
 $ErrorActionPreference = "Stop"
 
@@ -118,8 +119,21 @@ Execute-WithRetry{
                     # authenticate with the Azure CLI
                     Write-Host "##octopus[stdout-verbose]"
 
-                    $env:AZURE_CONFIG_DIR = [System.IO.Path]::Combine($env:OctopusCalamariWorkingDirectory, "azure-cli")
-                    EnsureDirectoryExists($env:AZURE_CONFIG_DIR)
+                    # Config directory is set to make sure that our security is right for the step running it  
+                    # and not using the one in the default config dir to avoid issues with user defined ones 
+                    $env:AZURE_CONFIG_DIR = [System.IO.Path]::Combine($env:OctopusCalamariWorkingDirectory, "azure-cli") 
+                    EnsureDirectoryExists($env:AZURE_CONFIG_DIR) 
+ 
+                    # Set the azure extensions directory to $HOME\.azure\cliextension as that's the default, but it's getting 
+                    # overridden above when we set the azure config dir. By defining $env:AZURE_EXTENSION_DIR we can override the 
+                    # directory again back to the default 
+                    if($OctopusAzureExtensionsDirectory) 
+                    { 
+                        Write-Host "Setting Azure CLI extensions directory to $OctopusAzureExtensionsDirectory" 
+                        $env:AZURE_EXTENSION_DIR = $OctopusAzureExtensionsDirectory 
+                    } else { 
+                        $env:AZURE_EXTENSION_DIR = "$($HOME)\.azure\cliextensions" 
+                    } 
 
                     $previousErrorAction = $ErrorActionPreference
                     $ErrorActionPreference = "Continue"

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -207,6 +207,7 @@ namespace Calamari.Deployment
                 public static readonly string LogExtractedCspkg = "Octopus.Action.Azure.LogExtractedCspkg";
                 public static readonly string CloudServiceConfigurationFileRelativePath = "Octopus.Action.Azure.CloudServiceConfigurationFileRelativePath";
                 public static readonly string DeploymentLabel = "Octopus.Action.Azure.DeploymentLabel";
+                public static readonly string ExtensionsDirectory = "Octopus.Action.Azure.ExtensionsDirectory";
 
                 public static readonly string ResourceGroupName = "Octopus.Action.Azure.ResourceGroupName";
                 public static readonly string ResourceGroupDeploymentName = "Octopus.Action.Azure.ResourceGroupDeploymentName";

--- a/source/Calamari.Tests/AzureFixtures/AzurePowerShellContextFixture.cs
+++ b/source/Calamari.Tests/AzureFixtures/AzurePowerShellContextFixture.cs
@@ -4,6 +4,7 @@ using Calamari.Azure.Integration;
 using Calamari.Deployment;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;
+using Calamari.Tests.Fixtures;
 using Calamari.Tests.Helpers;
 using Calamari.Variables;
 using FluentAssertions;
@@ -40,6 +41,7 @@ namespace Calamari.Tests.AzureFixtures
         [TestCase("")]
         [TestCase("C:\\Azure\\Modules")]
         [TestCase("/etc/azure/modules")]
+        [RequiresPowerShell5OrAbove]
         public void AzureExtension(string extensionsDirectory)
         {
             var variables = new Dictionary<string, string>()

--- a/source/Calamari.Tests/AzureFixtures/AzurePowerShellContextFixture.cs
+++ b/source/Calamari.Tests/AzureFixtures/AzurePowerShellContextFixture.cs
@@ -1,8 +1,10 @@
 #if AZURE_CORE
+using System.Collections.Generic;
 using Calamari.Azure.Integration;
 using Calamari.Deployment;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;
+using Calamari.Tests.Helpers;
 using Calamari.Variables;
 using FluentAssertions;
 using NUnit.Framework;
@@ -10,8 +12,13 @@ using NUnit.Framework;
 namespace Calamari.Tests.AzureFixtures
 {
     [TestFixture]
-    public class AzurePowerShellContextFixture
+    public class AzurePowerShellContextFixture : CalamariFixture
     {
+        static readonly string AzureSubscriptId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
+        static readonly string AzureTenantId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId);
+        static readonly string AzureClientId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId);
+        static readonly string AzurePassword = ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword);
+        
         [Test]
         [TestCase("Azure", "", ScriptSyntax.PowerShell, true)]
         [TestCase("Nope", "", ScriptSyntax.PowerShell, false)]
@@ -27,6 +34,27 @@ namespace Calamari.Tests.AzureFixtures
             var target = new AzurePowerShellContext(variables);
             var actual = target.IsEnabled(syntax);
             actual.Should().Be(expected);
+        }
+        
+        [Test]
+        [TestCase("")]
+        [TestCase("C:\\Azure\\Modules")]
+        [TestCase("/etc/azure/modules")]
+        public void AzureExtension(string extensionsDirectory)
+        {
+            var variables = new Dictionary<string, string>()
+            {
+                {SpecialVariables.Account.AccountType, "AzureServicePrincipal"},
+                {SpecialVariables.Action.Azure.TenantId, AzureTenantId},
+                {SpecialVariables.Action.Azure.ClientId, AzureClientId},
+                {SpecialVariables.Action.Azure.Password, AzurePassword},
+                {SpecialVariables.Action.Azure.SubscriptionId, AzureSubscriptId},
+                {SpecialVariables.Action.Azure.ExtensionsDirectory, extensionsDirectory},
+            };
+            
+            (CalamariResult result, _) = RunScript("azExtensionsModuleFolder.ps1", variables, extensions: new List<string>() {"Calamari.Azure"});
+
+            result.AssertSuccess();
         }
     }
 }

--- a/source/Calamari.Tests/AzureFixtures/Scripts/azExtensionsModuleFolder.ps1
+++ b/source/Calamari.Tests/AzureFixtures/Scripts/azExtensionsModuleFolder.ps1
@@ -1,0 +1,11 @@
+﻿if($OctopusParameters["Octopus.Action.Azure.ExtensionsDirectory"] -eq "") {
+    if($env:AZURE_EXTENSION_DIR -eq "$($HOME)\.azure\cliextensions") {
+        exit 0
+    }
+} else {
+    if($env:AZURE_EXTENSION_DIR -eq $OctopusParameters["Octopus.Action.Azure.ExtensionsDirectory"]) {
+        exit 0
+    }
+}
+
+exit 1

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -64,6 +64,9 @@
     <EmbeddedResource Include="Fixtures\FSharp\Scripts\HelloDefaultValue.fsx" />
     <EmbeddedResource Include="Fixtures\FSharp\Scripts\HelloDirectValue.fsx" />
     <EmbeddedResource Include="Fixtures\FSharp\Scripts\HelloVariableSubstitution.fsx" />
+    <None Include="AzureFixtures\Scripts\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Fixtures\ConfigurationVariables\Samples\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -145,6 +148,9 @@
     <Compile Remove="Fixtures\Deployment\Packages\**\obj\**" />
     <None Remove="Fixtures\Deployment\Packages\**\bin\**" />
     <None Remove="Fixtures\Deployment\Packages\**\obj\**" />
+    <None Update="AzureFixtures\Scripts\azExtensionsModuleFolder.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Remove="TestResults\**" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -148,9 +148,6 @@
     <Compile Remove="Fixtures\Deployment\Packages\**\obj\**" />
     <None Remove="Fixtures\Deployment\Packages\**\bin\**" />
     <None Remove="Fixtures\Deployment\Packages\**\obj\**" />
-    <None Update="AzureFixtures\Scripts\azExtensionsModuleFolder.ps1">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <None Remove="TestResults\**" />

--- a/source/Calamari.Tests/Helpers/CalamariFixture.cs
+++ b/source/Calamari.Tests/Helpers/CalamariFixture.cs
@@ -100,7 +100,8 @@ namespace Calamari.Tests.Helpers
         protected (CalamariResult result, IVariables variables) RunScript(string scriptName,
             Dictionary<string, string> additionalVariables = null,
             Dictionary<string, string> additionalParameters = null,
-            string sensitiveVariablesPassword = null)
+            string sensitiveVariablesPassword = null,
+            IEnumerable<string> extensions = null)
         {
             var variablesFile = Path.GetTempFileName();
             var variables = new CalamariVariables();
@@ -127,6 +128,11 @@ namespace Calamari.Tests.Helpers
                         .Argument("sensitiveVariablesPassword", sensitiveVariablesPassword);
                 }
 
+                if (extensions != null)
+                {
+                    cmdBase.Argument("extensions", string.Join(",", extensions));
+                }
+                
                 cmdBase = (additionalParameters ?? new Dictionary<string, string>()).Aggregate(cmdBase, (cmd, param) => cmd.Argument(param.Key, param.Value));
 
                 var output = Invoke(cmdBase, variables);


### PR DESCRIPTION
If people were trying to use installed extensions such as `az eventgrid` it was setting the extensions directory to within the working directory as the azure cli config directory was being setting and that was overriding the default extensions directors which is expected to have been $HOME/.azure/cliextensions.

Added variable to override the default directory. 

Doc update PR: https://github.com/OctopusDeploy/docs/pull/780

