### PR TITLE
Refactor most of the code out of the Json convention.

### DIFF
--- a/source/Calamari.Azure.CloudServices/Commands/DeployAzureCloudServiceCommand.cs
+++ b/source/Calamari.Azure.CloudServices/Commands/DeployAzureCloudServiceCommand.cs
@@ -80,7 +80,7 @@ namespace Calamari.Azure.CloudServices.Commands
             var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
-            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem, log);
 
             var conventions = new List<IConvention>
             {

--- a/source/Calamari.Azure.CloudServices/Commands/DeployAzureCloudServiceCommand.cs
+++ b/source/Calamari.Azure.CloudServices/Commands/DeployAzureCloudServiceCommand.cs
@@ -77,9 +77,10 @@ namespace Calamari.Azure.CloudServices.Commands
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables);
             var transformFileLocator = new TransformFileLocator(fileSystem);
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
-            var jsonVariablesReplacer = new StructuredConfigVariableReplacer(
+            var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
 
             var conventions = new List<IConvention>
             {
@@ -95,7 +96,7 @@ namespace Calamari.Azure.CloudServices.Commands
                 new DelegateInstallConvention(d => substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(d)),
                 new ConfigurationTransformsConvention(fileSystem, configurationTransformer, transformFileLocator),
                 new ConfigurationVariablesConvention(fileSystem, replacer),
-                new JsonConfigurationVariablesConvention(jsonVariablesReplacer, fileSystem),
+                new JsonConfigurationVariablesConvention(structuredConfigVariablesService),
                 new PackagedScriptConvention(log, DeploymentStages.Deploy, fileSystem, scriptEngine, commandLineRunner),
                 new ConfiguredScriptConvention(DeploymentStages.Deploy, fileSystem, scriptEngine, commandLineRunner),
                 new RePackageCloudServiceConvention(fileSystem),

--- a/source/Calamari.Azure.ServiceFabric/Commands/DeployAzureServiceFabricAppCommand.cs
+++ b/source/Calamari.Azure.ServiceFabric/Commands/DeployAzureServiceFabricAppCommand.cs
@@ -81,7 +81,7 @@ namespace Calamari.Azure.ServiceFabric.Commands
             var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
-            var structuredConfigFileService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
+            var structuredConfigFileService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem, log);
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables);
             var transformFileLocator = new TransformFileLocator(fileSystem);
 

--- a/source/Calamari.Azure.ServiceFabric/Commands/DeployAzureServiceFabricAppCommand.cs
+++ b/source/Calamari.Azure.ServiceFabric/Commands/DeployAzureServiceFabricAppCommand.cs
@@ -78,9 +78,10 @@ namespace Calamari.Azure.ServiceFabric.Commands
             var fileSystem = new WindowsPhysicalFileSystem();
             var embeddedResources = new AssemblyEmbeddedResources();
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
-            var jsonReplacer = new StructuredConfigVariableReplacer(
+            var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
+            var structuredConfigFileService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables);
             var transformFileLocator = new TransformFileLocator(fileSystem);
 
@@ -96,7 +97,7 @@ namespace Calamari.Azure.ServiceFabric.Commands
                 new DelegateInstallConvention(d => substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(d)),
                 new ConfigurationTransformsConvention(fileSystem, configurationTransformer, transformFileLocator),
                 new ConfigurationVariablesConvention(fileSystem, replacer),
-                new JsonConfigurationVariablesConvention(jsonReplacer, fileSystem),
+                new JsonConfigurationVariablesConvention(structuredConfigFileService),
 
                 // Deploy stage
                 new PackagedScriptConvention(log, DeploymentStages.Deploy, fileSystem, scriptEngine, commandLineRunner),

--- a/source/Calamari.Azure.WebApps/Commands/DeployAzureWebCommand.cs
+++ b/source/Calamari.Azure.WebApps/Commands/DeployAzureWebCommand.cs
@@ -68,7 +68,7 @@ namespace Calamari.Azure.WebApps.Commands
             var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
-            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem, log);
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables);
             var transformFileLocator = new TransformFileLocator(fileSystem);
 

--- a/source/Calamari.Azure.WebApps/Commands/DeployAzureWebCommand.cs
+++ b/source/Calamari.Azure.WebApps/Commands/DeployAzureWebCommand.cs
@@ -65,9 +65,10 @@ namespace Calamari.Azure.WebApps.Commands
 
             var fileSystem = new WindowsPhysicalFileSystem();
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
-            var jsonReplacer = new StructuredConfigVariableReplacer(
+            var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables);
             var transformFileLocator = new TransformFileLocator(fileSystem);
 
