### PR TITLE
Preserve YAML comments

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
@@ -126,6 +126,19 @@ namespace Calamari.Common.Features.StructuredVariables
                              scalar.Start,
                              scalar.End);
         }
+
+        public static Comment RestoreLeadingSpaces(this Comment comment)
+        {
+            var leadingSpaces = comment.Start.Line == comment.End.Line
+                ? comment.End.Column - comment.Value.Length - comment.Start.Column - 2
+                : 0;
+            return leadingSpaces > 0
+                ? new Comment(new string(' ', leadingSpaces) + comment.Value,
+                              comment.IsInline,
+                              comment.Start,
+                              comment.End)
+                : comment;
+        }
     }
 
     public class YamlEventStreamClassifier

--- a/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
@@ -129,8 +129,11 @@ namespace Calamari.Common.Features.StructuredVariables
 
         public static Comment RestoreLeadingSpaces(this Comment comment)
         {
+            // The YamlDotNet Parser strips leading spaces, but we can get closer to preserving alignment by
+            // putting some back based on input file offset information.
+            const int outputCommentPrefixLength = 2; // The YamlDotNet Emitter is hard-coded to output `# `
             var leadingSpaces = comment.Start.Line == comment.End.Line
-                ? comment.End.Column - comment.Value.Length - comment.Start.Column - 2
+                ? comment.End.Column - comment.Value.Length - comment.Start.Column - outputCommentPrefixLength
                 : 0;
             return leadingSpaces > 0
                 ? new Comment(new string(' ', leadingSpaces) + comment.Value,

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -39,13 +39,17 @@ namespace Calamari.Common.Features.StructuredVariables
 
                 using (var reader = new StreamReader(filePath))
                 {
-                    var parser = new Parser(reader);
+                    var scanner = new Scanner(reader, false);
+                    var parser = new Parser(scanner);
                     var classifier = new YamlEventStreamClassifier();
                     while (parser.MoveNext())
                     {
                         var ev = parser.Current;
                         if (ev == null)
                             continue;
+
+                        if (ev is Comment c)
+                            ev = c.RestoreLeadingSpaces();
 
                         var node = classifier.Process(ev);
 

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
@@ -1,0 +1,21 @@
+﻿platform: x64
+environment:
+  matrix:
+  - DC: dmd
+    # DVersion: nightly
+    arch: x64
+  - DC: dmd
+    # DVersion: nightly
+    arch: x86
+    # - DC: dmd
+    #   DVersion: beta
+    #   arch: x64  
+  - DC: dmd
+    DVersion: stable
+    arch: x86
+skip_tags: false
+branches:
+  only:
+  - main
+  # - alt
+  - aux

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
@@ -1,0 +1,21 @@
+platform: x64
+environment:
+  matrix:
+  - DC: dmd
+    # DVersion: nightly
+    arch: x64
+  - DC: dmd
+    # DVersion: nightly
+    arch: x86
+    # - DC: dmd
+    #   DVersion: beta
+    #   arch: x64  
+  - DC: dmd
+    DVersion: beta
+    arch: x86
+skip_tags: false
+branches:
+  only:
+  - main
+  # - alt
+  - aux

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -213,5 +213,16 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "application.directives.yaml"),
                         TestEnvironment.AssentYamlConfiguration);
         }
+
+        [Test]
+        public void ShouldPreserveComments()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "environment:matrix:2:DVersion", "stable" },
+                                },
+                                "comments.yml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
     }
 }


### PR DESCRIPTION
This change adjusts the scanner to no longer discard comments, and restores some leading spaces using Mark information.

Includes a test demonstrating mapping, sequence, and mixed content indentation.

Unfortunately, there are some limitations here with YamlDotNet:
- the Emitter enforces a space after the output `#`
- Comments at the point of an indenting reduction lose that context, so they may look more indented than we'd prefer (as in line 10 of the test file).