### PR TITLE
Removed Structured Configuration feature flag

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
@@ -38,7 +38,6 @@ namespace Calamari.Common.Features.StructuredVariables
         public void ReplaceVariables(RunningDeployment deployment)
         {
             var targets = deployment.Variables.GetPaths(ActionVariables.StructuredConfigurationVariablesTargets);
-            var supportNonJsonReplacement = deployment.Variables.GetFlag(ActionVariables.StructuredConfigurationFeatureFlag);
             
             foreach (var target in targets)
             {
@@ -59,7 +58,7 @@ namespace Calamari.Common.Features.StructuredVariables
                 foreach (var filePath in matchingFiles)
                 {
                     // TODO: once we allow users to specify a file format, pass it through here.
-                    var replacersToTry = GetReplacersToTryForFile(filePath, null, supportNonJsonReplacement);
+                    var replacersToTry = GetReplacersToTryForFile(filePath, null);
                     DoReplacement(filePath, deployment.Variables, replacersToTry);
                 }
             }
@@ -78,18 +77,8 @@ namespace Calamari.Common.Features.StructuredVariables
             return files;
         }
 
-        IFileFormatVariableReplacer[] GetReplacersToTryForFile(string filePath, string? specifiedFileFormat, bool supportNonJsonReplacement)
+        IFileFormatVariableReplacer[] GetReplacersToTryForFile(string filePath, string? specifiedFileFormat)
         {
-            if (!supportNonJsonReplacement)
-            {
-                return new []
-                {
-                    jsonReplacer
-                };
-            }
-
-            log.Info($"Feature toggle flag {ActionVariables.StructuredConfigurationFeatureFlag} detected. Considering replacers for all supported file formats.");
-
             if (!string.IsNullOrWhiteSpace(specifiedFileFormat))
             {
                 var specifiedReplacer = TryFindReplacerForFormat(specifiedFileFormat);

--- a/source/Calamari.Common/Plumbing/Variables/ActionVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/ActionVariables.cs
@@ -14,7 +14,6 @@ namespace Calamari.Common.Plumbing.Variables
          the old Octopus Variable names. */
         public static readonly string StructuredConfigurationVariablesEnabled = "Octopus.Action.Package.JsonConfigurationVariablesEnabled";
         public static readonly string StructuredConfigurationVariablesTargets = "Octopus.Action.Package.JsonConfigurationVariablesTargets";
-        public static readonly string StructuredConfigurationFeatureFlag = "Octopus.Action.StructuredConfigurationFeatureFlag";
 
         public static string GetOutputVariableName(string actionName, string variableName)
         {

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
@@ -24,46 +24,12 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        public void FailsAndWarnsIfAFileCannotBeParsedWhenFeatureFlagIsNotSet()
-        {
-            using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
-            {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
-                Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, MalformedFileName);
-                Variables.Set("key", "new-value");
-
-                var result = DeployPackage(file.FilePath);
-                result.AssertFailure();
-
-                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: ^. Path '', line 0, position 0.");
-            }
-        }
-        
-        [Test]
-        public void ShouldNotTreatYamlFileAsYamlWhenFeatureFlagIsNotSet()
-        {
-            using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
-            {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
-                Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, YamlFileName);
-                Variables.Set("key", "new-value");
-
-                var result = DeployPackage(file.FilePath);
-                result.AssertFailure();
-
-                // Indicates we tried to parse yaml as JSON.
-                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: k. Path '', line 0, position 0.");
-            }
-        }
-
-        [Test]
         public void ShouldPerformReplacementInYamlIfFlagIsSet()
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
                 Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, YamlFileName);
-                Variables.AddFlag(ActionVariables.StructuredConfigurationFeatureFlag, true);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
@@ -82,7 +48,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             {
                 Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, YamlFileName);
-                Variables.AddFlag(ActionVariables.StructuredConfigurationFeatureFlag, true);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
@@ -99,7 +64,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             {
                 Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, "doesnt-exist.json");
-                Variables.AddFlag(ActionVariables.StructuredConfigurationFeatureFlag, true);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
@@ -116,7 +80,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             {
                 Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, ConfigFileName);
-                Variables.AddFlag(ActionVariables.StructuredConfigurationFeatureFlag, true);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
@@ -135,7 +98,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             {
                 Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, $"{JsonFileName}\n{YamlFileName}");
-                Variables.AddFlag(ActionVariables.StructuredConfigurationFeatureFlag, true);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
@@ -156,7 +118,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             {
                 Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, "values.*");
-                Variables.AddFlag(ActionVariables.StructuredConfigurationFeatureFlag, true);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
@@ -179,7 +140,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             {
                 Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, "*.json");
-                Variables.AddFlag(ActionVariables.StructuredConfigurationFeatureFlag, true);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
@@ -196,7 +156,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             {
                 Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, $"{JsonFileName}\n{MalformedFileName}");
-                Variables.AddFlag(ActionVariables.StructuredConfigurationFeatureFlag, true);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
@@ -212,7 +171,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             {
                 Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, ".");
-                Variables.AddFlag(ActionVariables.StructuredConfigurationFeatureFlag, true);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
@@ -234,7 +192,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             {
                 Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, MalformedFileName);
-                Variables.AddFlag(ActionVariables.StructuredConfigurationFeatureFlag, true);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);


### PR DESCRIPTION
Removes the feature flag and tests around cheking behaviour when feature flag is disabled for Structured Configuration. This means that it will always go down the path of Structured Configuration now and no longer down old path of only doing JSON Configuration Variable replacement.  