### PR TITLE
Removing feature flags no longer in use

### DIFF
--- a/source/Calamari.Common/Features/Behaviours/ConfigurationVariablesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/ConfigurationVariablesBehaviour.cs
@@ -25,7 +25,10 @@ namespace Calamari.Common.Features.Behaviours
 
         public bool IsEnabled(RunningDeployment context)
         {
-            return context.Variables.GetFlag(KnownVariables.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings);
+            var features = context.Variables.GetStrings(KnownVariables.Package.EnabledFeatures)
+                                  .Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+
+            return features.Contains(KnownVariables.Features.ConfigurationVariables);
         }
 
         public Task Execute(RunningDeployment context)

--- a/source/Calamari.Common/Features/Behaviours/StructuredConfigurationVariablesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/StructuredConfigurationVariablesBehaviour.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.StructuredVariables;
@@ -18,7 +19,10 @@ namespace Calamari.Common.Features.Behaviours
 
         public bool IsEnabled(RunningDeployment context)
         {
-            return context.Variables.GetFlag(ActionVariables.StructuredConfigurationVariablesEnabled);
+            var features = context.Variables.GetStrings(KnownVariables.Package.EnabledFeatures)
+                                  .Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+
+            return features.Contains(KnownVariables.Features.StructuredConfigurationVariables);
         }
 
         public Task Execute(RunningDeployment context)

