### PR TITLE
Test other changes introduced in #652

### DIFF
--- a/source/Calamari.Tests/Fixtures/Substitutions/Samples/ANSI.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Samples/ANSI.txt
@@ -1,1 +1,3 @@
-† ‡ µ ¢ £ € « » Math: - × ÷ ±
+† ‡ µ ¢ £ € « »
+Math: - × ÷ ±
+LocalCacheFolderName: #{LocalCacheFolderName}

--- a/source/Calamari.Tests/Fixtures/Substitutions/Samples/ASCII.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Samples/ASCII.txt
@@ -1,1 +1,2 @@
-This is plain old ASCII text
+This is plain old ASCII text.
+LocalCacheFolderName: #{LocalCacheFolderName}

--- a/source/Calamari.Tests/Fixtures/Substitutions/Samples/UTF8.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Samples/UTF8.txt
@@ -1,1 +1,3 @@
-½ ¼ ¾ ⅓ ⅔ † ‡ µ ¢ £ € « » ♤ ♧ ♥ ♢ ¿ �. Math: - × ÷ ± ∞ π
+½ ¼ ¾ ⅓ ⅔ † ‡ µ ¢ £ € « » ♤ ♧ ♥ ♢ ¿ �.
+Math: - × ÷ ± ∞ π
+LocalCacheFolderName: #{LocalCacheFolderName}

--- a/source/Calamari.Tests/Fixtures/Substitutions/Samples/UTF8BOM.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Samples/UTF8BOM.txt
@@ -1,1 +1,3 @@
-﻿½ ¼ ¾ ⅓ ⅔ † ‡ µ ¢ £ € « » ♤ ♧ ♥ ♢ ¿ �. Math: - × ÷ ± ∞ π 
+﻿½ ¼ ¾ ⅓ ⅔ † ‡ µ ¢ £ € « » ♤ ♧ ♥ ♢ ¿ �.
+Math: - × ÷ ± ∞ π 
+LocalCacheFolderName: #{LocalCacheFolderName}

--- a/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
@@ -28,11 +28,13 @@ namespace Calamari.Tests.Fixtures.Substitutions
         [Test]
         public void ShouldSubstitute()
         {
-            var variables = new CalamariVariables();
-            variables["ServerEndpoints[FOREXUAT01].Name"] = "forexuat01.local";
-            variables["ServerEndpoints[FOREXUAT01].Port"] = "1566";
-            variables["ServerEndpoints[FOREXUAT02].Name"] = "forexuat02.local";
-            variables["ServerEndpoints[FOREXUAT02].Port"] = "1566";
+            var variables = new CalamariVariables
+            {
+                ["ServerEndpoints[FOREXUAT01].Name"] = "forexuat01.local",
+                ["ServerEndpoints[FOREXUAT01].Port"] = "1566",
+                ["ServerEndpoints[FOREXUAT02].Name"] = "forexuat02.local",
+                ["ServerEndpoints[FOREXUAT02].Port"] = "1566"
+            };
 
             var text = PerformTest(GetFixtureResource("Samples", "Servers.json"), variables).text;
 


### PR DESCRIPTION
SubstitutionsFixture:

- Assert that line endings are preserved
- Add test AmbiguouslyEncodedInputRetainsUnicodeVariables
- Add test WhenAnsiCannotRepresentOutputUtf8IsUsed