### PR TITLE
Apply code cleanup etc

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/JsonFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/JsonFormatVariableReplacer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
@@ -17,14 +16,14 @@ namespace Calamari.Common.Features.StructuredVariables
     public class JsonFormatVariableReplacer : IJsonFormatVariableReplacer
     {
         readonly ICalamariFileSystem fileSystem;
-        
-        public string FileFormatName => "JSON";
 
         public JsonFormatVariableReplacer(ICalamariFileSystem fileSystem)
         {
             this.fileSystem = fileSystem;
         }
-        
+
+        public string FileFormatName => "JSON";
+
         public bool TryModifyFile(string filePath, IVariables variables)
         {
             JToken root;
@@ -84,7 +83,7 @@ namespace Calamari.Common.Features.StructuredVariables
             {
                 if (key == null)
                     throw new InvalidOperationException("Path has not been pushed");
-            
+
                 map[key] = t => j.Replace(JToken.Parse(t));
             }
 
@@ -138,23 +137,23 @@ namespace Calamari.Common.Features.StructuredVariables
             if (key == null)
                 throw new InvalidOperationException("Path has not been pushed");
             map[key] = t =>
-            {
-                long longvalue;
-                if (long.TryParse(t, out longvalue))
-                {
-                    value.Replace(JToken.FromObject(longvalue));
-                    return;
-                }
+                       {
+                           long longvalue;
+                           if (long.TryParse(t, out longvalue))
+                           {
+                               value.Replace(JToken.FromObject(longvalue));
+                               return;
+                           }
 
-                double doublevalue;
-                if (double.TryParse(t, out doublevalue))
-                {
-                    value.Replace(JToken.FromObject(doublevalue));
-                    return;
-                }
+                           double doublevalue;
+                           if (double.TryParse(t, out doublevalue))
+                           {
+                               value.Replace(JToken.FromObject(doublevalue));
+                               return;
+                           }
 
-                value.Replace(JToken.FromObject(t));
-            };
+                           value.Replace(JToken.FromObject(t));
+                       };
         }
 
         void MapBool(JToken value)
@@ -162,16 +161,16 @@ namespace Calamari.Common.Features.StructuredVariables
             if (key == null)
                 throw new InvalidOperationException("Path has not been pushed");
             map[key] = t =>
-            {
-                bool boolvalue;
-                if (bool.TryParse(t, out boolvalue))
-                {
-                    value.Replace(JToken.FromObject(boolvalue));
-                    return;
-                }
+                       {
+                           bool boolvalue;
+                           if (bool.TryParse(t, out boolvalue))
+                           {
+                               value.Replace(JToken.FromObject(boolvalue));
+                               return;
+                           }
 
-                value.Replace(JToken.FromObject(t));
-            };
+                           value.Replace(JToken.FromObject(t));
+                       };
         }
 
         void MapArray(JContainer array, bool first = false)
@@ -180,7 +179,7 @@ namespace Calamari.Common.Features.StructuredVariables
             {
                 if (key == null)
                     throw new InvalidOperationException("Path has not been pushed");
-            
+
                 map[key] = t => array.Replace(JToken.Parse(t));
             }
 

--- a/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
@@ -40,12 +40,10 @@ namespace Calamari.Common.Features.StructuredVariables
         IEnumerable<string> GetPathComponents()
         {
             foreach (var stackItem in stack.Reverse())
-            {
                 if (stackItem.MappingKey != null)
                     yield return stackItem.MappingKey;
                 else if (stackItem.Type == YamlStructure.Sequence && stackItem.SequenceIndex != -1)
                     yield return stackItem.SequenceIndex.ToString();
-            }
         }
 
         public string GetPath()
@@ -56,7 +54,7 @@ namespace Calamari.Common.Features.StructuredVariables
         public bool TopIsSequence()
         {
             return stack.Count > 0
-                && stack.Peek().Type == YamlStructure.Sequence;
+                   && stack.Peek().Type == YamlStructure.Sequence;
         }
 
         public void TopSequenceIncrementIndex()
