### PR TITLE
Update Octostache to 2.8.0

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -61,7 +61,7 @@
 
     <ItemGroup>
       <PackageReference Include="Octopus.Versioning" Version="4.2.1" />
-      <PackageReference Include="Octostache" Version="2.7.0" />
+      <PackageReference Include="Octostache" Version="2.8.0" />
       <PackageReference Include="SharpCompress" Version="0.24.0" />
       <PackageReference Include="YamlDotNet" Version="8.1.2" />
       <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="Octopus.Versioning" Version="4.2.1" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
-    <PackageReference Include="Octostache" Version="2.7.0" />
+    <PackageReference Include="Octostache" Version="2.8.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -148,6 +148,9 @@
     <None Include="Fixtures\Substitutions\Samples\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Fixtures\Substitutions\Approved\*.approved.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Helpers\Certificates\SampleCertificateFiles\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/source/Calamari.Tests/Fixtures/Substitutions/Approved/SubstitutionsFixture.ShouldApplyFiltersDuringSubstitution.approved.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Approved/SubstitutionsFixture.ShouldApplyFiltersDuringSubstitution.approved.txt
@@ -1,0 +1,9 @@
+JsonEscape: =:'\"\\\r\n\t <>
+XmlEscape: =:&apos;&quot;\
+	 &lt;&gt;
+YamlDoubleQuoteEscape: =:'\"\\\r\n\t <>
+YamlSingleQuoteEscape: =:''"\
+
+	 <>
+PropertiesKeyEscape: \=\:'"\\\r\n\t\ <>
+PropertiesValueEscape: =:'"\\\r\n\t <>

--- a/source/Calamari.Tests/Fixtures/Substitutions/Samples/Filters.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Samples/Filters.txt
@@ -1,0 +1,6 @@
+JsonEscape: #{var | JsonEscape}
+XmlEscape: #{var | XmlEscape}
+YamlDoubleQuoteEscape: #{var | YamlDoubleQuoteEscape}
+YamlSingleQuoteEscape: #{var | YamlSingleQuoteEscape}
+PropertiesKeyEscape: #{var | PropertiesKeyEscape}
+PropertiesValueEscape: #{var | PropertiesValueEscape}

--- a/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using Assent;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.FileSystem;
@@ -29,6 +30,18 @@ namespace Calamari.Tests.Fixtures.Substitutions
             var text = PerformTest(GetFixtureResouce("Samples","Servers.json"), variables).text;
 
             Assert.That(Regex.Replace(text, "\\s+", ""), Is.EqualTo(@"{""Servers"":[{""Name"":""forexuat01.local"",""Port"":1566},{""Name"":""forexuat02.local"",""Port"":1566}]}"));
+        }
+
+        [Test]
+        public void ShouldApplyFiltersDuringSubstitution()
+        {
+            var variables = new CalamariVariables
+            {
+                { "var", "=:'\"\\\r\n\t <>" }
+            };
+            
+            var textAfterReplacement = PerformTest(GetFixtureResouce("Samples", "Filters.txt"), variables).text;
+            this.Assent(textAfterReplacement, TestEnvironment.AssentConfiguration);
         }
 
         [Test]


### PR DESCRIPTION
This PR updates Octostache to version 2.8.0, which adds 4 new filters:

- `YamlSingleQuoteEscape`
- `YamlDoubleQuoteEscape`
- `PropertiesKeyEscape`
- `PropertiesValueEscape`

See these PRs for details:

- https://github.com/OctopusDeploy/Octostache/pull/41
- https://github.com/OctopusDeploy/Octostache/pull/43