### PR TITLE
Package update for new version of Octostache

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -62,7 +62,7 @@
     <ItemGroup>
       <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
       <PackageReference Include="Octopus.Versioning" Version="4.2.1" />
-      <PackageReference Include="Octostache" Version="2.8.0" />
+      <PackageReference Include="Octostache" Version="2.8.1-enh-nullablereftype5" />
       <PackageReference Include="SharpCompress" Version="0.24.0" />
       <PackageReference Include="XPath2" Version="1.0.12" />
       <PackageReference Include="YamlDotNet" Version="8.1.2" />

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -62,7 +62,7 @@
     <ItemGroup>
       <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
       <PackageReference Include="Octopus.Versioning" Version="4.2.1" />
-      <PackageReference Include="Octostache" Version="2.8.1-enh-nullablereftype5" />
+      <PackageReference Include="Octostache" Version="2.9.1" />
       <PackageReference Include="SharpCompress" Version="0.24.0" />
       <PackageReference Include="XPath2" Version="1.0.12" />
       <PackageReference Include="YamlDotNet" Version="8.1.2" />

--- a/source/Calamari.Common/Features/Behaviours/ConfiguredScriptBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/ConfiguredScriptBehaviour.cs
@@ -41,8 +41,7 @@ namespace Calamari.Common.Features.Behaviours
             foreach (ScriptSyntax scriptType in Enum.GetValues(typeof(ScriptSyntax)))
             {
                 var scriptName = KnownVariables.Action.CustomScripts.GetCustomScriptStage(deploymentStage, scriptType);
-                string error;
-                var scriptBody = context.Variables.Get(scriptName, out error);
+                var scriptBody = context.Variables.Get(scriptName, out var error);
                 if (!string.IsNullOrEmpty(error))
                     log.VerboseFormat(
                         "Parsing script for phase {0} with Octostache returned the following error: `{1}`",

--- a/source/Calamari.Common/Features/FunctionScriptContributions/FunctionAppenderScriptWrapper.cs
+++ b/source/Calamari.Common/Features/FunctionScriptContributions/FunctionAppenderScriptWrapper.cs
@@ -26,7 +26,7 @@ namespace Calamari.Common.Features.FunctionScriptContributions
         }
 
         public int Priority { get; } = ScriptWrapperPriorities.ToolConfigPriority;
-        public IScriptWrapper NextWrapper { get; set; }
+        public IScriptWrapper? NextWrapper { get; set; }
 
         public bool IsEnabled(ScriptSyntax syntax)
         {
@@ -57,6 +57,9 @@ namespace Calamari.Common.Features.FunctionScriptContributions
 
                 File.Copy(scriptFile, destinationFile, true);
             }
+
+            if (NextWrapper == null)
+                throw new InvalidOperationException("Next script wrapper has not been initialized correctly");
 
             using (var contextScriptFile = new TemporaryFile(scriptFile))
             {

--- a/source/Calamari.Common/Features/Scripting/IScriptWrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/IScriptWrapper.cs
@@ -21,7 +21,7 @@ namespace Calamari.Common.Features.Scripting
         /// a linked list through the NextWrapper property, and scipts are
         /// wrapped up in multiple wrapper as they move through the list.
         /// </summary>
-        IScriptWrapper NextWrapper { get; set; }
+        IScriptWrapper? NextWrapper { get; set; }
 
         /// <summary>
         /// true if this wrapper is enabled, and false otherwise. If

--- a/source/Calamari.Common/Features/Scripting/TerminalScriptWrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/TerminalScriptWrapper.cs
@@ -22,7 +22,7 @@ namespace Calamari.Common.Features.Scripting
 
         public int Priority => ScriptWrapperPriorities.TerminalScriptPriority;
 
-        public IScriptWrapper NextWrapper
+        public IScriptWrapper? NextWrapper
         {
             get => throw new MethodAccessException("TerminalScriptWrapper does not have a NextWrapper");
             set => throw new MethodAccessException("TerminalScriptWrapper does not have a NextWrapper");

--- a/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/XmlFormatVariableReplacer.cs
@@ -130,13 +130,13 @@ namespace Calamari.Common.Features.StructuredVariables
                                      encoding);
         }
 
-        void TrySetInnerXml(XmlElement element, string xpathExpression, string variableValue)
+        void TrySetInnerXml(XmlElement element, string xpathExpression, string? variableValue)
         {
             var previousInnerXml = element.InnerXml;
 
             try
             {
-                element.InnerXml = variableValue;
+                element.InnerXml = variableValue ?? string.Empty;
             }
             catch (XmlException)
             {
@@ -199,7 +199,7 @@ namespace Calamari.Common.Features.StructuredVariables
                 yield return namespaceFromDescendants;
         }
 
-        XPath2Expression TryGetXPathFromVariableKey(string variableKey, IXmlNamespaceResolver nsResolver)
+        XPath2Expression? TryGetXPathFromVariableKey(string variableKey, IXmlNamespaceResolver nsResolver)
         {
             // Prevent 'Octopus*' and other unintended variables being recognized as XPath expressions selecting the document node
             if (!variableKey.Contains("/")

--- a/source/Calamari.Common/Features/Substitutions/FileSubstituter.cs
+++ b/source/Calamari.Common/Features/Substitutions/FileSubstituter.cs
@@ -33,6 +33,11 @@ namespace Calamari.Common.Features.Substitutions
 
             if (!string.IsNullOrEmpty(error))
                 log.VerboseFormat("Parsing file '{0}' with Octostache returned the following error: `{1}`", sourceFile, error);
+            if (string.IsNullOrEmpty(result))
+            {
+                log.WarnFormat("Couldn't parsing file '{0}' and Octostache returned no error", sourceFile);
+                return;
+            }
 
             fileSystem.OverwriteFile(targetFile, result, encoding);
         }

--- a/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
@@ -287,8 +287,10 @@ namespace Calamari.Common.Plumbing.FileSystem
             return File.ReadAllBytes(path);
         }
 
-        public void OverwriteFile(string path, string contents, Encoding? encoding = null)
+        public void OverwriteFile(string path, string? contents, Encoding? encoding = null)
         {
+            if (contents == null)
+                return;
             RetryTrackerFileAction(() => WriteAllText(path, contents, encoding), path, "overwrite");
         }
 
@@ -321,7 +323,7 @@ namespace Calamari.Common.Plumbing.FileSystem
                 Log.Warn($"The supplied encoding '{e}' does not raise errors for unsupported characters, so the subsequent "
                          + "encoder will never be used. Please set DecoderFallback to ExceptionFallback or use Unicode.");
 
-            byte[] bytes = null;
+            byte[]? bytes = null;
             (Encoding encoding, Exception exception)? lastFailure = null;
             foreach (var currentEncoding in encodingsToTry)
             {

--- a/source/Calamari.Common/Plumbing/FileSystem/ICalamariFileSystem.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/ICalamariFileSystem.cs
@@ -24,7 +24,7 @@ namespace Calamari.Common.Plumbing.FileSystem
         string ReadFile(string path);
         string ReadFile(string path, out Encoding encoding);
         string ReadAllText(byte[] bytes, out Encoding encoding, ICollection<Encoding> encodingPrecedence);
-        void OverwriteFile(string path, string contents, Encoding? encoding = null);
+        void OverwriteFile(string path, string? contents, Encoding? encoding = null);
         void OverwriteFile(string path, Action<TextWriter> writeToWriter, Encoding? encoding = null);
         void OverwriteFile(string path, byte[] data);
         void WriteAllText(string path, string contents, Encoding? encoding = null);

--- a/source/Calamari.Common/Plumbing/Variables/IVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/IVariables.cs
@@ -10,13 +10,13 @@ namespace Calamari.Common.Plumbing.Variables
         bool IsSet(string name);
         void Set(string name, string? value);
         void SetStrings(string variableName, IEnumerable<string> values, string separator);
-        string GetRaw(string variableName);
+        string? GetRaw(string variableName);
         [return: NotNullIfNotNull("defaultValue")]
         string? Get(string variableName, string? defaultValue = null);
         [return: NotNullIfNotNull("defaultValue")]
-        string? Get(string variableName, out string error, string? defaultValue = null);
-        string Evaluate(string expressionOrVariableOrText, out string error, bool haltOnError = true);
-        string Evaluate(string expressionOrVariableOrText);
+        string? Get(string variableName, out string? error, string? defaultValue = null);
+        string? Evaluate(string expressionOrVariableOrText, out string? error, bool haltOnError = true);
+        string? Evaluate(string expressionOrVariableOrText);
         List<string> GetStrings(string variableName, params char[] separators);
         List<string> GetPaths(string variableName);
         bool GetFlag(string variableName, bool defaultValueIfUnset = false);

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -56,7 +56,6 @@
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="Octopus.Versioning" Version="4.2.1" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
-    <PackageReference Include="Octostache" Version="2.8.1-enh-nullablereftype5" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="Sprache" Version="2.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="Octopus.Versioning" Version="4.2.1" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
-    <PackageReference Include="Octostache" Version="2.8.0" />
+    <PackageReference Include="Octostache" Version="2.8.1-enh-nullablereftype5" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="Sprache" Version="2.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/source/Calamari.Testing/EnvironmentVariables.cs
+++ b/source/Calamari.Testing/EnvironmentVariables.cs
@@ -61,14 +61,14 @@ namespace Calamari.Testing
         {
             var missingVariables = Enum.GetValues(typeof(ExternalVariable)).Cast<ExternalVariable>()
                                        .Select(prop => EnvironmentVariableAttribute.Get(prop))
-                                       .Where(attr => Environment.GetEnvironmentVariable(attr.Name) == null)
+                                       .Where(attr => Environment.GetEnvironmentVariable(attr!.Name) == null)
                                        .ToList();
 
             if (!missingVariables.Any())
                 return;
 
             Log.Warn($"The following environment variables could not be found: " +
-                     $"\n{string.Join("\n", missingVariables.Select(var => $" - {var.Name}\t\tSource: {var.LastPassName}"))}" +
+                     $"\n{string.Join("\n", missingVariables.Select(var => $" - {var!.Name}\t\tSource: {var.LastPassName}"))}" +
                      $"\n\nTests that rely on these variables are likely to fail.");
         }
 


### PR DESCRIPTION
New version is Netstandard2.1 and supports Nullable Reference Types.