### PR TITLE
Expand types in TypesAreInfluencedByThePositionInTheInputDocument

### DIFF
--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.TypesAreInfluencedByThePositionInTheInputDocument.approved.txt
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.TypesAreInfluencedByThePositionInTheInputDocument.approved.txt
@@ -1,9 +1,13 @@
 ﻿null1: ~
+null2: !!null null
 bool1: true
+bool2: !!bool no
 int1: 99
 float1: 1.99
 str1: 'true'
 str2: '~'
+str3: !!str aye
+str4: !!str cats.com
 obj1:
   fruit: apple
   animal: sloth
@@ -11,3 +15,8 @@ seq1:
 - scissors
 - paper
 - rock
+seq2:
+- &flag Orange
+- Beachball
+- Cartoon
+- *flag

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/types.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/types.yaml
@@ -1,12 +1,21 @@
 ﻿null1: null
+null2: !!null ~
 bool1: false
+bool2: !!bool true
 int1: 1
 float1: 0.67
 str1: 'false'
 str2: 'null'
+str3: !<tag:yaml.org,2002:str> no
+str4: !!str pets.com
 obj1:
   key1: one
   key2: two
 seq1:
 - foo
 - bar
+seq2:
+- &flag Apple
+- Beachball
+- Cartoon
+- *flag

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -69,13 +69,19 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             this.Assent(Replace(new CalamariVariables
                                 {
                                     { "null1", "~" },
+                                    { "null2", "null" },
                                     { "bool1", "true" },
+                                    { "bool2", "no" },
                                     { "int1", "99" },
                                     { "float1", "1.99" },
                                     { "str1", "true" },
                                     { "str2", "~" },
+                                    { "str3", "true" },
+                                    { "str3", "aye" },
+                                    { "str4", "cats.com" },
                                     { "obj1", $"fruit: apple{Environment.NewLine}animal: sloth" },
-                                    { "seq1", $"- scissors{Environment.NewLine}- paper{Environment.NewLine}- rock" }
+                                    { "seq1", $"- scissors{Environment.NewLine}- paper{Environment.NewLine}- rock" },
+                                    { "seq2:0", "Orange" }
                                 },
                                 "types.yaml"),
                         TestEnvironment.AssentConfiguration);


### PR DESCRIPTION
This change adds cases confirming type preservation for tagged nulls, bools, strings, and of anchors.