### PR TITLE
Add support for session duration during aws sts:assumerole

### DIFF
--- a/source/Calamari.Aws/Commands/ApplyCloudFormationChangesetCommand.cs
+++ b/source/Calamari.Aws/Commands/ApplyCloudFormationChangesetCommand.cs
@@ -51,8 +51,8 @@ namespace Calamari.Aws.Commands
             };
             
             var deployment = new RunningDeployment(packageFile, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
             
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
             conventionRunner.RunConventions();
             return 0;
         }

--- a/source/Calamari.Aws/Commands/DeleteCloudFormationCommand.cs
+++ b/source/Calamari.Aws/Commands/DeleteCloudFormationCommand.cs
@@ -51,8 +51,8 @@ namespace Calamari.Aws.Commands
             };
             
             var deployment = new RunningDeployment(packageFile, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
             
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
             conventionRunner.RunConventions();
             return 0;
         }

--- a/source/Calamari.Aws/Commands/DeployAwsCloudFormationCommand.cs
+++ b/source/Calamari.Aws/Commands/DeployAwsCloudFormationCommand.cs
@@ -112,7 +112,7 @@ namespace Calamari.Aws.Commands
             };
 
             var deployment = new RunningDeployment(pathToPackage, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
 
             conventionRunner.RunConventions();
             return 0;

--- a/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
+++ b/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
@@ -82,7 +82,7 @@ namespace Calamari.Aws.Commands
             };
 
             var deployment = new RunningDeployment(pathToPackage, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
 
             conventionRunner.RunConventions();
             return 0;

--- a/source/Calamari.Aws/Exceptions/PermissionException.cs
+++ b/source/Calamari.Aws/Exceptions/PermissionException.cs
@@ -1,16 +1,13 @@
 ﻿using System;
+using Calamari.Commands.Support;
 
 namespace Calamari.Aws.Exceptions
 {
     /// <summary>
     /// Represents a failed attempt to query the AWS API
     /// </summary>
-    public class PermissionException : Exception
+    public class PermissionException : CommandException
     {
-        public PermissionException()
-        {
-        }
-
         public PermissionException(string message)
             : base(message)
         {

--- a/source/Calamari.Aws/Exceptions/RollbackException.cs
+++ b/source/Calamari.Aws/Exceptions/RollbackException.cs
@@ -1,16 +1,13 @@
 ﻿using System;
+using Calamari.Commands.Support;
 
 namespace Calamari.Aws.Exceptions
 {
     /// <summary>
     /// Represents a failed deployment that resulted in a rollback state
     /// </summary>
-    public class RollbackException : Exception
+    public class RollbackException : CommandException
     {
-        public RollbackException()
-        {
-        }
-
         public RollbackException(string message)
             : base(message)
         {

--- a/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
@@ -131,7 +131,7 @@ namespace Calamari.Aws.Integration.CloudFormation
             catch (AmazonCloudFormationException ex) when (ex.ErrorCode == "ExpiredToken")
             {
                 throw new PermissionException(
-                    "Security token has expired. Please increase the session duration and/or check that the system date and time are set correctly." +
+                    "Security token has expired. Please increase the session duration and/or check that the system date and time are set correctly. " +
                     ex.Message);
             }
             catch (AmazonCloudFormationException)

--- a/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
@@ -128,6 +128,12 @@ namespace Calamari.Aws.Integration.CloudFormation
                     "Please ensure the current account has permission to perform action 'cloudformation:DescribeStackEvents'" +
                     ex.Message);
             }
+            catch (AmazonCloudFormationException ex) when (ex.ErrorCode == "ExpiredToken")
+            {
+                throw new PermissionException(
+                    "The security token has expired. Please increase the session duration and/or check that the system date and time are set correctly." +
+                    ex.Message);
+            }
             catch (AmazonCloudFormationException)
             {
                 return Maybe<StackEvent>.None;

--- a/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
@@ -131,7 +131,7 @@ namespace Calamari.Aws.Integration.CloudFormation
             catch (AmazonCloudFormationException ex) when (ex.ErrorCode == "ExpiredToken")
             {
                 throw new PermissionException(
-                    "The security token has expired. Please increase the session duration and/or check that the system date and time are set correctly." +
+                    "Security token has expired. Please increase the session duration and/or check that the system date and time are set correctly." +
                     ex.Message);
             }
             catch (AmazonCloudFormationException)

--- a/source/Calamari.Azure.CloudServices/Commands/DeployAzureCloudServiceCommand.cs
+++ b/source/Calamari.Azure.CloudServices/Commands/DeployAzureCloudServiceCommand.cs
@@ -101,7 +101,7 @@ namespace Calamari.Azure.CloudServices.Commands
             };
 
             var deployment = new RunningDeployment(pathToPackage, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
             conventionRunner.RunConventions();
 
             return 0;

--- a/source/Calamari.Azure.CloudServices/Commands/ExtractAzureCloudServicePackageCommand.cs
+++ b/source/Calamari.Azure.CloudServices/Commands/ExtractAzureCloudServicePackageCommand.cs
@@ -47,7 +47,7 @@ namespace Calamari.Azure.CloudServices.Commands
             };
 
             var deployment = new RunningDeployment(packageFile, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
             conventionRunner.RunConventions();
 
             return 0;

--- a/source/Calamari.Azure.ServiceFabric/Commands/DeployAzureServiceFabricAppCommand.cs
+++ b/source/Calamari.Azure.ServiceFabric/Commands/DeployAzureServiceFabricAppCommand.cs
@@ -110,7 +110,7 @@ namespace Calamari.Azure.ServiceFabric.Commands
             };
 
             var deployment = new RunningDeployment(pathToPackage, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
             conventionRunner.RunConventions();
 
             return 0;

--- a/source/Calamari.Azure.WebApps/Commands/DeployAzureWebCommand.cs
+++ b/source/Calamari.Azure.WebApps/Commands/DeployAzureWebCommand.cs
@@ -84,7 +84,7 @@ namespace Calamari.Azure.WebApps.Commands
             };
 
             var deployment = new RunningDeployment(pathToPackage, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
 
             conventionRunner.RunConventions();
 

--- a/source/Calamari.Azure/Commands/DeployAzureResourceGroupCommand.cs
+++ b/source/Calamari.Azure/Commands/DeployAzureResourceGroupCommand.cs
@@ -69,7 +69,7 @@ namespace Calamari.Azure.Commands
             };
 
             var deployment = new RunningDeployment(pathToPackage, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
 
             conventionRunner.RunConventions();
             return 0;

--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -25,6 +25,7 @@ namespace Calamari.CloudAccounts
         readonly string assumeRoleArn;
         readonly string assumeRoleExternalId;
         readonly string assumeRoleSession;
+        readonly string assumeRoleDurationSeconds;
 
         public static async Task<AwsEnvironmentGeneration> Create(ILog log, IVariables variables)
         {
@@ -61,6 +62,7 @@ namespace Calamari.CloudAccounts
             assumeRoleArn = variables.Get("Octopus.Action.Aws.AssumedRoleArn")?.Trim();
             assumeRoleExternalId = variables.Get("Octopus.Action.Aws.AssumeRoleExternalId")?.Trim();
             assumeRoleSession = variables.Get("Octopus.Action.Aws.AssumedRoleSession")?.Trim();
+            assumeRoleDurationSeconds = variables.Get("Octopus.Action.Aws.AssumeRoleSessionDurationSeconds")?.Trim();
         }
 
         /// <summary>
@@ -187,7 +189,8 @@ namespace Calamari.CloudAccounts
                    {
                        RoleArn = assumeRoleArn,
                        RoleSessionName = assumeRoleSession,
-                       ExternalId = string.IsNullOrWhiteSpace(assumeRoleExternalId) ? null : assumeRoleExternalId
+                       ExternalId = string.IsNullOrWhiteSpace(assumeRoleExternalId) ? null : assumeRoleExternalId,
+                       DurationSeconds = int.TryParse(assumeRoleDurationSeconds, out var durationSeconds) ? durationSeconds : 3600
                    })
                ).Credentials;
 

--- a/source/Calamari.CloudAccounts/Properties/AssemblyInfo.cs
+++ b/source/Calamari.CloudAccounts/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Calamari.Tests")]

--- a/source/Calamari.Shared/Deployment/ConventionProcessor.cs
+++ b/source/Calamari.Shared/Deployment/ConventionProcessor.cs
@@ -39,7 +39,9 @@ namespace Calamari.Deployment
                     log.Verbose(installException.ToString());
                 }
                 else
+                {
                     Console.Error.WriteLine(installException);
+                }
 
                 Console.Error.WriteLine("Running rollback conventions...");
 
@@ -55,19 +57,18 @@ namespace Calamari.Deployment
                 }
                 catch (Exception rollbackException)
                 {
-                    if (rollbackException is CommandException)
+                    //if the "rollback" exception message is identical to the exception we got during "install", dont log it
+                    if (rollbackException.Message != installException.Message)
                     {
-                        Console.Error.WriteLine(rollbackException.Message);
-                        log.Verbose(installException.ToString());
+                        if (rollbackException is CommandException || rollbackException is RecursiveDefinitionException)
+                        {
+                            Console.Error.WriteLine(rollbackException.Message);
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine(rollbackException);
+                        }
                     }
-                    else if (rollbackException is RecursiveDefinitionException && rollbackException.Message != installException.Message)
-                    {
-                        //dont duplicate these error messages
-                        Console.Error.WriteLine(rollbackException.Message);
-                        log.Verbose(installException.ToString());
-                    }
-                    else if (!(rollbackException is RecursiveDefinitionException))
-                        Console.Error.WriteLine(rollbackException);
                 }
                 throw;
             }

--- a/source/Calamari.Shared/Deployment/ConventionProcessor.cs
+++ b/source/Calamari.Shared/Deployment/ConventionProcessor.cs
@@ -34,14 +34,9 @@ namespace Calamari.Deployment
             catch (Exception installException)
             {
                 if (installException is CommandException || installException is RecursiveDefinitionException)
-                {
-                    Console.Error.WriteLine(installException.Message);
                     log.Verbose(installException.ToString());
-                }
                 else
-                {
                     Console.Error.WriteLine(installException);
-                }
 
                 Console.Error.WriteLine("Running rollback conventions...");
 
@@ -61,13 +56,9 @@ namespace Calamari.Deployment
                     if (rollbackException.Message != installException.Message)
                     {
                         if (rollbackException is CommandException || rollbackException is RecursiveDefinitionException)
-                        {
-                            Console.Error.WriteLine(rollbackException.Message);
-                        }
+                            log.Verbose(installException.ToString());
                         else
-                        {
                             Console.Error.WriteLine(rollbackException);
-                        }
                     }
                 }
                 throw;

--- a/source/Calamari.Shared/Deployment/ConventionProcessor.cs
+++ b/source/Calamari.Shared/Deployment/ConventionProcessor.cs
@@ -12,11 +12,13 @@ namespace Calamari.Deployment
     {
         readonly RunningDeployment deployment;
         readonly List<IConvention> conventions;
+        readonly ILog log;
 
-        public ConventionProcessor(RunningDeployment deployment, List<IConvention> conventions)
+        public ConventionProcessor(RunningDeployment deployment, List<IConvention> conventions, ILog log)
         {
             this.deployment = deployment;
             this.conventions = conventions;
+            this.log = log;
         }
 
         public void RunConventions()
@@ -32,7 +34,10 @@ namespace Calamari.Deployment
             catch (Exception installException)
             {
                 if (installException is CommandException || installException is RecursiveDefinitionException)
+                {
                     Console.Error.WriteLine(installException.Message);
+                    log.Verbose(installException.ToString());
+                }
                 else
                     Console.Error.WriteLine(installException);
 
@@ -51,10 +56,16 @@ namespace Calamari.Deployment
                 catch (Exception rollbackException)
                 {
                     if (rollbackException is CommandException)
+                    {
                         Console.Error.WriteLine(rollbackException.Message);
+                        log.Verbose(installException.ToString());
+                    }
                     else if (rollbackException is RecursiveDefinitionException && rollbackException.Message != installException.Message)
+                    {
                         //dont duplicate these error messages
                         Console.Error.WriteLine(rollbackException.Message);
+                        log.Verbose(installException.ToString());
+                    }
                     else if (!(rollbackException is RecursiveDefinitionException))
                         Console.Error.WriteLine(rollbackException);
                 }

--- a/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
+++ b/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
@@ -1,0 +1,31 @@
+using Calamari.CloudAccounts;
+using Calamari.Variables;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.AWS
+{
+    [TestFixture]
+    public class AwsEnvironmentGenerationFixture
+    {
+        [Test]
+        [TestCase("arn:aws:iam::0123456789AB:role/test-role", "My session name", "900", 900)]
+        [TestCase("arn:aws:iam::0123456789AB:role/test-role", "My session name", null, 0)]
+        [TestCase("arn:aws:iam::0123456789AB:role/test-role", "My session name", "", 0)]
+        public void CreatesAssumeRoleRequestWithExpectedParams(string arn, string sessionName, string duration, int? expectedDuration)
+        {
+            IVariables variables = new CalamariVariables();
+            variables.Add("Octopus.Action.Aws.AssumeRole", "True");
+            variables.Add("Octopus.Action.Aws.AssumedRoleArn", arn);
+            variables.Add("Octopus.Action.Aws.AssumedRoleSession", sessionName);
+            variables.Add("Octopus.Action.Aws.AssumeRoleSessionDurationSeconds", duration);
+
+            var awsEnvironmentGenerator = new AwsEnvironmentGeneration(Substitute.For<ILog>(), variables);
+            var request = awsEnvironmentGenerator.GetAssumeRoleRequest();
+            request.RoleArn.Should().Be(arn);
+            request.RoleSessionName.Should().Be(sessionName);
+            request.DurationSeconds.Should().Be(expectedDuration);
+        }
+    }
+}

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -116,7 +116,7 @@ namespace Calamari.Commands
             };
 
             var deployment = new RunningDeployment(pathToPackage, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
 
             try
             {

--- a/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
+++ b/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
@@ -113,7 +113,7 @@ namespace Calamari.Commands.Java
             };
 
             var deployment = new RunningDeployment(archiveFile, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
 
             try
             {

--- a/source/Calamari/Commands/Java/JavaLibraryCommand.cs
+++ b/source/Calamari/Commands/Java/JavaLibraryCommand.cs
@@ -17,19 +17,21 @@ namespace Calamari.Commands.Java
     [Command("java-library", Description = "Invokes the Octopus java library")]
     public class JavaLibraryCommand : Command
     {
+        readonly ILog log;
         string actionType;
         readonly IScriptEngine scriptEngine;
         readonly ICalamariFileSystem fileSystem;
         readonly IVariables variables;
         readonly ICommandLineRunner commandLineRunner;
 
-        public JavaLibraryCommand(IScriptEngine scriptEngine, ICalamariFileSystem fileSystem, IVariables variables, ICommandLineRunner commandLineRunner)
+        public JavaLibraryCommand(IScriptEngine scriptEngine, ICalamariFileSystem fileSystem, IVariables variables, ICommandLineRunner commandLineRunner, ILog log)
         {
             Options.Add("actionType=", "The step type being invoked.", v => actionType = v);
             this.scriptEngine = scriptEngine;
             this.fileSystem = fileSystem;
             this.variables = variables;
             this.commandLineRunner = commandLineRunner;
+            this.log = log;
         }
 
         public override int Execute(string[] commandLineArguments)
@@ -47,7 +49,7 @@ namespace Calamari.Commands.Java
             };
 
             var deployment = new RunningDeployment(null, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
             conventionRunner.RunConventions();
 
             return 0;

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -81,7 +81,7 @@ namespace Calamari.Commands
             };
 
             var deployment = new RunningDeployment(packageFile, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
 
             conventionRunner.RunConventions();
             var exitCode = variables.GetInt32(SpecialVariables.Action.Script.ExitCode);

--- a/source/Calamari/Commands/TransferPackageCommand.cs
+++ b/source/Calamari/Commands/TransferPackageCommand.cs
@@ -42,7 +42,7 @@ namespace Calamari.Commands
             };
 
             var deployment = new RunningDeployment(packageFile, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
 
             try
             {

--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -80,8 +80,8 @@ namespace Calamari.Kubernetes.Commands
                 new ConfiguredScriptConvention(DeploymentStages.PostDeploy, fileSystem, scriptEngine, commandLineRunner),
             };
             var deployment = new RunningDeployment(pathToPackage, variables);
-            var conventionRunner = new ConventionProcessor(deployment, conventions);
             
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
             try
             {
                 conventionRunner.RunConventions();


### PR DESCRIPTION
Customers were hitting time outs when deploying a long running cloud formation task.

This PR adds support for a new variable `Octopus.Action.Aws.AssumeRoleSessionDurationSeconds` which is passed to the AWS AssumeRole call.

This PR also adds nicer logging when it hits that timeout to prompt them to up the timeout. It also cleans up exception handling so that exception stack traces are logged as verbose and not duplicated.

Relates to https://github.com/OctopusDeploy/Issues/issues/6430

## Review

* please consider the name I've used the the variable. Is there a better one you can think of?
* please consider if there's any edge cases I've missed in the error handling changes