--- a/source/Calamari.Common/Features/Behaviours/SubstituteInFilesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/SubstituteInFilesBehaviour.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Substitutions;
@@ -7,7 +8,7 @@ using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Common.Features.Behaviours
 {
-    class SubstituteInFilesBehaviour : IBehaviour
+    public class SubstituteInFilesBehaviour : IBehaviour
     {
         readonly ISubstituteInFiles substituteInFiles;
 
@@ -18,7 +19,10 @@ namespace Calamari.Common.Features.Behaviours
 
         public bool IsEnabled(RunningDeployment context)
         {
-            return context.Variables.GetFlag(PackageVariables.SubstituteInFilesEnabled);
+            var features = context.Variables.GetStrings(KnownVariables.Package.EnabledFeatures)
+                                  .Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+
+            return features.Contains(KnownVariables.Features.SubstituteInFiles);
         }
 
         public Task Execute(RunningDeployment context)

--- a/source/Calamari.Common/Plumbing/FileSystem/SubstituteInFiles.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/SubstituteInFiles.cs
@@ -26,10 +26,6 @@ namespace Calamari.Common.Plumbing.FileSystem
 
         public void SubstituteBasedSettingsInSuppliedVariables(RunningDeployment deployment)
         {
-            var substituteInFilesEnabled = variables.GetFlag(PackageVariables.SubstituteInFilesEnabled);
-            if (!substituteInFilesEnabled)
-                return;
-
             var filesToTarget = variables.GetPaths(PackageVariables.SubstituteInFilesTargets);
             Substitute(deployment, filesToTarget);
         }

--- a/source/Calamari.Common/Plumbing/Variables/ActionVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/ActionVariables.cs
@@ -6,18 +6,12 @@ namespace Calamari.Common.Plumbing.Variables
     {
         public const string Name = "Octopus.Action.Name";
         public const string AdditionalPaths = "Octopus.Action.AdditionalPaths";
-        
-        /* We've renamed these two variables from "Json*" to "Structured*" as they're being used with the renamed config feature
-         Structured Configuration Variables. TThese values appear in deployment process resources sent between clients and the API, 
-         so until we have support for API versioning (https://github.com/OctopusDeploy/Architecture/pull/11), it is not feasible to 
-         change their values without causing a breaking change. For this reason, for the time being we're going to continue using 
-         the old Octopus Variable names. */
-        public static readonly string StructuredConfigurationVariablesEnabled = "Octopus.Action.Package.JsonConfigurationVariablesEnabled";
+
         public static readonly string StructuredConfigurationVariablesTargets = "Octopus.Action.Package.JsonConfigurationVariablesTargets";
         /* If this flag still exists after 2020.5.0 releases, please reach out to those involved with adding the fallback flag for
-         Structured Configuration in this PR (https://github.com/OctopusDeploy/Calamari/pull/629) so we can assess if the feature 
+         Structured Configuration in this PR (https://github.com/OctopusDeploy/Calamari/pull/629) so we can assess if the feature
          has been stable for long enough to tidy up the fallback flag. */
-        public static readonly string StructuredConfigurationFallbackFlag = "Octopus.Action.StructuredConfigurationFallbackFlag";	
+        public static readonly string StructuredConfigurationFallbackFlag = "Octopus.Action.StructuredConfigurationFallbackFlag";
 
         public static string GetOutputVariableName(string actionName, string variableName)
         {

--- a/source/Calamari.Common/Plumbing/Variables/KnownVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/KnownVariables.cs
@@ -38,7 +38,10 @@ namespace Calamari.Common.Plumbing.Variables
         public static class Features
         {
             public const string CustomScripts = "Octopus.Features.CustomScripts";
+            public const string ConfigurationVariables = "Octopus.Features.ConfigurationVariables";
             public const string ConfigurationTransforms = "Octopus.Features.ConfigurationTransforms";
+            public const string SubstituteInFiles = "Octopus.Features.SubstituteInFiles";
+            public const string StructuredConfigurationVariables = "Octopus.Features.JsonConfigurationVariables";
         }
 
         public static class Package
@@ -47,7 +50,6 @@ namespace Calamari.Common.Plumbing.Variables
             public static readonly string EnabledFeatures = "Octopus.Action.EnabledFeatures";
             public static readonly string UpdateIisWebsite = "Octopus.Action.Package.UpdateIisWebsite";
             public static readonly string UpdateIisWebsiteName = "Octopus.Action.Package.UpdateIisWebsiteName";
-            public static readonly string AutomaticallyUpdateAppSettingsAndConnectionStrings = "Octopus.Action.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings";
             public static readonly string JsonConfigurationVariablesEnabled = "Octopus.Action.Package.JsonConfigurationVariablesEnabled";
             public static readonly string JsonConfigurationVariablesTargets = "Octopus.Action.Package.JsonConfigurationVariablesTargets";
             public static readonly string AutomaticallyRunConfigurationTransformationFiles = "Octopus.Action.Package.AutomaticallyRunConfigurationTransformationFiles";

--- a/source/Calamari.Common/Plumbing/Variables/PackageVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/PackageVariables.cs
@@ -14,7 +14,6 @@ namespace Calamari.Common.Plumbing.Variables
         public static readonly string CustomInstallationDirectoryPurgeExclusions = "Octopus.Action.Package.CustomInstallationDirectoryPurgeExclusions";
         public static readonly string EnableNoMatchWarning = "Octopus.Action.SubstituteInFiles.EnableNoMatchWarning";
         public static readonly string SubstituteInFilesOutputEncoding = "Octopus.Action.SubstituteInFiles.OutputEncoding";
-        public static readonly string SubstituteInFilesEnabled = "Octopus.Action.SubstituteInFiles.Enabled";
         public static readonly string SubstituteInFilesTargets = "Octopus.Action.SubstituteInFiles.TargetFiles";
         public static readonly string PackageCollection = "Octopus.Action.Package";
 

--- a/source/Calamari.Shared/Deployment/Conventions/SubstituteInFilesConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/SubstituteInFilesConvention.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Behaviours;
+
+namespace Calamari.Deployment.Conventions
+{
+    public class SubstituteInFilesConvention : IInstallConvention
+    {
+        readonly SubstituteInFilesBehaviour substituteInFilesBehaviour;
+
+        public SubstituteInFilesConvention(SubstituteInFilesBehaviour substituteInFilesBehaviour)
+        {
+            this.substituteInFilesBehaviour = substituteInFilesBehaviour;
+        }
+
+        public void Install(RunningDeployment deployment)
+        {
+            if (substituteInFilesBehaviour.IsEnabled(deployment))
+            {
+                substituteInFilesBehaviour.Execute(deployment).Wait();
+            }
+        }
+    }
+}

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -65,8 +65,6 @@ namespace Calamari.Deployment
             public static readonly string ShouldDownloadOnTentacle = "Octopus.Action.Package.DownloadOnTentacle";
             public static readonly string UpdateIisWebsite = "Octopus.Action.Package.UpdateIisWebsite";
             public static readonly string UpdateIisWebsiteName = "Octopus.Action.Package.UpdateIisWebsiteName";
-            public static readonly string AutomaticallyUpdateAppSettingsAndConnectionStrings = "Octopus.Action.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings";
-            public static readonly string AutomaticallyRunConfigurationTransformationFiles = "Octopus.Action.Package.AutomaticallyRunConfigurationTransformationFiles";
             public static readonly string TreatConfigTransformationWarningsAsErrors = "Octopus.Action.Package.TreatConfigTransformationWarningsAsErrors";
             public static readonly string IgnoreConfigTransformationErrors = "Octopus.Action.Package.IgnoreConfigTransformationErrors";
             public static readonly string SuppressConfigTransformationLogging = "Octopus.Action.Package.SuppressConfigTransformationLogging";
@@ -103,9 +101,7 @@ namespace Calamari.Deployment
 
         public static class Features
         {
-            public const string CustomScripts = "Octopus.Features.CustomScripts";
             public const string Vhd = "Octopus.Features.Vhd";
-            public const string ConfigurationTransforms = "Octopus.Features.ConfigurationTransforms";
         }
 
         public static class Action

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfigurationTransformConventionFixture.cs
@@ -38,16 +38,21 @@ namespace Calamari.Tests.Fixtures.Conventions
             var deployDirectory = BuildConfigPath(null);
 
             variables = new CalamariVariables();
-            variables.Set(KnownVariables.Package.EnabledFeatures, SpecialVariables.Features.ConfigurationTransforms);
+            variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.ConfigurationTransforms);
             variables.Set(KnownVariables.OriginalPackageDirectoryPath, deployDirectory);
 
             deployment = new RunningDeployment(deployDirectory, variables);
         }
 
+        void AddConfigurationVariablesFlag()
+        {
+            variables.Set(KnownVariables.Package.AutomaticallyRunConfigurationTransformationFiles, true.ToString());
+        }
+
         [Test]
         public void ShouldApplyReleaseTransformIfAutomaticallyRunConfigurationTransformationFilesFlagIsSet()
         {
-            variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, true.ToString());
+            AddConfigurationVariablesFlag();
 
             CreateConvention().Install(deployment);
 
@@ -57,8 +62,6 @@ namespace Calamari.Tests.Fixtures.Conventions
         [Test]
         public void ShouldNotApplyReleaseTransformIfAutomaticallyRunConfigurationTransformationFilesFlagNotSet()
         {
-            variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, false.ToString());
-
             CreateConvention().Install(deployment);
 
             AssertTransformNotRun("bar.config", "bar.Release.config");
@@ -69,7 +72,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             const string environment = "Production";
 
-            variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, true.ToString());
+            AddConfigurationVariablesFlag();
             variables.Set(DeploymentEnvironment.Name, environment);
 
             CreateConvention().Install(deployment);
@@ -84,7 +87,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             const string environment = "Production";
             const string tenant = "Tenant-1";
 
-            variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, true.ToString());
+            AddConfigurationVariablesFlag();
             variables.Set(DeploymentEnvironment.Name, environment);
             variables.Set(DeploymentVariables.Tenant.Name, tenant);
 
