### PR TITLE
Remove New-OctopusAzureCloudServiceTarget func

### DIFF
--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -235,23 +235,6 @@ function New-OctopusAzureServiceFabricTarget([string]$name, [string]$azureConnec
 	Write-Host "##octopus[create-azureservicefabrictarget $($parameters)]"
 }
 
-function New-OctopusAzureCloudServiceTarget([string]$name, [string]$azureCloudServiceName, [string]$azureStorageAccount, [string]$azureDeploymentSlot, [string]$swap, [string]$instanceCount, [string]$octopusAccountIdOrName, [string]$octopusRoles, [switch]$updateIfExisting)
-{
-	$name = Convert-ToServiceMessageParameter -name "name" -value $name
-	$azureCloudServiceName = Convert-ToServiceMessageParameter -name "azureCloudServiceName" -value $azureCloudServiceName
-	$azureStorageAccount = Convert-ToServiceMessageParameter -name "azureStorageAccount" -value $azureStorageAccount
-	$azureDeploymentSlot = Convert-ToServiceMessageParameter -name "azureDeploymentSlot" -value $azureDeploymentSlot
-	$swap = Convert-ToServiceMessageParameter -name "swap" -value $swap
-	$instanceCount = Convert-ToServiceMessageParameter -name "instanceCount" -value $instanceCount
-	$octopusAccountIdOrName = Convert-ToServiceMessageParameter -name "octopusAccountIdOrName" -value $octopusAccountIdOrName
-	$octopusRoles = Convert-ToServiceMessageParameter -name "octopusRoles" -value $octopusRoles
-	$updateIfExistingParameter = Convert-ToServiceMessageParameter -name "updateIfExisting" -value $updateIfExisting
-
-	$parameters = $name, $azureCloudServiceName, $azureStorageAccount, $azureDeploymentSlot, $swap, $instanceCount, $octopusAccountIdOrName, $octopusRoles, $updateIfExistingParameter -join ' '
-
-	Write-Host "##octopus[create-azurecloudservicetarget $($parameters)]"
-}
-
 function Remove-OctopusTarget([string] $targetIdOrName)
 {
 	$targetIdOrName = Convert-ToServiceMessageParameter -name "machine" -value $targetIdOrName


### PR DESCRIPTION
As title, the bootstrap ps1 function `New-OctopusAzureCloudServiceTarget` is now generated based on the dynamic script function registration in the corresponding `Sashimi.AzureCloudService` project.

Please refer to its [Sashimi PR](https://github.com/OctopusDeploy/Sashimi.AzureCloudService/pull/1)