### PR TITLE
Accept null values in YAML replacer

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 
 namespace Calamari.Common.Features.StructuredVariables
@@ -107,15 +108,23 @@ namespace Calamari.Common.Features.StructuredVariables
     {
         public static Scalar ReplaceValue(this Scalar scalar, string newValue)
         {
-            return new Scalar(
-                              scalar.Anchor,
-                              scalar.Tag,
-                              newValue,
-                              scalar.Style,
-                              scalar.IsPlainImplicit,
-                              scalar.IsQuotedImplicit,
-                              scalar.Start,
-                              scalar.End);
+            return newValue != null
+                ? new Scalar(scalar.Anchor,
+                             scalar.Tag,
+                             newValue,
+                             scalar.Style,
+                             scalar.IsPlainImplicit,
+                             scalar.IsQuotedImplicit,
+                             scalar.Start,
+                             scalar.End)
+                : new Scalar(scalar.Anchor,
+                             "!!null",
+                             "null",
+                             ScalarStyle.Plain,
+                             true,
+                             false,
+                             scalar.Start,
+                             scalar.End);
         }
     }
 

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldReplaceWithNull.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldReplaceWithNull.approved.yaml
@@ -1,0 +1,17 @@
+﻿null1: null
+null2: !!null ~
+bool1: null
+bool2: !!bool true
+int1: ~
+float1: null
+str1: null
+str2: 'null'
+str3: !!str no
+str4: !!str pets.com
+obj1: ~
+seq1: null
+seq2:
+- &flag ~
+- Beachball
+- Cartoon
+- *flag

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -100,6 +100,25 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
         }
 
         [Test]
+        public void ShouldReplaceWithNull()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    // Note: although these replacements are unquoted in the output to match input style,
+                                    // YAML strings do not require quotes, so they still string-equal to our variables.
+                                    { "bool1", "null" },
+                                    { "int1", "~" },
+                                    { "float1", "null" },
+                                    { "str1", null },
+                                    { "obj1", "~" },
+                                    { "seq1", "null" },
+                                    { "seq2:0", "~" }
+                                },
+                                "types.yaml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
+
+        [Test]
         public void ShouldIgnoreOctopusPrefix()
         {
             this.Assent(Replace(new CalamariVariables


### PR DESCRIPTION
This change handles any cases of null variable values. I don't know when/if these normally can happen, but the JSON implementation specifically tests for this in `JsonFormatVariableReplacerFixture.ShouldReplaceWithNull()`.

The YAML test also establishes that when null-compatible literal values are set using variables, they are not quoted if the input style was unquoted. Because YAML strings do not require quotes, these outputs are still string-equal to our variables, but preserving the input style will also allow users to set natural-looking nulls at most (non-string) document locations.