### PR TITLE
Fix retention policy

### DIFF
--- a/source/Calamari.Tests/Fixtures/Deployment/CleanFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/CleanFixture.cs
@@ -7,7 +7,6 @@ using Calamari.Common.Features.Processes.Semaphores;
 using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
-using Calamari.Integration.FileSystem;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
 
@@ -109,7 +108,7 @@ namespace Calamari.Tests.Fixtures.Deployment
             return Invoke(Calamari()
                 .Action("clean")
                 .Argument("retentionPolicySet", retentionPolicySet)
-                .Argument(days.HasValue ? "days" : "releases", days.HasValue ? days.ToString() : releases.ToString()));
+                .Argument(days.HasValue ? "days" : "deployments", days.HasValue ? days.ToString() : releases.ToString()));
         }
     }
 }

--- a/source/Calamari/Commands/CleanCommand.cs
+++ b/source/Calamari/Commands/CleanCommand.cs
@@ -18,7 +18,7 @@ namespace Calamari.Commands
 
         string retentionPolicySet;
         int days;
-        int releases;
+        int deployments;
 
         public CleanCommand(IVariables variables, ICalamariFileSystem fileSystem)
         {
@@ -26,7 +26,7 @@ namespace Calamari.Commands
             this.fileSystem = fileSystem;
             Options.Add("retentionPolicySet=", "The release-policy-set ID", x => retentionPolicySet = x);
             Options.Add("days=", "Number of days to keep artifacts", x => int.TryParse(x, out days));
-            Options.Add("releases=", "Number of releases to keep artifacts for", x => int.TryParse(x, out releases));
+            Options.Add("deployments=", "Number of successful deployments to keep artifacts for", x => int.TryParse(x, out deployments));
         }
 
         public override int Execute(string[] commandLineArguments)
@@ -35,14 +35,14 @@ namespace Calamari.Commands
 
             Guard.NotNullOrWhiteSpace(retentionPolicySet, "No retention-policy-set was specified. Please pass --retentionPolicySet \"Environments-2/projects-161/Step-Package B/machines-65/<default>\"");
 
-            if (days <=0 && releases <= 0)
-                throw new CommandException("A value must be provided for either --days or --releases");
+            if (days <=0 && deployments <= 0)
+                throw new CommandException("A value must be provided for either --days or --deployments");
 
             var deploymentJournal = new DeploymentJournal(fileSystem, SemaphoreFactory.Get(), variables);
             var clock = new SystemClock();
 
             var retentionPolicy = new RetentionPolicy(fileSystem, deploymentJournal, clock);
-            retentionPolicy.ApplyRetentionPolicy(retentionPolicySet, days, releases);
+            retentionPolicy.ApplyRetentionPolicy(retentionPolicySet, days, deployments);
 
             return 0;
         }


### PR DESCRIPTION
# Background

If users configure to keep N deployments, our target retention policy doesn't clean up files properly for unsuccessful deployments in between the successful deployments we would like to keep. 

e.g.
If users configure to keep 1 deployment, we currently only remove files for deployments occurred prior to deployment 1 (inclusive) instead of all deployments excluding deployment 99 and 2 at deployment 99.
**Deployment Journal:**
- Deployment 99 Success 06/09/2020 -> To Keep (Current)
- Deployment 98 Failed    05/09/2020 -> To Keep
- Deployment 97 Failed    04/09/2020 -> To Keep
- Deployment 96 Failed    03/09/2020 -> To Keep
- (Other failed deployments)                -> To Keep
- Deployment 2 Success   02/09/2020 -> To Keep
- Deployment 1 Failed      01/09/2020 -> To Remove
- ... (any deployments older than the previous one) -> To Remove

# Result

Only keeping Deployment 99 and 2 when retention is triggered at deployment 99
