### PR TITLE
Searched more locations for the Chart.yaml file

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -126,6 +126,25 @@ namespace Calamari.Tests.KubernetesFixtures
 
             Assert.AreEqual("Hello Embedded Variables", result.CapturedOutput.OutputVariables["Message"]);
         }
+        
+        [Test]
+        [RequiresNonFreeBSDPlatform]
+        [RequiresNon32BitWindows]
+        [RequiresNonMac]
+        [Category(TestCategory.PlatformAgnostic)]
+        public void MismatchPackageIDAndPathWorks()
+        {
+            Variables.Set(PackageVariables.PackageId, "thisisnotamatch");
+            Variables.Set(PackageVariables.PackageVersion, "0.3.7");
+            Variables.Set(PackageVariables.IndexedPackageId(""), $"#{{{PackageVariables.PackageId}}}");
+            Variables.Set(PackageVariables.IndexedPackageVersion(""), $"#{{{PackageVariables.PackageVersion}}}");
+            
+            var result = DeployPackage();
+
+            result.AssertSuccess();
+
+            Assert.AreEqual("Hello Embedded Variables", result.CapturedOutput.OutputVariables["Message"]);
+        }
 
         [Test]
         [RequiresNonFreeBSDPlatform]

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -127,7 +127,7 @@ namespace Calamari.Tests.KubernetesFixtures
             Assert.AreEqual("Hello Embedded Variables", result.CapturedOutput.OutputVariables["Message"]);
         }
         
-        [Test]
+        [Test(Description = "Test the case where the package ID does not match the directory inside the helm archive.")]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [RequiresNonMac]

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -132,7 +132,7 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNon32BitWindows]
         [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
-        public void MismatchPackageIDAndPathWorks()
+        public void MismatchPackageIDAndHelmArchivePathWorks()
         {
             Variables.Set(PackageVariables.PackageId, "thisisnotamatch");
             Variables.Set(PackageVariables.PackageVersion, "0.3.7");

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -276,22 +276,35 @@ namespace Calamari.Kubernetes.Conventions
 
         string GetChartLocation(RunningDeployment deployment)
         {
-            var packagePath = deployment.Variables.Get(PackageVariables.Output.InstallationDirectoryPath);
-            
+            var installDir = deployment.Variables.Get(PackageVariables.Output.InstallationDirectoryPath);
+
             var packageId = deployment.Variables.Get(PackageVariables.IndexedPackageId(string.Empty));
 
-            if (fileSystem.FileExists(Path.Combine(packagePath, "Chart.yaml")))
+            // Try the root directory
+            if (fileSystem.FileExists(Path.Combine(installDir, "Chart.yaml")))
             {
-                return Path.Combine(packagePath, "Chart.yaml");
+                return Path.Combine(installDir, "Chart.yaml");
             }
 
-            packagePath = Path.Combine(packagePath, packageId);
-            if (!fileSystem.DirectoryExists(packagePath) || !fileSystem.FileExists(Path.Combine(packagePath, "Chart.yaml")))
+            // Try the directory that matches the package id
+            var packageIdPath = Path.Combine(installDir, packageId);
+            if (fileSystem.DirectoryExists(packageIdPath) && fileSystem.FileExists(Path.Combine(packageIdPath, "Chart.yaml")))
             {
-                throw new CommandException($"Unexpected error. Chart.yaml was not found in {packagePath}");
+                return packageIdPath;
+                
             }
-
-            return packagePath;
+            
+            // Find the first subdirectory with a Chart.yaml file.
+            foreach (var dir in fileSystem.EnumerateDirectories(installDir))
+            {
+                if (fileSystem.FileExists(Path.Combine(dir, "Chart.yaml")))
+                {
+                    return dir;
+                }
+            }
+            
+            // Nothing worked
+            throw new CommandException($"Unexpected error. Chart.yaml was not found in {packageIdPath}");
         }
 
         static bool TryAddRawValuesYaml(RunningDeployment deployment, out string fileName)

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -294,7 +294,11 @@ namespace Calamari.Kubernetes.Conventions
                 
             }
             
-            // Find the first subdirectory with a Chart.yaml file.
+            /*
+             * Although conventions suggests that the directory inside the helm archive matches the package ID, this
+             * can not be assumed. If the standard locations above failed to locate the Chart.yaml file, loop over
+             * all subdirectories to try and find the file.
+             */
             foreach (var dir in fileSystem.EnumerateDirectories(installDir))
             {
                 if (fileSystem.FileExists(Path.Combine(dir, "Chart.yaml")))


### PR DESCRIPTION
This PR allows the helm upgrade step to search all sub-directories for the Helm Chart.yaml file. This means the package ID no longer needs to match the directory inside the helm archive.

The likely case where this happens is if someone uploads a chart to the built in feed, but uses a filename like `chart-1.1.1.tgz`. This results in a package id like `chart-1` and a version of `1.1`.

See https://octopususergroup.slack.com/archives/C6UGLUWMQ/p1597331156100800 for an example