@@ -101,7 +104,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             const string environment = "Production";
             const string tenant = "Tenant-1";
 
-            variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, true.ToString());
+            AddConfigurationVariablesFlag();
             variables.Set(DeploymentEnvironment.Name, environment);
             variables.Set(DeploymentVariables.Tenant.Name, tenant);
 
@@ -130,8 +133,6 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldApplySpecificCustomTransform()
         {
             variables.Set(SpecialVariables.Package.AdditionalXmlConfigurationTransforms, "foo.bar.config => foo.config");
-            // This will be applied even if the automatically run flag is set to false
-            variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, false.ToString());
 
             CreateConvention().Install(deployment);
 
@@ -166,7 +167,6 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldApplyAdvancedTransformations(string sourceFile, string transformDefinition, string expectedAppliedTransform)
         {
             variables.Set(SpecialVariables.Package.AdditionalXmlConfigurationTransforms, transformDefinition.Replace('\\', Path.DirectorySeparatorChar));
-            variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, false.ToString());
 
             CreateConvention().Install(deployment);
 
@@ -178,7 +178,6 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldApplyMultipleWildcardsToSourceFile()
         {
             variables.Set(SpecialVariables.Package.AdditionalXmlConfigurationTransforms, "*.bar.blah => bar.blah");
-            variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, false.ToString());
 
             CreateConvention().Install(deployment);
 
@@ -191,7 +190,6 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldApplyTransformToMulipleTargetFiles()
         {
             variables.Set(SpecialVariables.Package.AdditionalXmlConfigurationTransforms, "bar.blah => *.bar.blah");
-            variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, false.ToString());
 
             CreateConvention().Install(deployment);
 
@@ -208,7 +206,6 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void CaseInsensitiveOnWindows(string pattern, string from, string to)
         {
             variables.Set(SpecialVariables.Package.AdditionalXmlConfigurationTransforms, pattern);
-            variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, false.ToString());
 
             CreateConvention().Install(deployment);
 
@@ -226,7 +223,6 @@ namespace Calamari.Tests.Fixtures.Conventions
                 Assert.Ignore("This test is designed to run on *nix");
 
             variables.Set(SpecialVariables.Package.AdditionalXmlConfigurationTransforms, pattern);
-            variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, false.ToString());
 
             CreateConvention().Install(deployment);
 
@@ -239,12 +235,12 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             var calamariFileSystem = Substitute.For<ICalamariFileSystem>();
             var deploymentVariables = new CalamariVariables();
+            deploymentVariables.Set(KnownVariables.Package.AutomaticallyRunConfigurationTransformationFiles, true.ToString());
             deploymentVariables.Set(SpecialVariables.Action.Azure.CloudServicePackagePath, @"MyPackage.1.0.0.nupkg");
             deploymentVariables.Set(SpecialVariables.Package.AdditionalXmlConfigurationTransforms, @"MyApplication.ProcessingServer.WorkerRole.dll.my-test-env.config => MyApplication.ProcessingServer.WorkerRole.dll.config");
-            deploymentVariables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, "True");
             deploymentVariables.Set(DeploymentEnvironment.Name, "my-test-env");
             deploymentVariables.Set(SpecialVariables.Package.EnableDiagnosticsConfigTransformationLogging, "True");
-            deploymentVariables.Set(KnownVariables.Package.EnabledFeatures, SpecialVariables.Features.ConfigurationTransforms);
+            deploymentVariables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.ConfigurationTransforms);
             var runningDeployment = new RunningDeployment(@"c:\temp\MyPackage.1.0.0.nupkg", deploymentVariables);
 
             //mock the world

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfigurationVariablesConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfigurationVariablesConventionFixture.cs
@@ -44,7 +44,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         [Test]
         public void ShouldFindAndCallDeployScripts()
         {
-            deployment.Variables.Set(SpecialVariables.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings, "true");
+            deployment.Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.ConfigurationVariables);
             var convention = new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, replacer, new InMemoryLog()));
             convention.Install(deployment);
             replacer.Received().ModifyConfigurationFile("C:\\App\\MyApp\\Web.config", deployment.Variables);

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfiguredScriptConventionFixture.cs
@@ -37,7 +37,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             scriptEngine.GetSupportedTypes().Returns(new[] { ScriptSyntax.PowerShell });
 
             variables = new CalamariVariables();
