### PR TITLE
Ignore Octopus variables in YamlFormatVariableReplacer

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using YamlDotNet.Core;
@@ -15,11 +16,14 @@ namespace Calamari.Common.Features.StructuredVariables
 
     public class YamlFormatVariableReplacer : IYamlFormatVariableReplacer
     {
+        readonly Regex octopusReservedVariablePattern = new Regex(@"^Octopus([^:]|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         public string FileFormatName => "YAML";
 
         public bool TryModifyFile(string filePath, IVariables variables)
         {
             var variablesByKey = variables
+                                 .Where(v => !octopusReservedVariablePattern.IsMatch(v.Key))
                                  .DistinctBy(v => v.Key)
                                  .ToDictionary(v => v.Key, v => v.Value, StringComparer.OrdinalIgnoreCase);
 

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldIgnoreOctopusPrefix.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldIgnoreOctopusPrefix.approved.yaml
@@ -1,0 +1,6 @@
+﻿MyMessage: Hello world!
+IThinkOctopusIsGreat: Yes, I do!
+OctopusRocks: Yes it does
+Octopus:
+  Section: Should work
+  Rocks: is not changed

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.ignore-octopus.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.ignore-octopus.yaml
@@ -1,0 +1,6 @@
+﻿MyMessage: Hello world
+IThinkOctopusIsGreat: Yes, I do
+OctopusRocks: Yes it does
+Octopus:
+  Section: Does not work
+  Rocks: is not changed

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -86,5 +86,21 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "types.yaml"),
                         TestEnvironment.AssentYamlConfiguration);
         }
+
+        [Test]
+        public void ShouldIgnoreOctopusPrefix()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "MyMessage", "Hello world!" },
+                                    { "IThinkOctopusIsGreat", "Yes, I do!" },
+                                    { "Octopus", "Foo: Bar" },
+                                    { "OctopusRocks", "This is ignored" },
+                                    { "Octopus.Rocks", "So is this" },
+                                    { "Octopus:Section", "Should work" }
+                                },
+                                "application.ignore-octopus.yaml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
     }
 }


### PR DESCRIPTION
This change ensures that variables beginning with `Octopus` - unless followed directly by a colon `:` - are not applied as replacements. This matches the JSON functionality demonstrated in `JsonFormatVariableReplacerFixture.ShouldIgnoreOctopusPrefix`.