### PR TITLE
Remove New-OctopusAwsAccount and New-OctopusAzureServicePrincipalAccount functions

### DIFF
--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -169,18 +169,6 @@ function New-OctopusTokenAccount([string]$name, [string]$token, [switch]$updateI
     Write-Host "##octopus[create-tokenaccount $($parameters)]"
 }
 
-function New-OctopusAwsAccount([string]$name, [string]$secretKey, [string]$accessKey, [switch]$updateIfExisting)
-{
-	$name = Convert-ToServiceMessageParameter -name "name" -value $name
-	$secretKey = Convert-ToServiceMessageParameter -name "secretKey" -value $secretKey
- 	$accessKey = Convert-ToServiceMessageParameter -name "accessKey" -value $accessKey
-	$updateIfExistingParameter = Convert-ToServiceMessageParameter -name "updateIfExisting" -value $updateIfExisting
-
-	$parameters = $name, $secretKey, $accessKey, $updateIfExistingParameter -join ' '
-
-    Write-Host "##octopus[create-awsaccount $($parameters)]"
-}
-
 function New-OctopusUserPassAccount([string]$name, [string]$username, [string]$password, [switch]$updateIfExisting)
 {
 	$name = Convert-ToServiceMessageParameter -name "name" -value $name
@@ -191,29 +179,6 @@ function New-OctopusUserPassAccount([string]$name, [string]$username, [string]$p
 	$parameters = $name, $username, $password, $updateIfExistingParameter -join ' '
 
     Write-Host "##octopus[create-userpassaccount $($parameters)]"
-}
-
-function New-OctopusAzureServicePrincipalAccount([string]$name, [string]$azureSubscriptionId, [string]$azureApplicationId, [string]$azureTenantId, [string]$azurePassword, [string]$azureEnvironment, [string]$azureBaseUri, [string]$azureResourceManagementBaseUri, [switch]$updateIfExisting)
-{
-	$name = Convert-ToServiceMessageParameter -name "name" -value $name
- 	$azureSubscription = Convert-ToServiceMessageParameter -name "azSubscriptionId" -value $azureSubscriptionId
- 	$azureApplicationId = Convert-ToServiceMessageParameter -name "azApplicationId" -value $azureApplicationId
- 	$azureTenantId = Convert-ToServiceMessageParameter -name "azTenantId" -value $azureTenantId
- 	$azurePassword = Convert-ToServiceMessageParameter -name "azPassword" -value $azurePassword
-	$type = Convert-ToServiceMessageParameter -name "type" -value "serviceprincipal"
-	$updateIfExistingParameter = Convert-ToServiceMessageParameter -name "updateIfExisting" -value $updateIfExisting
-
-	$parameters = $type, $name, $azureSubscription, $azureApplicationId, $azureTenantId, $azurePassword, $updateIfExistingParameter -join ' '
-
-	if (![string]::IsNullOrEmpty($azureEnvironment))
-	{
-		$azureEnvironment = Convert-ToServiceMessageParameter -name "azEnvironment" -value $azureEnvironment
-		$azureBaseUri = Convert-ToServiceMessageParameter -name "azBaseUri" -value $azureBaseUri
-		$azureResourceManagementBaseUri = Convert-ToServiceMessageParameter -name "azResourceManagementBaseUri" -value $azureResourceManagementBaseUri
-		$parameters = $parameters, $azureEnvironment, $azureBaseUri, $azureResourceManagementBaseUri -join ' '
-	}
-
-    Write-Host "##octopus[create-azureaccount $($parameters)]"
 }
 
 function Remove-OctopusTarget([string] $targetIdOrName)


### PR DESCRIPTION
As title, both bootstrap ps1 function `New-OctopusAwsAccount` and `New-OctopusAzureServicePrincipalAccount` are now generated based on the dynamic script function registration in the corresponding `Sashimi` project.

Please refer to its [Sashimi PR](https://github.com/OctopusDeploy/Sashimi/pull/94) & [Server PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/6624)