### PR TITLE
Add YAML replacer test ShouldReplaceWithEmpty

### DIFF
--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldReplaceWithEmpty.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldReplaceWithEmpty.approved.yaml
@@ -1,0 +1,17 @@
+﻿null1: null
+null2: !!null ~
+bool1: false
+bool2: !!bool true
+int1: 1
+float1: 0.67
+str1: 'false'
+str2: 'null'
+str3: !!str no
+str4: !!str pets.com
+obj1: {}
+seq1: []
+seq2:
+- &flag Apple
+- Beachball
+- Cartoon
+- *flag

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -119,6 +119,18 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
         }
 
         [Test]
+        public void ShouldReplaceWithEmpty()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "obj1", "{}" },
+                                    { "seq1", "[]" }
+                                },
+                                "types.yaml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
+
+        [Test]
         public void ShouldIgnoreOctopusPrefix()
         {
             this.Assent(Replace(new CalamariVariables


### PR DESCRIPTION
This shows that YAML mappings (objects) and sequences (arrays) can be replaced with empty ones.