### PR TITLE
Added fallback flag for structured configuration to only do json replacement

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
@@ -38,6 +38,7 @@ namespace Calamari.Common.Features.StructuredVariables
         public void ReplaceVariables(RunningDeployment deployment)
         {
             var targets = deployment.Variables.GetPaths(ActionVariables.StructuredConfigurationVariablesTargets);
+            var onlyPerformJsonReplacement = deployment.Variables.GetFlag(ActionVariables.StructuredConfigurationFallbackFlag);	
             
             foreach (var target in targets)
             {
@@ -58,7 +59,7 @@ namespace Calamari.Common.Features.StructuredVariables
                 foreach (var filePath in matchingFiles)
                 {
                     // TODO: once we allow users to specify a file format, pass it through here.
-                    var replacersToTry = GetReplacersToTryForFile(filePath, null);
+                    var replacersToTry = GetReplacersToTryForFile(filePath, null, onlyPerformJsonReplacement);
                     DoReplacement(filePath, deployment.Variables, replacersToTry);
                 }
             }
@@ -77,8 +78,16 @@ namespace Calamari.Common.Features.StructuredVariables
             return files;
         }
 
-        IFileFormatVariableReplacer[] GetReplacersToTryForFile(string filePath, string? specifiedFileFormat)
+        IFileFormatVariableReplacer[] GetReplacersToTryForFile(string filePath, string? specifiedFileFormat, bool onlyPerformJsonReplacement)
         {
+            if (onlyPerformJsonReplacement)	
+            {	
+                return new []	
+                {	
+                    jsonReplacer	
+                };	
+            }
+            
             if (!string.IsNullOrWhiteSpace(specifiedFileFormat))
             {
                 var specifiedReplacer = TryFindReplacerForFormat(specifiedFileFormat);

--- a/source/Calamari.Common/Plumbing/Variables/ActionVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/ActionVariables.cs
@@ -14,6 +14,7 @@ namespace Calamari.Common.Plumbing.Variables
          the old Octopus Variable names. */
         public static readonly string StructuredConfigurationVariablesEnabled = "Octopus.Action.Package.JsonConfigurationVariablesEnabled";
         public static readonly string StructuredConfigurationVariablesTargets = "Octopus.Action.Package.JsonConfigurationVariablesTargets";
+        public static readonly string StructuredConfigurationFallbackFlag = "Octopus.Action.StructuredConfigurationFallbackFlag";	
 
         public static string GetOutputVariableName(string actionName, string variableName)
         {

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
@@ -22,6 +22,41 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             base.SetUp();
         }
+        
+        [Test]	
+        public void FailsAndWarnsIfAFileCannotBeParsedWhenFallbackFlagIsSet()	
+        {	
+            using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))	
+            {	
+                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);	
+                Variables.AddFlag(ActionVariables.StructuredConfigurationFallbackFlag, true);
+                Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, MalformedFileName);	
+                Variables.Set("key", "new-value");
+
+                var result = DeployPackage(file.FilePath);	
+                result.AssertFailure();	
+
+                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: ^. Path '', line 0, position 0.");	
+            }	
+        }	
+
+        [Test]	
+        public void ShouldNotTreatYamlFileAsYamlWhenFallbackFlagIsSet()	
+        {	
+            using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))	
+            {	
+                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);	
+                Variables.AddFlag(ActionVariables.StructuredConfigurationFallbackFlag, true);
+                Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, YamlFileName);	
+                Variables.Set("key", "new-value");	
+
+                var result = DeployPackage(file.FilePath);	
+                result.AssertFailure();	
+
+                // Indicates we tried to parse yaml as JSON.	
+                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: k. Path '', line 0, position 0.");	
+            }	
+        }
 
         [Test]
         public void ShouldPerformReplacementInYamlIfFlagIsSet()


### PR DESCRIPTION
Added a fallback flag for Structured Configuration to turn off the YAML replacement - the idea behind this is when we roll out to production, if there's a P1 issue around structured configuration, we can tell the customer to enable this flag in their project and de-escalate the problem. 