### PR TITLE
Move the JSON variable replacer to Calamari.Common.

### DIFF
--- a/source/Calamari.Azure.CloudServices/Commands/DeployAzureCloudServiceCommand.cs
+++ b/source/Calamari.Azure.CloudServices/Commands/DeployAzureCloudServiceCommand.cs
@@ -13,7 +13,7 @@ using Calamari.Integration.ConfigurationTransforms;
 using Calamari.Integration.ConfigurationVariables;
 using Calamari.Integration.EmbeddedResources;
 using Calamari.Integration.FileSystem;
-using Calamari.Integration.JsonVariables;
+using Calamari.Features.StructuredVariables;
 using Calamari.Integration.Packages;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;

--- a/source/Calamari.Azure.ServiceFabric/Commands/DeployAzureServiceFabricAppCommand.cs
+++ b/source/Calamari.Azure.ServiceFabric/Commands/DeployAzureServiceFabricAppCommand.cs
@@ -12,7 +12,7 @@ using Calamari.Integration.ConfigurationTransforms;
 using Calamari.Integration.ConfigurationVariables;
 using Calamari.Integration.EmbeddedResources;
 using Calamari.Integration.FileSystem;
-using Calamari.Integration.JsonVariables;
+using Calamari.Features.StructuredVariables;
 using Calamari.Integration.Packages;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;

--- a/source/Calamari.Azure.WebApps/Commands/DeployAzureWebCommand.cs
+++ b/source/Calamari.Azure.WebApps/Commands/DeployAzureWebCommand.cs
@@ -9,7 +9,7 @@ using Calamari.Deployment.Conventions;
 using Calamari.Integration.ConfigurationTransforms;
 using Calamari.Integration.ConfigurationVariables;
 using Calamari.Integration.FileSystem;
-using Calamari.Integration.JsonVariables;
+using Calamari.Features.StructuredVariables;
 using Calamari.Integration.Packages;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;

--- a/source/Calamari.Common/Features/StructuredVariables/IJsonConfigurationVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/IJsonConfigurationVariableReplacer.cs
@@ -1,6 +1,6 @@
 ﻿using Octostache;
 
-namespace Calamari.Integration.JsonVariables
+namespace Calamari.Features.StructuredVariables
 {
     public interface IJsonConfigurationVariableReplacer
     {

--- a/source/Calamari.Common/Features/StructuredVariables/JsonConfigurationVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/JsonConfigurationVariableReplacer.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Octostache;
 
-namespace Calamari.Integration.JsonVariables
+namespace Calamari.Features.StructuredVariables
 {
     public class JsonConfigurationVariableReplacer : IJsonConfigurationVariableReplacer
     {

--- a/source/Calamari.Shared/Deployment/Conventions/JsonConfigurationVariablesConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/JsonConfigurationVariablesConvention.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using Calamari.Common.Variables;
 using Calamari.Integration.FileSystem;
-using Calamari.Integration.JsonVariables;
+using Calamari.Features.StructuredVariables;
 
 namespace Calamari.Deployment.Conventions
 {

--- a/source/Calamari.Tests/Fixtures/Conventions/JsonConfigurationVariablesConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/JsonConfigurationVariablesConventionFixture.cs
@@ -4,7 +4,7 @@ using Calamari.Common.Variables;
 using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
 using Calamari.Integration.FileSystem;
-using Calamari.Integration.JsonVariables;
+using Calamari.Features.StructuredVariables;
 using Calamari.Integration.Processes;
 using Calamari.Tests.Helpers;
 using Calamari.Variables;

--- a/source/Calamari.Tests/Fixtures/JsonVariables/JsonConfigurationVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/JsonVariables/JsonConfigurationVariableReplacerFixture.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using Assent;
 using Calamari.Integration.FileSystem;
-using Calamari.Integration.JsonVariables;
+using Calamari.Features.StructuredVariables;
 using Calamari.Tests.Helpers;
 using Calamari.Variables;
 using NUnit.Framework;

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -12,7 +12,7 @@ using Calamari.Integration.ConfigurationVariables;
 using Calamari.Integration.EmbeddedResources;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Iis;
-using Calamari.Integration.JsonVariables;
+using Calamari.Features.StructuredVariables;
 using Calamari.Integration.Nginx;
 using Calamari.Integration.Packages;
 using Calamari.Integration.Processes;

--- a/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
+++ b/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
@@ -10,7 +10,7 @@ using Calamari.Deployment.Features.Java;
 using Calamari.Deployment.Journal;
 using Calamari.Integration.EmbeddedResources;
 using Calamari.Integration.FileSystem;
-using Calamari.Integration.JsonVariables;
+using Calamari.Features.StructuredVariables;
 using Calamari.Integration.Packages.Java;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Processes.Semaphores;

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -13,7 +13,7 @@ using Calamari.Common.Features.Scripting;
 using Calamari.Common.Variables;
 using Calamari.Integration.ConfigurationTransforms;
 using Calamari.Integration.ConfigurationVariables;
-using Calamari.Integration.JsonVariables;
+using Calamari.Features.StructuredVariables;
 using Calamari.Integration.Packages;
 using Calamari.Util;
 

--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -14,7 +14,7 @@ using Calamari.Integration.Certificates;
 using Calamari.Integration.ConfigurationTransforms;
 using Calamari.Integration.EmbeddedResources;
 using Calamari.Integration.FileSystem;
-using Calamari.Integration.JsonVariables;
+using Calamari.Features.StructuredVariables;
 using Calamari.Integration.Packages;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Scripting;


### PR DESCRIPTION
# Background
This PR moves the `JsonConfigurationVariableReplacer` class and `IJsonConfigurationVariableReplacer` interface from `Calamari.Shared` into `Calamari.Common`, and updates existing usages. This move puts `JsonConfigurationVariableReplacer` into the `Features` namespace, which is consistent with other features and the future plans for Calamari.

We have some PRs coming up that will touch on this code, so this is just a tidy up to make future PRs simpler.

# How to review this PR

- 👀 the code
- Is this consistent with where things should be in Calamari?