-            variables.Set(KnownVariables.Package.EnabledFeatures, SpecialVariables.Features.CustomScripts);
+            variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.CustomScripts);
 
             deployment = new RunningDeployment("C:\\packages", variables) { StagingDirectory = stagingDirectory };
         }

--- a/source/Calamari.Tests/Fixtures/Conventions/StructuredConfigurationVariablesConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/StructuredConfigurationVariablesConventionFixture.cs
@@ -36,7 +36,6 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldNotRunIfVariableIsFalse()
         {
             var convention = new StructuredConfigurationVariablesConvention(new StructuredConfigurationVariablesBehaviour(service));
-            deployment.Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, false);
             convention.Install(deployment);
             service.DidNotReceiveWithAnyArgs().ReplaceVariables(deployment);
         }
@@ -45,7 +44,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldRunIfVariableIsTrue()
         {
             var convention = new StructuredConfigurationVariablesConvention(new StructuredConfigurationVariablesBehaviour(service));
-            deployment.Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+            deployment.Variables.Add(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
             convention.Install(deployment);
             service.Received().ReplaceVariables(deployment);
         }

--- a/source/Calamari.Tests/Fixtures/Conventions/SubstituteInFilesFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/SubstituteInFilesFixture.cs
@@ -31,13 +31,13 @@ namespace Calamari.Tests.Fixtures.Conventions
 
             var variables = new CalamariVariables();
             variables.Set(PackageVariables.SubstituteInFilesTargets, glob);
-            variables.Set(PackageVariables.SubstituteInFilesEnabled, true.ToString());
+            variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.SubstituteInFiles);
 
             var deployment = new RunningDeployment(TestEnvironment.ConstructRootedPath("packages"), variables)
             {
                 StagingDirectory = StagingDirectory
             };
-            
+
             var fileSystem = Substitute.For<ICalamariFileSystem>();
             fileSystem.EnumerateFilesWithGlob(StagingDirectory, glob).Returns(new[] { Path.Combine(StagingDirectory, actualMatch) });
 
@@ -47,7 +47,7 @@ namespace Calamari.Tests.Fixtures.Conventions
 
             substituter.Received().PerformSubstitution(Path.Combine(StagingDirectory, actualMatch), variables);
         }
-        
+
 
     }
 }

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithJsonConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithJsonConfigurationFixture.cs
@@ -19,13 +19,13 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             base.SetUp();
         }
-        
+
         [Test]
         public void ShouldReplaceJsonPropertiesFromVariables()
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, JsonFileName);
                 Variables.Set("departments:0:employees:0:name", "Jane");
                 Variables.Set("departments:0:employees:1:age", "40");
@@ -41,7 +41,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 this.Assent(extractedPackageUpdatedJsonFile, TestEnvironment.AssentJsonConfiguration);
             }
         }
-        
+
         [TearDown]
         public override void CleanUp()
         {

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
@@ -24,39 +24,39 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             base.SetUp();
         }
-        
+
         [Test]
-        public void FailsAndWarnsIfAFileCannotBeParsedWhenFallbackFlagIsSet()	
-        {	
-            using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))	
-            {	
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);	
+        public void FailsAndWarnsIfAFileCannotBeParsedWhenFallbackFlagIsSet()
+        {
+            using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
+            {
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.AddFlag(ActionVariables.StructuredConfigurationFallbackFlag, true);
-                Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, MalformedFileName);	
+                Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, MalformedFileName);
                 Variables.Set("key", "new-value");
 
-                var result = DeployPackage(file.FilePath);	
+                var result = DeployPackage(file.FilePath);
                 result.AssertFailure();
-                result.AssertErrorOutput("The file could not be parsed as Json");	
-            }	
-        }	
+                result.AssertErrorOutput("The file could not be parsed as Json");
+            }
+        }
 
         [Test]
-        public void ShouldNotTreatYamlFileAsYamlWhenFallbackFlagIsSet()	
-        {	
-            using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))	
-            {	
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);	
+        public void ShouldNotTreatYamlFileAsYamlWhenFallbackFlagIsSet()
+        {
+            using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
+            {
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.AddFlag(ActionVariables.StructuredConfigurationFallbackFlag, true);
-                Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, YamlFileName);	
-                Variables.Set("key", "new-value");	
+                Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, YamlFileName);
+                Variables.Set("key", "new-value");
 
-                var result = DeployPackage(file.FilePath);	
-                result.AssertFailure();	
+                var result = DeployPackage(file.FilePath);
+                result.AssertFailure();
 
                 // Indicates we tried to parse yaml as JSON.
-                result.AssertErrorOutput("The file could not be parsed as Json");	
-            }	
+                result.AssertErrorOutput("The file could not be parsed as Json");
+            }
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, YamlFileName);
                 Variables.Set("key", "new-value");
 
@@ -82,7 +82,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, XmlFileName);
                 Variables.Set("/document/key", "new-value");
 
