### PR TITLE
Ensure Tar extractor uses UTF8

### DIFF
--- a/source/Calamari.Common/Features/Packages/TarPackageExtractor.cs
+++ b/source/Calamari.Common/Features/Packages/TarPackageExtractor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using Calamari.Common.Plumbing.Logging;
 using SharpCompress.Common;
 using SharpCompress.Readers;
@@ -30,7 +31,7 @@ namespace Calamari.Common.Features.Packages
                 var compressionStream = GetCompressionStream(inStream);
                 try
                 {
-                    using (var reader = TarReader.Open(compressionStream))
+                    using (var reader = TarReader.Open(compressionStream, new ReaderOptions { ArchiveEncoding = new ArchiveEncoding { Default = Encoding.UTF8 } }))
                     {
                         while (reader.MoveToNextEntry())
                         {


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/6472

I've decided to just use a small pool of random characters from different alphabets.
I am using Latin, Greek and Arabic. 