### PR TITLE
Attribute to not run tests on ARMx64 and applied to relevant failing tests

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -42,6 +42,7 @@
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <ProjectReference Include="..\Calamari.Azure.ServiceFabric\Calamari.Azure.ServiceFabric.csproj" />
     <ProjectReference Include="..\Calamari.Azure.WebApps\Calamari.Azure.WebApps.csproj" />
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellScriptEngineFixture.cs
@@ -12,6 +12,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
     {
         [Test]
         [RequiresNonFreeBSDPlatform]
+        [RequiresNonARM64Bit]
         public void PowerShellDecryptsVariables()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
@@ -88,6 +89,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
         [TestCase("false")]
         [TestCase("")]
         [RequiresNonFreeBSDPlatform]
+        [RequiresNonARM64Bit]
         public void PowerShellDoesntForceTraceMode(string variableValue)
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
@@ -107,6 +109,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
 
         [Test]
         [RequiresNonFreeBSDPlatform]
+        [RequiresNonARM64Bit]
         public void PowerShellWorksWithStrictMode()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
@@ -128,6 +131,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
         [TestCase("false")]
         [TestCase("")]
         [RequiresNonFreeBSDPlatform]
+        [RequiresNonARM64Bit]
         public void PowerShellDoesntForceStrictMode(string variableValue)
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/PowerShellScriptEngineFixture.cs
@@ -12,7 +12,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
     {
         [Test]
         [RequiresNonFreeBSDPlatform]
-        [RequiresNonARM64Bit]
+        [RequiresNonARM64Bit("As of June 2020, PowerShell Core for ARM is still an experimental release that is unsupported.")]
         public void PowerShellDecryptsVariables()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
@@ -89,7 +89,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
         [TestCase("false")]
         [TestCase("")]
         [RequiresNonFreeBSDPlatform]
-        [RequiresNonARM64Bit]
+        [RequiresNonARM64Bit("As of June 2020, PowerShell Core for ARM is still an experimental release that is unsupported.")]
         public void PowerShellDoesntForceTraceMode(string variableValue)
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
@@ -109,7 +109,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
 
         [Test]
         [RequiresNonFreeBSDPlatform]
-        [RequiresNonARM64Bit]
+        [RequiresNonARM64Bit("As of June 2020, PowerShell Core for ARM is still an experimental release that is unsupported.")]
         public void PowerShellWorksWithStrictMode()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))
@@ -131,7 +131,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
         [TestCase("false")]
         [TestCase("")]
         [RequiresNonFreeBSDPlatform]
-        [RequiresNonARM64Bit]
+        [RequiresNonARM64Bit("As of June 2020, PowerShell Core for ARM is still an experimental release that is unsupported.")]
         public void PowerShellDoesntForceStrictMode(string variableValue)
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "ps1")))

--- a/source/Calamari.Tests/Fixtures/RequiresNonARM64BitAttribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresNonARM64BitAttribute.cs
@@ -1,0 +1,19 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using System.Runtime.InteropServices;
+    
+namespace Calamari.Tests.Fixtures
+{
+    public class RequiresNonARM64BitAttribute : NUnitAttribute, IApplyToTest
+    {
+        public void ApplyToTest(Test test)
+        {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                test.RunState = RunState.Skipped;
+                test.Properties.Set(PropertyNames.SkipReason, "This test does not run on ARMx64");
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/RequiresNonARM64BitAttribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresNonARM64BitAttribute.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using System.Runtime.InteropServices;
@@ -13,11 +14,25 @@ namespace Calamari.Tests.Fixtures
         
         public void ApplyToTest(Test test)
         {
-            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            try
             {
-                test.RunState = RunState.Skipped;
-                test.Properties.Set(PropertyNames.SkipReason, "This test does not run on ARMx64");
+                if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+                {
+                    test.RunState = RunState.Skipped;
+                    test.Properties.Set(PropertyNames.SkipReason, "This test does not run on ARMx64");
+                }
             }
+            catch(Exception e)
+            {
+                if (CalamariEnvironment.IsRunningOnMono)
+                {
+                    Assert.Ignore("Ignoring test as Mono 4.x has problems with System.Runtime.InteropServices.RuntimeInformation");
+                    return;
+                }
+
+                Assert.Fail(e.StackTrace);
+            }
+            
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/RequiresNonARM64BitAttribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresNonARM64BitAttribute.cs
@@ -7,6 +7,10 @@ namespace Calamari.Tests.Fixtures
 {
     public class RequiresNonARM64BitAttribute : NUnitAttribute, IApplyToTest
     {
+        public RequiresNonARM64BitAttribute(string attributeReason)
+        {
+        }
+        
         public void ApplyToTest(Test test)
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)


### PR DESCRIPTION
Our Ubuntu 18.04 ARMx64 agent is paused as there are some tests that don't run on it. This attribute will allow skipping tests on ARMx64 if applied to the tests which means we can skip the tests which don't run on ARMx64 and re-enable the agent.