@@ -79,7 +80,7 @@ namespace Calamari.Azure.WebApps.Commands
                 new DelegateInstallConvention(d => substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(d)),
                 new ConfigurationTransformsConvention(fileSystem, configurationTransformer, transformFileLocator),
                 new ConfigurationVariablesConvention(fileSystem, replacer),
-                new JsonConfigurationVariablesConvention(jsonReplacer, fileSystem),
+                new JsonConfigurationVariablesConvention(structuredConfigVariablesService),
                 new PackagedScriptConvention(log, DeploymentStages.Deploy, fileSystem, scriptEngine, commandLineRunner),
                 new ConfiguredScriptConvention(DeploymentStages.Deploy, fileSystem, scriptEngine, commandLineRunner),
                 new AzureWebAppConvention(log),

--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
@@ -17,11 +17,16 @@ namespace Calamari.Common.Features.StructuredVariables
     {
         readonly IStructuredConfigVariableReplacer structuredConfigVariableReplacer;
         readonly ICalamariFileSystem fileSystem;
+        readonly ILog log;
 
-        public StructuredConfigVariablesService(IStructuredConfigVariableReplacer structuredConfigVariableReplacer, ICalamariFileSystem fileSystem)
+        public StructuredConfigVariablesService(
+            IStructuredConfigVariableReplacer structuredConfigVariableReplacer, 
+            ICalamariFileSystem fileSystem,
+            ILog log)
         {
             this.structuredConfigVariableReplacer = structuredConfigVariableReplacer;
             this.fileSystem = fileSystem;
+            this.log = log;
         }
 
         public void ReplaceVariables(RunningDeployment deployment)
@@ -30,7 +35,7 @@ namespace Calamari.Common.Features.StructuredVariables
             {
                 if (fileSystem.DirectoryExists(target))
                 {
-                    Log.Warn($"Skipping JSON variable replacement on '{target}' because it is a directory.");
+                    log.Warn($"Skipping JSON variable replacement on '{target}' because it is a directory.");
                     continue;
                 }
 
@@ -38,13 +43,13 @@ namespace Calamari.Common.Features.StructuredVariables
 
                 if (!matchingFiles.Any())
                 {
-                    Log.Warn($"No files were found that match the replacement target pattern '{target}'");
+                    log.Warn($"No files were found that match the replacement target pattern '{target}'");
                     continue;
                 }
 
                 foreach (var file in matchingFiles)
                 {
-                    Log.Info($"Performing JSON variable replacement on '{file}'");
+                    log.Info($"Performing JSON variable replacement on '{file}'");
                     structuredConfigVariableReplacer.ModifyFile(file, deployment.Variables);
                 }
             }

--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Common.Features.StructuredVariables
+{
+    public interface IStructuredConfigVariablesService
+    {
+        void ReplaceVariables(RunningDeployment deployment);
+    }
+
+    public class StructuredConfigVariablesService : IStructuredConfigVariablesService
+    {
+        readonly IStructuredConfigVariableReplacer structuredConfigVariableReplacer;
+        readonly ICalamariFileSystem fileSystem;
+
+        public StructuredConfigVariablesService(IStructuredConfigVariableReplacer structuredConfigVariableReplacer, ICalamariFileSystem fileSystem)
+        {
+            this.structuredConfigVariableReplacer = structuredConfigVariableReplacer;
+            this.fileSystem = fileSystem;
+        }
+
+        public void ReplaceVariables(RunningDeployment deployment)
+        {
+            foreach (var target in deployment.Variables.GetPaths(PackageVariables.JsonConfigurationVariablesTargets))
+            {
+                if (fileSystem.DirectoryExists(target))
+                {
+                    Log.Warn($"Skipping JSON variable replacement on '{target}' because it is a directory.");
+                    continue;
+                }
+
+                var matchingFiles = MatchingFiles(deployment, target);
+
+                if (!matchingFiles.Any())
+                {
+                    Log.Warn($"No files were found that match the replacement target pattern '{target}'");
+                    continue;
+                }
+
+                foreach (var file in matchingFiles)
+                {
+                    Log.Info($"Performing JSON variable replacement on '{file}'");
+                    structuredConfigVariableReplacer.ModifyFile(file, deployment.Variables);
+                }
+            }
+        }
+        
+        List<string> MatchingFiles(RunningDeployment deployment, string target)
+        {
+            var files = fileSystem.EnumerateFilesWithGlob(deployment.CurrentDirectory, target).Select(Path.GetFullPath).ToList();
+
+            foreach (var path in deployment.Variables.GetStrings(ActionVariables.AdditionalPaths).Where(s => !string.IsNullOrWhiteSpace(s)))
+            {
+                var pathFiles = fileSystem.EnumerateFilesWithGlob(path, target).Select(Path.GetFullPath);
+                files.AddRange(pathFiles);
+            }
+
+            return files;
+        }
+    }
+}

--- a/source/Calamari.Common/Plumbing/Variables/PackageVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/PackageVariables.cs
@@ -17,6 +17,8 @@ namespace Calamari.Common.Plumbing.Variables
         public static readonly string SubstituteInFilesEnabled = "Octopus.Action.SubstituteInFiles.Enabled";
         public static readonly string SubstituteInFilesTargets = "Octopus.Action.SubstituteInFiles.TargetFiles";
         public static readonly string PackageCollection = "Octopus.Action.Package";
+        public static readonly string JsonConfigurationVariablesEnabled = "Octopus.Action.Package.JsonConfigurationVariablesEnabled";
+        public static readonly string JsonConfigurationVariablesTargets = "Octopus.Action.Package.JsonConfigurationVariablesTargets";
 
         public static string IndexedPackageId(string packageReferenceName)
         {

--- a/source/Calamari.Shared/Deployment/Conventions/JsonConfigurationVariablesConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/JsonConfigurationVariablesConvention.cs
@@ -1,65 +1,24 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using Calamari.Common.Commands;
+﻿using Calamari.Common.Commands;
 using Calamari.Common.Features.StructuredVariables;
-using Calamari.Common.Plumbing.FileSystem;
-using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Deployment.Conventions
 {
     public class JsonConfigurationVariablesConvention : IInstallConvention
     {
-        readonly IStructuredConfigVariableReplacer structuredConfigVariableReplacer;
-        readonly ICalamariFileSystem fileSystem;
+        readonly IStructuredConfigVariablesService structuredConfigVariablesService;
 
-        public JsonConfigurationVariablesConvention(IStructuredConfigVariableReplacer structuredConfigVariableReplacer, ICalamariFileSystem fileSystem)
+        public JsonConfigurationVariablesConvention(IStructuredConfigVariablesService structuredConfigVariablesService)
         {
-            this.structuredConfigVariableReplacer = structuredConfigVariableReplacer;
-            this.fileSystem = fileSystem;
+            this.structuredConfigVariablesService = structuredConfigVariablesService;
         }
 
         public void Install(RunningDeployment deployment)
         {
-            if (!deployment.Variables.GetFlag(SpecialVariables.Package.JsonConfigurationVariablesEnabled))
+            if (!deployment.Variables.GetFlag(PackageVariables.JsonConfigurationVariablesEnabled))
                 return;
 
-            foreach (var target in deployment.Variables.GetPaths(SpecialVariables.Package.JsonConfigurationVariablesTargets))
-            {
-                if (fileSystem.DirectoryExists(target))
-                {
-                    Log.Warn($"Skipping JSON variable replacement on '{target}' because it is a directory.");
-                    continue;
-                }
-
-                var matchingFiles = MatchingFiles(deployment, target);
-
-                if (!matchingFiles.Any())
-                {
-                    Log.Warn($"No files were found that match the replacement target pattern '{target}'");
-                    continue;
-                }
-
-                foreach (var file in matchingFiles)
-                {
-                    Log.Info($"Performing JSON variable replacement on '{file}'");
-                    structuredConfigVariableReplacer.ModifyFile(file, deployment.Variables);
-                }
-            }
-        }
-
-        private List<string> MatchingFiles(RunningDeployment deployment, string target)
-        {
-            var files = fileSystem.EnumerateFilesWithGlob(deployment.CurrentDirectory, target).Select(Path.GetFullPath).ToList();
-
-            foreach (var path in deployment.Variables.GetStrings(ActionVariables.AdditionalPaths).Where(s => !string.IsNullOrWhiteSpace(s)))
-            {
-                var pathFiles = fileSystem.EnumerateFilesWithGlob(path, target).Select(Path.GetFullPath);
-                files.AddRange(pathFiles);
-            }
-
-            return files;
+            structuredConfigVariablesService.ReplaceVariables(deployment);
         }
     }
 }

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -71,8 +71,6 @@ namespace Calamari.Deployment
             public static readonly string UpdateIisWebsite = "Octopus.Action.Package.UpdateIisWebsite";
             public static readonly string UpdateIisWebsiteName = "Octopus.Action.Package.UpdateIisWebsiteName";
             public static readonly string AutomaticallyUpdateAppSettingsAndConnectionStrings = "Octopus.Action.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings";
-            public static readonly string JsonConfigurationVariablesEnabled = "Octopus.Action.Package.JsonConfigurationVariablesEnabled";
-            public static readonly string JsonConfigurationVariablesTargets = "Octopus.Action.Package.JsonConfigurationVariablesTargets";
             public static readonly string AutomaticallyRunConfigurationTransformationFiles = "Octopus.Action.Package.AutomaticallyRunConfigurationTransformationFiles";
             public static readonly string TreatConfigTransformationWarningsAsErrors = "Octopus.Action.Package.TreatConfigTransformationWarningsAsErrors";
             public static readonly string IgnoreConfigTransformationErrors = "Octopus.Action.Package.IgnoreConfigTransformationErrors";

--- a/source/Calamari.Tests/Fixtures/Conventions/JsonConfigurationVariablesConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/JsonConfigurationVariablesConventionFixture.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment.Conventions;
 using Calamari.Tests.Helpers;
@@ -17,6 +18,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         RunningDeployment deployment;
         IStructuredConfigVariableReplacer configVariableReplacer;
         ICalamariFileSystem fileSystem;
+        ILog log;
         const string StagingDirectory = "C:\\applications\\Acme\\1.0.0";
 
         [SetUp]
@@ -28,12 +30,13 @@ namespace Calamari.Tests.Fixtures.Conventions
             configVariableReplacer = Substitute.For<IStructuredConfigVariableReplacer>();
             fileSystem = Substitute.For<ICalamariFileSystem>();
             fileSystem.DirectoryExists(Arg.Any<string>()).Returns(false);
+            log = Substitute.For<ILog>();
         }
 
         [Test]
         public void ShouldNotRunIfVariableNotSet()
         {
-            var service = new StructuredConfigVariablesService(configVariableReplacer, fileSystem);
+            var service = new StructuredConfigVariablesService(configVariableReplacer, fileSystem, log);
             var convention = new JsonConfigurationVariablesConvention(service);
             convention.Install(deployment);
             configVariableReplacer.DidNotReceiveWithAnyArgs().ModifyFile(null, null);
@@ -48,7 +51,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             deployment.Variables.Set(PackageVariables.JsonConfigurationVariablesEnabled, "true");
             deployment.Variables.Set(PackageVariables.JsonConfigurationVariablesTargets, "appsettings.environment.json");
             
-            var service = new StructuredConfigVariablesService(configVariableReplacer, fileSystem);
+            var service = new StructuredConfigVariablesService(configVariableReplacer, fileSystem, log);
             var convention = new JsonConfigurationVariablesConvention(service);
             convention.Install(deployment);
             configVariableReplacer.Received().ModifyFile(TestEnvironment.ConstructRootedPath("applications", "Acme", "1.0.0", "appsettings.environment.json"), deployment.Variables);
@@ -72,7 +75,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             deployment.Variables.Set(PackageVariables.JsonConfigurationVariablesEnabled, "true");
             deployment.Variables.Set(PackageVariables.JsonConfigurationVariablesTargets, string.Join(Environment.NewLine, "config.json", "config.*.json"));
 
-            var service = new StructuredConfigVariablesService(configVariableReplacer, fileSystem);
+            var service = new StructuredConfigVariablesService(configVariableReplacer, fileSystem, log);
             var convention = new JsonConfigurationVariablesConvention(service);
             convention.Install(deployment);
 
@@ -90,7 +93,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             deployment.Variables.Set(PackageVariables.JsonConfigurationVariablesTargets, "approot");
             fileSystem.DirectoryExists(Arg.Any<string>()).Returns(true);
 
-            var service = new StructuredConfigVariablesService(configVariableReplacer, fileSystem);
+            var service = new StructuredConfigVariablesService(configVariableReplacer, fileSystem, log);
             var convention = new JsonConfigurationVariablesConvention(service);
             convention.Install(deployment);
             configVariableReplacer.DidNotReceiveWithAnyArgs().ModifyFile(null, null);

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithJsonConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithJsonConfigurationFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System.IO;
 using Assent;
 using Calamari.Common.Plumbing.FileSystem;
-using Calamari.Deployment;
+using Calamari.Common.Plumbing.Variables;
 using Calamari.Tests.Fixtures.Deployment.Packages;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
@@ -25,8 +25,8 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(SpecialVariables.Package.JsonConfigurationVariablesEnabled, true);
-                Variables.Set(SpecialVariables.Package.JsonConfigurationVariablesTargets, JsonFileName);
+                Variables.AddFlag(PackageVariables.JsonConfigurationVariablesEnabled, true);
+                Variables.Set(PackageVariables.JsonConfigurationVariablesTargets, JsonFileName);
                 Variables.Set("departments:0:employees:0:name", "Jane");
                 Variables.Set("departments:0:employees:1:age", "40");
                 Variables.Set("phone", "0123 456 789");

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployVhdFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployVhdFixture.cs
@@ -41,8 +41,8 @@ namespace Calamari.Tests.Fixtures.Deployment
             Variables[PackageVariables.SubstituteInFilesEnabled] = "True";
             Variables[SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles] = "True";
             Variables[DeploymentEnvironment.Name] = Environment;
-            Variables[SpecialVariables.Package.JsonConfigurationVariablesEnabled] = "True";
-            Variables[SpecialVariables.Package.JsonConfigurationVariablesTargets] = "appsettings.json";
+            Variables[PackageVariables.JsonConfigurationVariablesEnabled] = "True";
+            Variables[PackageVariables.JsonConfigurationVariablesTargets] = "appsettings.json";
 
             using (var vhd = new TemporaryFile(VhdBuilder.BuildSampleVhd(ServiceName)))
             using (var file = new TemporaryFile(PackageBuilder.BuildSimpleZip(ServiceName, "1.0.0", Path.GetDirectoryName(vhd.FilePath))))
@@ -85,8 +85,8 @@ namespace Calamari.Tests.Fixtures.Deployment
             Variables[PackageVariables.SubstituteInFilesEnabled] = "True";
             Variables[SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles] = "True";
             Variables[DeploymentEnvironment.Name] = Environment;
-            Variables[SpecialVariables.Package.JsonConfigurationVariablesEnabled] = "True";
-            Variables[SpecialVariables.Package.JsonConfigurationVariablesTargets] = "appsettings.json";
+            Variables[PackageVariables.JsonConfigurationVariablesEnabled] = "True";
+            Variables[PackageVariables.JsonConfigurationVariablesTargets] = "appsettings.json";
 
             Variables["OctopusVhdPartitions[1].ApplicationPath"] = "PathThatDoesNotExist";
 
@@ -137,8 +137,8 @@ namespace Calamari.Tests.Fixtures.Deployment
             Variables[PackageVariables.SubstituteInFilesEnabled] = "True";
             Variables[SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles] = "True";
             Variables[DeploymentEnvironment.Name] = Environment;
-            Variables[SpecialVariables.Package.JsonConfigurationVariablesEnabled] = "True";
-            Variables[SpecialVariables.Package.JsonConfigurationVariablesTargets] = "appsettings.json";
+            Variables[PackageVariables.JsonConfigurationVariablesEnabled] = "True";
+            Variables[PackageVariables.JsonConfigurationVariablesTargets] = "appsettings.json";
 
             Variables["OctopusVhdPartitions[0].Mount"] = "false";
             Variables["OctopusVhdPartitions[1].ApplicationPath"] = "AlternateApplicationPath";

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -73,9 +73,10 @@ namespace Calamari.Commands
             var featureClasses = new List<IFeature>();
 
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
-            var generator = new StructuredConfigVariableReplacer(
+            var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables);
             var transformFileLocator = new TransformFileLocator(fileSystem);
             var embeddedResources = new AssemblyEmbeddedResources();
@@ -102,7 +103,7 @@ namespace Calamari.Commands
                 new DelegateInstallConvention(d => substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(d)),
                 new ConfigurationTransformsConvention(fileSystem, configurationTransformer, transformFileLocator),
                 new ConfigurationVariablesConvention(fileSystem, replacer),
-                new JsonConfigurationVariablesConvention(generator, fileSystem),
+                new JsonConfigurationVariablesConvention(structuredConfigVariablesService),
                 new CopyPackageToCustomInstallationDirectoryConvention(fileSystem),
                 new FeatureConvention(DeploymentStages.BeforeDeploy, featureClasses, fileSystem, scriptEngine, commandLineRunner, embeddedResources),
                 new PackagedScriptConvention(log, DeploymentStages.Deploy, fileSystem, scriptEngine, commandLineRunner),

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -76,7 +76,7 @@ namespace Calamari.Commands
             var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
-            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem, log);
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables);
             var transformFileLocator = new TransformFileLocator(fileSystem);
             var embeddedResources = new AssemblyEmbeddedResources();

