### PR TITLE
Implement path-based scalar value YamlFileFormatVariableReplacer

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
@@ -83,12 +83,24 @@ namespace Calamari.Common.Features.StructuredVariables
 
     public class YamlScalarValueNode : YamlNode
     {
+        readonly Scalar scalar;
+
         public string Value { get; }
 
-        public YamlScalarValueNode(IList<ParsingEvent> parsingEvents, string path, string value)
-            : base(parsingEvents, path)
+        public YamlScalarValueNode(Scalar scalar, string path, string value)
+            : base(new List<ParsingEvent>
+            {
+                scalar
+            }, path)
         {
+            this.scalar = scalar;
             Value = value;
+        }
+
+        public Scalar ReplaceValue(string newValue)
+        {
+            return new Scalar(scalar.Anchor, scalar.Tag, newValue, scalar.Style, scalar.IsPlainImplicit,
+                scalar.IsQuotedImplicit, scalar.Start, scalar.End);
         }
     }
 
@@ -130,7 +142,7 @@ namespace Calamari.Common.Features.StructuredVariables
                     else
                     {
                         // This is a value in a map or sequence
-                        result = new YamlScalarValueNode(new[] {ev}, stack.GetPath(), sc.Value);
+                        result = new YamlScalarValueNode(sc, stack.GetPath(), sc.Value);
                         stack.TopMappingKeyEnd();
                     }
 

