### PR TITLE
Add YAML replacer test OutputShouldBeStringEqualToVariableWhenInputTypeDoesNotMatch

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -52,7 +52,6 @@ namespace Calamari.Common.Features.StructuredVariables
 
                             if (node is YamlNode<Scalar> scalar
                                 && variablesByKey.TryGetValue(scalar.Path, out var newValue))
-                                // TODO ZDY: Preserve input document types for explicit tags, ambiguous inputs - currently preserves decorations only
                                 outputEvents.Add(scalar.Event.ReplaceValue(newValue()));
                             else if (node is YamlNode<MappingStart> mappingStart
                                      && variablesByKey.TryGetValue(mappingStart.Path, out var mappingReplacement))

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/JsonFormatVariableReplacerFixture.ShouldFallBackToStringIfTypePreservationFails.approved.json
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/JsonFormatVariableReplacerFixture.ShouldFallBackToStringIfTypePreservationFails.approved.json
@@ -1,6 +1,9 @@
 {
   "null2num": "33",
+  "null2str": "bananas",
   "null2obj": "{\"x\": 1}",
+  "null2arr": "[3, 2]",
+  "bool2null": "null",
   "bool2num": "52",
   "num2null": "null",
   "num2bool": "true",

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.OutputShouldBeStringEqualToVariableWhenInputTypeDoesNotMatch.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.OutputShouldBeStringEqualToVariableWhenInputTypeDoesNotMatch.approved.yaml
@@ -1,0 +1,10 @@
+﻿null2num: 33
+null2str: bananas
+null2obj: '{"x": 1}'
+null2arr: '[3, 2]'
+bool2null: null
+bool2num: 52
+num2null: null
+num2bool: true
+num2arr: '[1]'
+str2bool: false

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/JsonFormatVariableReplacerFixture.cs
@@ -201,7 +201,10 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             this.Assent(Replace(new CalamariVariables
                                 {
                                     { "null2num", "33" },
+                                    { "null2str", "bananas" },
                                     { "null2obj", @"{""x"": 1}" },
+                                    { "null2arr", "[3, 2]" },
+                                    { "bool2null", "null" },
                                     { "bool2num", "52" },
                                     { "num2null", "null" },
                                     { "num2bool", "true" },

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/types-fall-back.json
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/types-fall-back.json
@@ -1,6 +1,9 @@
 ﻿{
   "null2num": null,
+  "null2str": null,
   "null2obj": null,
+  "null2arr": null,
+  "bool2null": false,
   "bool2num": true,
   "num2null": 1,
   "num2bool": 2,

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/types-fall-back.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/types-fall-back.yaml
@@ -1,0 +1,10 @@
+﻿null2num: null
+null2str: null
+null2obj: null
+null2arr: null
+bool2null: false
+bool2num: true
+num2null: 1
+num2bool: 2
+num2arr: 3
+str2bool: kittens

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -126,5 +126,27 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "application.yaml"),
                         TestEnvironment.AssentYamlConfiguration);
         }
+
+        [Test]
+        public void OutputShouldBeStringEqualToVariableWhenInputTypeDoesNotMatch()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    // Note: although these replacements are unquoted in the output to match input style,
+                                    // YAML strings do not require quotes, so they still string-equal to our variables.
+                                    { "null2num", "33" },
+                                    { "null2str", "bananas" },
+                                    { "null2obj", @"{""x"": 1}" },
+                                    { "null2arr", "[3, 2]" },
+                                    { "bool2null", "null" },
+                                    { "bool2num", "52" },
+                                    { "num2null", "null" },
+                                    { "num2bool", "true" },
+                                    { "num2arr", "[1]" },
+                                    { "str2bool", "false" }
+                                },
+                                "types-fall-back.yaml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
     }
 }


### PR DESCRIPTION
This adds a YAML test, establishing that when variable values are applied that do not match the type in the input document, the output is instead string-equal to the variables.

Note that this currently preserves input style, including quoted-or-not, where possible. Because YAML strings do not require quotes, these outputs are still string-equal to our variables, but preserving the input style will also allow users to set natural-looking non-string literals at most non-string document locations.