### PR TITLE
Add new stage to PipelineCommand and allow implementations to specify auto registration on more than one assembly

### DIFF
--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -85,9 +85,9 @@ namespace Calamari.Common
                 .Named<PipelineCommand>(t => t.GetCustomAttribute<CommandAttribute>().Name);
         }
 
-        Assembly GetProgramAssemblyToRegister()
+        protected virtual Assembly[] GetProgramAssembliesToRegister()
         {
-            return GetType().Assembly;
+            return new []{GetType().Assembly};
         }
 
         protected async Task<int> Run(string[] args)
@@ -130,10 +130,11 @@ namespace Calamari.Common
 
         IEnumerable<Assembly> GetAllAssembliesToRegister()
         {
-            var programAssembly = GetProgramAssemblyToRegister();
+            var programAssembly = GetProgramAssembliesToRegister();
             if (programAssembly != null)
             {
-                yield return programAssembly; // Calamari Flavour
+                foreach (var assembly in programAssembly)
+                    yield return assembly; // Calamari Flavour & dependencies
             }
 
             yield return typeof(CalamariFlavourProgramAsync).Assembly; // Calamari.Common

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -87,9 +87,9 @@ namespace Calamari.Common
                 .Named<PipelineCommand>(t => t.GetCustomAttribute<CommandAttribute>().Name);
         }
 
-        protected virtual Assembly[] GetProgramAssembliesToRegister()
+        protected virtual IEnumerable<Assembly> GetProgramAssembliesToRegister()
         {
-            return new []{GetType().Assembly};
+            yield return GetType().Assembly;
         }
 
         protected async Task<int> Run(string[] args)
@@ -132,12 +132,10 @@ namespace Calamari.Common
 
         IEnumerable<Assembly> GetAllAssembliesToRegister()
         {
-            var programAssembly = GetProgramAssembliesToRegister();
-            if (programAssembly != null)
-            {
-                foreach (var assembly in programAssembly)
-                    yield return assembly; // Calamari Flavour & dependencies
-            }
+            var programAssemblies = GetProgramAssembliesToRegister();
+
+            foreach (var assembly in programAssemblies)
+                yield return assembly; // Calamari Flavour & dependencies
 
             yield return typeof(CalamariFlavourProgramAsync).Assembly; // Calamari.Common
         }

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -18,6 +18,7 @@ using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Commands;
+using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
@@ -58,6 +59,7 @@ namespace Calamari.Common
             builder.RegisterType<YamlFormatVariableReplacer>().As<IFileFormatVariableReplacer>();
             builder.RegisterType<StructuredConfigVariablesService>().As<IStructuredConfigVariablesService>();
             builder.Register(context => ConfigurationTransformer.FromVariables(context.Resolve<IVariables>(), context.Resolve<ILog>())).As<IConfigurationTransformer>();
+            builder.RegisterType<DeploymentJournalWriter>().As<IDeploymentJournalWriter>().SingleInstance();
 
             var assemblies = GetAllAssembliesToRegister().ToArray();
 

