### PR TITLE
Fix handling of variables that reference other variables in XML files.

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
@@ -52,38 +52,39 @@ namespace Calamari.Common.Features.StructuredVariables
                 if (TryGetXPathFromVariableKey(variable.Key, nsManager) is {} xPathExpression)
                 {
                     var selectedNodes = navigator.XPath2SelectNodes(xPathExpression, nsManager);
+                    var variableValue = variables.Get(variable.Key);
 
                     foreach (XPathNavigator selectedNode in selectedNodes)
                         switch (selectedNode.UnderlyingObject)
                         {
                             case XmlText text:
-                                text.Data = variable.Value;
+                                text.Data = variableValue;
                                 break;
 
                             case XmlAttribute attribute:
-                                attribute.Value = variable.Value;
+                                attribute.Value = variableValue;
                                 break;
 
                             case XmlComment comment:
-                                comment.Data = variable.Value;
+                                comment.Data = variableValue;
                                 break;
 
                             case XmlElement element:
                                 if (element.ChildNodes.Count == 1 && element.ChildNodes[0].NodeType == XmlNodeType.CDATA)
                                     // Try to preserve CDatas in the output.
-                                    element.ChildNodes[0].Value = variable.Value;
+                                    element.ChildNodes[0].Value = variableValue;
                                 else if (ContainsElements(element))
-                                    TrySetInnerXml(element, variable.Key, variable.Value);
+                                    TrySetInnerXml(element, variable.Key, variableValue);
                                 else
-                                    element.InnerText = variable.Value;
+                                    element.InnerText = variables.Get(variable.Key);
                                 break;
 
                             case XmlCharacterData cData:
-                                cData.Data = variable.Value;
+                                cData.Data = variableValue;
                                 break;
 
                             case XmlProcessingInstruction processingInstruction:
-                                processingInstruction.Data = variable.Value;
+                                processingInstruction.Data = variableValue;
                                 break;
 
                             case XmlNode node:

--- a/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
@@ -76,7 +76,7 @@ namespace Calamari.Common.Features.StructuredVariables
                                 else if (ContainsElements(element))
                                     TrySetInnerXml(element, variable.Key, variableValue);
                                 else
-                                    element.InnerText = variables.Get(variable.Key);
+                                    element.InnerText = variableValue;
                                 break;
 
                             case XmlCharacterData cData:

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.HandlesVariablesThatReferenceOtherVariables.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.HandlesVariablesThatReferenceOtherVariables.approved.xml
@@ -1,0 +1,6 @@
+<document>
+  <selfclosing>value-new</selfclosing>
+  <empty>
+  </empty>
+  <mixed>This is <b>some</b> text</mixed>
+</document>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/XmlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/XmlVariableReplacerFixture.cs
@@ -255,6 +255,18 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
         }
 
         [Test]
+        public void HandlesVariablesThatReferenceOtherVariables()
+        {
+            var vars = new CalamariVariables
+            {
+                { "/document/selfclosing", "#{a}" },
+                { "a", "#{b}" },
+                { "b", "value-new" },
+            };
+            RunTest(vars, "elements.xml");
+        }
+
+        [Test]
         public void ShouldPreserveEncodingUtf8DosBom()
         {
             this.Assent(ReplaceToHex(new CalamariVariables(), "enc-utf8-dos-bom.xml"),


### PR DESCRIPTION
This PR fixes the way that we evaluate variables in `XmlFormatVariableReplacer`, so that variables that reference other variables are correctly handled.