### PR TITLE
Include default directives in ShouldPreserveDirectives() so the test doesn't enforce the side-effect

### DIFF
--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.directives.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/application.directives.yaml
@@ -1,5 +1,7 @@
 ﻿%YAML 1.2
 %TAG !yams! tag:yaml.org,2002:
+%TAG ! !
+%TAG !! tag:yaml.org,2002:
 ---
 server:
   ports:

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -206,6 +206,8 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
         [Test]
         public void ShouldPreserveDirectives()
         {
+            // Note: because YamlDotNet outputs the default directives alongside any custom ones, they have been
+            // included in the input file here to avoid implying we require them to be added.
             this.Assent(Replace(new CalamariVariables
                                 {
                                     { "spring:h2:console:enabled", "true" }


### PR DESCRIPTION
# Background

Because YamlDotNet adds the default directives to output when any custom ones are specified, this test currently is unintentionally implying they *should* be added.

# Change

This adds them to the input as well so it's clear that the test's focus is on *preservation* of input.