### PR TITLE
Expand Octopus variables during YAML replacement

### DIFF
--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/JsonFormatVariableReplacerFixture.ShouldExpandOctopusVariableReferences.approved.json
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/JsonFormatVariableReplacerFixture.ShouldExpandOctopusVariableReferences.approved.json
@@ -1,0 +1,11 @@
+{
+  "MyMessage": "Hello world",
+  "EmailSettings": {
+    "SmtpPort": "23",
+    "SmtpHost": "mail.example.com",
+    "DefaultRecipients": {
+      "To": "paul@octopus.com",
+      "Cc": "mike@octopus.com"
+    }
+  }
+}

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldExpandOctopusVariableReferences.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldExpandOctopusVariableReferences.approved.yaml
@@ -1,0 +1,20 @@
+﻿server:
+  ports:
+  - "8080"
+spring:
+  h2:
+    console:
+      enabled: "true"
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+  datasource:
+    url: jdbc:h2:mem:testdb
+    dbcp2:
+      driver-class-name: org.h2.Driver
+  flyway:
+    locations: classpath:db/migration/{vendor}
+  loggers:
+  - name: console
+  - name: file
+    pattern: '%n.log'
+environment: development

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
@@ -211,5 +211,17 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "types-fall-back.json"),
                         TestEnvironment.AssentJsonDeepCompareConfiguration);
         }
+
+        [Test]
+        public void ShouldExpandOctopusVariableReferences()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "Smtp.Host", "mail.example.com" },
+                                    { "EmailSettings:SmtpHost", "#{Smtp.Host}" }
+                                },
+                                "appsettings.simple.json"),
+                        TestEnvironment.AssentJsonDeepCompareConfiguration);
+        }
     }
 }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -114,5 +114,17 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "application.ignore-octopus.yaml"),
                         TestEnvironment.AssentYamlConfiguration);
         }
+
+        [Test]
+        public void ShouldExpandOctopusVariableReferences()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "Server.Port", "8080" },
+                                    { "Server:Ports:0", "#{Server.Port}" }
+                                },
+                                "application.yaml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
     }
 }


### PR DESCRIPTION
This uses `IVariables.Get()` to resolve variable values, causing expansion of any references to other Octopus variables.

Includes a test for the new functionality, and also a test of the existing JSON replacer functionality.