### PR TITLE
Tidy up the logs output by structured config var replacement.

### DIFF
--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
@@ -25,7 +25,7 @@ namespace Calamari.Tests.Fixtures.Deployment
             base.SetUp();
         }
         
-        [Test]	
+        [Test]
         public void FailsAndWarnsIfAFileCannotBeParsedWhenFallbackFlagIsSet()	
         {	
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))	
@@ -36,13 +36,12 @@ namespace Calamari.Tests.Fixtures.Deployment
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);	
-                result.AssertFailure();	
-
-                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: ^. Path '', line 0, position 0.");	
+                result.AssertFailure();
+                result.AssertErrorOutput("The file could not be parsed as Json");	
             }	
         }	
 
-        [Test]	
+        [Test]
         public void ShouldNotTreatYamlFileAsYamlWhenFallbackFlagIsSet()	
         {	
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))	
@@ -55,8 +54,8 @@ namespace Calamari.Tests.Fixtures.Deployment
                 var result = DeployPackage(file.FilePath);	
                 result.AssertFailure();	
 
-                // Indicates we tried to parse yaml as JSON.	
-                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: k. Path '', line 0, position 0.");	
+                // Indicates we tried to parse yaml as JSON.
+                result.AssertErrorOutput("The file could not be parsed as Json");	
             }	
         }
 
@@ -164,8 +163,8 @@ namespace Calamari.Tests.Fixtures.Deployment
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
-                result.AssertOutputMatches("Attempting structured variable replacement on file .*?values.yaml with formats: Json, Yaml.");
-
+                result.AssertOutput("The file will be tried as Json first for backwards compatibility");
+                result.AssertOutputMatches("Structured variable replacement succeeded on file .+? with format Yaml");
             }
         }
 
@@ -257,7 +256,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 var result = DeployPackage(file.FilePath);
                 
                 result.AssertFailure();
-                result.AssertOutput("Unterminated string. Expected delimiter: \". Path '', line 3, position 1.");
+                result.AssertErrorOutput("The file could not be parsed as Json");
             }
         }
         
@@ -272,7 +271,7 @@ namespace Calamari.Tests.Fixtures.Deployment
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertFailure();
-                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: ^. Path '', line 0, position 0.");
+                result.AssertErrorOutput("The file could not be parsed as Json");
             }
         }
 
@@ -308,8 +307,7 @@ namespace Calamari.Tests.Fixtures.Deployment
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertFailure();
-
-                result.AssertOutput("Syntax error when parsing the file as Json: Unexpected character encountered while parsing value: ^. Path '', line 0, position 0.");
+                result.AssertErrorOutput("The file could not be parsed as Json");
             }
         }
 

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployVhdFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployVhdFixture.cs
@@ -69,7 +69,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 result.AssertOutputMatches(@"Transforming '[A-Z]:\\ApplicationPath\\web\.config' using '[A-Z]:\\ApplicationPath\\web\.Production\.config'");
 
                 // json substitutions
-                result.AssertOutputMatches("Structured variable replacement succeeded on file [A-Z]:\\\\ApplicationPath\\\\appsettings.json with format 'Json'");
+                result.AssertOutputMatches("Structured variable replacement succeeded on file [A-Z]:\\\\ApplicationPath\\\\appsettings.json with format Json");
             }
         }
 
@@ -121,7 +121,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 result.AssertOutputMatches(@"Transforming '[A-Z]:\\ApplicationPath\\web\.config' using '[A-Z]:\\ApplicationPath\\web\.Production\.config'");
 
                 // json substitutions
-                result.AssertOutputMatches("Structured variable replacement succeeded on file [A-Z]:\\\\ApplicationPath\\\\appsettings.json with format 'Json'");
+                result.AssertOutputMatches("Structured variable replacement succeeded on file [A-Z]:\\\\ApplicationPath\\\\appsettings.json with format Json");
             }
         }
 
@@ -171,7 +171,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 result.AssertOutputMatches(@"Transforming '[A-Z]:\\AlternateApplicationPath\\web\.config' using '[A-Z]:\\AlternateApplicationPath\\web\.Production\.config'");
 
                 // json substitutions
-                result.AssertOutputMatches("Structured variable replacement succeeded on file [A-Z]:\\\\AlternateApplicationPath\\\\appsettings.json with format 'Json'");
+                result.AssertOutputMatches("Structured variable replacement succeeded on file [A-Z]:\\\\AlternateApplicationPath\\\\appsettings.json with format Json");
             }
         }
     }


### PR DESCRIPTION
This PR changes the logging in `StructuredConfigVariablesService` to be a bit less confusing. Previously, failing to parse a yaml file would produce:

- 4 warnings
- 1 error

This was confusing as the user would see both JSON and YAML parsing failure messages (with `Warning` severity) for a YAML file. This is because we always try JSON first for backwards compatibility, but reading the logs was confusing.

This PR changes the behaviour:

- The logs now explain how Calamari chooses the file formats to try
- If the file parses successfully, there will be a single `Info` level log saying `Structured variable replacement succeeded on file {path} with format {format}`
- If the file doesn't parse, there will be a single `Error` level log containing details of the parsing failure

# Before
```
VERBOSE Attempting structured variable replacement on file {path} with formats: Json, Yaml. 
VERBOSE Attempting structured variable replacement on file {path} with format 'Json' 
WARNING Attempting structured variable replacement on file {path} with format 'Yaml' 
WARNING Structured variable replacement failed on file {path}. 
WARNING Syntax error when parsing the file as Json: Additional text encountered after finished reading JSON content: ,. Path '', line 1, position 0. 
WARNING Syntax error when parsing the file as Yaml: (Line: 1, Col: 1, Idx: 0) - (Line: 1, Col: 2, Idx: 1): While parsing a node, did not find expected node content. 
ERROR   System.Exception: The file at {path} could not be parsed with any of the formats tried. See logs for more details.
```

# After
```
VERBOSE The file at {path} matches a known filename pattern, and will be treated as Yaml. The file will be tried as Json first for backwards compatibility.
VERBOSE Attempting structured variable replacement on file {path} with format Json
VERBOSE The file at {path} couldn't be parsed as Json: Additional text encountered after finished reading JSON content: ,. Path '', line 1, position 0.
VERBOSE Attempting structured variable replacement on file {path} with format Yaml
ERROR   System.Exception: Structured variable replacement failed on file {path}. The file could not be parsed as Yaml: (Line: 1, Col: 1, Idx: 0) - (Line: 1, Col: 2, Idx: 1): While parsing a node, did not find expected node content. See verbose logs for more details.
```

# Out of scope for this PR
Calamari still logs exceptions during "install" conventions twice, and it still logs the full stack trace. That behaviour has not been changed in this PR, but may be addressed elsewhere.
