### PR TITLE
Upgrade Microsoft.Web.Xdt reference

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -16,7 +16,7 @@
         <PlatformTarget>anycpu</PlatformTarget>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-        <DefineConstants>$(DefineConstants);USE_NUGET_V3_LIBS;WORKAROUND_FOR_EMPTY_STRING_BUG;HAS_NULLABLE_REF_TYPES;USE_OCTOPUS_XMLT</DefineConstants>
+        <DefineConstants>$(DefineConstants);USE_NUGET_V3_LIBS;WORKAROUND_FOR_EMPTY_STRING_BUG;HAS_NULLABLE_REF_TYPES</DefineConstants>
     </PropertyGroup>
     <PropertyGroup>
       <LangVersion>8</LangVersion>
@@ -35,7 +35,6 @@
         <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
         <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
         <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
-        <PackageReference Include="Octopus.Web.XmlTransform" Version="1.0.0-ci0018" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
@@ -56,18 +55,17 @@
         <PackageReference Include="NuGet.Core" Version="2.14.0" />
         <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
         <PackageReference Include="AlphaFS" Version="2.1.3-octopus0006" />
-        <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
-      <PackageReference Include="Octopus.Versioning" Version="4.2.1" />
-      <PackageReference Include="Octostache" Version="2.8.0" />
-      <PackageReference Include="SharpCompress" Version="0.24.0" />
-      <PackageReference Include="XPath2" Version="1.0.12" />
-      <PackageReference Include="YamlDotNet" Version="8.1.2" />
-      <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-
+        <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
+        <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
+        <PackageReference Include="Octopus.Versioning" Version="4.2.1" />
+        <PackageReference Include="Octostache" Version="2.8.0" />
+        <PackageReference Include="SharpCompress" Version="0.24.0" />
+        <PackageReference Include="XPath2" Version="1.0.12" />
+        <PackageReference Include="YamlDotNet" Version="8.1.2" />
+        <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Calamari.Common/Features/ConfigurationTransforms/VerboseTransformLogger.cs
+++ b/source/Calamari.Common/Features/ConfigurationTransforms/VerboseTransformLogger.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using Calamari.Common.Plumbing.Logging;
-#if USE_OCTOPUS_XMLT
-using Octopus.Web.XmlTransform;
-#else
 using Microsoft.Web.XmlTransform;
-#endif
 
 namespace Calamari.Common.Features.ConfigurationTransforms
 {

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -61,11 +61,11 @@
     <PackageReference Include="Sprache" Version="2.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
+    <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="NuGet.Commands" Version="3.5.0" />
     <PackageReference Include="Markdown" Version="2.1.0" />
-    <PackageReference Include="Octopus.Web.XmlTransform" Version="1.0.0-ci0018" />
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
     <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
@@ -81,7 +81,6 @@
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="Microsoft.Web.Administration" Version="7.0.0.0" />
     <PackageReference Include="Microsoft.Web.Deployment" Version="3.6.0" />
-    <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
     <PackageReference Include="NuGet.CommandLine" Version="2.8.6" />
     <PackageReference Include="NuGet.Core" Version="2.14.0" />
     <PackageReference Include="AlphaFS" Version="2.1.3-octopus0006" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -18,7 +18,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);NETCORE;AZURE_CORE;USE_OCTOPUS_XMLT;JAVA_SUPPORT</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCORE;AZURE_CORE;JAVA_SUPPORT</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);NETFX;AWS;IIS_SUPPORT;USE_NUGET_V2_LIBS;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT;WINDOWS_USER_ACCOUNT_SUPPORT;WINDOWS_REGISTRY_SUPPORT</DefineConstants>

--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/Approved/ConfigurationTransformsFixture.XmlWithNamespacesIsCorrectlyProcessed.approved.txt
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/Approved/ConfigurationTransformsFixture.XmlWithNamespacesIsCorrectlyProcessed.approved.txt
@@ -1,0 +1,10 @@
+<nlog autoReload="true" xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <targets>
+    <target name="csv" xsi:type="File" fileName="log.txt" archiveFileName="log.txt">
+      <layout xsi:type="CSVLayout"></layout>
+    </target>
+  </targets>
+  <rules>
+    <logger name="*" minlevel="Info" writeTo="csv" />
+  </rules>
+</nlog>

