### PR TITLE
Add YAML replacer test ShouldReplaceWithColonInName

### DIFF
--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldReplaceWithColonInName.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldReplaceWithColonInName.approved.yaml
@@ -1,0 +1,5 @@
+﻿spring:
+  h2:
+    console:
+      enabled: "false"
+  h2:console:enabled: "false"

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.colon-in-name.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.colon-in-name.yaml
@@ -1,0 +1,5 @@
+﻿spring:
+  h2:
+    console:
+      enabled: "true"
+  h2:console:enabled: "true"

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -145,5 +145,16 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "application.yaml"),
                         TestEnvironment.AssentYamlConfiguration);
         }
+        public void ShouldReplaceWithColonInName()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "spring:h2:console:enabled", "false" }
+                                },
+                                "application.colon-in-name.yaml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
+
+        [Test]
     }
 }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -145,6 +145,8 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "application.yaml"),
                         TestEnvironment.AssentYamlConfiguration);
         }
+
+        [Test]
         public void ShouldReplaceWithColonInName()
         {
             this.Assent(Replace(new CalamariVariables
@@ -154,7 +156,5 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "application.colon-in-name.yaml"),
                         TestEnvironment.AssentYamlConfiguration);
         }
-
-        [Test]
     }
 }


### PR DESCRIPTION
Because keys can have colons, a variable may match more than one structure. This confirms the YAML replacer matches the expected behaviour, and the JSON behaviour shown in `JsonFormatVariableReplacerFixture.ShouldReplaceWithColonInName`.