### PR TITLE
Change how we choose the file format for structured variable replacement

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/JsonFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/JsonFormatVariableReplacer.cs
@@ -24,7 +24,7 @@ namespace Calamari.Common.Features.StructuredVariables
         {
             return fileName.EndsWith(".json", StringComparison.InvariantCultureIgnoreCase);
         }
-        
+
         public void ModifyFile(string filePath, IVariables variables)
         {
             try

--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigFileParseException.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigFileParseException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Calamari.Common.Features.StructuredVariables
+{
+    public class StructuredConfigFileParseException : Exception
+    {
+        public StructuredConfigFileParseException(string message, Exception e) : base(message, e)
+        {
+            
+        }
+    }
+}

--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
@@ -158,9 +158,9 @@ namespace Calamari.Common.Features.StructuredVariables
                 
                 try
                 {
-                    log.Verbose($"Attempting structured variable replacement on file {filePath} as {replacer.FileFormatName}");
+                    log.Verbose($"Attempting structured variable replacement on file {filePath} with format '{replacer.FileFormatName}'");
                     replacer.ModifyFile(filePath, variables);
-                    log.Info($"Structured variable replacement succeeded on file {filePath} as {replacer.FileFormatName}");
+                    log.Info($"Structured variable replacement succeeded on file {filePath} with format '{replacer.FileFormatName}'");
                     return;
                 }
                 catch (StructuredConfigFileParseException parseException)

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures.Deployment
 {
-    // ReSharper disable once ClassNeverInstantiated.Global
     public class DeployPackageWithStructuredConfigurationFixture : DeployPackageFixture
     {
         const string ServiceName = "Acme.StructuredConfigFiles";

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
@@ -35,7 +35,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 var result = DeployPackage(file.FilePath);
                 result.AssertFailure();
 
-                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: ?. Path '', line 0, position 0.");
+                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: ^. Path '', line 0, position 0.");
             }
         }
         
@@ -201,7 +201,7 @@ namespace Calamari.Tests.Fixtures.Deployment
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertFailure();
-                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: ?. Path '', line 0, position 0.");
+                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: ^. Path '', line 0, position 0.");
             }
         }
 
@@ -240,7 +240,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 var result = DeployPackage(file.FilePath);
                 result.AssertFailure();
 
-                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: ?. Path '', line 0, position 0.");
+                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: ^. Path '', line 0, position 0.");
             }
         }
 

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployVhdFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployVhdFixture.cs
@@ -69,7 +69,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 result.AssertOutputMatches(@"Transforming '[A-Z]:\\ApplicationPath\\web\.config' using '[A-Z]:\\ApplicationPath\\web\.Production\.config'");
 
                 // json substitutions
-                result.AssertOutputMatches(@"Performing structured variable replacement on '[A-Z]:\\ApplicationPath\\appsettings\.json' with file format 'Json'");
+                result.AssertOutputMatches("Structured variable replacement succeeded on file [A-Z]:\\\\ApplicationPath\\\\appsettings.json with format 'Json'");
             }
         }
 
@@ -121,7 +121,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 result.AssertOutputMatches(@"Transforming '[A-Z]:\\ApplicationPath\\web\.config' using '[A-Z]:\\ApplicationPath\\web\.Production\.config'");
 
                 // json substitutions
-                result.AssertOutputMatches(@"Performing structured variable replacement on '[A-Z]:\\ApplicationPath\\appsettings\.json' with file format 'Json'");
+                result.AssertOutputMatches("Structured variable replacement succeeded on file [A-Z]:\\\\ApplicationPath\\\\appsettings.json with format 'Json'");
             }
         }
 
@@ -171,7 +171,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 result.AssertOutputMatches(@"Transforming '[A-Z]:\\AlternateApplicationPath\\web\.config' using '[A-Z]:\\AlternateApplicationPath\\web\.Production\.config'");
 
                 // json substitutions
-                result.AssertOutputMatches(@"Performing structured variable replacement on '[A-Z]:\\AlternateApplicationPath\\appsettings\.json' with file format 'Json'");
+                result.AssertOutputMatches("Structured variable replacement succeeded on file [A-Z]:\\\\AlternateApplicationPath\\\\appsettings.json with format 'Json'");
             }
         }
     }

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/malformed.file
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/malformed.file
@@ -1,2 +1,2 @@
-﻿🐛^**🤕<<&*())(
+﻿^**<<&*())(
 This file should be unparseable in every format we support


### PR DESCRIPTION
This PR changes the logic in `StructuredConfigVariablesService` to the following pseudocode:

```
if !featureFlagSet
    if tryParse(json)
        success
    else
        failure
else
    if fileFormatSpecifiedByUser
        if tryParse(fileFormatSpecifiedByUser)
            success
        else
            failure
    else
        if tryParse(json)
            success
        else
            guessedFormat := tryGuessFormatFromFileName()
            if (guessedFormat)
                if tryParse(guessedFormat)
                    success
                else
                    failure
```

The key change is that when no format has been explicitly supplied, we try to parse as JSON before trying to guess the file format based on the file extension.