### PR TITLE
The private-alpine image was deleted (as we didnt know it was in use)

### DIFF
--- a/source/Calamari.Tests/EnvironmentVariables.cs
+++ b/source/Calamari.Tests/EnvironmentVariables.cs
@@ -39,10 +39,10 @@ namespace Calamari.Tests
         [EnvironmentVariable("K8S_OctopusAPITester_Server", "GKS Kubernetes API Test Cluster Url")]
         KubernetesClusterUrl,
         
-        [EnvironmentVariable("Helm_OctopusAPITester_Password", "Helm Password for https://octopusdeploy.jfrog.io")]
+        [EnvironmentVariable("Helm_OctopusAPITester_Password", "Artifactory Test Account")]
         HelmPassword,
         
-        [EnvironmentVariable("DockerHub_TestReaderAccount_Password", "Password for DockerHub Test reader account")]
+        [EnvironmentVariable("DockerHub_TestReaderAccount_Password", "DockerHub Test Reader Account")]
         DockerReaderPassword,
 
         [EnvironmentVariable("AWS.E2E.AccessKeyId", "AWS E2E Test User Keys")]

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
@@ -58,7 +58,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         public void DockerHubWithCredentials_Loads()
         {
             const string privateImage = "octopusdeploy/octo-prerelease";
-            var version =  new SemanticVersion("7.3.7");
+            var version =  new SemanticVersion("7.3.7-alpine");
 
             var downloader = GetDownloader();
             var pkg = downloader.DownloadPackage(privateImage, 

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
@@ -57,8 +57,8 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [RequiresDockerInstalledAttribute]
         public void DockerHubWithCredentials_Loads()
         {
-            const string privateImage = "octopusdeploy/private-alpine";
-            var version =  new SemanticVersion("1.0.0");
+            const string privateImage = "octopusdeploy/octo-prerelease";
+            var version =  new SemanticVersion("7.3.7");
 
             var downloader = GetDownloader();
             var pkg = downloader.DownloadPackage(privateImage, 


### PR DESCRIPTION
And we were running out of private repositories. This changes over to use a private image we know exists