### PR TITLE
Obey any XML encoding declaration, and update if necessary

### DIFF
--- a/source/Calamari.Common/Plumbing/FileSystem/ICalamariFileSystem.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/ICalamariFileSystem.cs
@@ -23,6 +23,7 @@ namespace Calamari.Common.Plumbing.FileSystem
         long GetFileSize(string path);
         string ReadFile(string path);
         string ReadFile(string path, out Encoding encoding);
+        string ReadAllText(byte[] bytes, out Encoding encoding, ICollection<Encoding> encodingPrecedence);
         void OverwriteFile(string path, string contents, Encoding? encoding = null);
         void OverwriteFile(string path, Action<TextWriter> writeToWriter, Encoding? encoding = null);
         void OverwriteFile(string path, byte[] data);

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanInferNamespacePrefixesFromDocument.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanInferNamespacePrefixesFromDocument.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanInsertTextIntoASelfClosingElement.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanInsertTextIntoASelfClosingElement.approved.xml
@@ -1,6 +1,5 @@
 <document>
   <selfclosing>value&lt;new</selfclosing>
-  <empty>
-  </empty>
+  <empty></empty>
   <mixed>This is <b>some</b> text</mixed>
 </document>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAComment.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAComment.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!--New Comment-->
   <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceATextNode.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceATextNode.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-new</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAnAttribute.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAnAttribute.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-new">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAnElementsChildren.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAnElementsChildren.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAnElementsChildrenWhenTheElementHasMixedContent.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAnElementsChildrenWhenTheElementHasMixedContent.approved.xml
@@ -1,7 +1,6 @@
 <document>
   <selfclosing />
-  <empty>
-  </empty>
+  <empty></empty>
   <mixed>
     <newElement />
   </mixed>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAnElementsChildrenWhenTheNewChildrenHaveNamespaces.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAnElementsChildrenWhenTheNewChildrenHaveNamespaces.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAnElementsText.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceAnElementsText.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value&lt;new</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceCData.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceCData.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceCDataInAnElement.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceCDataInAnElement.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceMultipleElements.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceMultipleElements.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-new</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceMultipleElementsInDifferentPartsOfTheTree.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceMultipleElementsInDifferentPartsOfTheTree.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-new</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceProcessingInstructions.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanReplaceProcessingInstructions.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanUseXPath2Wildcards.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.CanUseXPath2Wildcards.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.DoesNotModifyDocumentWhenVariableCannotBeParsedAsMarkup.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.DoesNotModifyDocumentWhenVariableCannotBeParsedAsMarkup.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.DoesNotThrowOnUnrecognisedNamespace.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.DoesNotThrowOnUnrecognisedNamespace.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.DoesNothingIfThereAreNoVariables.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.DoesNothingIfThereAreNoVariables.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.DoesntTreatVariableAsMarkupWhenReplacingAnElementThatContainsNoElementChildren.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.DoesntTreatVariableAsMarkupWhenReplacingAnElementThatContainsNoElementChildren.approved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
   <!-- Comment -->
   <setting id="id-1">&lt;a /&gt;</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.HandlesVariablesThatReferenceOtherVariables.approved.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.HandlesVariablesThatReferenceOtherVariables.approved.xml
@@ -1,6 +1,5 @@
 <document>
   <selfclosing>value-new</selfclosing>
