### PR TITLE
Replace structures with blanks instead of removing them

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
@@ -106,7 +106,7 @@ namespace Calamari.Common.Features.StructuredVariables
 
     public static class ParsingEventExtensions
     {
-        public static Scalar ReplaceValue(this Scalar scalar, string newValue)
+        public static Scalar ReplaceValue(this Scalar scalar, string? newValue)
         {
             return newValue != null
                 ? new Scalar(scalar.Anchor,

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -37,9 +37,9 @@ namespace Calamari.Common.Features.StructuredVariables
                 var variablesByKey = variables
                                      .Where(v => !OctopusReservedVariablePattern.IsMatch(v.Key))
                                      .DistinctBy(v => v.Key)
-                                     .ToDictionary<KeyValuePair<string, string>, string, Func<string>>(v => v.Key,
-                                                                                                       v => () => variables.Get(v.Key),
-                                                                                                       StringComparer.OrdinalIgnoreCase);
+                                     .ToDictionary<KeyValuePair<string, string>, string, Func<string?>>(v => v.Key,
+                                                                                                        v => () => variables.Get(v.Key),
+                                                                                                        StringComparer.OrdinalIgnoreCase);
 
                 // Read and transform the input file
                 var fileText = fileSystem.ReadFile(filePath, out var encoding);
@@ -53,7 +53,7 @@ namespace Calamari.Common.Features.StructuredVariables
                     var scanner = new Scanner(reader, false);
                     var parser = new Parser(scanner);
                     var classifier = new YamlEventStreamClassifier();
-                    (IYamlNode startEvent, string replacementValue)? structureWeAreReplacing = null;
+                    (IYamlNode startEvent, string? replacementValue)? structureWeAreReplacing = null;
                     while (parser.MoveNext())
                     {
                         var ev = parser.Current;
@@ -125,7 +125,7 @@ namespace Calamari.Common.Features.StructuredVariables
             }
         }
 
-        List<ParsingEvent> ParseFragment(string value, string? anchor, string? tag)
+        List<ParsingEvent> ParseFragment(string? value, string? anchor, string? tag)
         {
             var result = new List<ParsingEvent>();
             try

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -133,26 +133,36 @@ namespace Calamari.Common.Features.StructuredVariables
                 using (var reader = new StringReader(value))
                 {
                     var parser = new Parser(reader);
+                    bool added = false;
                     while (parser.MoveNext())
                     {
                         var ev = parser.Current;
                         if (ev != null && !(ev is StreamStart || ev is StreamEnd || ev is DocumentStart || ev is DocumentEnd))
+                        {
                             result.Add(ev);
+                            added = true;
+                        }
                     }
+                    if (!added)
+                        throw new Exception("No content found in fragment");
                 }
             }
             catch
             {
                 // The input could not be recognized as a structure. Falling back to treating it as a string.
-                return new List<ParsingEvent>
-                {
-                    new Scalar(anchor,
-                               tag,
-                               value,
-                               ScalarStyle.DoubleQuoted,
-                               true,
-                               true)
-                };
+                result.Add(value != null
+                               ? new Scalar(anchor,
+                                            tag,
+                                            value,
+                                            ScalarStyle.DoubleQuoted,
+                                            true,
+                                            true)
+                               : new Scalar(anchor,
+                                            tag,
+                                            "null",
+                                            ScalarStyle.Plain,
+                                            true,
+                                            false));
             }
 
             return result;

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceStructuresWithBlank.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceStructuresWithBlank.approved.yaml
@@ -8,6 +8,6 @@ str1: 'false'
 str2: 'null'
 str3: !!str no
 str4: !!str pets.com
-obj1: ''
+obj1: ""
 seq1: null
-seq2: ''
+seq2: ""

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceStructuresWithBlank.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.CanReplaceStructuresWithBlank.approved.yaml
@@ -1,0 +1,13 @@
+null1: null
+null2: !!null ~
+bool1: false
+bool2: !!bool true
+int1: 1
+float1: 0.67
+str1: 'false'
+str2: 'null'
+str3: !!str no
+str4: !!str pets.com
+obj1: ''
+seq1: null
+seq2: ''

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/YamlVariableReplacerFixture.cs
@@ -145,6 +145,19 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
         }
 
         [Test]
+        public void CanReplaceStructuresWithBlank()
+        {
+            this.Assent(Replace(new CalamariVariables
+                                {
+                                    { "obj1", "" },
+                                    { "seq1", null },
+                                    { "seq2", "" }
+                                },
+                                "types.yaml"),
+                        TestEnvironment.AssentYamlConfiguration);
+        }
+
+        [Test]
         public void ShouldIgnoreOctopusPrefix()
         {
             this.Assent(Replace(new CalamariVariables


### PR DESCRIPTION
# Background

I was squashing a nullable reference warning when I realized that when we insert a parsed replacement, and it's empty, we would remove the node instead of replacing it with anything. This can be quite unfortunate for mappings when things like this happen:

Input -
```
key1:
  remove-me: 1
key2: val
```

Output -
```
key1: key2
val:
```

# Change

This makes sure we fall back to some kind of scalar in all cases.
