### PR TITLE
Add JSON replacer test ShouldFallBackToStringIfTypePreservationFails

### DIFF
--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/JsonFormatVariableReplacerFixture.ShouldFallBackToStringIfTypePreservationFails.approved.json
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/JsonFormatVariableReplacerFixture.ShouldFallBackToStringIfTypePreservationFails.approved.json
@@ -1,0 +1,9 @@
+{
+  "null2num": "33",
+  "null2obj": "{\"x\": 1}",
+  "bool2num": "52",
+  "num2null": "null",
+  "num2bool": "true",
+  "num2arr": "[1]",
+  "str2bool": "false"
+}

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
@@ -194,5 +194,22 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "appsettings.array.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
+
+        [Test]
+        public void ShouldFallBackToStringIfTypePreservationFails()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "null2num", "33" },
+                                    { "null2obj", @"{""x"": 1}" },
+                                    { "bool2num", "52" },
+                                    { "num2null", "null" },
+                                    { "num2bool", "true" },
+                                    { "num2arr", "[1]" },
+                                    { "str2bool", "false" }
+                                },
+                                "types-fall-back.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
+        }
     }
 }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/types-fall-back.json
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/types-fall-back.json
@@ -1,0 +1,9 @@
+﻿{
+  "null2num": null,
+  "null2obj": null,
+  "bool2num": true,
+  "num2null": 1,
+  "num2bool": 2,
+  "num2arr": 3,
+  "str2bool": "kittens"
+}


### PR DESCRIPTION
This change confirms the existing behaviour of the JSON replacer, where variables whose type can not fit the type in the input document, fall back towards strings.