@@ -68,8 +66,8 @@ namespace Calamari.Common.Features.StructuredVariables
         public bool TopIsMappingExpectingKey()
         {
             return stack.Count > 0
-                && stack.Peek().Type == YamlStructure.Mapping
-                && stack.Peek().MappingKey == null;
+                   && stack.Peek().Type == YamlStructure.Mapping
+                   && stack.Peek().MappingKey == null;
         }
 
         public void TopMappingKeyStart(string key)
@@ -110,14 +108,14 @@ namespace Calamari.Common.Features.StructuredVariables
         public static Scalar ReplaceValue(this Scalar scalar, string newValue)
         {
             return new Scalar(
-                scalar.Anchor,
-                scalar.Tag,
-                newValue,
-                scalar.Style,
-                scalar.IsPlainImplicit,
-                scalar.IsQuotedImplicit,
-                scalar.Start,
-                scalar.End);
+                              scalar.Anchor,
+                              scalar.Tag,
+                              newValue,
+                              scalar.Style,
+                              scalar.IsPlainImplicit,
+                              scalar.IsQuotedImplicit,
+                              scalar.Start,
+                              scalar.End);
         }
     }
 
@@ -130,9 +128,7 @@ namespace Calamari.Common.Features.StructuredVariables
             IYamlNode? classifiedNode = null;
 
             if (stack.TopIsSequence() && (ev is MappingStart || ev is SequenceStart || ev is Scalar))
-            {
                 stack.TopSequenceIncrementIndex();
-            }
 
             switch (ev)
             {

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -20,8 +20,8 @@ namespace Calamari.Common.Features.StructuredVariables
         public bool TryModifyFile(string filePath, IVariables variables)
         {
             var variablesByKey = variables
-                .DistinctBy(v => v.Key)
-                .ToDictionary(v => v.Key, v => v.Value, StringComparer.OrdinalIgnoreCase);
+                                 .DistinctBy(v => v.Key)
+                                 .ToDictionary(v => v.Key, v => v.Value, StringComparer.OrdinalIgnoreCase);
 
             // Read and transform the input file
             var outputEvents = new List<ParsingEvent>();
@@ -45,25 +45,17 @@ namespace Calamari.Common.Features.StructuredVariables
                             // Not replacing: searching for things to replace, copying events to output.
 
                             if (node is YamlNode<Scalar> scalar
-                                && variablesByKey.TryGetValue(scalar.Path, out string newValue))
-                            {
+                                && variablesByKey.TryGetValue(scalar.Path, out var newValue))
                                 // TODO ZDY: Preserve input document types for explicit tags, ambiguous inputs - currently preserves decorations only
                                 outputEvents.Add(scalar.Event.ReplaceValue(newValue));
-                            }
                             else if (node is YamlNode<MappingStart> mappingStart
                                      && variablesByKey.TryGetValue(mappingStart.Path, out var mappingReplacement))
-                            {
                                 structureWeAreReplacing = (mappingStart, mappingReplacement);
-                            }
                             else if (node is YamlNode<SequenceStart> sequenceStart
                                      && variablesByKey.TryGetValue(sequenceStart.Path, out var sequenceReplacement))
-                            {
                                 structureWeAreReplacing = (sequenceStart, sequenceReplacement);
-                            }
                             else
-                            {
                                 outputEvents.Add(node.Event);
-                            }
                         }
                         else
                         {
@@ -103,9 +95,7 @@ namespace Calamari.Common.Features.StructuredVariables
             {
                 var emitter = new Emitter(writer);
                 foreach (var outputEvent in outputEvents)
-                {
                     emitter.Emit(outputEvent);
-                }
 
                 writer.Close();
                 outputText = writer.ToString();
@@ -140,8 +130,8 @@ namespace Calamari.Common.Features.StructuredVariables
                                tag,
                                value,
                                ScalarStyle.DoubleQuoted,
-                               isPlainImplicit: true,
-                               isQuotedImplicit: true)
+                               true,
+                               true)
                 };
             }
 


### PR DESCRIPTION
This re-applies Full Code Cleanup to the other StructuredVariables namespace that I evidently did not apply in the previous PR.

I think these seem acceptable.