### PR TITLE
Add YAML replacer test ShouldPreserveDirectives

### DIFF
--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveDirectives.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveDirectives.approved.yaml
@@ -1,0 +1,19 @@
+﻿%YAML 1.2
+%TAG !yams! tag:yaml.org,2002:
+%TAG ! !
+%TAG !! tag:yaml.org,2002:
+---
+server:
+  ports:
+  - "5555"
+spring:
+  h2:
+    console:
+      enabled: !yams!bool "true"
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+  loggers:
+  - name: console
+  - name: file
+    pattern: '%n.log'
+environment: development

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.directives.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.directives.yaml
@@ -1,0 +1,17 @@
+﻿%YAML 1.2
+%TAG !yams! tag:yaml.org,2002:
+---
+server:
+  ports:
+  - "5555"
+spring:
+  h2:
+    console:
+      enabled: !yams!bool "false"
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+  loggers:
+  - name: console
+  - name: file
+    pattern: '%n.log'
+environment: development

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -145,5 +145,16 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "application.yaml"),
                         TestEnvironment.AssentYamlConfiguration);
         }
+
+        [Test]
+        public void ShouldPreserveDirectives()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "spring:h2:console:enabled", "true" }
+                                },
+                                "application.directives.yaml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
     }
 }


### PR DESCRIPTION
This confirms that version directives like `%YAML 1.2` and tag directives like `%TAG !yams! tag:yaml.org,2002:` are passed through to the output document, and that replacements can be made on values with custom tags (in this case `!yams!bool "true"`).

Note: the emitter we are using also outputs the default tag directives if any custom ones are specified, so the output here has 4 directives. This isn't ideal but I don't think it will have any harmful effects.