### PR TITLE
Add timeout argument to run-script command.

### DIFF
--- a/source/Calamari.Common/Features/Processes/CommandLineInvocation.cs
+++ b/source/Calamari.Common/Features/Processes/CommandLineInvocation.cs
@@ -27,6 +27,12 @@ namespace Calamari.Common.Features.Processes
 
         public Dictionary<string, string>? EnvironmentVars { get; set; }
 
+
+        /// <summary>
+        /// Gets or sets a timeour in milliseconds for the command line process execution
+        /// </summary>
+        public TimeSpan Timeout { get; set; } = TimeSpan.Zero;
+
         /// <summary>
         /// Prevent this execution from starting if another execution is running that also has this set to true.
         /// It does not isolate from executions that have this set to false.

--- a/source/Calamari.Common/Features/Processes/CommandLineRunner.cs
+++ b/source/Calamari.Common/Features/Processes/CommandLineRunner.cs
@@ -33,13 +33,15 @@ namespace Calamari.Common.Features.Processes
                     invocation.UserName,
                     invocation.Password,
                     commandOutput.WriteInfo,
-                    commandOutput.WriteError);
+                    commandOutput.WriteError,
+                    invocation.Timeout);
 
                 return new CommandResult(
                     invocation.ToString(),
                     exitCode.ExitCode,
                     exitCode.ErrorOutput,
-                    invocation.WorkingDirectory);
+                    invocation.WorkingDirectory,
+                    exitCode.TimedOut);
             }
             catch (Exception ex)
             {

--- a/source/Calamari.Common/Features/Processes/CommandResult.cs
+++ b/source/Calamari.Common/Features/Processes/CommandResult.cs
@@ -6,13 +6,15 @@ namespace Calamari.Common.Features.Processes
     {
         readonly string command;
         readonly string? workingDirectory;
+        readonly bool timedOut;
 
-        public CommandResult(string command, int exitCode, string? additionalErrors = null, string? workingDirectory = null)
+        public CommandResult(string command, int exitCode, string? additionalErrors = null, string? workingDirectory = null, bool timedOut = false)
         {
             this.command = command;
             ExitCode = exitCode;
             Errors = additionalErrors;
             this.workingDirectory = workingDirectory;
+            this.timedOut = timedOut;
         }
 
         public int ExitCode { get; }
@@ -20,6 +22,8 @@ namespace Calamari.Common.Features.Processes
         public string? Errors { get; }
 
         public bool HasErrors => !string.IsNullOrWhiteSpace(Errors);
+
+        public bool TimedOut => this.timedOut;
 
         public void VerifySuccess()
         {

--- a/source/Calamari.Common/Features/Processes/SilentProcessRunnerResult.cs
+++ b/source/Calamari.Common/Features/Processes/SilentProcessRunnerResult.cs
@@ -4,14 +4,17 @@ namespace Calamari.Common.Features.Processes
 {
     public class SilentProcessRunnerResult
     {
-        public SilentProcessRunnerResult(int exitCode, string errorOutput)
+        public SilentProcessRunnerResult(int exitCode, string errorOutput, bool timedOut = false)
         {
             ExitCode = exitCode;
             ErrorOutput = errorOutput;
+            TimedOut = timedOut;
         }
 
         public int ExitCode { get; }
 
         public string ErrorOutput { get; }
+
+        public bool TimedOut { get; }
     }
 }

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -218,6 +218,7 @@ namespace Calamari.Deployment
                 public static readonly string ScriptParameters = "Octopus.Action.Script.ScriptParameters";
                 public static readonly string ScriptSource = "Octopus.Action.Script.ScriptSource";
                 public static readonly string ExitCode = "Octopus.Action.Script.ExitCode";
+                public static readonly string Timeout = "Octopus.Action.Script.Timeout";
 
                 public static string ScriptBodyBySyntax(ScriptSyntax syntax)
                 {

--- a/source/Calamari.Tests/Fixtures/Integration/Process/CommandLineRunnerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Process/CommandLineRunnerFixture.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.Deployment;
 using Calamari.Integration.Processes;
 using Calamari.Tests.Helpers;
 using FluentAssertions;
@@ -18,6 +23,62 @@ namespace Calamari.Tests.Fixtures.Integration.Process
             var result = subject.Execute(new CommandLineInvocation(executable, "--version"));
             result.HasErrors.Should().BeTrue();
             subject.Output.Errors.Should().Contain(CommandLineRunner.ConstructWin32ExceptionMessage(executable));
+        }
+
+        [Test]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
+        public void ScriptShouldFailWhenTimeoutIsSpecifiedAfterSomeTimeInWindowsSystems()
+        {
+            // For the sake of those running it with test adapters
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            // Windows function. See TIMEOUT /?
+            const string executable = "TIMEOUT";
+
+            // Script is a timeout for 100 seconds to stimulate a deployment that is stuck
+            var invocation = new CommandLineInvocation(
+                executable: executable,
+                 arguments: "100 /NOBREAK")
+            {
+                Timeout = TimeSpan.FromMilliseconds(500)
+            };
+
+            var subject = new TestCommandLineRunner(new InMemoryLog(), new CalamariVariables());
+            var result = subject.Execute(invocation);
+            result.HasErrors.Should().BeFalse();
+            result.TimedOut.Should().BeTrue();
+            subject.Output.Errors.Any(x => x.Contains("Script execution timed out after")).Should().BeTrue();
+        }
+
+        [Test]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
+        public void ScriptShouldFailWhenTimeoutIsSpecifiedAfterSomeTimeInNixSystems()
+        {
+            // For the sake of those running it with test adapters
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            // Nix function. See 'man sleep' 
+            const string executable = "sleep";
+
+            // Script is a timeout for 100 seconds to stimulate a deployment that is stuck
+            var invocation = new CommandLineInvocation(
+                executable: executable,
+                 arguments: "100 /NOBREAK")
+            {
+                Timeout = TimeSpan.FromMilliseconds(500)
+            };
+
+            var subject = new TestCommandLineRunner(new InMemoryLog(), new CalamariVariables());
+            var result = subject.Execute(invocation);
+            result.HasErrors.Should().BeFalse();
+            result.TimedOut.Should().BeTrue();
+            subject.Output.Errors.Any(x => x.Contains("Script execution timed out after")).Should().BeTrue();
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/ScriptExecutorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ScriptExecutorFixture.cs
@@ -1,0 +1,68 @@
+﻿using Calamari.Common.Features.Processes;
+using Calamari.Common.Features.Scripting;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Deployment;
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Calamari.Tests.Fixtures
+{
+    class ScriptExecutorFixture
+    {
+        [Test]
+        public void EnsureTimeoutSetForVariable()
+        {
+            var variables = new CalamariVariables();
+            variables.Set(SpecialVariables.Action.Script.Timeout, "100");
+
+            // the scripts typically coulb be C#, powershell, bash etc - we're only concerned that the
+            // CommandLineInvocation picks up the variable, which is then used in the SilentProcessRunnerResult
+            var script = new Script("script.ps1");
+            var mockCommandLineRunner = new MockCommandLineRunner();
+
+            var executor = new TestScriptExecutor();
+            executor.Execute(
+                script,
+                variables,
+                mockCommandLineRunner);
+
+            mockCommandLineRunner.Invocations.Count().Should().Be(1);
+            mockCommandLineRunner.Invocations.All(x => x.Timeout == TimeSpan.FromMilliseconds(100)).Should().BeTrue();
+        }
+
+        public class TestScriptExecutor : ScriptExecutor
+        {
+            protected override IEnumerable<ScriptExecution> PrepareExecution(
+                Script script, 
+                IVariables variables, 
+                Dictionary<string, string> environmentVars = null)
+            {
+                yield return new ScriptExecution(
+                    new CommandLineInvocation("program")
+                    {
+                        WorkingDirectory = TestContext.CurrentContext.TestDirectory,
+                        EnvironmentVars = environmentVars
+                    },
+                    Enumerable.Empty<string>());
+            }
+        }
+
+        public class MockCommandLineRunner : ICommandLineRunner
+        {
+            private readonly List<CommandLineInvocation> _invocations = new List<CommandLineInvocation>();
+
+            public CommandResult Execute(CommandLineInvocation invocation)
+            {
+                _invocations.Add(invocation);
+                return new CommandResult(invocation.Executable, 0);
+            }
+
+            public IEnumerable<CommandLineInvocation> Invocations => _invocations;
+        }
+    }
+}

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -29,6 +29,7 @@ namespace Calamari.Commands
         string scriptFileArg;
         string packageFile;
         string scriptParametersArg;
+        TimeSpan timeout;
         readonly ILog log;
         readonly IDeploymentJournalWriter deploymentJournalWriter;
         readonly IVariables variables;
@@ -50,6 +51,7 @@ namespace Calamari.Commands
             Options.Add("package=", "Path to the package to extract that contains the script.", v => packageFile = Path.GetFullPath(v));
             Options.Add("script=", $"Path to the script to execute. If --package is used, it can be a script inside the package.", v => scriptFileArg = v);
             Options.Add("scriptParameters=", $"Parameters to pass to the script.", v => scriptParametersArg = v);
+            Options.Add("timeout=", $"Timeout for script in milliseconds.", v => timeout = int.TryParse(v, out var timeoutMs) && timeoutMs > 0 ? TimeSpan.FromMilliseconds(timeoutMs) : TimeSpan.Zero);
             this.log = log;
             this.deploymentJournalWriter = deploymentJournalWriter;
             this.variables = variables;
@@ -198,6 +200,11 @@ namespace Calamari.Commands
                 {
                     variables.Set(SpecialVariables.Action.Script.ScriptParameters, scriptParametersArg);
                 }
+            }
+
+            if(timeout > TimeSpan.Zero)
+            {
+                variables.Set(SpecialVariables.Action.Script.Timeout, timeout.TotalMilliseconds.ToString());
             }
         }
 


### PR DESCRIPTION
This PR address the issue defined here, up to date with Tag version 16.4: https://github.com/OctopusDeploy/Calamari/pull/468#issue-362311331

**Issue**
Tentacles wait indefinitely on actions which run scripts. For the most part, this is desirable by design and handled here. There are many valid cases were a timeout on scripts should be supported to prevent tentacles from being indefinitely stuck processing action scripts (and thus preventing other operations such as clean up via Script Console, Runbooks, or other deployments).

**Pull Request**

This PR adds the special variable Octopus.Action.Script.Timeout to allow a millisecond timeout to be defined via a process's variables that will be used to limit the amount of time a process can wait. If no timeout is defined, the default behavior of waiting indefinitely will be used. 

Added tests for CommandLineRunner and ScriptExecutor to ensure timeout is applied to both the command line instruction, and is applied during execution.