-  <empty>
-  </empty>
+  <empty></empty>
   <mixed>This is <b>some</b> text</mixed>
 </document>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.ShouldAdaptDeclaredEncodingWhenNecessary.approved.txt
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.ShouldAdaptDeclaredEncodingWhenNecessary.approved.txt
@@ -1,0 +1,49 @@
+3C 3F 78 6D 6C 20 76 65   <?xml ve
+72 73 69 6F 6E 3D 22 31   rsion="1
+2E 30 22 20 65 6E 63 6F   .0" enco
+64 69 6E 67 3D 22 75 74   ding="ut
+66 2D 38 22 3F 3E 0A 3C   f-8"?>^<
+74 6F 70 2D 6E 61 6D 65   top-name
+73 2D 66 6F 72 2D 62 6F   s-for-bo
+79 73 3E 0A 20 20 3C 6E   ys>^  <n
+61 6D 65 3E 4A 61 6B 75   ame>Jaku
+62 3C 2F 6E 61 6D 65 3E   b</name>
+0A 20 20 3C 6E 61 6D 65   ^  <name
+3E 53 7A 79 6D 6F 6E 3C   >Szymon<
+2F 6E 61 6D 65 3E 0A 20   /name>^ 
+20 3C 6E 61 6D 65 3E 4B    <name>K
+61 63 70 65 72 3C 2F 6E   acper</n
+61 6D 65 3E 0A 20 20 3C   ame>^  <
+6E 61 6D 65 3E 46 69 6C   name>Fil
+69 70 3C 2F 6E 61 6D 65   ip</name
+3E 0A 20 20 3C 6E 61 6D   >^  <nam
+65 3E 4D 69 63 68 61 C5   e>Micha?
+82 3C 2F 6E 61 6D 65 3E   ?</name>
+0A 20 20 3C 6E 61 6D 65   ^  <name
+3E 4D 61 74 65 75 73 7A   >Mateusz
+3C 2F 6E 61 6D 65 3E 0A   </name>^
+20 20 3C 6E 61 6D 65 3E     <name>
+42 61 72 74 6F 73 7A 3C   Bartosz<
+2F 6E 61 6D 65 3E 0A 20   /name>^ 
+20 3C 6E 61 6D 65 3E 57    <name>W
+6F 6A 63 69 65 63 68 3C   ojciech<
+2F 6E 61 6D 65 3E 0A 20   /name>^ 
+20 3C 6E 61 6D 65 3E 41    <name>A
+64 61 6D 3C 2F 6E 61 6D   dam</nam
+65 3E 0A 20 20 3C 6E 61   e>^  <na
+6D 65 3E 57 69 6B 74 6F   me>Wikto
+72 3C 2F 6E 61 6D 65 3E   r</name>
+0A 20 20 3C 6E 61 6D 65   ^  <name
+3E 50 69 6F 74 72 3C 2F   >Piotr</
+6E 61 6D 65 3E 0A 20 20   name>^  
+3C 6E 61 6D 65 3E 4A 61   <name>Ja
+6E 3C 2F 6E 61 6D 65 3E   n</name>
+0A 20 20 3C 6E 61 6D 65   ^  <name
+3E 44 61 77 69 64 3C 2F   >Dawid</
+6E 61 6D 65 3E 0A 20 20   name>^  
+3C 6E 61 6D 65 3E E5 BC   <name>??
+A0 E4 BC 9F 3C 2F 6E 61   ????</na
+6D 65 3E 0A 3C 2F 74 6F   me>^</to
+70 2D 6E 61 6D 65 73 2D   p-names-
+66 6F 72 2D 62 6F 79 73   for-boys
+3E                        >

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.ShouldPreserveEncodingIso88592UnixNoBom.approved.txt
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/XmlVariableReplacerFixture.ShouldPreserveEncodingIso88592UnixNoBom.approved.txt
@@ -1,0 +1,49 @@
+3C 3F 78 6D 6C 20 76 65   <?xml ve
+72 73 69 6F 6E 3D 22 31   rsion="1
+2E 30 22 20 65 6E 63 6F   .0" enco
+64 69 6E 67 3D 22 69 73   ding="is
+6F 2D 38 38 35 39 2D 32   o-8859-2
+22 3F 3E 0A 3C 74 6F 70   "?>^<top
+2D 6E 61 6D 65 73 2D 66   -names-f
+6F 72 2D 62 6F 79 73 3E   or-boys>
+0A 20 20 3C 6E 61 6D 65   ^  <name
+3E 4A 61 6B 75 62 3C 2F   >Jakub</
+6E 61 6D 65 3E 0A 20 20   name>^  
+3C 6E 61 6D 65 3E 53 7A   <name>Sz
+79 6D 6F 6E 3C 2F 6E 61   ymon</na
+6D 65 3E 0A 20 20 3C 6E   me>^  <n
+61 6D 65 3E 4B 61 63 70   ame>Kacp
+65 72 3C 2F 6E 61 6D 65   er</name
+3E 0A 20 20 3C 6E 61 6D   >^  <nam
+65 3E 46 69 6C 69 70 3C   e>Filip<
+2F 6E 61 6D 65 3E 0A 20   /name>^ 
+20 3C 6E 61 6D 65 3E 4D    <name>M
+69 63 68 61 B3 2B 3C 2F   icha?+</
+6E 61 6D 65 3E 0A 20 20   name>^  
+3C 6E 61 6D 65 3E 4D 61   <name>Ma
+74 65 75 73 7A 3C 2F 6E   teusz</n
+61 6D 65 3E 0A 20 20 3C   ame>^  <
+6E 61 6D 65 3E 42 61 72   name>Bar
+74 6F 73 7A 3C 2F 6E 61   tosz</na
+6D 65 3E 0A 20 20 3C 6E   me>^  <n
+61 6D 65 3E 57 6F 6A 63   ame>Wojc
+69 65 63 68 3C 2F 6E 61   iech</na
+6D 65 3E 0A 20 20 3C 6E   me>^  <n
+61 6D 65 3E 41 64 61 6D   ame>Adam
+3C 2F 6E 61 6D 65 3E 0A   </name>^
+20 20 3C 6E 61 6D 65 3E     <name>
+57 69 6B 74 6F 72 3C 2F   Wiktor</
+6E 61 6D 65 3E 0A 20 20   name>^  
+3C 6E 61 6D 65 3E 50 69   <name>Pi
+6F 74 72 3C 2F 6E 61 6D   otr</nam
+65 3E 0A 20 20 3C 6E 61   e>^  <na
+6D 65 3E 4A 61 6E 3C 2F   me>Jan</
+6E 61 6D 65 3E 0A 20 20   name>^  
+3C 6E 61 6D 65 3E 44 61   <name>Da
+77 69 64 3C 2F 6E 61 6D   wid</nam
+65 3E 0A 20 20 3C 6E 61   e>^  <na
+6D 65 3E 4D 69 6B 6F B3   me>Miko?
+61 6A 3C 2F 6E 61 6D 65   aj</name
+3E 0A 3C 2F 74 6F 70 2D   >^</top-
+6E 61 6D 65 73 2D 66 6F   names-fo
+72 2D 62 6F 79 73 3E      r-boys>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/complex.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/complex.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <document xmlns:db="http://octopus.com/duplicate1" xmlns:unique="http://octopus.com/unique">
     <!-- Comment -->
     <setting id="id-1">value-1</setting>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/enc-iso88592-unix-nobom.xml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/enc-iso88592-unix-nobom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="iso-8859-2" ?>
