### PR TITLE
Log structured replacements, display info if nothing was replaced

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/FileFormatVariableReplacers.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/FileFormatVariableReplacers.cs
@@ -10,9 +10,9 @@ namespace Calamari.Common.Features.StructuredVariables
             return new IFileFormatVariableReplacer[]
             {
                 new JsonFormatVariableReplacer(fileSystem, log),
-                new YamlFormatVariableReplacer(fileSystem),
+                new YamlFormatVariableReplacer(fileSystem, log),
                 new XmlFormatVariableReplacer(fileSystem, log),
-                new PropertiesFormatVariableReplacer(fileSystem)
+                new PropertiesFormatVariableReplacer(fileSystem, log)
             };
         }
     }

--- a/source/Calamari.Common/Features/StructuredVariables/JsonUpdateMap.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/JsonUpdateMap.cs
@@ -155,21 +155,17 @@ namespace Calamari.Common.Features.StructuredVariables
 
         public void Update(IVariables variables)
         {
-            bool VariableNameIsNotASystemVariable(string v)
+            bool VariableNameIsMappedPath(string v)
             {
-                if (v.StartsWith("Octopus", StringComparison.OrdinalIgnoreCase))
-                {
+                if (v.StartsWith("Octopus", StringComparison.OrdinalIgnoreCase)
+                    && !v.StartsWith("Octopus:", StringComparison.OrdinalIgnoreCase))
                     // Only include variables starting with 'Octopus'
                     // if it also has a colon (:)
-                    if (v.StartsWith("Octopus:", StringComparison.OrdinalIgnoreCase))
-                        return map.ContainsKey(v);
                     return false;
-                }
-
                 return map.ContainsKey(v);
             }
 
-            foreach (var name in variables.GetNames().Where(VariableNameIsNotASystemVariable))
+            foreach (var name in variables.GetNames().Where(VariableNameIsMappedPath))
                 try
                 {
                     map[name](variables.Get(name));

--- a/source/Calamari.Common/Features/StructuredVariables/JsonUpdateMap.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/JsonUpdateMap.cs
@@ -165,15 +165,21 @@ namespace Calamari.Common.Features.StructuredVariables
                 return map.ContainsKey(v);
             }
 
+            var replaced = 0;
             foreach (var name in variables.GetNames().Where(VariableNameIsMappedPath))
                 try
                 {
+                    log.Verbose(StructuredConfigMessages.StructureFound(name));
+                    replaced++;
                     map[name](variables.Get(name));
                 }
                 catch (Exception e)
                 {
                     log.WarnFormat("Unable to set value for {0}. The following error occurred: {1}", name, e.Message);
                 }
+
+            if (replaced == 0)
+                log.Info(StructuredConfigMessages.NoStructuresFound);
         }
     }
 }

--- a/source/Calamari.Common/Features/StructuredVariables/PropertiesFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/PropertiesFormatVariableReplacer.cs
@@ -38,7 +38,7 @@ namespace Calamari.Common.Features.StructuredVariables
                 var updated = parsed.Mutate(expr =>
                                             {
                                                 var newExpr = TryReplaceValue(expr, variables);
-                                                if (!Equals(newExpr, expr))
+                                                if (!ReferenceEquals(newExpr, expr))
                                                     replaced++;
                                                 return newExpr;
                                             });

