### PR TITLE
Initialises parameters string before use in PowerShell codegen

### DIFF
--- a/source/Calamari.Common/Features/FunctionScriptContributions/PowerShellLanguage.cs
+++ b/source/Calamari.Common/Features/FunctionScriptContributions/PowerShellLanguage.cs
@@ -49,6 +49,7 @@ namespace Calamari.Common.Features.FunctionScriptContributions
 
                 TabIndentedAppendLine(")");
                 TabIndentedAppendLine("{");
+                TabIndentedAppendLine("$parameters = \"\"");
 
                 foreach (var pair in registration.Parameters)
                 {

--- a/source/Calamari.Tests/Fixtures/FunctionCodeGen/Approved/DynamicFunctionFixture.EnsurePowerShellLanguageCodeGen.approved.txt
+++ b/source/Calamari.Tests/Fixtures/FunctionCodeGen/Approved/DynamicFunctionFixture.EnsurePowerShellLanguageCodeGen.approved.txt
@@ -1,5 +1,6 @@
 function New-MyFunc([string] $mystring, [switch] $myboolean, [int] $mynumber)
 {
+	$parameters = ""
 	$tempParameter = Convert-ToServiceMessageParameter -name "mystring" -value $mystring
 	$parameters = $parameters, $tempParameter -join ' '
 	$tempParameter = Convert-ToServiceMessageParameter -name "myboolean" -value $myboolean
@@ -11,6 +12,7 @@ function New-MyFunc([string] $mystring, [switch] $myboolean, [int] $mynumber)
 
 function New-MyFunc2([string] $mystring, [switch] $myboolean, [int] $mynumber)
 {
+	$parameters = ""
 	if ($myboolean -eq $true)
 	{
 		$tempParameter = Convert-ToServiceMessageParameter -name "mystring" -value $mystring


### PR DESCRIPTION
This PR is the Calamari side of fixing https://github.com/OctopusDeploy/Issues/issues/6641

It ensures the parameters variable declared in our Powershell code gen is initialized before usage.

We will add an E2E test in Server to cover this case.