### PR TITLE
Fix exception catch & enforce reporting of YAML parse error positions

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigFileParseException.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigFileParseException.cs
@@ -4,7 +4,7 @@ namespace Calamari.Common.Features.StructuredVariables
 {
     public class StructuredConfigFileParseException : Exception
     {
-        public StructuredConfigFileParseException(string message, Exception e) : base(message, e)
+        public StructuredConfigFileParseException(string message, Exception innerException) : base(message, innerException)
         {
             
         }

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -109,7 +109,7 @@ namespace Calamari.Common.Features.StructuredVariables
 
                 File.WriteAllText(filePath, outputText);
             }
-            catch (SyntaxErrorException e)
+            catch (Exception e) when (e is SyntaxErrorException || e is SemanticErrorException)
             {
                 throw new StructuredConfigFileParseException(e.Message, e);
             }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/broken.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/broken.yaml
@@ -1,0 +1,4 @@
+this: file
+contains: an error on
+line: |
+four the block must be indented

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -3,6 +3,7 @@ using Assent;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Tests.Helpers;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures.StructuredVariables
@@ -225,6 +226,23 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 },
                                 "comments.yml"),
                         TestEnvironment.AssentYamlConfiguration);
+        }
+
+        [Test]
+        public void ParsingErrorPositionIsReportedToUser()
+        {
+            var message = "";
+            try
+            {
+                Replace(new CalamariVariables(), "broken.yaml");
+            }
+            catch (StructuredConfigFileParseException ex)
+            {
+                message = ex.Message;
+            }
+
+            message.Should().MatchRegex(@"(?i)\bLine\W+4\b");
+            message.Should().MatchRegex(@"(?i)\bCol\w*\W+1\b");
         }
     }
 }


### PR DESCRIPTION
This change:

- expands the exception re-throw to include instances of `SemanticErrorException`
- asserts that the error message contains the correct indication of "line M" and "col N"