### PR TITLE
Add YAML test ShouldMatchAndReplaceIgnoringCase

### DIFF
--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldMatchAndReplaceIgnoringCase.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldMatchAndReplaceIgnoringCase.approved.yaml
@@ -1,0 +1,8 @@
+﻿server:
+  ports:
+  - "5555"
+spring:
+  H2:
+    console:
+      Enabled: "false"
+environment: development

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.mixed-case.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.mixed-case.yaml
@@ -1,0 +1,8 @@
+﻿server:
+  ports:
+  - "5555"
+spring:
+  H2:
+    console:
+      Enabled: "true"
+environment: development

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -21,11 +21,22 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             this.Assent(Replace(new CalamariVariables
                                 {
                                     { "server:ports:0", "8080" },
-                                    { "Spring:H2:Console:Enabled", "false" },
+                                    { "spring:h2:console:enabled", "false" },
                                     { "spring:loggers:1:name", "rolling-file" },
                                     { "environment", "production" }
                                 },
                                 "application.yaml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
+
+        [Test]
+        public void ShouldMatchAndReplaceIgnoringCase()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "Spring:h2:Console:enabled", "false" }
+                                },
+                                "application.mixed-case.yaml"),
                         TestEnvironment.AssentYamlConfiguration);
         }
 


### PR DESCRIPTION
This establishes that YAML replacement paths are case-insensitive.