--- a/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
+++ b/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
@@ -75,7 +75,7 @@ namespace Calamari.Commands.Java
             var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
-            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem, log);
             var jarTools = new JarTool(commandLineRunner, log, variables);
             var packageExtractor = new JarPackageExtractor(jarTools);
             var embeddedResources = new AssemblyEmbeddedResources();

--- a/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
+++ b/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
@@ -72,9 +72,10 @@ namespace Calamari.Commands.Java
             var semaphore = SemaphoreFactory.Get();
             var journal = new DeploymentJournal(fileSystem, semaphore, variables);
 
-            var jsonReplacer = new StructuredConfigVariableReplacer(
+            var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
             var jarTools = new JarTool(commandLineRunner, log, variables);
             var packageExtractor = new JarPackageExtractor(jarTools);
             var embeddedResources = new AssemblyEmbeddedResources();
@@ -102,7 +103,7 @@ namespace Calamari.Commands.Java
                 new PackagedScriptConvention(log, DeploymentStages.PreDeploy, fileSystem, scriptEngine, commandLineRunner),
                 new FeatureConvention(DeploymentStages.AfterPreDeploy, featureClasses, fileSystem, scriptEngine, commandLineRunner, embeddedResources),
                 new DelegateInstallConvention(d => substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(d)),
-                new JsonConfigurationVariablesConvention(jsonReplacer, fileSystem),
+                new JsonConfigurationVariablesConvention(structuredConfigVariablesService),
                 new RePackArchiveConvention(log, fileSystem, jarTools),
                 new CopyPackageToCustomInstallationDirectoryConvention(fileSystem),
                 new FeatureConvention(DeploymentStages.BeforeDeploy, featureClasses, fileSystem, scriptEngine, commandLineRunner, embeddedResources),

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -68,7 +68,7 @@ namespace Calamari.Commands
             var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
-            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem, log);
 
             ValidateArguments();
             WriteVariableScriptToFile();

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -65,9 +65,10 @@ namespace Calamari.Commands
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables);
             var transformFileLocator = new TransformFileLocator(fileSystem);
             var replacer = new ConfigurationVariablesReplacer(variables.GetFlag(SpecialVariables.Package.IgnoreVariableReplacementErrors));
