### PR TITLE
Apply code cleanup

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Calamari.Tests</AssemblyName>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
@@ -1,7 +1,8 @@
-﻿using Assent;
-using Calamari.Common.Plumbing.Variables;
+﻿using System;
+using Assent;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Variables;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
 
@@ -25,7 +26,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                     { "EmailSettings:DefaultRecipients:To", "paul@octopus.com" },
                                     { "EmailSettings:DefaultRecipients:Cc", "henrik@octopus.com" }
                                 },
-                                existingFile: "appsettings.simple.json"),
+                                "appsettings.simple.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -40,7 +41,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                     { "Octopus.Rocks", "So is this" },
                                     { "Octopus:Section", "Should work" }
                                 },
-                                existingFile: "appsettings.ignore-octopus.json"),
+                                "appsettings.ignore-octopus.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -51,7 +52,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 {
                                     { "0:Property", "NewValue" }
                                 },
-                                existingFile: "appsettings.top-level-array.json"),
+                                "appsettings.top-level-array.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -64,7 +65,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                     { "EmailSettings:SmtpPort", "24" },
                                     { "EmailSettings:DefaultRecipients:Cc", "damo@octopus.com" }
                                 },
-                                existingFile: "appsettings.existing-expected.json"),
+                                "appsettings.existing-expected.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -77,7 +78,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                     { "EmailSettings:Defaultrecipients:To", "mark@octopus.com" },
                                     { "EmailSettings:defaultRecipients:Cc", "henrik@octopus.com" }
                                 },
-                                existingFile: "appsettings.simple.json"),
+                                "appsettings.simple.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -88,7 +89,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 {
                                     { "MyMessage", "" }
                                 },
-                                existingFile: "appsettings.single.json"),
+                                "appsettings.single.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -99,7 +100,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 {
                                     { "MyMessage", null }
                                 },
-                                existingFile: "appsettings.single.json"),
+                                "appsettings.single.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -110,7 +111,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 {
                                     { "EnvironmentVariables:Hosting:Environment", "Production" }
                                 },
-                                existingFile: "appsettings.colon-in-name.json"),
+                                "appsettings.colon-in-name.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -121,7 +122,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 {
                                     { "EmailSettings:DefaultRecipients", @"{""To"": ""rob@octopus.com"", ""Cc"": ""henrik@octopus.com""}" }
                                 },
-                                existingFile: "appsettings.simple.json"),
+                                "appsettings.simple.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -132,7 +133,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 {
                                     { "EmailSettings:DefaultRecipients:1", "henrik@octopus.com" }
                                 },
-                                existingFile: "appsettings.array.json"),
+                                "appsettings.array.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -143,7 +144,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 {
                                     { "EmailSettings:DefaultRecipients:1:Email", "henrik@octopus.com" }
                                 },
-                                existingFile: "appsettings.object-array.json"),
+                                "appsettings.object-array.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -154,7 +155,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 {
                                     { "EmailSettings:DefaultRecipients", @"[""mike@octopus.com"", ""henrik@octopus.com""]" }
                                 },
-                                existingFile: "appsettings.array.json"),
+                                "appsettings.array.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -165,7 +166,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 {
                                     { "EmailSettings:SmtpPort", "8023" }
                                 },
-                                existingFile: "appsettings.array.json"),
+                                "appsettings.array.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -179,7 +180,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                     { "StringValue", "60.0" },
                                     { "IntegerValue", "70" }
                                 },
-                                existingFile: "appsettings.decimals.json"),
+                                "appsettings.decimals.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
 
@@ -190,7 +191,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 {
                                     { "EmailSettings:UseProxy", "true" }
                                 },
-                                existingFile: "appsettings.array.json"),
+                                "appsettings.array.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
     }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredVariableReplacerFixture.cs