--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/ConfigurationTransformsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/ConfigurationTransformsFixture.cs
@@ -28,6 +28,12 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
         }
 
         [Test]
+        public void XmlWithNamespacesIsCorrectlyProcessed()
+        {
+            PerformTest(GetFixtureResource("Samples", "nlog.config"), GetFixtureResource("Samples", "nlog.Release.config"));
+        }
+
+        [Test]
         [RequiresMonoVersion423OrAbove] //Bug in mono < 4.2.3 https://bugzilla.xamarin.com/show_bug.cgi?id=19426
         public void WebReleaseConfig()
         {
@@ -43,12 +49,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
 
         [Test]
         [RequiresMonoVersion423OrAbove] //Bug in mono < 4.2.3 https://bugzilla.xamarin.com/show_bug.cgi?id=19426
-#if USE_OCTOPUS_XMLT
-        //vs shows ambiguous refence here but it builds and runs fine?
-        [ExpectedException(typeof(Octopus.System.Xml.XmlException))]
-#else
         [ExpectedException(typeof(System.Xml.XmlException))]
-#endif
         public void ShouldThrowExceptionForBadConfig()
         {
             PerformTest(GetFixtureResource("Samples", "Bad.config"), GetFixtureResource("Samples", "Web.Release.config"));

--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/ConfigurationTransformsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/ConfigurationTransformsFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using Assent;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.ConfigurationTransforms;
 using Calamari.Common.Plumbing.FileSystem;
@@ -30,7 +31,10 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
         [Test]
         public void XmlWithNamespacesIsCorrectlyProcessed()
         {
-            PerformTest(GetFixtureResource("Samples", "nlog.config"), GetFixtureResource("Samples", "nlog.Release.config"));
+            var text = PerformTest(GetFixtureResource("Samples", "nlog.config"), GetFixtureResource("Samples", "nlog.Release.config"));
+            var document = XDocument.Parse(text);
+
+            this.Assent(document.ToString(), TestEnvironment.AssentConfiguration);
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/Samples/nlog.Release.config
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/Samples/nlog.Release.config
@@ -1,0 +1,10 @@
+<nlog
+        xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+        xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+    <targets>
+        <target name="csv" fileName="log.txt" archiveFileName="log.txt" xdt:Transform="SetAttributes" xdt:Locator="Match(name)" />
+    </targets>
+    <rules>
+        <logger name="*" minlevel="Info" xdt:Transform="SetAttributes" xdt:Locator="Match(name)" />
+    </rules>
+</nlog>

--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/Samples/nlog.config
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/Samples/nlog.config
@@ -1,0 +1,15 @@
+<nlog autoReload="true" 
+      xmlns="http://www.nlog-project.org/schemas/NLog.xsd" 
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <targets>
+        <target name="csv"
+                xsi:type="File">
+            <layout xsi:type="CSVLayout">
+            </layout>
+        </target>
+    </targets>
+
+    <rules>
+        <logger name="*" minlevel="Debug" writeTo="csv" />
+    </rules>
+</nlog>


### PR DESCRIPTION
We forked Microsoft.Web.Xdt back in 2016 when the package did not target netstandard, but now the package does target netstandard so we updating to use it instead.
Fixes https://github.com/OctopusDeploy/Issues/issues/6569

The actual fix is [this line](https://github.com/dotnet/xdt/blob/cf071c1878487a728495acb3d233afb389edaa54/src/Microsoft.Web.XmlTransform/XmlAttributePreservationDict.cs#L70) which our fork does not contain https://github.com/OctopusDeploy/Octopus.Web.Xdt/blob/c14be275c8eabbc621908db1e9722072e34ac672/Octopus.Web.XmlTransform/XmlAttributePreservationDict.cs#L68-L69