--- a/source/Calamari.Common/Plumbing/Deployment/Journal/DeploymentJournalWriter.cs
+++ b/source/Calamari.Common/Plumbing/Deployment/Journal/DeploymentJournalWriter.cs
@@ -6,7 +6,7 @@ using Calamari.Common.Features.Processes.Semaphores;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 
-namespace Calamari.Deployment.Journal
+namespace Calamari.Common.Plumbing.Deployment.Journal
 {
     public class DeploymentJournalWriter : IDeploymentJournalWriter
     {
@@ -16,7 +16,7 @@ namespace Calamari.Deployment.Journal
         {
             this.fileSystem = fileSystem;
         }
-        
+
         /// <summary>
         /// Conditionally Write To Journal if there were packages that may need to be cleaned up during retention
         /// </summary>
@@ -28,12 +28,12 @@ namespace Calamari.Deployment.Journal
         {
             var semaphore = SemaphoreFactory.Get();
             var journal = new DeploymentJournal(fileSystem, semaphore, deployment.Variables);
-            
+
             var hasPackages = !string.IsNullOrWhiteSpace(packageFile) ||
                               deployment.Variables.GetIndexes(PackageVariables.PackageCollection).Any();
-            
+
             var canWrite = deployment.Variables.Get(TentacleVariables.Agent.JournalPath) != null;
-            
+
             if(canWrite && hasPackages && !deployment.SkipJournal)
                 journal.AddJournalEntry(new JournalEntry(deployment, wasSuccessful));
         }

--- a/source/Calamari.Common/Plumbing/Deployment/Journal/IDeploymentJournalWriter.cs
+++ b/source/Calamari.Common/Plumbing/Deployment/Journal/IDeploymentJournalWriter.cs
@@ -1,6 +1,7 @@
-﻿using Calamari.Common.Commands;
+﻿using System;
+using Calamari.Common.Commands;
 
-namespace Calamari.Deployment.Journal
+namespace Calamari.Common.Plumbing.Deployment.Journal
 {
     public interface IDeploymentJournalWriter
     {

--- a/source/Calamari.Common/Plumbing/Pipeline/IOnFinishBehaviour.cs
+++ b/source/Calamari.Common/Plumbing/Pipeline/IOnFinishBehaviour.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Calamari.Common.Plumbing.Pipeline
+{
+    public interface IOnFinishBehaviour: IBehaviour
+    {
+    }
+}

--- a/source/Calamari.Common/Plumbing/Pipeline/OnFinishResolver.cs
+++ b/source/Calamari.Common/Plumbing/Pipeline/OnFinishResolver.cs
@@ -1,0 +1,12 @@
+using System;
+using Autofac;
+
+namespace Calamari.Common.Plumbing.Pipeline
+{
+    public class OnFinishResolver: Resolver<IOnFinishBehaviour>
+    {
+        public OnFinishResolver(ILifetimeScope lifetimeScope) : base(lifetimeScope)
+        {
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Deployment/CleanFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/CleanFixture.cs
@@ -7,7 +7,6 @@ using Calamari.Common.Features.Processes.Semaphores;
 using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
-using Calamari.Deployment.Journal;
 using Calamari.Integration.FileSystem;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;

--- a/source/Calamari.Tests/Fixtures/Retention/RetentionPolicyFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Retention/RetentionPolicyFixture.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Calamari.Common.Features.Deployment.Journal;
 using Calamari.Common.Plumbing.FileSystem;
-using Calamari.Deployment.Journal;
 using Calamari.Deployment.Retention;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Time;

--- a/source/Calamari.Tests/Fixtures/Variables/DeploymentJournalVariableContributorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Variables/DeploymentJournalVariableContributorFixture.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Calamari.Common.Features.Deployment.Journal;
 using Calamari.Common.Plumbing.Variables;
-using Calamari.Deployment.Journal;
 using NSubstitute;
 using NUnit.Framework;
 

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -1,7 +1,6 @@
 ﻿using Calamari.Commands.Support;
 using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
-using Calamari.Deployment.Journal;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -16,6 +15,7 @@ using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.Scripts;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
+using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;

--- a/source/Calamari/Commands/TransferPackageCommand.cs
+++ b/source/Calamari/Commands/TransferPackageCommand.cs
@@ -4,13 +4,13 @@ using Calamari.Commands.Support;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Deployment.Journal;
 using Calamari.Common.Features.Processes.Semaphores;
+using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
-using Calamari.Deployment.Journal;
 
 namespace Calamari.Commands
 {

--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -12,12 +12,12 @@ using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing.Deployment;
+using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
-using Calamari.Deployment.Journal;
 using Calamari.Kubernetes.Conventions;
 
 namespace Calamari.Kubernetes.Commands

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -8,8 +8,8 @@ using Calamari.Commands;
 using Calamari.Common;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Commands;
+using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.Logging;
-using Calamari.Deployment.Journal;
 using Calamari.Integration.Certificates;
 using Calamari.Integration.FileSystem;
 using NuGet;
@@ -23,7 +23,7 @@ namespace Calamari
         protected Program(ILog log) : base(log)
         {
         }
-        
+
         public static int Main(string[] args)
         {
             return new Program(ConsoleLog.Instance).Run(args);
@@ -45,9 +45,9 @@ namespace Calamari
             // Setting extensions here as in the new Modularity world we don't register extensions
             // and GetAllAssembliesToRegister doesn't get passed CommonOptions
             extensions = options.Extensions;
-            
+
             base.ConfigureContainer(builder, options);
-            
+
             builder.RegisterType<CalamariCertificateStore>().As<ICertificateStore>().SingleInstance();
             builder.RegisterType<DeploymentJournalWriter>().As<IDeploymentJournalWriter>().SingleInstance();
             builder.RegisterType<PackageStore>().As<IPackageStore>().SingleInstance();
@@ -72,9 +72,9 @@ namespace Calamari
             {
                 yield return assembly;
             }
-            
+
             yield return typeof(ApplyDeltaCommand).Assembly; // Calamari.Shared
-            
+
             var extensionAssemblies = GetExtensionAssemblies();
             foreach (var extensionAssembly in extensionAssemblies)
             {


### PR DESCRIPTION
Sashimi PR: https://github.com/OctopusDeploy/Sashimi/pull/87

This is to make it easier for Sashimi to share a common RunScript command