+<top-names-for-boys>
+  <name>Jakub</name>
+  <name>Szymon</name>
+  <name>Kacper</name>
+  <name>Filip</name>
+  <name>Michał</name>
+  <name>Mateusz</name>
+  <name>Bartosz</name>
+  <name>Wojciech</name>
+  <name>Adam</name>
+  <name>Wiktor</name>
+  <name>Piotr</name>
+  <name>Jan</name>
+  <name>Dawid</name>
+  <name>???</name>
+</top-names-for-boys>

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/XmlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/XmlVariableReplacerFixture.cs
@@ -301,6 +301,25 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                         TestEnvironment.AssentConfiguration);
         }
 
+        [Test]
+        public void ShouldPreserveEncodingIso88592UnixNoBom()
+        {
+            this.Assent(ReplaceToHex(new CalamariVariables
+                                     {
+                                         { "//name[14]", "Miko\u0142aj" },
+                                         { "//name[.='Micha\u0142']", "Micha\u0142+"}
+                                     },
+                                     "enc-iso88592-unix-nobom.xml"),
+                        TestEnvironment.AssentConfiguration);
+        }
+
+        [Test]
+        public void ShouldAdaptDeclaredEncodingWhenNecessary()
+        {
+            this.Assent(ReplaceToHex(new CalamariVariables { { "//name[14]", "\u5F20\u4F1F" } }, "enc-iso88592-unix-nobom.xml"),
+                        TestEnvironment.AssentConfiguration);
+        }
+
         void RunTest(CalamariVariables vars,
                      string file,
                      [CallerMemberName]


### PR DESCRIPTION
This checks the input file for any XML declaration that includes an encoding, and tries to read, and later write, using that encoding.

If the introduction of exotic characters means that we write another encoding, the declared encoding in the output is updated.