### PR TITLE
Fix a typo, apply some Substitutions cleanup

### DIFF
--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/ConfigurationTransformsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/ConfigurationTransformsFixture.cs
@@ -31,7 +31,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
         [RequiresMonoVersion423OrAbove] //Bug in mono < 4.2.3 https://bugzilla.xamarin.com/show_bug.cgi?id=19426
         public void WebReleaseConfig()
         {
-            var text = PerformTest(GetFixtureResouce("Samples", "Web.config"), GetFixtureResouce("Samples", "Web.Release.config"));
+            var text = PerformTest(GetFixtureResource("Samples", "Web.config"), GetFixtureResource("Samples", "Web.Release.config"));
             var contents = XDocument.Parse(text);
 
             Assert.IsNull(GetDebugAttribute(contents));
@@ -51,7 +51,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
 #endif
         public void ShouldThrowExceptionForBadConfig()
         {
-            PerformTest(GetFixtureResouce("Samples", "Bad.config"), GetFixtureResouce("Samples", "Web.Release.config"));
+            PerformTest(GetFixtureResource("Samples", "Bad.config"), GetFixtureResource("Samples", "Web.Release.config"));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
             variables.Set(SpecialVariables.Package.IgnoreConfigTransformationErrors, "true");
             configurationTransformer = ConfigurationTransformer.FromVariables(variables, log);
 
-            PerformTest(GetFixtureResouce("Samples", "Bad.config"), GetFixtureResouce("Samples", "Web.Release.config"));
+            PerformTest(GetFixtureResource("Samples", "Bad.config"), GetFixtureResource("Samples", "Web.Release.config"));
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
         [ExpectedException(typeof(CommandException))]
         public void ShouldThrowExceptionForTransformWarnings()
         {
-            PerformTest(GetFixtureResouce("Samples", "Web.config"), GetFixtureResouce("Samples", "Web.Warning.config"));
+            PerformTest(GetFixtureResource("Samples", "Web.config"), GetFixtureResource("Samples", "Web.Warning.config"));
         }
 
         [Test]
@@ -81,14 +81,14 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
             variables.Set(SpecialVariables.Package.TreatConfigTransformationWarningsAsErrors, "false");
             configurationTransformer = ConfigurationTransformer.FromVariables(variables, log);
 
-            PerformTest(GetFixtureResouce("Samples", "Web.config"), GetFixtureResouce("Samples", "Web.Warning.config"));
+            PerformTest(GetFixtureResource("Samples", "Web.config"), GetFixtureResource("Samples", "Web.Warning.config"));
         }
 
         [Test]
         [RequiresMonoVersion423OrAbove] //Bug in mono < 4.2.3 https://bugzilla.xamarin.com/show_bug.cgi?id=19426
         public void ShouldShowMessageWhenResultIsInvalidXml()
         {
-            PerformTest(GetFixtureResouce("Samples", "Web.config"), GetFixtureResouce("Samples", "Web.Empty.config"));
+            PerformTest(GetFixtureResource("Samples", "Web.config"), GetFixtureResource("Samples", "Web.Empty.config"));
             log.Messages.Where(m => m.Level == InMemoryLog.Level.Error)
                 .Select(m => m.MessageFormat)
                 .Should()

--- a/source/Calamari.Tests/Fixtures/ConfigurationVariables/ConfigurationVariablesFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ConfigurationVariables/ConfigurationVariablesFixture.cs
@@ -30,7 +30,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationVariables
             variables.Set("LogFile", "C:\\Log.txt");
             variables.Set("DatabaseConnection", null);
 
-            var text = PerformTest(GetFixtureResouce("Samples", "NoHeader.config"), variables);
+            var text = PerformTest(GetFixtureResource("Samples", "NoHeader.config"), variables);
             Assert.That(text, Does.StartWith("<configuration"));
         }
 
@@ -41,7 +41,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationVariables
             variables.Set("LogFile", "C:\\Log.txt");
             variables.Set("DatabaseConnection", null);
 
-            var text = PerformTest(GetFixtureResouce("Samples","CrazyNamespace.config"), variables);
+            var text = PerformTest(GetFixtureResource("Samples","CrazyNamespace.config"), variables);
 
             var contents = XDocument.Parse(text);
 
@@ -57,7 +57,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationVariables
             variables.Set("LogFile", "C:\\Log.txt");
             variables.Set("DatabaseConnection", null);
 
-            var text = PerformTest(GetFixtureResouce("Samples", "App.config"), variables);
+            var text = PerformTest(GetFixtureResource("Samples", "App.config"), variables);
 
             var contents = XDocument.Parse(text);
 
@@ -73,7 +73,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationVariables
             variables.Set("LogFile", "C:\\Log.txt");
             variables.Set("DatabaseConnection", null);
 
-            var text = PerformTest(GetFixtureResouce("Samples", "StrongTyped.config"), variables);
+            var text = PerformTest(GetFixtureResource("Samples", "StrongTyped.config"), variables);
 
             var contents = XDocument.Parse(text);
 
@@ -86,7 +86,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationVariables
             variables.Set("MyDb1", "Server=foo");
             variables.Set("MyDb2", "Server=bar&bar=123");
 
-            var text = PerformTest(GetFixtureResouce("Samples", "App.config"), variables);
+            var text = PerformTest(GetFixtureResource("Samples", "App.config"), variables);
 
             var contents = XDocument.Parse(text);
 
@@ -98,7 +98,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationVariables
         [ExpectedException(typeof (System.Xml.XmlException))]
         public void ShouldThrowExceptionForBadConfig()
         {
-            PerformTest(GetFixtureResouce("Samples", "Bad.config"), variables);
+            PerformTest(GetFixtureResource("Samples", "Bad.config"), variables);
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationVariables
         {
             variables.AddFlag(KnownVariables.Package.IgnoreVariableReplacementErrors, true);
             configurationVariablesReplacer = new ConfigurationVariablesReplacer(variables, new InMemoryLog());
-            PerformTest(GetFixtureResouce("Samples", "Bad.config"), variables);
+            PerformTest(GetFixtureResource("Samples", "Bad.config"), variables);
         }
 
         string PerformTest(string sampleFile, IVariables variables)

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetFilesystemDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetFilesystemDownloaderFixture.cs
@@ -21,9 +21,9 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [SetUp]
         public void Setup()
         {
-            rootDir = GetFixtureResouce(this.GetType().Name);
+            rootDir = GetFixtureResource(this.GetType().Name);
             TearDown();
-            Directory.CreateDirectory(GetFixtureResouce(rootDir));
+            Directory.CreateDirectory(GetFixtureResource(rootDir));
         }
 
         [TearDown]
@@ -39,7 +39,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         public void FindsAndCopiesNugetPackageWithNugetFileFormat()
         {
             var originalPath = Path.Combine(rootDir, "Acme.Core.1.0.0.0-bugfix.nupkg");
-            File.Copy(GetFixtureResouce("Samples", "Acme.Core.1.0.0.0-bugfix.nupkg"), originalPath);
+            File.Copy(GetFixtureResource("Samples", "Acme.Core.1.0.0.0-bugfix.nupkg"), originalPath);
             var downloadPath = Path.Combine(rootDir, "DummyFile.nupkg");
 
             NuGetFileSystemDownloader.DownloadPackage("Acme.Core", new SemanticVersion("1.0.0.0-bugfix"), new Uri(rootDir), downloadPath);
@@ -49,7 +49,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [Test]
         public void IgnoresZipPackages()
         {
-            File.Copy(GetFixtureResouce("Samples", "Acme.Core.1.0.0.0-bugfix.zip"), Path.Combine(rootDir, "Acme.Core.1.0.0.0-bugfix.zip"));
+            File.Copy(GetFixtureResource("Samples", "Acme.Core.1.0.0.0-bugfix.zip"), Path.Combine(rootDir, "Acme.Core.1.0.0.0-bugfix.zip"));
             var downloadPath = Path.Combine(rootDir, "DummyFile.nupkg");
 
             Assert.Throws<Exception>(() =>
@@ -60,7 +60,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
 
         private string GetFileName()
         {
-            return GetFixtureResouce("Samples", "Acme.Core.1.0.0.0-bugfix.nupkg");
+            return GetFixtureResource("Samples", "Acme.Core.1.0.0.0-bugfix.nupkg");
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/PackageExtractorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/PackageExtractorFixture.cs
@@ -124,7 +124,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         public void ExtractIgnoresSymbolicLinks()
         {
             var log = new InMemoryLog();
-            var fileName = GetFixtureResouce("Samples", string.Format("{0}.{1}.{2}", PackageId, "1.0.0.0-symlink", "tar.gz"));
+            var fileName = GetFixtureResource("Samples", string.Format("{0}.{1}.{2}", PackageId, "1.0.0.0-symlink", "tar.gz"));
 
             var extractor = new TarGzipPackageExtractor(log);
             var targetDir = GetTargetDir(typeof(TarGzipPackageExtractor), fileName);
@@ -142,7 +142,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
 
         private string GetFileName(string extension)
         {
-            return GetFixtureResouce("Samples", string.Format("{0}.{1}.{2}", PackageId, PackageVersion, extension));
+            return GetFixtureResource("Samples", string.Format("{0}.{1}.{2}", PackageId, PackageVersion, extension));
         }
 
         private string GetTargetDir(Type extractorType, string fileName)

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
@@ -56,7 +56,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
             
             var output = InvokeCalamariForPowerShell(calamari => calamari
                 .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", ProfileScript)), 
+                .Argument("script", GetFixtureResource("Scripts", ProfileScript)), 
                 variables);
 
             output.AssertSuccess();
@@ -98,7 +98,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
         {
             var output = InvokeCalamariForPowerShell(calamari => calamari
                 .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", "Hello.ps1")));
+                .Argument("script", GetFixtureResource("Scripts", "Hello.ps1")));
 
             output.AssertSuccess();
             output.AssertOutput($"##octopus[stdout-warning]{Environment.NewLine}The `--script` parameter is deprecated.");
@@ -299,7 +299,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
         {
             var output = InvokeCalamariForPowerShell(calamari => calamari
                 .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", "CanDotSource.ps1")));
+                .Argument("script", GetFixtureResource("Scripts", "CanDotSource.ps1")));
 
             output.AssertSuccess();
             output.AssertOutput("Hello!");
@@ -484,7 +484,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
             var output = InvokeCalamariForPowerShell(calamari => calamari
                 .Action("run-script")
-                .Argument("package", GetFixtureResouce("Packages", "PackagedScript.1.0.0.zip")), variables);
+                .Argument("package", GetFixtureResource("Packages", "PackagedScript.1.0.0.zip")), variables);
 
             output.AssertSuccess();
             output.AssertOutput("Extracting package");
@@ -514,7 +514,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
         {
             var output = InvokeCalamariForPowerShell(calamari => calamari
                 .Action("run-script")
-                .Argument("script", GetFixtureResouce(Path.Combine("Scripts", "Path With '"), "PathWithSingleQuote.ps1")));
+                .Argument("script", GetFixtureResource(Path.Combine("Scripts", "Path With '"), "PathWithSingleQuote.ps1")));
 
             output.AssertSuccess();
             output.AssertOutput("Hello from a path containing a '");
@@ -526,7 +526,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
         {
             var output = InvokeCalamariForPowerShell(calamari => calamari
                 .Action("run-script")
-                .Argument("script", GetFixtureResouce(Path.Combine("Scripts", "Path With $"), "PathWithDollar.ps1")));
+                .Argument("script", GetFixtureResource(Path.Combine("Scripts", "Path With $"), "PathWithDollar.ps1")));
 
             output.AssertSuccess();
             output.AssertOutput("Hello from a path containing a $");

--- a/source/Calamari.Tests/Fixtures/PowerShell/WindowsPowerShellFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/WindowsPowerShellFixture.cs
@@ -27,7 +27,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
             // Let's just use the Hello.ps1 script for something simples
             var output = InvokeCalamariForPowerShell(calamari => calamari
                 .Action("run-script")
-                .Argument("script", GetFixtureResouce("Scripts", "Hello.ps1")), variables);
+                .Argument("script", GetFixtureResource("Scripts", "Hello.ps1")), variables);
 
             if (output.CapturedOutput.AllMessages
                 .Select(line => new string(line.ToCharArray().Where(c => c != '\u0000').ToArray()))

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/VariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/VariableReplacerFixture.cs
@@ -19,7 +19,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
         public string Replace(IVariables variables, string existingFile, Func<string, string> outputFileReader)
         {
             var temp = Path.GetTempFileName();
-            File.Copy(GetFixtureResouce("Samples", existingFile), temp, true);
+            File.Copy(GetFixtureResource("Samples", existingFile), temp, true);
 
             using (new TemporaryFile(temp))
             {

--- a/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
@@ -27,7 +27,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
             variables["ServerEndpoints[FOREXUAT02].Name"] = "forexuat02.local";
             variables["ServerEndpoints[FOREXUAT02].Port"] = "1566";
             
-            var text = PerformTest(GetFixtureResouce("Samples","Servers.json"), variables).text;
+            var text = PerformTest(GetFixtureResource("Samples","Servers.json"), variables).text;
 
             Assert.That(Regex.Replace(text, "\\s+", ""), Is.EqualTo(@"{""Servers"":[{""Name"":""forexuat01.local"",""Port"":1566},{""Name"":""forexuat02.local"",""Port"":1566}]}"));
         }
@@ -40,7 +40,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
                 { "var", "=:'\"\\\r\n\t <>" }
             };
             
-            var textAfterReplacement = PerformTest(GetFixtureResouce("Samples", "Filters.txt"), variables).text;
+            var textAfterReplacement = PerformTest(GetFixtureResource("Samples", "Filters.txt"), variables).text;
             this.Assent(textAfterReplacement, TestEnvironment.AssentConfiguration);
         }
 
@@ -50,7 +50,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
             var variables = new CalamariVariables();
             variables["fox"] = "replaced fox";
 
-            var text = PerformTest(GetFixtureResouce("Samples", "ParserErrors.txt"), variables).text;
+            var text = PerformTest(GetFixtureResource("Samples", "ParserErrors.txt"), variables).text;
 
             // Environment.Newline returning \r\n when running tests on mono, but \n on dotnet core, just replace
             Assert.AreEqual("the quick brown replaced fox jumps over the lazy #{dog\nthe quick brown replaced fox jumps over the lazy #{dog #{", text.Replace("\r\n", "\n"));
@@ -59,7 +59,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void ShouldRetainEncodingIfNoneSet()
         {
-            var filePath = GetFixtureResouce("Samples", "UTF16LE.ini");
+            var filePath = GetFixtureResource("Samples", "UTF16LE.ini");
             var variables = new CalamariVariables();
             variables["LocalCacheFolderName"] = "SpongeBob";
 
@@ -76,7 +76,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
         public void ShouldOverrideEncodingIfProvided()
         {
 
-            var filePath = GetFixtureResouce("Samples", "UTF16LE.ini");
+            var filePath = GetFixtureResource("Samples", "UTF16LE.ini");
             var variables = new CalamariVariables();
             variables[PackageVariables.SubstituteInFilesOutputEncoding] = "utf-8";
 
@@ -92,7 +92,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
         public void ShouldRevertToExistingEncodingIfInvalid()
         {
 
-            var filePath = GetFixtureResouce("Samples", "UTF16LE.ini");
+            var filePath = GetFixtureResource("Samples", "UTF16LE.ini");
             var variables = new CalamariVariables();
             variables[PackageVariables.SubstituteInFilesOutputEncoding] = "utf-666";
 
@@ -107,7 +107,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void ShouldDetectUTF8WithNoBom()
         {
-            var filePath = GetFixtureResouce("Samples", "UTF8.txt");
+            var filePath = GetFixtureResource("Samples", "UTF8.txt");
 
             Encoding encoding;
             FileSystem.ReadFile(filePath, out encoding);
@@ -118,7 +118,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void ShouldDetectUTF8WithBom()
         {
-            var filePath = GetFixtureResouce("Samples", "UTF8BOM.txt");
+            var filePath = GetFixtureResource("Samples", "UTF8BOM.txt");
 
             Encoding encoding;
             FileSystem.ReadFile(filePath, out encoding);
@@ -128,7 +128,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void ShouldDetectASCII()
         {
-            var filePath = GetFixtureResouce("Samples", "ASCII.txt");
+            var filePath = GetFixtureResource("Samples", "ASCII.txt");
 
             Encoding encoding;
             FileSystem.ReadFile(filePath, out encoding);
@@ -139,7 +139,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void ShouldFallBackToDefaultCodePage()
         {
-            var filePath = GetFixtureResouce("Samples", "ANSI.txt");
+            var filePath = GetFixtureResource("Samples", "ANSI.txt");
 
             Encoding encoding;
             FileSystem.ReadFile(filePath, out encoding);
@@ -149,7 +149,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void RetainANSI()
         {
-            var filePath = GetFixtureResouce("Samples", "ANSI.txt");
+            var filePath = GetFixtureResource("Samples", "ANSI.txt");
             var variables = new CalamariVariables();
             variables["LocalCacheFolderName"] = "SpongeBob";
 
@@ -164,7 +164,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void RetainASCII()
         {
-            var filePath = GetFixtureResouce("Samples", "ASCII.txt");
+            var filePath = GetFixtureResource("Samples", "ASCII.txt");
             var variables = new CalamariVariables();
             variables["LocalCacheFolderName"] = "SpongeBob";
 
@@ -179,7 +179,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void RetainUTF8()
         {
-            var filePath = GetFixtureResouce("Samples", "UTF8.txt");
+            var filePath = GetFixtureResource("Samples", "UTF8.txt");
             var variables = new CalamariVariables();
             variables["LocalCacheFolderName"] = "SpongeBob";
 
@@ -196,7 +196,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void RetainUTF8Bom()
         {
-            var filePath = GetFixtureResouce("Samples", "UTF8BOM.txt");
+            var filePath = GetFixtureResource("Samples", "UTF8BOM.txt");
             var variables = new CalamariVariables();
             variables["LocalCacheFolderName"] = "SpongeBob";
 

--- a/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
@@ -7,7 +7,6 @@ using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
-using Calamari.Integration.FileSystem;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
 
@@ -16,7 +15,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
     [TestFixture]
     public class SubstitutionsFixture : CalamariFixture
     {
-        static readonly CalamariPhysicalFileSystem FileSystem = CalamariEnvironment.IsRunningOnWindows ? (CalamariPhysicalFileSystem) new WindowsPhysicalFileSystem() : new NixCalamariPhysicalFileSystem();
+        static readonly CalamariPhysicalFileSystem FileSystem = CalamariEnvironment.IsRunningOnWindows ? (CalamariPhysicalFileSystem)new WindowsPhysicalFileSystem() : new NixCalamariPhysicalFileSystem();
 
         [Test]
         public void ShouldSubstitute()
@@ -26,8 +25,8 @@ namespace Calamari.Tests.Fixtures.Substitutions
             variables["ServerEndpoints[FOREXUAT01].Port"] = "1566";
             variables["ServerEndpoints[FOREXUAT02].Name"] = "forexuat02.local";
             variables["ServerEndpoints[FOREXUAT02].Port"] = "1566";
-            
-            var text = PerformTest(GetFixtureResource("Samples","Servers.json"), variables).text;
+
+            var text = PerformTest(GetFixtureResource("Samples", "Servers.json"), variables).text;
 
             Assert.That(Regex.Replace(text, "\\s+", ""), Is.EqualTo(@"{""Servers"":[{""Name"":""forexuat01.local"",""Port"":1566},{""Name"":""forexuat02.local"",""Port"":1566}]}"));
         }
@@ -37,9 +36,9 @@ namespace Calamari.Tests.Fixtures.Substitutions
         {
             var variables = new CalamariVariables
             {
-                { "var", "=:'\"\\\r\n\t <>" }
+                ["var"] = "=:'\"\\\r\n\t <>"
             };
-            
+
             var textAfterReplacement = PerformTest(GetFixtureResource("Samples", "Filters.txt"), variables).text;
             this.Assent(textAfterReplacement, TestEnvironment.AssentConfiguration);
         }
@@ -47,8 +46,10 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void ShouldIgnoreParserErrors()
         {
-            var variables = new CalamariVariables();
-            variables["fox"] = "replaced fox";
+            var variables = new CalamariVariables
+            {
+                ["fox"] = "replaced fox"
+            };
 
             var text = PerformTest(GetFixtureResource("Samples", "ParserErrors.txt"), variables).text;
 
@@ -60,14 +61,15 @@ namespace Calamari.Tests.Fixtures.Substitutions
         public void ShouldRetainEncodingIfNoneSet()
         {
             var filePath = GetFixtureResource("Samples", "UTF16LE.ini");
-            var variables = new CalamariVariables();
-            variables["LocalCacheFolderName"] = "SpongeBob";
+            var variables = new CalamariVariables
+            {
+                ["LocalCacheFolderName"] = "SpongeBob"
+            };
 
             var result = PerformTest(filePath, variables);
 
-            Encoding encoding;
-            FileSystem.ReadFile(filePath, out encoding);
-            Assert.AreEqual(Encoding.Unicode, encoding);
+            FileSystem.ReadFile(filePath, out var inputEncoding);
+            Assert.AreEqual(Encoding.Unicode, inputEncoding);
             Assert.AreEqual(Encoding.Unicode, result.encoding);
             Assert.True(Regex.Match(result.text, "\\bLocalCacheFolderName=SpongeBob\\b").Success);
         }
@@ -75,136 +77,135 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void ShouldOverrideEncodingIfProvided()
         {
-
             var filePath = GetFixtureResource("Samples", "UTF16LE.ini");
-            var variables = new CalamariVariables();
-            variables[PackageVariables.SubstituteInFilesOutputEncoding] = "utf-8";
+            var variables = new CalamariVariables
+            {
+                [PackageVariables.SubstituteInFilesOutputEncoding] = "utf-8"
+            };
 
-            var encoding = (Encoding)PerformTest(filePath, variables).encoding;
+            var result = PerformTest(filePath, variables);
 
-            Encoding fileEncoding;
-            FileSystem.ReadFile(filePath, out fileEncoding);
-            Assert.AreEqual(Encoding.Unicode, fileEncoding);
-            Assert.AreEqual(Encoding.UTF8, encoding);
+            FileSystem.ReadFile(filePath, out var inputEncoding);
+            Assert.AreEqual(Encoding.Unicode, inputEncoding);
+            Assert.AreEqual(Encoding.UTF8, result.encoding);
         }
 
         [Test]
         public void ShouldRevertToExistingEncodingIfInvalid()
         {
-
             var filePath = GetFixtureResource("Samples", "UTF16LE.ini");
-            var variables = new CalamariVariables();
-            variables[PackageVariables.SubstituteInFilesOutputEncoding] = "utf-666";
+            var variables = new CalamariVariables
+            {
+                [PackageVariables.SubstituteInFilesOutputEncoding] = "utf-666"
+            };
 
-            var encoding = (Encoding)PerformTest(filePath, variables).encoding;
+            var result = PerformTest(filePath, variables);
 
-            Encoding fileEncoding;
-            FileSystem.ReadFile(filePath, out fileEncoding);
-            Assert.AreEqual(Encoding.Unicode, fileEncoding);
-            Assert.AreEqual(Encoding.Unicode, encoding);
+            FileSystem.ReadFile(filePath, out var inputEncoding);
+            Assert.AreEqual(Encoding.Unicode, inputEncoding);
+            Assert.AreEqual(Encoding.Unicode, result.encoding);
         }
 
         [Test]
-        public void ShouldDetectUTF8WithNoBom()
+        public void ShouldDetectUtf8WithNoBom()
         {
             var filePath = GetFixtureResource("Samples", "UTF8.txt");
 
-            Encoding encoding;
-            FileSystem.ReadFile(filePath, out encoding);
+            FileSystem.ReadFile(filePath, out var encoding);
             Assert.AreNotEqual(Encoding.UTF8, encoding); //not the static encoder (which does bom)
             Assert.AreEqual(Encoding.UTF8.EncodingName, encoding.EncodingName); //but are both utf-8
         }
 
         [Test]
-        public void ShouldDetectUTF8WithBom()
+        public void ShouldDetectUtf8WithBom()
         {
             var filePath = GetFixtureResource("Samples", "UTF8BOM.txt");
 
-            Encoding encoding;
-            FileSystem.ReadFile(filePath, out encoding);
+            FileSystem.ReadFile(filePath, out var encoding);
             Assert.AreEqual(Encoding.UTF8, encoding);
         }
 
         [Test]
-        public void ShouldDetectASCII()
+        public void ShouldDetectAscii()
         {
             var filePath = GetFixtureResource("Samples", "ASCII.txt");
 
-            Encoding encoding;
-            FileSystem.ReadFile(filePath, out encoding);
+            FileSystem.ReadFile(filePath, out var encoding);
             Assert.AreEqual(Encoding.ASCII, encoding);
         }
-
 
         [Test]
         public void ShouldFallBackToDefaultCodePage()
         {
             var filePath = GetFixtureResource("Samples", "ANSI.txt");
 
-            Encoding encoding;
-            FileSystem.ReadFile(filePath, out encoding);
+            FileSystem.ReadFile(filePath, out var encoding);
             Assert.AreEqual(Encoding.Default, encoding);
         }
 
         [Test]
-        public void RetainANSI()
+        public void RetainAnsi()
         {
             var filePath = GetFixtureResource("Samples", "ANSI.txt");
-            var variables = new CalamariVariables();
-            variables["LocalCacheFolderName"] = "SpongeBob";
+            var variables = new CalamariVariables
+            {
+                ["LocalCacheFolderName"] = "SpongeBob"
+            };
 
             var result = PerformTest(filePath, variables);
 
-            Encoding encoding;
-            FileSystem.ReadFile(filePath, out encoding);
-            Assert.AreEqual(Encoding.Default, encoding);
+            FileSystem.ReadFile(filePath, out var inputEncoding);
+            Assert.AreEqual(Encoding.Default, inputEncoding);
             Assert.AreEqual(Encoding.Default, result.encoding);
         }
 
         [Test]
-        public void RetainASCII()
+        public void RetainAscii()
         {
             var filePath = GetFixtureResource("Samples", "ASCII.txt");
-            var variables = new CalamariVariables();
-            variables["LocalCacheFolderName"] = "SpongeBob";
+            var variables = new CalamariVariables
+            {
+                ["LocalCacheFolderName"] = "SpongeBob"
+            };
 
             var result = PerformTest(filePath, variables);
 
-            Encoding encoding;
-            FileSystem.ReadFile(filePath, out encoding);
-            Assert.AreEqual(Encoding.ASCII, encoding);
+            FileSystem.ReadFile(filePath, out var inputEncoding);
+            Assert.AreEqual(Encoding.ASCII, inputEncoding);
             Assert.AreEqual(Encoding.ASCII, result.encoding);
         }
 
         [Test]
-        public void RetainUTF8()
+        public void RetainUtf8()
         {
             var filePath = GetFixtureResource("Samples", "UTF8.txt");
-            var variables = new CalamariVariables();
-            variables["LocalCacheFolderName"] = "SpongeBob";
+            var variables = new CalamariVariables
+            {
+                ["LocalCacheFolderName"] = "SpongeBob"
+            };
 
             var result = PerformTest(filePath, variables);
 
-            Encoding encoding;
-            FileSystem.ReadFile(filePath, out encoding);
-            Assert.AreNotEqual(Encoding.UTF8, encoding); //not the static encoder (which does bom)
-            Assert.AreEqual(Encoding.UTF8.EncodingName, encoding.EncodingName); //but are both utf-8
+            FileSystem.ReadFile(filePath, out var inputEncoding);
+            Assert.AreNotEqual(Encoding.UTF8, inputEncoding); //not the static encoder (which does bom)
+            Assert.AreEqual(Encoding.UTF8.EncodingName, inputEncoding.EncodingName); //but are both utf-8
             Assert.AreNotEqual(Encoding.UTF8, result.encoding); //not the static encoder (which does bom)
             Assert.AreEqual(Encoding.UTF8.EncodingName, result.encoding.EncodingName); //but are both utf-8
         }
 
         [Test]
-        public void RetainUTF8Bom()
+        public void RetainUtf8Bom()
         {
             var filePath = GetFixtureResource("Samples", "UTF8BOM.txt");
-            var variables = new CalamariVariables();
-            variables["LocalCacheFolderName"] = "SpongeBob";
+            var variables = new CalamariVariables
+            {
+                ["LocalCacheFolderName"] = "SpongeBob"
+            };
 
             var result = PerformTest(filePath, variables);
 
-            Encoding encoding;
-            FileSystem.ReadFile(filePath, out encoding);
-            Assert.AreEqual(Encoding.UTF8, encoding);
+            FileSystem.ReadFile(filePath, out var inputEncoding);
+            Assert.AreEqual(Encoding.UTF8, inputEncoding);
             Assert.AreEqual(Encoding.UTF8, result.encoding);
         }
 
@@ -215,8 +216,7 @@ namespace Calamari.Tests.Fixtures.Substitutions
             {
                 var substituter = new FileSubstituter(new InMemoryLog(), FileSystem);
                 substituter.PerformSubstitution(sampleFile, variables, temp);
-                Encoding encoding;
-                var text = FileSystem.ReadFile(temp, out encoding);
+                var text = FileSystem.ReadFile(temp, out var encoding);
                 return (text, encoding);
             }
         }

--- a/source/Calamari.Tests/Helpers/CIAssentNamer.cs
+++ b/source/Calamari.Tests/Helpers/CIAssentNamer.cs
@@ -6,7 +6,7 @@ namespace Calamari.Tests.Helpers
     {
         public string GetName(TestMetadata metadata)
         {
-            return CalamariFixture.GetFixtureResouce(
+            return CalamariFixture.GetFixtureResource(
                 metadata.TestFixture.GetType(),
                 "Approved",
                 $"{metadata.TestFixture.GetType().Name}.{metadata.TestName}"

--- a/source/Calamari.Tests/Helpers/CalamariFixture.cs
+++ b/source/Calamari.Tests/Helpers/CalamariFixture.cs
@@ -81,13 +81,13 @@ namespace Calamari.Tests.Helpers
         }
 
 
-        protected string GetFixtureResouce(params string[] paths)
+        protected string GetFixtureResource(params string[] paths)
         {
             var type = GetType();
-            return GetFixtureResouce(type, paths);
+            return GetFixtureResource(type, paths);
         }
 
-        public static string GetFixtureResouce(Type type, params string[] paths)
+        public static string GetFixtureResource(Type type, params string[] paths)
         {
             var path = type.Namespace.Replace("Calamari.Tests.", String.Empty);
             path = path.Replace('.', Path.DirectorySeparatorChar);
@@ -103,7 +103,7 @@ namespace Calamari.Tests.Helpers
             var variablesFile = Path.GetTempFileName();
             var variables = new CalamariVariables();
             variables.Set(ScriptVariables.ScriptFileName, scriptName);
-            variables.Set(ScriptVariables.ScriptBody, File.ReadAllText(GetFixtureResouce("Scripts", scriptName)));
+            variables.Set(ScriptVariables.ScriptBody, File.ReadAllText(GetFixtureResource("Scripts", scriptName)));
             variables.Set(ScriptVariables.Syntax, scriptName.ToScriptType().ToString());
 
             additionalVariables?.ToList().ForEach(v => variables[v.Key] = v.Value);

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -152,7 +152,7 @@ namespace Calamari.Tests.KubernetesFixtures
             //Additional Package
             Variables.Set(PackageVariables.IndexedPackageId("Pack-1"), "CustomValues");
             Variables.Set(PackageVariables.IndexedPackageVersion("Pack-1"), "2.0.0");
-            Variables.Set(PackageVariables.IndexedOriginalPath("Pack-1"), GetFixtureResouce("Charts", "CustomValues.2.0.0.zip"));
+            Variables.Set(PackageVariables.IndexedOriginalPath("Pack-1"), GetFixtureResource("Charts", "CustomValues.2.0.0.zip"));
             Variables.Set(Kubernetes.SpecialVariables.Helm.Packages.ValuesFilePath("Pack-1"), "values.yaml");
 
             //Variable that will replace packaged value in package
@@ -208,7 +208,7 @@ namespace Calamari.Tests.KubernetesFixtures
             Variables.Set(PackageVariables.IndexedPackageId("Pack-1"), "CustomValues");
             Variables.Set(PackageVariables.IndexedPackageVersion("Pack-1"), "2.0.0");
             Variables.Set(PackageVariables.IndexedOriginalPath("Pack-1"),
-                GetFixtureResouce("Charts", "CustomValues.2.0.0.zip"));
+                GetFixtureResource("Charts", "CustomValues.2.0.0.zip"));
             Variables.Set(Kubernetes.SpecialVariables.Helm.Packages.ValuesFilePath("Pack-1"), "values.yaml");
 
             //Variable that will replace packaged value in package
@@ -336,7 +336,7 @@ namespace Calamari.Tests.KubernetesFixtures
         {
             using (var variablesFile = new TemporaryFile(Path.GetTempFileName()))
             {
-                var pkg = GetFixtureResouce("Charts", ChartPackageName);
+                var pkg = GetFixtureResource("Charts", ChartPackageName);
                 Variables.Save(variablesFile.FilePath);
 
                 return InvokeInProcess(Calamari()


### PR DESCRIPTION
This is mostly Rider suggestions.

A couple of the identifiers in the tests have been standardized to be easier to read: most of the "encoding" have been clarified as to whether they refer to input or output.