@@ -100,14 +100,14 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, "duplicate-prefixes.xml");
                 Variables.Set("//parent/dupe:node", "new-value");
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
                 result.AssertOutputMatches("You can avoid this by ensuring all namespaces in your document have unique prefixes\\.");
-                
+
                 var extractedPackageUpdatedXmlFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, "duplicate-prefixes.xml"));
 
                 this.Assent(extractedPackageUpdatedXmlFile, TestEnvironment.AssentXmlConfiguration);
@@ -119,14 +119,14 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, "values.xml");
                 Variables.Set("/document", "<<<");
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
                 result.AssertOutputContains("Could not set the value of the XML element at XPath '/document' to '<<<'. Expected a valid XML fragment. Skipping replacement of this element.");
-                
+
                 var extractedPackageUpdatedXmlFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, "values.xml"));
 
                 this.Assent(extractedPackageUpdatedXmlFile, TestEnvironment.AssentXmlConfiguration);
@@ -138,7 +138,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, PropertiesFileName);
                 Variables.Set("debug", "false");
                 Variables.Set("port", "80");
@@ -157,7 +157,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, YamlFileName);
                 Variables.Set("key", "new-value");
 
@@ -173,13 +173,13 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, "doesnt-exist.json");
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
-                
+
                 result.AssertOutputContains("No files were found that match the replacement target pattern 'doesnt-exist.json'");
             }
         }
@@ -189,13 +189,13 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, ConfigFileName);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
-                
+
                 var extractedPackageUpdatedConfigFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, ConfigFileName));
 
                 this.Assent(extractedPackageUpdatedConfigFile, TestEnvironment.AssentJsonConfiguration);
@@ -207,13 +207,13 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, $"{JsonFileName}\n{YamlFileName}");
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
-                
+
                 var extractedPackageUpdatedJsonFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, JsonFileName));
                 var extractedPackageUpdatedYamlFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, YamlFileName));
 
@@ -227,13 +227,13 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, "values.*");
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
-                
+
                 var extractedPackageUpdatedJsonFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, JsonFileName));
                 var extractedPackageUpdatedYamlFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, YamlFileName));
                 var extractedPackageUpdatedConfigFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, ConfigFileName));
@@ -249,23 +249,23 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, "*.json");
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
-                
+
                 result.AssertFailure();
                 result.AssertErrorOutput("The file could not be parsed as Json");
             }
         }
-        
+
         [Test]
         public void FailsIfAFileFailsToParseWhenThereAreManyGlobs()
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, $"{JsonFileName}\n{MalformedFileName}");
                 Variables.Set("key", "new-value");
 
@@ -280,14 +280,14 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, ".");
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
                 result.AssertOutputContains("Skipping structured variable replacement on '.' because it is a directory.");
-                
+
                 var unchangedJsonFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, JsonFileName));
                 var unchangedYamlFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, YamlFileName));
 
@@ -295,13 +295,13 @@ namespace Calamari.Tests.Fixtures.Deployment
                 this.Assent(unchangedYamlFile, TestEnvironment.AssentYamlConfiguration);
             }
         }
-        
+
         [Test]
         public void FailsAndWarnsIfAFileCannotBeParsed()
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
-                Variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                 Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, MalformedFileName);
                 Variables.Set("key", "new-value");
 

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployVhdFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployVhdFixture.cs
@@ -2,7 +2,6 @@ using System.IO;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment;
-using Calamari.Integration.FileSystem;
 using Calamari.Tests.Fixtures.Deployment.Packages;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
