### PR TITLE
Fix helm steps in runbooks

### DIFF
--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -278,7 +278,7 @@ namespace Calamari.Kubernetes.Conventions
         {
             var packagePath = deployment.Variables.Get(PackageVariables.Output.InstallationDirectoryPath);
             
-            var packageId = deployment.Variables.Get(PackageVariables.PackageId);
+            var packageId = deployment.Variables.Get(PackageVariables.IndexedPackageId(string.Empty));
 
             if (fileSystem.FileExists(Path.Combine(packagePath, "Chart.yaml")))
             {


### PR DESCRIPTION
`Octopus.Action.Package.PackageId` doesn't exist in runbooks, but `Octopus.Action.Package[].PackageId` does. This PR uses the newer variable type instead of the legacy one.

This fixes this error:

![image](https://user-images.githubusercontent.com/160104/90589938-a5ffed80-e222-11ea-80e7-c2734fdb2c08.png)

Here is the new variable in the runbooks:

![image](https://user-images.githubusercontent.com/160104/90590064-e95a5c00-e222-11ea-9d25-414ea79e1a7d.png)

