### PR TITLE
Preserve most common input indent

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -50,12 +50,18 @@ namespace Calamari.Common.Features.StructuredVariables
                         if (ev == null)
                             continue;
 
-                        if (ev.NestingIncrease != 0)
+                        if (ev.NestingIncrease > 0
+                            && (ev is MappingStart ms && ms.Style != MappingStyle.Flow
+                                || ev is SequenceStart ss && ss.Style != SequenceStyle.Flow))
                         {
-                            if (ev.Start.Column > lastNestingChangeColumn)
-                                indents.Add(ev.Start.Column - lastNestingChangeColumn);
+                            var startColumnChange = ev.Start.Column - lastNestingChangeColumn;
+                            if (startColumnChange >= 2 && startColumnChange <= 9)
+                                indents.Add(startColumnChange);
                             lastNestingChangeColumn = ev.Start.Column;
                         }
+
+                        if (ev.NestingIncrease < 1 && ev.Start.Column < lastNestingChangeColumn)
+                            lastNestingChangeColumn = ev.Start.Column;
 
                         if (ev is Comment c)
                             ev = c.RestoreLeadingSpaces();

--- a/source/Calamari.Common/Features/StructuredVariables/YamlIndentDetector.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlIndentDetector.cs
@@ -17,7 +17,7 @@ namespace Calamari.Common.Features.StructuredVariables
                     || ev is SequenceStart ss && ss.Style != SequenceStyle.Flow))
             {
                 var startColumnChange = ev.Start.Column - lastNestingChangeColumn;
-                if (IndentSupportedByEmitter(startColumnChange))
+                if (IndentDoesNotCrashYamlDotNetEmitter(startColumnChange))
                     indents.Add(startColumnChange);
                 lastNestingChangeColumn = ev.Start.Column;
             }
@@ -26,7 +26,7 @@ namespace Calamari.Common.Features.StructuredVariables
                 lastNestingChangeColumn = ev.Start.Column;
         }
 
-        static bool IndentSupportedByEmitter(int indent)
+        static bool IndentDoesNotCrashYamlDotNetEmitter(int indent)
         {
             return indent >= 2 && indent <= 9;
         }

--- a/source/Calamari.Common/Features/StructuredVariables/YamlIndentDetector.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlIndentDetector.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.Core.Events;
+
+namespace Calamari.Common.Features.StructuredVariables
+{
+    public class YamlIndentDetector
+    {
+        readonly List<int> indents = new List<int>();
+        int lastNestingChangeColumn = 1;
+
+        public void Process(ParsingEvent ev)
+        {
+            if (ev.NestingIncrease > 0
+                && (ev is MappingStart ms && ms.Style != MappingStyle.Flow
+                    || ev is SequenceStart ss && ss.Style != SequenceStyle.Flow))
+            {
+                var startColumnChange = ev.Start.Column - lastNestingChangeColumn;
+                if (IndentSupportedByEmitter(startColumnChange))
+                    indents.Add(startColumnChange);
+                lastNestingChangeColumn = ev.Start.Column;
+            }
+
+            if (ev.NestingIncrease < 1 && ev.Start.Column < lastNestingChangeColumn)
+                lastNestingChangeColumn = ev.Start.Column;
+        }
+
+        static bool IndentSupportedByEmitter(int indent)
+        {
+            return indent >= 2 && indent <= 9;
+        }
+
+        public int GetMostCommonIndent()
+        {
+            return indents.GroupBy(indent => indent)
+                          .OrderByDescending(group => group.Count())
+                          .FirstOrDefault()
+                          ?.Key
+                   ?? 2;
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveMostCommonIndent.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveMostCommonIndent.approved.yaml
@@ -1,0 +1,9 @@
+﻿aaa:
+    this: is
+    less: nested
+bbb:
+    this:
+        is: much more
+    nested:
+    - one
+    - two

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveMostCommonIndent.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveMostCommonIndent.approved.yaml
@@ -7,3 +7,9 @@ bbb:
     nested:
     - one
     - two
+ccc: [1, 2, 3]
+ddd: {one: 1}
+eee: [1, 2, 3]
+fff: {one: 1}
+ggg: [1, 2, 3]
+hhh: {one: 1}

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/indenting.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/indenting.yaml
@@ -7,3 +7,9 @@ bbb:
     nested:
     - one
     - two
+ccc: [1, 2, 3]
+ddd: {one: 1}
+eee: [1, 2, 3]
+fff: {one: 1}
+ggg: [1, 2, 3]
+hhh: {one: 1}

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/indenting.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/indenting.yaml
@@ -1,0 +1,9 @@
+﻿aaa:
+  this: is
+  less: nested
+bbb:
+    this:
+        is: more
+    nested:
+    - one
+    - two

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -267,5 +267,13 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                                 "pets.yaml"),
                         TestEnvironment.AssentYamlConfiguration);
         }
+
+        [Test]
+        public void ShouldPreserveMostCommonIndent()
+        {
+            this.Assent(Replace(new CalamariVariables { { "bbb:this:is", "much more" } },
+                                "indenting.yaml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
     }
 }


### PR DESCRIPTION
# Background

YamlDotNet doesn't directly tell us about indenting, but I realized this is another thing we can detect from the input marks.

# Change

This detects the most common indenting change and sets that as the output indent size.

Includes a unit test.