@@ -34,15 +33,13 @@ namespace Calamari.Tests.Fixtures.Deployment
         [RequiresWindowsServer2012OrAbove]
         public void ShouldDeployAVhd()
         {
-            Variables[KnownVariables.Package.EnabledFeatures] = "Octopus.Features.Vhd,Octopus.Features.ConfigurationTransforms";
             Variables[SpecialVariables.Vhd.ApplicationPath] = "ApplicationPath";
             Variables["foo"] = "bar";
             Variables[PackageVariables.SubstituteInFilesTargets] = "web.config";
-            Variables[PackageVariables.SubstituteInFilesEnabled] = "True";
-            Variables[SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles] = "True";
+            Variables[KnownVariables.Package.AutomaticallyRunConfigurationTransformationFiles] = "True";
             Variables[DeploymentEnvironment.Name] = Environment;
-            Variables[ActionVariables.StructuredConfigurationVariablesEnabled] = "True";
             Variables[ActionVariables.StructuredConfigurationVariablesTargets] = "appsettings.json";
+            Variables[KnownVariables.Package.EnabledFeatures] = $"{KnownVariables.Features.StructuredConfigurationVariables},{KnownVariables.Features.SubstituteInFiles}, {KnownVariables.Features.ConfigurationTransforms},Octopus.Features.Vhd";
 
             using (var vhd = new TemporaryFile(VhdBuilder.BuildSampleVhd(ServiceName)))
             using (var file = new TemporaryFile(PackageBuilder.BuildSimpleZip(ServiceName, "1.0.0", Path.GetDirectoryName(vhd.FilePath))))
@@ -78,15 +75,13 @@ namespace Calamari.Tests.Fixtures.Deployment
         [RequiresWindowsServer2012OrAbove]
         public void ShouldDeployAVhdWithTwoPartitions()
         {
-            Variables[KnownVariables.Package.EnabledFeatures] = "Octopus.Features.Vhd,Octopus.Features.ConfigurationTransforms";
             Variables[SpecialVariables.Vhd.ApplicationPath] = "ApplicationPath";
             Variables["foo"] = "bar";
             Variables[PackageVariables.SubstituteInFilesTargets] = "web.config";
-            Variables[PackageVariables.SubstituteInFilesEnabled] = "True";
-            Variables[SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles] = "True";
+            Variables[KnownVariables.Package.AutomaticallyRunConfigurationTransformationFiles] = "True";
             Variables[DeploymentEnvironment.Name] = Environment;
-            Variables[ActionVariables.StructuredConfigurationVariablesEnabled] = "True";
             Variables[ActionVariables.StructuredConfigurationVariablesTargets] = "appsettings.json";
+            Variables[KnownVariables.Package.EnabledFeatures] = $"{KnownVariables.Features.StructuredConfigurationVariables},{KnownVariables.Features.SubstituteInFiles}, {KnownVariables.Features.ConfigurationTransforms},Octopus.Features.Vhd";
 
             Variables["OctopusVhdPartitions[1].ApplicationPath"] = "PathThatDoesNotExist";
 
@@ -134,11 +129,10 @@ namespace Calamari.Tests.Fixtures.Deployment
             Variables[SpecialVariables.Vhd.ApplicationPath] = "ApplicationPath";
             Variables["foo"] = "bar";
             Variables[PackageVariables.SubstituteInFilesTargets] = "web.config";
-            Variables[PackageVariables.SubstituteInFilesEnabled] = "True";
-            Variables[SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles] = "True";
+            Variables[KnownVariables.Package.AutomaticallyRunConfigurationTransformationFiles] = "True";
             Variables[DeploymentEnvironment.Name] = Environment;
-            Variables[ActionVariables.StructuredConfigurationVariablesEnabled] = "True";
             Variables[ActionVariables.StructuredConfigurationVariablesTargets] = "appsettings.json";
+            Variables[KnownVariables.Package.EnabledFeatures] = $"{KnownVariables.Features.StructuredConfigurationVariables},{KnownVariables.Features.SubstituteInFiles},{KnownVariables.Features.ConfigurationTransforms},Octopus.Features.Vhd";
 
             Variables["OctopusVhdPartitions[0].Mount"] = "false";
             Variables["OctopusVhdPartitions[1].ApplicationPath"] = "AlternateApplicationPath";

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -96,7 +96,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             Variables.Set("foo", "bar");
             // Enable file substitution and configure the target
-            Variables.Set(PackageVariables.SubstituteInFilesEnabled, true.ToString());
+            Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.SubstituteInFiles);
             Variables.Set(PackageVariables.SubstituteInFilesTargets, "web.config");
 
             DeployPackage();
@@ -113,7 +113,7 @@ namespace Calamari.Tests.Fixtures.Deployment
             var path = Path.Combine("assets", "README.txt");
 
             // Enable file substitution and configure the target
-            Variables.Set(PackageVariables.SubstituteInFilesEnabled, true.ToString());
+            Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.SubstituteInFiles);
             Variables.Set(PackageVariables.SubstituteInFilesTargets, path);
 
             DeployPackage();
@@ -129,8 +129,8 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             // Set the environment, and the flag to automatically run config transforms
             Variables.Set(DeploymentEnvironment.Name, "Production");
-            Variables.Set(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, true.ToString());
-            Variables.Set(KnownVariables.Package.EnabledFeatures, SpecialVariables.Features.ConfigurationTransforms);
+            Variables.Set(KnownVariables.Package.AutomaticallyRunConfigurationTransformationFiles, true.ToString());
+            Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.ConfigurationTransforms);
 
             var result = DeployPackage();
 
@@ -224,7 +224,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         [Test]
         public void ShouldRunConfiguredScripts()
         {
-            Variables.Set(KnownVariables.Package.EnabledFeatures, SpecialVariables.Features.CustomScripts);
+            Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.CustomScripts);
 
             if (CalamariEnvironment.IsRunningOnNix || CalamariEnvironment.IsRunningOnMac)
             {

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
@@ -22,7 +22,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
         static readonly string ConfigFileInAdditionalPath = Path.Combine(AdditionalPath, FileName);
 
         void RunAdditionalPathsTest(
-            bool fileExistsInPath, 
+            bool fileExistsInPath,
             bool fileExistsInAdditionalPath,
             Action<IFileFormatVariableReplacer> replacerAssertions = null,
             Action<InMemoryLog> logAssertions = null)
@@ -38,7 +38,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             var replacer = Substitute.For<IFileFormatVariableReplacer>();
             replacer.FileFormatName.Returns(StructuredConfigVariablesFileFormats.Json);
             replacer.IsBestReplacerForFileName(Arg.Any<string>()).Returns(true);
-            
+
             var log = new InMemoryLog();
             var service = new StructuredConfigVariablesService(new []
             {
@@ -47,7 +47,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
 
             var variables = new CalamariVariables();
             variables.Set(ActionVariables.AdditionalPaths, AdditionalPath);
-            variables.AddFlag(ActionVariables.StructuredConfigurationVariablesEnabled, true);
+            variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
             variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, FileName);
             variables.Set(PackageVariables.CustomInstallationDirectory, CurrentPath);
 
@@ -70,10 +70,10 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
                 replacer.Received().ModifyFile(ConfigFileInCurrentPath, Arg.Any<IVariables>());
                 replacer.Received().ModifyFile(ConfigFileInAdditionalPath, Arg.Any<IVariables>());
             }
-            
+
             RunAdditionalPathsTest(true, true, Assertions);
         }
