### PR TITLE
XML replacer: ignore Octopus Prefix and other unintentional variables

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
@@ -181,6 +181,9 @@ namespace Calamari.Common.Features.StructuredVariables
 
         XPath2Expression TryGetXPathFromVariableKey(string variableKey, IXmlNamespaceResolver nsResolver)
         {
+            if (!variableKey.Contains("/")) // Prevent simple variable names being recognized as XPath unintentionally
+                return null;
+            
             try
             {
                 return XPath2Expression.Compile(variableKey, nsResolver);

--- a/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
@@ -49,9 +49,8 @@ namespace Calamari.Common.Features.StructuredVariables
             var navigator = doc.CreateNavigator();
 
             foreach (var variable in variables)
-                if (IsValidXPath(variable.Key, nsManager))
+                if (TryGetXPathFromVariableKey(variable.Key, nsManager) is {} xPathExpression)
                 {
-                    var xPathExpression = variable.Key;
                     var selectedNodes = navigator.XPath2SelectNodes(xPathExpression, nsManager);
 
                     foreach (XPathNavigator selectedNode in selectedNodes)
@@ -74,7 +73,7 @@ namespace Calamari.Common.Features.StructuredVariables
                                     // Try to preserve CDatas in the output.
                                     element.ChildNodes[0].Value = variable.Value;
                                 else if (ContainsElements(element))
-                                    TrySetInnerXml(element, xPathExpression, variable.Value);
+                                    TrySetInnerXml(element, variable.Key, variable.Value);
                                 else
                                     element.InnerText = variable.Value;
                                 break;
@@ -180,16 +179,15 @@ namespace Calamari.Common.Features.StructuredVariables
                 }
         }
 
-        bool IsValidXPath(string xPath, IXmlNamespaceResolver nsResolver)
+        XPath2Expression TryGetXPathFromVariableKey(string variableKey, IXmlNamespaceResolver nsResolver)
         {
             try
             {
-                XPath2Expression.Compile(xPath, nsResolver);
-                return true;
+                return XPath2Expression.Compile(variableKey, nsResolver);
             }
             catch (XPath2Exception)
             {
-                return false;
+                return null;
             }
         }
 

--- a/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
@@ -181,9 +181,11 @@ namespace Calamari.Common.Features.StructuredVariables
 
         XPath2Expression TryGetXPathFromVariableKey(string variableKey, IXmlNamespaceResolver nsResolver)
         {
-            if (!variableKey.Contains("/")) // Prevent simple variable names being recognized as XPath unintentionally
+            // Prevent 'Octopus*' and other unintended variables being recognized as XPath expressions selecting the document node
+            if (!variableKey.Contains("/")
+                && !variableKey.Contains(":"))
                 return null;
-            
+
             try
             {
                 return XPath2Expression.Compile(variableKey, nsResolver);

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.ShouldIgnoreOctopusPrefix.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.ShouldIgnoreOctopusPrefix.approved.xml
@@ -1,0 +1,1 @@
+<Octopus.Release.Id />

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/ignore-octopus.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/ignore-octopus.xml
@@ -1,0 +1,1 @@
+﻿<Octopus.Release.Id />

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/XmlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/XmlVariableReplacerFixture.cs
@@ -227,7 +227,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
         {
             var vars = new CalamariVariables
             {
-                { "env:something", "value-new" }
+                { "//env:something", "value-new" }
             };
 
             RunTest(vars, "complex.xml");
@@ -242,6 +242,16 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             };
 
             RunTest(vars, "duplicate-prefixes.xml");
+        }
+
+        [Test]
+        public void ShouldIgnoreOctopusPrefix()
+        {
+            var vars = new CalamariVariables
+            {
+                { "Octopus.Release.Id", "999" }
+            };
+            RunTest(vars, "ignore-octopus.xml");
         }
 
         [Test]


### PR DESCRIPTION
# Background

In the existing JSON and YAML replacers, we avoid treating variable names starting with `Octopus` as replacements unless they continue with `:` to indicate they probably are replacements.

That doesn't quite directly translate over to XML since colon `:` is not the separator for XPaths.

# Change

I think we can probably afford to avoid processing any variable that doesn't contain `/`, since such an XPath would only match the document node anyway, and if the user really does want that, they can prepend `/`, which is the conventional way to do it anyway.

This includes a test that demonstrates how we avoid accidentally treating `Octopus.Release.Id` as an XPath.