### PR TITLE
Use CalamariFileSystem in JsonFormatVariableReplacer.

### DIFF
--- a/source/Calamari.Azure.CloudServices/Commands/DeployAzureCloudServiceCommand.cs
+++ b/source/Calamari.Azure.CloudServices/Commands/DeployAzureCloudServiceCommand.cs
@@ -78,7 +78,7 @@ namespace Calamari.Azure.CloudServices.Commands
             var transformFileLocator = new TransformFileLocator(fileSystem);
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
             var jsonVariablesReplacer = new StructuredConfigVariableReplacer(
-                new JsonFormatVariableReplacer(), 
+                new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
 
             var conventions = new List<IConvention>

--- a/source/Calamari.Azure.ServiceFabric/Commands/DeployAzureServiceFabricAppCommand.cs
+++ b/source/Calamari.Azure.ServiceFabric/Commands/DeployAzureServiceFabricAppCommand.cs
@@ -79,7 +79,7 @@ namespace Calamari.Azure.ServiceFabric.Commands
             var embeddedResources = new AssemblyEmbeddedResources();
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
             var jsonReplacer = new StructuredConfigVariableReplacer(
-                new JsonFormatVariableReplacer(), 
+                new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables);
             var transformFileLocator = new TransformFileLocator(fileSystem);

--- a/source/Calamari.Azure.WebApps/Commands/DeployAzureWebCommand.cs
+++ b/source/Calamari.Azure.WebApps/Commands/DeployAzureWebCommand.cs
@@ -66,7 +66,7 @@ namespace Calamari.Azure.WebApps.Commands
             var fileSystem = new WindowsPhysicalFileSystem();
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
             var jsonReplacer = new StructuredConfigVariableReplacer(
-                new JsonFormatVariableReplacer(), 
+                new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables);
             var transformFileLocator = new TransformFileLocator(fileSystem);

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
@@ -1,6 +1,7 @@
 ﻿using Assent;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Common.Features.StructuredVariables;
+using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
 
@@ -9,7 +10,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
     [TestFixture]
     public class JsonFormatVariableReplacerFixture : VariableReplacerFixture
     {
-        public JsonFormatVariableReplacerFixture() : base(new JsonFormatVariableReplacer())
+        public JsonFormatVariableReplacerFixture() : base(new JsonFormatVariableReplacer(CalamariPhysicalFileSystem.GetPhysicalFileSystem()))
         {
         }
 

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -74,7 +74,7 @@ namespace Calamari.Commands
 
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
             var generator = new StructuredConfigVariableReplacer(
-                new JsonFormatVariableReplacer(), 
+                new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables);
             var transformFileLocator = new TransformFileLocator(fileSystem);

--- a/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
+++ b/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
@@ -73,7 +73,7 @@ namespace Calamari.Commands.Java
             var journal = new DeploymentJournal(fileSystem, semaphore, variables);
 
             var jsonReplacer = new StructuredConfigVariableReplacer(
-                new JsonFormatVariableReplacer(), 
+                new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
             var jarTools = new JarTool(commandLineRunner, log, variables);
             var packageExtractor = new JarPackageExtractor(jarTools);

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -66,7 +66,7 @@ namespace Calamari.Commands
             var transformFileLocator = new TransformFileLocator(fileSystem);
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
             var jsonVariableReplacer = new StructuredConfigVariableReplacer(
-                new JsonFormatVariableReplacer(), 
+                new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
 
             ValidateArguments();


### PR DESCRIPTION
`JsonFormatVariableReplacer` currently uses the built in .net methods to access the file system, which makes it harder to test. This PR injects the existing `ICalamariFileSystem` into `JsonFormatVariableReplacer` so that we can more easily write tests.