-            var jsonVariableReplacer = new StructuredConfigVariableReplacer(
+            var structuredConfigVariableReplacer = new StructuredConfigVariableReplacer(
                 new JsonFormatVariableReplacer(fileSystem), 
                 new YamlFormatVariableReplacer());
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(structuredConfigVariableReplacer, fileSystem);
 
             ValidateArguments();
             WriteVariableScriptToFile();
@@ -81,7 +82,7 @@ namespace Calamari.Commands
                 new DelegateInstallConvention(d => substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(d)),
                 new ConfigurationTransformsConvention(fileSystem, configurationTransformer, transformFileLocator),
                 new ConfigurationVariablesConvention(fileSystem, replacer),
-                new JsonConfigurationVariablesConvention(jsonVariableReplacer, fileSystem),
+                new JsonConfigurationVariablesConvention(structuredConfigVariablesService),
                 new ExecuteScriptConvention(scriptEngine, commandLineRunner)
             };
 


### PR DESCRIPTION
This PR refactors most of the logic out of the `JsonConfigurationVariablesConvention` and into a service. This gets us a little closer to where we want to be with Calamari in general:

- Less in `Calamari.Shared` and more in `Calamari.Common`
- Less code in conventions, and more in services, so that the move to behaviours is simpler
- `ILog` being injected.

This change required moving `JsonConfigurationVariablesTargets` and `JsonConfigurationVariablesEnabled` out of `SpecialVariables` (in `Calamari.Shared`) into `PackageVariables` (in `Calamari.Common`).

One consideration: Not 100% sure yet where the boundary between `StructuredConfigVariableReplacer` and `StructuredConfigVariablesService` will lie. We might be able to roll them in together.