### PR TITLE
Add YAML replacer test CanReplaceNestedList

### DIFF
--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceNestedList.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceNestedList.approved.yaml
@@ -1,0 +1,10 @@
+﻿pets-config:
+  xyz: asdf
+  somelist:
+  - some element
+  - some other element
+  pets:
+  - name: Susan
+    species: Cuttlefish
+  - name: Craig
+    species: Manta Ray

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/pets.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/pets.yaml
@@ -1,0 +1,8 @@
+﻿pets-config:
+  xyz: asdf
+  somelist:
+  - some element
+  - some other element
+  pets:
+  - name: Fido
+    species: Dog

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -252,5 +252,20 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "flow-and-block-styles.yaml"),
                         TestEnvironment.AssentYamlConfiguration);
         }
+
+        [Test]
+        public void CanReplaceNestedList()
+        {
+            var nl = Environment.NewLine;
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    {
+                                        "pets-config:pets",
+                                        $"- name: Susan{nl}  species: Cuttlefish{nl}- name: Craig{nl}  species: Manta Ray"
+                                    }
+                                },
+                                "pets.yaml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
     }
 }


### PR DESCRIPTION
A test to confirm we can replace nested listed with new nested lists, and the structures mesh together appropriately.