--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigMessages.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigMessages.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Calamari.Common.Features.StructuredVariables
+{
+    public static class StructuredConfigMessages
+    {
+        public static readonly string NoStructuresFound = "No structures have been found that match variable names, so no structured variable replacements have been applied.";
+
+        public static string StructureFound(string name)
+        {
+            return $"Structure found matching the variable '{name}'. Replacing its content with the variable value.";
+        }
+    }
+}

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
@@ -16,10 +17,12 @@ namespace Calamari.Common.Features.StructuredVariables
         static readonly Regex OctopusReservedVariablePattern = new Regex(@"^Octopus([^:]|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         readonly ICalamariFileSystem fileSystem;
+        readonly ILog log;
 
-        public YamlFormatVariableReplacer(ICalamariFileSystem fileSystem)
+        public YamlFormatVariableReplacer(ICalamariFileSystem fileSystem, ILog log)
         {
             this.fileSystem = fileSystem;
+            this.log = log;
         }
 
         public string FileFormatName => StructuredConfigVariablesFileFormats.Yaml;
@@ -34,11 +37,20 @@ namespace Calamari.Common.Features.StructuredVariables
         {
             try
             {
+                void LogReplacement(string key)
+                    => log.Verbose(StructuredConfigMessages.StructureFound(key));
+
+                var replaced = 0;
                 var variablesByKey = variables
                                      .Where(v => !OctopusReservedVariablePattern.IsMatch(v.Key))
                                      .DistinctBy(v => v.Key)
                                      .ToDictionary<KeyValuePair<string, string>, string, Func<string>>(v => v.Key,
-                                                                                                       v => () => variables.Get(v.Key),
+                                                                                                       v => () =>
+                                                                                                            {
+                                                                                                                LogReplacement(v.Key);
+                                                                                                                replaced++;
+                                                                                                                return variables.Get(v.Key);
+                                                                                                            },
                                                                                                        StringComparer.OrdinalIgnoreCase);
 
                 // Read and transform the input file
@@ -107,6 +119,8 @@ namespace Calamari.Common.Features.StructuredVariables
                             }
                         }
                     }
+                    if (replaced == 0)
+                        log.Info(StructuredConfigMessages.NoStructuresFound);
                 }
 
                 fileSystem.OverwriteFile(filePath,

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/JsonFormatVariableReplacerFixture.DoesNothingIfThereAreNoVariables.approved.json
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/JsonFormatVariableReplacerFixture.DoesNothingIfThereAreNoVariables.approved.json
@@ -1,0 +1,11 @@
+{
+  "MyMessage": "Hello world",
+  "EmailSettings": {
+    "SmtpPort": "23",
+    "SmtpHost": "localhost",
+    "DefaultRecipients": {
+      "To": "paul@octopus.com",
+      "Cc": "mike@octopus.com"
+    }
+  }
+}

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.DoesNothingIfThereAreNoVariables.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.DoesNothingIfThereAreNoVariables.approved.yaml
@@ -1,0 +1,20 @@
+server:
+  ports:
+  - "5555"
+spring:
+  h2:
+    console:
+      enabled: "true"
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+  datasource:
+    url: jdbc:h2:mem:testdb
+    dbcp2:
+      driver-class-name: org.h2.Driver
+  flyway:
+    locations: classpath:db/migration/{vendor}
+  loggers:
+  - name: console
+  - name: file
+    pattern: '%n.log'
+environment: development

--- a/source/Calamari.Tests/Helpers/InMemoryLog.cs
+++ b/source/Calamari.Tests/Helpers/InMemoryLog.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Integration.Processes;
@@ -12,6 +13,11 @@ namespace Calamari.Tests.Helpers
         public List<Message> Messages { get; } = new List<Message>();
         public List<string> StandardOut { get; } = new List<string>();
         public List<string> StandardError  { get; }= new List<string>();
+
+        public IEnumerable<string> MessagesVerboseFormatted => Messages.Where(m => m.Level == Level.Verbose).Select(m => m.FormattedMessage);
+        public IEnumerable<string> MessagesInfoFormatted => Messages.Where(m => m.Level == Level.Info).Select(m => m.FormattedMessage);
+        public IEnumerable<string> MessagesWarnFormatted => Messages.Where(m => m.Level == Level.Warn).Select(m => m.FormattedMessage);
+        public IEnumerable<string> MessagesErrorFormatted => Messages.Where(m => m.Level == Level.Error).Select(m => m.FormattedMessage);
 
         protected override void StdOut(string message)
         {


### PR DESCRIPTION
This displays a Verbose log message when a structured replacement is made:

```
Structure found matching the variable '{name}'. Replacing its content with the variable value.
```

When no matches are found, it displays the following Info log message:

```
No structures have been found that match variable names, so no structured variable replacements have been applied.
```

Includes tests that confirm when these messages are displayed, and not displayed.