--- a/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
@@ -1,0 +1,143 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.Core.Events;
+
+namespace Calamari.Common.Features.StructuredVariables
+{
+    enum YamlStructure
+    {
+        Mapping,
+        Sequence
+    }
+
+    class YamlPathComponent
+    {
+        public YamlStructure Type { get; }
+        public string MappingKey { get; set; }
+        public int SequenceIndex { get; set; } = -1;
+
+        public YamlPathComponent(YamlStructure structure)
+        {
+            Type = structure;
+        }
+    }
+
+    class YamlPathStack
+    {
+        readonly Stack<YamlPathComponent> stack = new Stack<YamlPathComponent>();
+
+        public void Push(YamlStructure structure) => stack.Push(new YamlPathComponent(structure));
+
+        public void Pop() => stack.Pop();
+
+        IEnumerable<string> GetPathComponents()
+        {
+            foreach (var stackItem in stack.Reverse())
+            {
+                if (stackItem.MappingKey != null)
+                    yield return stackItem.MappingKey;
+                else if (stackItem.Type == YamlStructure.Sequence)
+                    yield return stackItem.SequenceIndex.ToString();
+            }
+        }
+
+        public string GetPath() => string.Join(":", GetPathComponents());
+
+        public bool TopIsSequence => stack.Count > 0
+                                     && stack.Peek().Type == YamlStructure.Sequence;
+
+        public void TopSequenceIncrementIndex()
+        {
+            if (TopIsSequence)
+                stack.Peek().SequenceIndex++;
+        }
+
+        public bool TopIsMappingExpectingKey => stack.Count > 0
+                                                && stack.Peek().Type == YamlStructure.Mapping
+                                                && stack.Peek().MappingKey == null;
+
+        public void TopMappingKeyStart(string key)
+        {
+            if (TopIsMappingExpectingKey)
+                stack.Peek().MappingKey = key;
+        }
+
+        public void TopMappingKeyEnd()
+        {
+            if (stack.Count > 0)
+                stack.Peek().MappingKey = null;
+        }
+    }
+
+    public abstract class YamlNode
+    {
+        public IList<ParsingEvent> ParsingEvents { get; }
+        public string Path { get; }
+
+        protected YamlNode(IList<ParsingEvent> parsingEvents, string path)
+        {
+            ParsingEvents = parsingEvents;
+            Path = path;
+        }
+    }
+
+    public class YamlScalarValueNode : YamlNode
+    {
+        public string Value { get; }
+
+        public YamlScalarValueNode(IList<ParsingEvent> parsingEvents, string path, string value)
+            : base(parsingEvents, path)
+        {
+            Value = value;
+        }
+    }
+
+    public class YamlEventStreamClassifier
+    {
+        readonly YamlPathStack stack = new YamlPathStack();
+
+        public YamlNode Process(ParsingEvent ev)
+        {
+            YamlNode result = null;
+
+            if (stack.TopIsSequence && (ev is MappingStart || ev is SequenceStart || ev is Scalar))
+            {
+                stack.TopSequenceIncrementIndex();
+            }
+
+            switch (ev)
+            {
+                case MappingStart _:
+                    stack.Push(YamlStructure.Mapping);
+                    break;
+                case MappingEnd _:
+                    stack.Pop();
+                    stack.TopMappingKeyEnd();
+                    break;
+                case SequenceStart _:
+                    stack.Push(YamlStructure.Sequence);
+                    break;
+                case SequenceEnd _:
+                    stack.Pop();
+                    stack.TopMappingKeyEnd();
+                    break;
+                case Scalar sc:
+                    if (stack.TopIsMappingExpectingKey)
+                    {
+                        // This is a map key
+                        stack.TopMappingKeyStart(sc.Value);
+                    }
+                    else
+                    {
+                        // This is a value in a map or sequence
+                        result = new YamlScalarValueNode(new[] {ev}, stack.GetPath(), sc.Value);
+                        stack.TopMappingKeyEnd();
+                    }
+
+                    break;
+            }
+
+            return result;
+        }
+    }
+}

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -1,4 +1,10 @@
-﻿namespace Calamari.Common.Features.StructuredVariables
+﻿using System.IO;
+using System.Linq;
+using Calamari.Integration.FileSystem;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace Calamari.Common.Features.StructuredVariables
 {
     public interface IYamlFormatVariableReplacer : IFileFormatVariableReplacer
     {
@@ -10,8 +16,46 @@
         
         public bool TryModifyFile(string filePath, IVariables variables)
         {
-            // Yaml not yet supported.
-            return false;
+            var variablesByKey = variables
+                .DistinctBy(v => v.Key)
+                .ToDictionary(v => v.Key, v => v.Value);
+
+            try
+            {
+                string updatedText;
+                using (var writer = new StringWriter())
+                using (var reader = new StreamReader(filePath))
+                {
+                    var parser = new Parser(reader);
+                    var classifier = new YamlEventStreamClassifier();
+                    var emitter = new Emitter(writer);
+                    while (parser.MoveNext())
+                    {
+                        var ev = parser.Current;
+                        if (ev == null)
+                            continue;
+
+                        var found = classifier.Process(ev);
+                        if (found is YamlScalarValueNode
+                            && variablesByKey.TryGetValue(found.Path, out string newValue))
+                        {
+                            ev = new Scalar(newValue);
+                        }
+
+                        emitter.Emit(ev);
+                    }
+
+                    writer.Close();
+                    updatedText = writer.ToString();
+                }
+
+                File.WriteAllText(filePath, updatedText);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -36,10 +36,10 @@ namespace Calamari.Common.Features.StructuredVariables
                             continue;
 
                         var found = classifier.Process(ev);
-                        if (found is YamlScalarValueNode
-                            && variablesByKey.TryGetValue(found.Path, out string newValue))
+                        if (found is YamlScalarValueNode scalar
+                            && variablesByKey.TryGetValue(scalar.Path, out string newValue))
                         {
-                            ev = new Scalar(newValue);
+                            ev = scalar.ReplaceValue(newValue);
                         }
 
                         emitter.Emit(ev);

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldReplaceSimpleStringYamlVariables.approved.txt
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldReplaceSimpleStringYamlVariables.approved.txt
@@ -1,0 +1,16 @@
+﻿server:
+  ports:
+  - "8080"
+spring:
+  h2:
+    console:
+      enabled: "false"
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+  datasource:
+    url: jdbc:h2:mem:testdb
+    dbcp2:
+      driver-class-name: org.h2.Driver
+  flyway:
+    locations: classpath:db/migration/{vendor}
+environment: production

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
@@ -1,25 +1,16 @@
-﻿using System;
-using System.IO;
-using Assent;
+﻿using Assent;
 using Calamari.Common.Features.StructuredVariables;
-using Calamari.Integration.FileSystem;
 using Calamari.Tests.Helpers;
 using Calamari.Variables;
-using FluentAssertions;
-using NSubstitute;
 using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures.StructuredVariables
 {
     [TestFixture]
-    public class JsonFormatVariableReplacerFixture : CalamariFixture
+    public class JsonFormatVariableReplacerFixture : VariableReplacerFixture
     {
-        JsonFormatVariableReplacer replacer;
-
-        [SetUp]
-        public void SetUp()
+        public JsonFormatVariableReplacerFixture() : base(new JsonFormatVariableReplacer())
         {
-            replacer = new JsonFormatVariableReplacer();
         }
 
         [Test]
@@ -185,20 +176,6 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
 
             var replaced = Replace(variables, existingFile: "appsettings.array.json");
             this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
-        }
-
-        string Replace(IVariables variables, string existingFile = null)
-        {
-            var temp = Path.GetTempFileName();
-            if (existingFile != null)
-                File.Copy(GetFixtureResouce("Samples", existingFile), temp, true);
-
-            using (new TemporaryFile(temp))
-            {
-                var success = replacer.TryModifyFile(temp, variables);
-                success.Should().BeTrue();
-                return File.ReadAllText(temp);
-            }
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application-simple-string.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application-simple-string.yaml
@@ -1,4 +1,0 @@
-﻿environment: development
-include:
-  - dev-system
-  - monitoring

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application-simple-string.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application-simple-string.yaml
@@ -1,0 +1,4 @@
+﻿environment: development
+include:
+  - dev-system
+  - monitoring

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.yaml
@@ -1,0 +1,17 @@
+﻿server:
+  port : "5555"
+
+spring:
+  h2:
+    console:
+      enabled: "true"
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+  datasource:
+    url: jdbc:h2:mem:testdb
+    dbcp2:
+      driver-class-name: org.h2.Driver
+  flyway:
+    locations: classpath:db/migration/{vendor}
+    
+environment: development

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.yaml
@@ -1,6 +1,6 @@
 ﻿server:
-  port : "5555"
-
+  ports:
+  - "5555"
 spring:
   h2:
     console:
@@ -13,5 +13,4 @@ spring:
       driver-class-name: org.h2.Driver
   flyway:
     locations: classpath:db/migration/{vendor}
-    
 environment: development

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/VariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/VariableReplacerFixture.cs
@@ -1,0 +1,32 @@
+﻿using System.IO;
+using Calamari.Common.Features.StructuredVariables;
+using Calamari.Integration.FileSystem;
+using Calamari.Tests.Helpers;
+using FluentAssertions;
+
+namespace Calamari.Tests.Fixtures.StructuredVariables
+{
+    public class VariableReplacerFixture : CalamariFixture
+    {
+        readonly IFileFormatVariableReplacer replacer;
+
+        public VariableReplacerFixture(IFileFormatVariableReplacer replacer)
+        {
+            this.replacer = replacer;
+        }
+
+        public string Replace(IVariables variables, string existingFile = null)
+        {
+            var temp = Path.GetTempFileName();
+            if (existingFile != null)
+                File.Copy(GetFixtureResouce("Samples", existingFile), temp, true);
+
+            using (new TemporaryFile(temp))
+            {
+                var success = replacer.TryModifyFile(temp, variables);
+                success.Should().BeTrue();
+                return File.ReadAllText(temp);
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlEventStreamClassifierFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlEventStreamClassifierFixture.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Calamari.Common.Features.StructuredVariables;
+using NUnit.Framework;
+using YamlDotNet.Core;
+
+namespace Calamari.Tests.Fixtures.StructuredVariables
+{
+    [TestFixture]
+    public class YamlEventStreamClassifierFixture
+    {
+        [Test]
+        public void YamlEventPathMonitorCalculatesValuePaths()
+        {
+            var input = @"
+                key: val
+                key2: val2
+                mapA: 
+                  keyA: vAA
+                  keyB: vAB
+                seqC: 
+                  - C0
+                  -
+                    F: vC1F
+                    G: vC1G
+                  -
+                    - vC20
+                    - vC21
+                  - C3
+                key3: val3";
+            var expectedScalarValues = new List<(string path, string value)>
+            {
+                ("key", "val"),
+                ("key2", "val2"),
+                ("mapA:keyA", "vAA"),
+                ("mapA:keyB", "vAB"),
+                ("seqC:0", "C0"),
+                ("seqC:1:F", "vC1F"),
+                ("seqC:1:G", "vC1G"),
+                ("seqC:2:0", "vC20"),
+                ("seqC:2:1", "vC21"),
+                ("seqC:3", "C3"),
+                ("key3", "val3")
+            };
+            CollectionAssert.AreEqual(expectedScalarValues, GetScalarValues(input));
+        }
+
+        List<(string path, string value)> GetScalarValues(string input)
+        {
+            var result = new List<(string path, string value)>();
+
+            using (var textReader = new StringReader(input))
+            {
+                var parser = new Parser(textReader);
+                var classifier = new YamlEventStreamClassifier();
+                while (parser.MoveNext())
+                {
+                    var found = classifier.Process(parser.Current);
+                    if (found is YamlScalarValueNode scalarValue)
+                    {
+                        result.Add((scalarValue.Path, scalarValue.Value));
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlTransformApproachComparisonDemoFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlTransformApproachComparisonDemoFixture.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.StructuredVariables
+{
+    [TestFixture, Explicit]
+    public class YamlTransformApproachComparisonDemoFixture
+    {
+        [Test]
+        public void YamlTransformApproachComparisonDemo()
+        {
+            var input = @"Numbers: !!omap [ one: 1, two: 2, three: 3, octy: 010, norway: no ]";
+
+            Demo(nameof(YamlDotNetSerializerIdentityTransform), () => YamlDotNetSerializerIdentityTransform(input));
+            Demo(nameof(YamlDotNetParserEmitterIdentityTransform),
+                () => YamlDotNetParserEmitterIdentityTransform(input));
+            //Demo(nameof(SharpYamlSerializerIdentityTransform), () => SharpYamlSerializerIdentityTransform(input));
+            //Demo(nameof(SharpYamlParserEmitterIdentityTransform), () => SharpYamlParserEmitterIdentityTransform(input));
+        }
+
+        public void Demo(string name, Func<string> transform)
+        {
+            string output = "";
+            try
+            {
+                output = transform();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"** {name} failed: {ex}");
+            }
+
+            Console.WriteLine($"{name}:");
+            Console.WriteLine("[[");
+            Console.WriteLine(output);
+            Console.WriteLine("]]");
+        }
+
+        string YamlDotNetSerializerIdentityTransform(string input)
+        {
+            using (var textReader = new StringReader(input))
+            using (var textWriter = new StringWriter())
+            {
+                var deserializer = new YamlDotNet.Serialization.DeserializerBuilder().Build();
+                var data = deserializer.Deserialize(textReader);
+                new YamlDotNet.Serialization.Serializer().Serialize(textWriter, data ?? "");
+
+                textWriter.Close();
+                return textWriter.ToString();
+            }
+        }
+
+        string YamlDotNetParserEmitterIdentityTransform(string input)
+        {
+            using (var textReader = new StringReader(input))
+            using (var textWriter = new StringWriter())
+            {
+                var parser = new YamlDotNet.Core.Parser(textReader);
+                var emitter = new YamlDotNet.Core.Emitter(textWriter);
+                while (parser.MoveNext())
+                {
+                    if (parser.Current != null)
+                        emitter.Emit(parser.Current);
+                }
+
+                textWriter.Close();
+                return textWriter.ToString();
+            }
+        }
+
+        /*string SharpYamlSerializerIdentityTransform(string input)
+        {
+            using (var textReader = new StringReader(input))
+            using (var textWriter = new StringWriter())
+            {
+                var serializer = new SharpYaml.Serialization.Serializer(new SharpYaml.Serialization.SerializerSettings
+                {
+                    EmitShortTypeName = true
+                });
+                var data = serializer.Deserialize(textReader);
+                serializer.Serialize(textWriter, data);
+
+                textWriter.Close();
+                return textWriter.ToString();
+            }
+        }*/
+
+        /*string SharpYamlParserEmitterIdentityTransform(string input)
+        {
+            using (var textReader = new StringReader(input))
+            using (var textWriter = new StringWriter())
+            {
+                var parser = new SharpYaml.Parser(textReader);
+                var emitter = new SharpYaml.Emitter(textWriter);
+                while (parser.MoveNext())
+                {
+                    emitter.Emit(parser.Current);
+                }
+
+                textWriter.Close();
+                return textWriter.ToString();
+            }
+        }*/
+    }
+}

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -1,6 +1,7 @@
-﻿using Calamari.Common.Features.StructuredVariables;
+﻿using Assent;
+using Calamari.Common.Features.StructuredVariables;
+using Calamari.Tests.Helpers;
 using Calamari.Variables;
-using FluentAssertions;
 using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures.StructuredVariables
@@ -15,24 +16,14 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
         [Test]
         public void ShouldReplaceSimpleStringYamlVariables()
         {
-            const string expected = @"environment: production
-include:
-- prod-system
-- monitoring
-";
-
             var variables = new CalamariVariables();
+            variables.Set("server:ports:0", "8080");
+            variables.Set("spring:h2:console:enabled", "false");
             variables.Set("environment", "production");
-            variables.Set("include:0", "prod-system");
 
-            var replaced = Replace(variables, "application-simple-string.yaml");
+            var replaced = Replace(variables, "application.yaml");
 
-            AssertYamlEquivalent(replaced, expected);
-        }
-
-        void AssertYamlEquivalent(string replaced, string expected)
-        {
-            replaced.Should().Be(expected);
+            this.Assent(replaced, TestEnvironment.AssentConfiguration);
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -1,0 +1,38 @@
+﻿using Calamari.Common.Features.StructuredVariables;
+using Calamari.Variables;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.StructuredVariables
+{
+    [TestFixture]
+    public class YamlVariableReplacerFixture : VariableReplacerFixture
+    {
+        public YamlVariableReplacerFixture() : base(new YamlFormatVariableReplacer())
+        {
+        }
+
+        [Test]
+        public void ShouldReplaceSimpleStringYamlVariables()
+        {
+            const string expected = @"environment: production
+include:
+- prod-system
+- monitoring
+";
+
+            var variables = new CalamariVariables();
+            variables.Set("environment", "production");
+            variables.Set("include:0", "prod-system");
+
+            var replaced = Replace(variables, "application-simple-string.yaml");
+
+            AssertYamlEquivalent(replaced, expected);
+        }
+
+        void AssertYamlEquivalent(string replaced, string expected)
+        {
+            replaced.Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
This includes an implementation of `YamlFileFormatVariableReplacer` which I believe is clarifying paths properly, although for now it only replaces scalar values present in the original document. Insertions and raw YAML replacements will come later, and will be bit a bit more complicated.

Most of the heavy lifting is done in `YamlEventStreamClassifier`. Many thanks to @Silcoish for a big pairing session where we figured out most of it.

This also includes `YamlTransformApproachComparisonDemoFixture`, which is an Explicit test that can aid experimentation with different parsers and different parsing approaches. We used it to conclude that YamlDotNet in streaming ParsingEvent mode applies the lowest amount of churn/canonicalization, and seems to handle advanced features the best, with the least amount of crashing.

Challenges to keep in mind:
- Both streaming parsers (which are the ones that handle advanced inputs a lot better) present mapping keys as scalars, which are tricky to differentiate from value scalars. We resolve this by paying attention to sequencing. For example, a flat key-value list looks like `[key, value, key, value, ...]`, but nested structures complicate things - we have to wait until they close and then set our expectation for the next key in the mapping.
- Both libraries we considered have some incomplete support for YAML 1.2, which seems to be **very** common with YAML parsers, despite the specification's age. The good news is that according to https://matrix.yaml.io/, YamlDotNet ranks highly, and the differences between 1.1 and 1.2 are mostly weird edge cases.