@@ -9,7 +9,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
 {
     public class StructuredVariableReplacerFixture
     {
-        private void RunTest(
+        void RunTest(
             bool canParseAsJson,
             bool canParseAsYaml,
             Action<Action> invocationAssertions
@@ -20,51 +20,51 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
 
             jsonReplacer.TryModifyFile(Arg.Any<string>(), Arg.Any<IVariables>()).Returns(canParseAsJson);
             yamlReplacer.TryModifyFile(Arg.Any<string>(), Arg.Any<IVariables>()).Returns(canParseAsYaml);
-            
+
             var replacer = new StructuredConfigVariableReplacer(jsonReplacer, yamlReplacer);
             var variables = new CalamariVariables
             {
-                {StructuredConfigVariableReplacer.FeatureToggleVariableName, "true"}
+                { StructuredConfigVariableReplacer.FeatureToggleVariableName, "true" }
             };
 
             invocationAssertions(replacer.Invoking(r => r.ModifyFile("path", variables)));
         }
-        
+
         [Test]
         public void ShouldNotThrowIfTheFileCanBeParsedAsJson()
         {
             RunTest(
-                canParseAsJson: true,
-                canParseAsYaml: false,
-                invocation => invocation
-                    .Should()
-                    .NotThrow()
-            );
+                    true,
+                    false,
+                    invocation => invocation
+                                  .Should()
+                                  .NotThrow()
+                   );
         }
-        
+
         [Test]
         public void ShouldNotThrowIfTheFileCanBeParsedAsYaml()
         {
             RunTest(
-                canParseAsJson: false,
-                canParseAsYaml: true,
-                invocation => invocation
-                    .Should()
-                    .NotThrow()
-            );
+                    false,
+                    true,
+                    invocation => invocation
+                                  .Should()
+                                  .NotThrow()
+                   );
         }
-        
+
         [Test]
         public void ShouldThrowIfTheFileCantBeParsedWithAllReplacers()
         {
             RunTest(
-                canParseAsJson: false,
-                canParseAsYaml: false,
-                invocation => invocation
-                    .Should()
-                    .ThrowExactly<Exception>()
-                    .WithMessage("The config file at 'path' couldn't be parsed.")
-            );
+                    false,
+                    false,
+                    invocation => invocation
+                                  .Should()
+                                  .ThrowExactly<Exception>()
+                                  .WithMessage("The config file at 'path' couldn't be parsed.")
+                   );
         }
 
         [Test]
@@ -74,16 +74,15 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             var yamlReplacer = Substitute.For<IYamlFormatVariableReplacer>();
 
             jsonReplacer.TryModifyFile(Arg.Any<string>(), Arg.Any<IVariables>()).Returns(true);
-            
+
             var replacer = new StructuredConfigVariableReplacer(jsonReplacer, yamlReplacer);
             var variables = new CalamariVariables
             {
-                {StructuredConfigVariableReplacer.FeatureToggleVariableName, "true"}
+                { StructuredConfigVariableReplacer.FeatureToggleVariableName, "true" }
             };
 
-
             replacer.ModifyFile("path", variables);
-            
+
             yamlReplacer.DidNotReceiveWithAnyArgs().TryModifyFile("", null);
         }
     }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/VariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/VariableReplacerFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlEventStreamClassifierFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlEventStreamClassifierFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Calamari.Common.Features.StructuredVariables;
 using NUnit.Framework;
@@ -58,9 +59,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                 {
                     var found = classifier.Process(parser.Current);
                     if (found is YamlNode<Scalar> scalarValue)
-                    {
                         result.Add((scalarValue.Path, scalarValue.Event.Value));
-                    }
                 }
             }
 

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlTransformApproachComparisonDemoFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlTransformApproachComparisonDemoFixture.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.IO;
 using NUnit.Framework;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
 
 namespace Calamari.Tests.Fixtures.StructuredVariables
 {
-    [TestFixture, Explicit]
+    [TestFixture]
+    [Explicit]
     public class YamlTransformApproachComparisonDemoFixture
     {
         [Test]
@@ -14,14 +17,14 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
 
             Demo(nameof(YamlDotNetSerializerIdentityTransform), () => YamlDotNetSerializerIdentityTransform(input));
             Demo(nameof(YamlDotNetParserEmitterIdentityTransform),
-                () => YamlDotNetParserEmitterIdentityTransform(input));
+                 () => YamlDotNetParserEmitterIdentityTransform(input));
             //Demo(nameof(SharpYamlSerializerIdentityTransform), () => SharpYamlSerializerIdentityTransform(input));
             //Demo(nameof(SharpYamlParserEmitterIdentityTransform), () => SharpYamlParserEmitterIdentityTransform(input));
         }
 
         public void Demo(string name, Func<string> transform)
         {
-            string output = "";
+            var output = "";
             try
             {
                 output = transform();
@@ -42,9 +45,9 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             using (var textReader = new StringReader(input))
             using (var textWriter = new StringWriter())
             {
-                var deserializer = new YamlDotNet.Serialization.DeserializerBuilder().Build();
+                var deserializer = new DeserializerBuilder().Build();
                 var data = deserializer.Deserialize(textReader);
-                new YamlDotNet.Serialization.Serializer().Serialize(textWriter, data ?? "");
+                new Serializer().Serialize(textWriter, data ?? "");
 
                 textWriter.Close();
                 return textWriter.ToString();
@@ -56,13 +59,11 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             using (var textReader = new StringReader(input))
             using (var textWriter = new StringWriter())
             {
-                var parser = new YamlDotNet.Core.Parser(textReader);
-                var emitter = new YamlDotNet.Core.Emitter(textWriter);
+                var parser = new Parser(textReader);
+                var emitter = new Emitter(textWriter);
                 while (parser.MoveNext())
-                {
                     if (parser.Current != null)
                         emitter.Emit(parser.Current);
-                }
 
                 textWriter.Close();
                 return textWriter.ToString();


### PR DESCRIPTION
This re-applies Full Code Cleanup to both StructuredVariables namespaces.

I think these seem acceptable, even though losing the bool parameter names isn't ideal - Shannon told me he did try to keep them but couldn't find a systematic way to do so.