-        
+
         [Test]
         public void ReplacesVariablesInAdditionalPathIfFileNotMatchedInWorkingDirectory()
         {
@@ -81,10 +81,10 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             {
                 replacer.Received().ModifyFile(ConfigFileInAdditionalPath, Arg.Any<IVariables>());
             }
-            
+
             RunAdditionalPathsTest(false, true, Assertions);
         }
-        
+
         [Test]
         public void DoesntReplacesVariablesInAdditionalPathIfFileNotMatchedInAdditionalPath()
         {
@@ -92,10 +92,10 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             {
                 replacer.Received().ModifyFile(ConfigFileInCurrentPath, Arg.Any<IVariables>());
             }
-            
+
             RunAdditionalPathsTest(true, false, Assertions);
         }
-        
+
         [Test]
         public void LogAWarningIfNoMatchingFileIsFoundInAnyPath()
         {

--- a/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
@@ -90,7 +90,7 @@ namespace Calamari.Tests.Java.Fixtures.Deployment
         public void CanTransformConfigInJar()
         {
             const string configFile = "config.properties";
-            variables.Set(PackageVariables.SubstituteInFilesEnabled, true.ToString());
+            variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.SubstituteInFiles);
             variables.Set(PackageVariables.SubstituteInFilesTargets, configFile);
 
             DeployPackage(TestEnvironment.GetTestPath("Java", "Fixtures", "Deployment", "Packages", "HelloWorld.0.0.1.jar"));
@@ -102,7 +102,7 @@ namespace Calamari.Tests.Java.Fixtures.Deployment
         {
             var command = new DeployJavaArchiveCommand(
                 log,
-                new ScriptEngine(Enumerable.Empty<IScriptWrapper>()), 
+                new ScriptEngine(Enumerable.Empty<IScriptWrapper>()),
                 variables,
                 fileSystem,
                 new CommandLineRunner(log, variables),

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -127,6 +127,25 @@ namespace Calamari.Tests.KubernetesFixtures
             Assert.AreEqual("Hello Embedded Variables", result.CapturedOutput.OutputVariables["Message"]);
         }
 
+        [Test(Description = "Test the case where the package ID does not match the directory inside the helm archive.")]
+        [RequiresNonFreeBSDPlatform]
+        [RequiresNon32BitWindows]
+        [RequiresNonMac]
+        [Category(TestCategory.PlatformAgnostic)]
+        public void MismatchPackageIDAndHelmArchivePathWorks()
+        {
+            Variables.Set(PackageVariables.PackageId, "thisisnotamatch");
+            Variables.Set(PackageVariables.PackageVersion, "0.3.7");
+            Variables.Set(PackageVariables.IndexedPackageId(""), $"#{{{PackageVariables.PackageId}}}");
+            Variables.Set(PackageVariables.IndexedPackageVersion(""), $"#{{{PackageVariables.PackageVersion}}}");
+
+            var result = DeployPackage();
+
+            result.AssertSuccess();
+
+            Assert.AreEqual("Hello Embedded Variables", result.CapturedOutput.OutputVariables["Message"]);
+        }
+
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
@@ -316,7 +335,7 @@ namespace Calamari.Tests.KubernetesFixtures
             }
 
             Variables.Set(SpecialVariables.Action.CustomScripts.GetCustomScriptStage(DeploymentStages.PostDeploy, syntax), script);
-            Variables.Set(KnownVariables.Package.EnabledFeatures, SpecialVariables.Features.CustomScripts);
+            Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.CustomScripts);
         }
 
         string DeleteCommand(string @namespace, string releaseName)

--- a/source/Calamari.Tests/NewPipeline/PipelineCommandFixture.cs
+++ b/source/Calamari.Tests/NewPipeline/PipelineCommandFixture.cs
@@ -11,7 +11,6 @@ using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Variables;
-using Calamari.Deployment;
 using Calamari.Testing;
 using Calamari.Tests.Fixtures;
 using Calamari.Tests.Helpers;
