### PR TITLE
Implement structure replacement & (incomplete) preservation of input document types

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -47,6 +47,7 @@ namespace Calamari.Common.Features.StructuredVariables
                             if (node is YamlNode<Scalar> scalar
                                 && variablesByKey.TryGetValue(scalar.Path, out string newValue))
                             {
+                                // TODO ZDY: Preserve input document types for explicit tags, ambiguous inputs - currently preserves decorations only 
                                 outputEvents.Add(scalar.Event.ReplaceValue(newValue));
                             }
                             else if (node is YamlNode<MappingStart> mappingStart

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceMappingDespiteReplacementInsideMapping.approved.txt
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceMappingDespiteReplacementInsideMapping.approved.txt
@@ -7,7 +7,7 @@ spring:
       enabled: "true"
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
-  datasource: "none"
+  datasource: none
   flyway:
     locations: classpath:db/migration/{vendor}
 environment: development

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceMappingWithString.approved.txt
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceMappingWithString.approved.txt
@@ -1,11 +1,11 @@
-﻿server: "local"
+﻿server: local
 spring:
   h2:
     console:
       enabled: "true"
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
-  datasource: "none"
+  datasource: none
   flyway:
     locations: classpath:db/migration/{vendor}
 environment: development

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceSequenceWithString.approved.txt
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceSequenceWithString.approved.txt
@@ -1,5 +1,5 @@
 ﻿server:
-  ports: "none"
+  ports: none
 spring:
   h2:
     console:

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.TypesAreInfluencedByThePositionInTheInputDocument.approved.txt
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.TypesAreInfluencedByThePositionInTheInputDocument.approved.txt
@@ -1,0 +1,13 @@
+﻿null1: ~
+bool1: true
+int1: 99
+float1: 1.99
+str1: 'true'
+str2: '~'
+obj1:
+  fruit: apple
+  animal: sloth
+seq1:
+- scissors
+- paper
+- rock

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
@@ -16,166 +16,181 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
         [Test]
         public void ShouldReplaceInSimpleFile()
         {
-            var variables = new CalamariVariables();
-            variables.Set("MyMessage", "Hello world");
-            variables.Set("EmailSettings:SmtpHost", "localhost");
-            variables.Set("EmailSettings:SmtpPort", "23");
-            variables.Set("EmailSettings:DefaultRecipients:To", "paul@octopus.com");
-            variables.Set("EmailSettings:DefaultRecipients:Cc", "henrik@octopus.com");
-
-            var replaced = Replace(variables, existingFile: "appsettings.simple.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "MyMessage", "Hello world" },
+                                    { "EmailSettings:SmtpHost", "localhost" },
+                                    { "EmailSettings:SmtpPort", "23" },
+                                    { "EmailSettings:DefaultRecipients:To", "paul@octopus.com" },
+                                    { "EmailSettings:DefaultRecipients:Cc", "henrik@octopus.com" }
+                                },
+                                existingFile: "appsettings.simple.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldIgnoreOctopusPrefix()
         {
-            var variables = new CalamariVariables();
-            variables.Set("MyMessage", "Hello world!");
-            variables.Set("IThinkOctopusIsGreat", "Yes, I do!");
-            variables.Set("OctopusRocks", "This is ignored");
-            variables.Set("Octopus.Rocks", "So is this");
-            variables.Set("Octopus:Section", "Should work");
-
-            var replaced = Replace(variables, existingFile: "appsettings.ignore-octopus.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "MyMessage", "Hello world!" },
+                                    { "IThinkOctopusIsGreat", "Yes, I do!" },
+                                    { "OctopusRocks", "This is ignored" },
+                                    { "Octopus.Rocks", "So is this" },
+                                    { "Octopus:Section", "Should work" }
+                                },
+                                existingFile: "appsettings.ignore-octopus.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldReplaceVariablesInTopLevelArray()
         {
-            var variables = new CalamariVariables();
-            variables.Set("0:Property", "NewValue");
-
-            var replaced = Replace(variables, existingFile: "appsettings.top-level-array.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "0:Property", "NewValue" }
+                                },
+                                existingFile: "appsettings.top-level-array.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldKeepExistingValues()
         {
-            var variables = new CalamariVariables();
-            variables.Set("MyMessage", "Hello world!");
-            variables.Set("EmailSettings:SmtpPort", "24");
-            variables.Set("EmailSettings:DefaultRecipients:Cc", "damo@octopus.com");
-
-            var replaced = Replace(variables, existingFile: "appsettings.existing-expected.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "MyMessage", "Hello world!" },
+                                    { "EmailSettings:SmtpPort", "24" },
+                                    { "EmailSettings:DefaultRecipients:Cc", "damo@octopus.com" }
+                                },
+                                existingFile: "appsettings.existing-expected.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldMatchAndReplaceIgnoringCase()
         {
-            var variables = new CalamariVariables();
-            variables.Set("mymessage", "Hello! world!");
-            variables.Set("EmailSettings:Defaultrecipients:To", "mark@octopus.com");
-            variables.Set("EmailSettings:defaultRecipients:Cc", "henrik@octopus.com");
-
-            var replaced = Replace(variables, existingFile: "appsettings.simple.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "mymessage", "Hello! world!" },
+                                    { "EmailSettings:Defaultrecipients:To", "mark@octopus.com" },
+                                    { "EmailSettings:defaultRecipients:Cc", "henrik@octopus.com" }
+                                },
+                                existingFile: "appsettings.simple.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldReplaceWithAnEmptyString()
         {
-            var variables = new CalamariVariables();
-            variables.Set("MyMessage", "");
-
-            var replaced = Replace(variables, existingFile: "appsettings.single.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "MyMessage", "" }
+                                },
+                                existingFile: "appsettings.single.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldReplaceWithNull()
         {
-            var variables = new CalamariVariables();
-            variables.Set("MyMessage", null);
-
-            var replaced = Replace(variables, existingFile: "appsettings.single.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "MyMessage", null }
+                                },
+                                existingFile: "appsettings.single.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldReplaceWithColonInName()
         {
-            var variables = new CalamariVariables();
-            variables.Set("EnvironmentVariables:Hosting:Environment", "Production");
-
-            var replaced = Replace(variables, existingFile: "appsettings.colon-in-name.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "EnvironmentVariables:Hosting:Environment", "Production" }
+                                },
+                                existingFile: "appsettings.colon-in-name.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldReplaceWholeObject()
         {
-            var variables = new CalamariVariables();
-            variables.Set("EmailSettings:DefaultRecipients", @"{""To"": ""rob@octopus.com"", ""Cc"": ""henrik@octopus.com""}");
-
-            var replaced = Replace(variables, existingFile: "appsettings.simple.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "EmailSettings:DefaultRecipients", @"{""To"": ""rob@octopus.com"", ""Cc"": ""henrik@octopus.com""}" }
+                                },
+                                existingFile: "appsettings.simple.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldReplaceElementInArray()
         {
-            var variables = new CalamariVariables();
-            variables.Set("EmailSettings:DefaultRecipients:1", "henrik@octopus.com");
-
-            var replaced = Replace(variables, existingFile: "appsettings.array.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "EmailSettings:DefaultRecipients:1", "henrik@octopus.com" }
+                                },
+                                existingFile: "appsettings.array.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldReplacePropertyOfAnElementInArray()
         {
-            var variables = new CalamariVariables();
-            variables.Set("EmailSettings:DefaultRecipients:1:Email", "henrik@octopus.com");
-
-            var replaced = Replace(variables, existingFile: "appsettings.object-array.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "EmailSettings:DefaultRecipients:1:Email", "henrik@octopus.com" }
+                                },
+                                existingFile: "appsettings.object-array.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldReplaceEntireArray()
         {
-            var variables = new CalamariVariables();
-            variables.Set("EmailSettings:DefaultRecipients", @"[""mike@octopus.com"", ""henrik@octopus.com""]");
-
-            var replaced = Replace(variables, existingFile: "appsettings.array.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "EmailSettings:DefaultRecipients", @"[""mike@octopus.com"", ""henrik@octopus.com""]" }
+                                },
+                                existingFile: "appsettings.array.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldReplaceNumber()
         {
-            var variables = new CalamariVariables();
-            variables.Set("EmailSettings:SmtpPort", "8023");
-
-            var replaced = Replace(variables, existingFile: "appsettings.array.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "EmailSettings:SmtpPort", "8023" }
+                                },
+                                existingFile: "appsettings.array.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldReplaceDecimal()
         {
-            var variables = new CalamariVariables();
-            variables.Set("DecimalValue", "50.0");
-            variables.Set("FloatValue", "456e-5");
-            variables.Set("StringValue", "60.0");
-            variables.Set("IntegerValue", "70");
-
-            var replaced = Replace(variables, existingFile: "appsettings.decimals.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "DecimalValue", "50.0" },
+                                    { "FloatValue", "456e-5" },
+                                    { "StringValue", "60.0" },
+                                    { "IntegerValue", "70" }
+                                },
+                                existingFile: "appsettings.decimals.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
         [Test]
         public void ShouldReplaceBoolean()
         {
-            var variables = new CalamariVariables();
-            variables.Set("EmailSettings:UseProxy", "true");
-
-            var replaced = Replace(variables, existingFile: "appsettings.array.json");
-            this.Assent(replaced, TestEnvironment.AssentJsonDeepCompareConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "EmailSettings:UseProxy", "true" }
+                                },
+                                existingFile: "appsettings.array.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/types.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/types.yaml
@@ -1,0 +1,12 @@
+﻿null1: null
+bool1: false
+int1: 1
+float1: 0.67
+str1: 'false'
+str2: 'null'
+obj1:
+  key1: one
+  key2: two
+seq1:
+- foo
+- bar

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -19,66 +19,66 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
         public void CanReplaceStringWithString()
         {
             this.Assent(Replace(new CalamariVariables
-                    {
-                        { "server:ports:0", "8080" },
-                        { "Spring:H2:Console:Enabled", "false" },
-                        { "environment", "production" }
-                    },
-                    "application.yaml"),
-                TestEnvironment.AssentConfiguration);
+                                {
+                                    { "server:ports:0", "8080" },
+                                    { "Spring:H2:Console:Enabled", "false" },
+                                    { "environment", "production" }
+                                },
+                                "application.yaml"),
+                        TestEnvironment.AssentConfiguration);
         }
 
         [Test]
         public void CanReplaceMappingWithString()
         {
             this.Assent(Replace(new CalamariVariables
-                    {
-                        { "server", "local" },
-                        { "spring:datasource", "none" }
-                    },
-                    "application.yaml"),
-                TestEnvironment.AssentConfiguration);
+                                {
+                                    { "server", "local" },
+                                    { "spring:datasource", "none" }
+                                },
+                                "application.yaml"),
+                        TestEnvironment.AssentConfiguration);
         }
 
         [Test]
         public void CanReplaceSequenceWithString()
         {
             this.Assent(Replace(new CalamariVariables
-                    {
-                        { "server:ports", "none" }
-                    },
-                    "application.yaml"),
-                TestEnvironment.AssentConfiguration);
+                                {
+                                    { "server:ports", "none" }
+                                },
+                                "application.yaml"),
+                        TestEnvironment.AssentConfiguration);
         }
 
         [Test]
         public void CanReplaceMappingDespiteReplacementInsideMapping()
         {
             this.Assent(Replace(new CalamariVariables
-                    {
-                        { "spring:datasource:dbcp2", "none" },
-                        { "spring:datasource", "none" }
-                    },
-                    "application.yaml"),
-                TestEnvironment.AssentConfiguration);
+                                {
+                                    { "spring:datasource:dbcp2", "none" },
+                                    { "spring:datasource", "none" }
+                                },
+                                "application.yaml"),
+                        TestEnvironment.AssentConfiguration);
         }
 
         [Test]
         public void TypesAreInfluencedByThePositionInTheInputDocument()
         {
             this.Assent(Replace(new CalamariVariables
-                    {
-                        { "null1", "~" },
-                        { "bool1", "true" },
-                        { "int1", "99" },
-                        { "float1", "1.99" },
-                        { "str1", "true" },
-                        { "str2", "~" },
-                        { "obj1", $"fruit: apple{Environment.NewLine}animal: sloth" },
-                        { "seq1", $"- scissors{Environment.NewLine}- paper{Environment.NewLine}- rock" }
-                    },
-                    "types.yaml"),
-                TestEnvironment.AssentConfiguration);
+                                {
+                                    { "null1", "~" },
+                                    { "bool1", "true" },
+                                    { "int1", "99" },
+                                    { "float1", "1.99" },
+                                    { "str1", "true" },
+                                    { "str2", "~" },
+                                    { "obj1", $"fruit: apple{Environment.NewLine}animal: sloth" },
+                                    { "seq1", $"- scissors{Environment.NewLine}- paper{Environment.NewLine}- rock" }
+                                },
+                                "types.yaml"),
+                        TestEnvironment.AssentConfiguration);
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -10,75 +10,75 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
     [TestFixture]
     public class YamlVariableReplacerFixture : VariableReplacerFixture
     {
-        public YamlVariableReplacerFixture() : base(new YamlFormatVariableReplacer())
+        public YamlVariableReplacerFixture()
+            : base(new YamlFormatVariableReplacer())
         {
         }
 
         [Test]
         public void CanReplaceStringWithString()
         {
-            var variables = new CalamariVariables();
-            variables.Set("server:ports:0", "8080");
-            variables.Set("Spring:H2:Console:Enabled", "false");
-            variables.Set("environment", "production");
-
-            var replaced = Replace(variables, "application.yaml");
-
-            this.Assent(replaced, TestEnvironment.AssentConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                    {
+                        { "server:ports:0", "8080" },
+                        { "Spring:H2:Console:Enabled", "false" },
+                        { "environment", "production" }
+                    },
+                    "application.yaml"),
+                TestEnvironment.AssentConfiguration);
         }
 
         [Test]
         public void CanReplaceMappingWithString()
         {
-            var variables = new CalamariVariables();
-            variables.Set("server", "local");
-            variables.Set("spring:datasource", "none");
-
-            var replaced = Replace(variables, "application.yaml");
-
-            this.Assent(replaced, TestEnvironment.AssentConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                    {
+                        { "server", "local" },
+                        { "spring:datasource", "none" }
+                    },
+                    "application.yaml"),
+                TestEnvironment.AssentConfiguration);
         }
 
         [Test]
         public void CanReplaceSequenceWithString()
         {
-            var variables = new CalamariVariables();
-            variables.Set("server:ports", "none");
-
-            var replaced = Replace(variables, "application.yaml");
-
-            this.Assent(replaced, TestEnvironment.AssentConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                    {
+                        { "server:ports", "none" }
+                    },
+                    "application.yaml"),
+                TestEnvironment.AssentConfiguration);
         }
 
         [Test]
         public void CanReplaceMappingDespiteReplacementInsideMapping()
         {
-            var variables = new CalamariVariables();
-            variables.Set("spring:datasource:dbcp2", "none");
-            variables.Set("spring:datasource", "none");
-
-            var replaced = Replace(variables, "application.yaml");
-
-            this.Assent(replaced, TestEnvironment.AssentConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                    {
+                        { "spring:datasource:dbcp2", "none" },
+                        { "spring:datasource", "none" }
+                    },
+                    "application.yaml"),
+                TestEnvironment.AssentConfiguration);
         }
 
         [Test]
         public void TypesAreInfluencedByThePositionInTheInputDocument()
         {
-            var variables = new CalamariVariables
-            {
-                { "null1", "~" },
-                { "bool1", "true" },
-                { "int1", "99" },
-                { "float1", "1.99" },
-                { "str1", "true" },
-                { "str2", "~" },
-                { "obj1", $"fruit: apple{Environment.NewLine}animal: sloth" },
-                { "seq1", $"- scissors{Environment.NewLine}- paper{Environment.NewLine}- rock" }
-            };
-            var replaced = Replace(variables, "types.yaml");
-
-            this.Assent(replaced, TestEnvironment.AssentConfiguration);
+            this.Assent(Replace(new CalamariVariables
+                    {
+                        { "null1", "~" },
+                        { "bool1", "true" },
+                        { "int1", "99" },
+                        { "float1", "1.99" },
+                        { "str1", "true" },
+                        { "str2", "~" },
+                        { "obj1", $"fruit: apple{Environment.NewLine}animal: sloth" },
+                        { "seq1", $"- scissors{Environment.NewLine}- paper{Environment.NewLine}- rock" }
+                    },
+                    "types.yaml"),
+                TestEnvironment.AssentConfiguration);
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -1,4 +1,5 @@
-﻿using Assent;
+﻿using System;
+using Assent;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Tests.Helpers;
@@ -57,6 +58,25 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             variables.Set("spring:datasource", "none");
 
             var replaced = Replace(variables, "application.yaml");
+
+            this.Assent(replaced, TestEnvironment.AssentConfiguration);
+        }
+
+        [Test]
+        public void TypesAreInfluencedByThePositionInTheInputDocument()
+        {
+            var variables = new CalamariVariables
+            {
+                { "null1", "~" },
+                { "bool1", "true" },
+                { "int1", "99" },
+                { "float1", "1.99" },
+                { "str1", "true" },
+                { "str2", "~" },
+                { "obj1", $"fruit: apple{Environment.NewLine}animal: sloth" },
+                { "seq1", $"- scissors{Environment.NewLine}- paper{Environment.NewLine}- rock" }
+            };
+            var replaced = Replace(variables, "types.yaml");
 
             this.Assent(replaced, TestEnvironment.AssentConfiguration);
         }


### PR DESCRIPTION
With this change, the YAML replacer:
- treats replacements for mappings and sequences as raw YAML if possible, falling back to a string scalar if parsing fails
- preserves input document types in a basic way, by preserving anchors, tags, style, and quoting (but quotes non-compliant input if special characters necessitate it). This works in most cases, but I'm still investigating edge cases, to be raised with more extensive test coverage in a future PR.

Note to reviewer: It will be easiest to review each commit separately. Only the 3rd ("Implement..." `34972a8`) includes functional changes; the others are refactors.