### PR TITLE
Remove New-OctopusTokenAccount, New-OctopusUserPassAccount and New-OctopusKubernetesTarget

### DIFF
--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -158,77 +158,11 @@ function Convert-ToServiceMessageParameter([string]$name, [string]$value)
 	return $param
 }
 
-function New-OctopusTokenAccount([string]$name, [string]$token, [switch]$updateIfExisting)
-{
-	$name = Convert-ToServiceMessageParameter -name "name" -value $name
- 	$token = Convert-ToServiceMessageParameter -name "token" -value $token
-	$updateIfExistingParameter = Convert-ToServiceMessageParameter -name "updateIfExisting" -value $updateIfExisting
-
-	$parameters = $name, $token, $updateIfExistingParameter -join ' '
-
-    Write-Host "##octopus[create-tokenaccount $($parameters)]"
-}
-
-function New-OctopusUserPassAccount([string]$name, [string]$username, [string]$password, [switch]$updateIfExisting)
-{
-	$name = Convert-ToServiceMessageParameter -name "name" -value $name
- 	$username = Convert-ToServiceMessageParameter -name "username" -value $username
-	$password = Convert-ToServiceMessageParameter -name "password" -value $password
-	$updateIfExistingParameter = Convert-ToServiceMessageParameter -name "updateIfExisting" -value $updateIfExisting
-
-	$parameters = $name, $username, $password, $updateIfExistingParameter -join ' '
-
-    Write-Host "##octopus[create-userpassaccount $($parameters)]"
-}
-
 function Remove-OctopusTarget([string] $targetIdOrName)
 {
 	$targetIdOrName = Convert-ToServiceMessageParameter -name "machine" -value $targetIdOrName
 	$parameters = $targetIdOrName -join ' '
 	Write-Host "##octopus[delete-target $($parameters)]"
-}
-
-function New-OctopusKubernetesTarget(
-	[string]$name,
-	[string]$clusterUrl,
-	[string]$clusterName,
-	[string]$clusterResourceGroup,
-	[string]$namespace,
-	[string]$skipTlsVerification,
-	[string]$octopusAccountIdOrName,
-	[string]$octopusClientCertificateIdOrName,
-	[string]$octopusServerCertificateIdOrName,
-	[string]$octopusRoles,
-	[string]$octopusDefaultWorkerPoolIdOrName,
-	[switch]$updateIfExisting)
-{
-	$name = Convert-ToServiceMessageParameter -name "name" -value $name
-	$clusterName = Convert-ToServiceMessageParameter -name "clusterName" -value $clusterName
-	$clusterResourceGroup = Convert-ToServiceMessageParameter -name "clusterResourceGroup" -value $clusterResourceGroup
-	$octopusClientCertificateIdOrName = Convert-ToServiceMessageParameter -name "clientCertificate" -value $octopusClientCertificateIdOrName
-	$octopusServerCertificateIdOrName = Convert-ToServiceMessageParameter -name "serverCertificate" -value $octopusServerCertificateIdOrName
-	$clusterUrl = Convert-ToServiceMessageParameter -name "clusterUrl" -value $clusterUrl
-	$namespace = Convert-ToServiceMessageParameter -name "namespace" -value $namespace
-	$octopusAccountIdOrName = Convert-ToServiceMessageParameter -name "octopusAccountIdOrName" -value $octopusAccountIdOrName
-	$octopusRoles = Convert-ToServiceMessageParameter -name "octopusRoles" -value $octopusRoles
-	$updateIfExistingParameter = Convert-ToServiceMessageParameter -name "updateIfExisting" -value $updateIfExisting
-	$octopusDefaultWorkerPoolIdOrName = Convert-ToServiceMessageParameter -name "defaultWorkerPool" -value $octopusDefaultWorkerPoolIdOrName
-	$skipTlsVerification = Convert-ToServiceMessageParameter -name "skipTlsVerification" -value $skipTlsVerification
-
-	$parameters = $name, `
-		$clusterUrl, `
-		$clusterName, `
-		$clusterResourceGroup, `
-		$octopusDefaultWorkerPoolIdOrName, `
-		$octopusClientCertificateIdOrName, `
-		$octopusServerCertificateIdOrName, `
-		$namespace, `
-		$octopusAccountIdOrName, `
-		$octopusRoles, `
-		$skipTlsVerification, `
-		$updateIfExistingParameter -join ' '
-
-	Write-Host "##octopus[create-kubernetestarget $($parameters)]"
 }
 
 function Fail-Step([string] $message)


### PR DESCRIPTION
As title, the bootstrap ps1 function(s) `New-OctopusTokenAccount`, `New-OctopusUserPassAccount` and `New-OctopusKubernetesTarget` are now generated based on the dynamic script function registration in the corresponding `Octopus.Server` project.

Please refer to the [Server PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/6629)