@@ -87,7 +86,7 @@ namespace Calamari.Tests.NewPipeline
                 await CommandTestBuilder.CreateAsync<MyCommand, MyProgram>()
                                         .WithArrange(context =>
                                                      {
-                                                         context.Variables.Add(PackageVariables.SubstituteInFilesEnabled, bool.TrueString);
+                                                         context.Variables.Add(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.SubstituteInFiles);
                                                          context.Variables.Add(PackageVariables.SubstituteInFilesTargets, glob);
                                                          context.Variables.Add("Hello", "Hello World");
                                                          context.WithFilesToCopy(tempPath.DirectoryPath);
@@ -124,8 +123,8 @@ namespace Calamari.Tests.NewPipeline
                 await CommandTestBuilder.CreateAsync<MyCommand, MyProgram>()
                                         .WithArrange(context =>
                                                      {
-                                                         context.Variables.Add(KnownVariables.Package.EnabledFeatures, SpecialVariables.Features.ConfigurationTransforms);
-                                                         context.Variables.Add(SpecialVariables.Package.AutomaticallyRunConfigurationTransformationFiles, bool.TrueString);
+                                                         context.Variables.Add(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.ConfigurationTransforms);
+                                                         context.Variables.Add(KnownVariables.Package.AutomaticallyRunConfigurationTransformationFiles, bool.TrueString);
                                                          context.WithFilesToCopy(tempPath.DirectoryPath);
                                                      })
                                         .WithAssert(result =>
@@ -156,7 +155,7 @@ namespace Calamari.Tests.NewPipeline
                 await CommandTestBuilder.CreateAsync<MyCommand, MyProgram>()
                                         .WithArrange(context =>
                                                      {
-                                                         context.Variables.Add(SpecialVariables.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings, bool.TrueString);
+                                                         context.Variables.Add(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.ConfigurationTransforms + "," + KnownVariables.Features.ConfigurationVariables);
                                                          context.Variables.Add("Environment", "Test");
                                                          context.WithFilesToCopy(tempPath.DirectoryPath);
                                                      })
@@ -184,7 +183,7 @@ namespace Calamari.Tests.NewPipeline
                 await CommandTestBuilder.CreateAsync<MyCommand, MyProgram>()
                                         .WithArrange(context =>
                                                      {
-                                                         context.Variables.Add(ActionVariables.StructuredConfigurationVariablesEnabled, bool.TrueString);
+                                                         context.Variables.Add(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
                                                          context.Variables.Add(ActionVariables.StructuredConfigurationVariablesTargets, "*.json");
                                                          context.Variables.Add("Environment", "Test");
                                                          context.WithFilesToCopy(tempPath.DirectoryPath);

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -100,7 +100,7 @@ namespace Calamari.Commands
                 new ConfiguredScriptConvention(new ConfiguredScriptBehaviour(DeploymentStages.PreDeploy, log, fileSystem, scriptEngine, commandLineRunner)),
                 new PackagedScriptConvention(new PackagedScriptBehaviour(log, DeploymentStages.PreDeploy, fileSystem, scriptEngine, commandLineRunner)),
                 new FeatureConvention(DeploymentStages.AfterPreDeploy, featureClasses, fileSystem, scriptEngine, commandLineRunner, embeddedResources),
-                new DelegateInstallConvention(d => substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(d)),
+                new SubstituteInFilesConvention(new SubstituteInFilesBehaviour(substituteInFiles)),
                 new ConfigurationTransformsConvention(new ConfigurationTransformsBehaviour(fileSystem, configurationTransformer, transformFileLocator, log)),
                 new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, replacer, log)),
                 new StructuredConfigurationVariablesConvention(new StructuredConfigurationVariablesBehaviour(structuredConfigVariablesService)),

--- a/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
+++ b/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
@@ -101,7 +101,7 @@ namespace Calamari.Commands.Java
                 new ConfiguredScriptConvention(new ConfiguredScriptBehaviour(DeploymentStages.PreDeploy, log, fileSystem, scriptEngine, commandLineRunner)),
                 new PackagedScriptConvention(new PackagedScriptBehaviour(log, DeploymentStages.PreDeploy, fileSystem, scriptEngine, commandLineRunner)),
                 new FeatureConvention(DeploymentStages.AfterPreDeploy, featureClasses, fileSystem, scriptEngine, commandLineRunner, embeddedResources),
-                new DelegateInstallConvention(d => substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(d)),
+                new SubstituteInFilesConvention(new SubstituteInFilesBehaviour(substituteInFiles)),
                 new StructuredConfigurationVariablesConvention(new StructuredConfigurationVariablesBehaviour(structuredConfigVariablesService)),
                 new RePackArchiveConvention(log, fileSystem, jarTools),
                 new CopyPackageToCustomInstallationDirectoryConvention(fileSystem),

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -78,7 +78,7 @@ namespace Calamari.Commands
                 // Substitute the script source file
                 new DelegateInstallConvention(d => substituteInFiles.Substitute(d, ScriptFileTargetFactory(d).ToList())),
                 // Substitute any user-specified files
-                new DelegateInstallConvention(d => substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(d)),
+                new SubstituteInFilesConvention(new SubstituteInFilesBehaviour(substituteInFiles)),
                 new ConfigurationTransformsConvention(new ConfigurationTransformsBehaviour(fileSystem, configurationTransformer, transformFileLocator, log)),
                 new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, replacer, log)),
                 new StructuredConfigurationVariablesConvention(new StructuredConfigurationVariablesBehaviour(structuredConfigVariablesService)),


### PR DESCRIPTION
This PR addresses the inconsistency among feature enable flag usage(s). 

Please refer to the relevant [Slack thread](https://octopusdeploy.slack.com/archives/CDANN5QLT/p1598843004074700) for clarification/direction.

TL;DR: We are moving towards using `Octopus.Action.EnabledFeatures` for all feature `enable` flag(s)