### PR TITLE
Rename feature toggle flag variable to Octopus.Action.StructuredConfigurationFeatureFlag

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariableReplacer.cs
@@ -5,7 +5,7 @@ namespace Calamari.Common.Features.StructuredVariables
 {
     public class StructuredConfigVariableReplacer : IStructuredConfigVariableReplacer
     {
-        public static readonly string FeatureToggleVariableName = "Octopus.Action.Package.StructuredConfigurationFeatureFlag";
+        public static readonly string FeatureToggleVariableName = "Octopus.Action.StructuredConfigurationFeatureFlag";
 
         readonly IFileFormatVariableReplacer[] replacers;
 


### PR DESCRIPTION
This renames our feature toggle flag variable to `Octopus.Action.StructuredConfigurationFeatureFlag`, removing the misleading reference to `.Package`