### PR TITLE
Implement feature toggle Octopus.Action.Package.StructuredConfigurationFeatureFlag

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariableReplacer.cs
@@ -29,9 +29,16 @@ namespace Calamari.Common.Features.StructuredVariables
             Log.Info($"Attempting to push variables into structured config file at '{filePath}'");
 
             // Toggle set of replacers based on feature flag
-            var replacersToTry = variables.GetFlag(featureToggleVariableName)
-                ? replacers.OfType<IJsonFormatVariableReplacer>().ToArray()
-                : replacers;
+            IFileFormatVariableReplacer[] replacersToTry;
+            if (variables.GetFlag(featureToggleVariableName))
+            {
+                Log.Info($"Feature toggle flag {featureToggleVariableName} detected. Trying replacers for all supported file formats.");
+                replacersToTry = replacers;
+            }
+            else
+            {
+                replacersToTry = replacers.OfType<IJsonFormatVariableReplacer>().ToArray<IFileFormatVariableReplacer>();
+            }
 
             foreach (var replacer in replacersToTry)
             {


### PR DESCRIPTION
This change makes it so that the user must set `Octopus.Action.Package.StructuredConfigurationFeatureFlag` to `true` in order to use the structured configuration feature with formats other than JSON.