### PR TITLE
Publish `netfx` package to assist with deployment of custom packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Octopus.Server.exe service --instance <instance> --start --nologo --console
 
 ** Ensure you update your build to the latest Calamari or revert to the bundled package when you upgrade Octopus Server **
 
+** If you're using a custom built package, you will need to ensure the package id of the nuget package is `Calamari.netfx` in order for it be executed on the server. By running `./build -IsCustomPackageBuild:1` or `dotnet cake --custom_build=true` the package id will be `Calamari.netfx` and omit the branch name from the package file. **
+
 ## Releasing
 
 After you finish merging to master to tag the Calamari NuGet package:

--- a/build.ps1
+++ b/build.ps1
@@ -30,6 +30,8 @@ No tasks will be executed.
 Tells Cake to use the Mono scripting engine.
 .PARAMETER SkipToolPackageRestore
 Skips restoring of packages.
+.PARAMETER IsCustomPackageBuild
+True to force package name to be Calamari.netfx to use as a custom build.
 .PARAMETER ScriptArgs
 Remaining arguments are added here.
 
@@ -53,7 +55,8 @@ Param(
     [switch]$Mono,
     [switch]$SkipToolPackageRestore,
     [string]$SigningCertificatePath = "./certificates/OctopusDevelopment.pfx",
-    [string]$SigningCertificatePassword = "Password01!"
+    [string]$SigningCertificatePassword = "Password01!",
+    [bool]$IsCustomPackageBuild = 0
 )
 
 [Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
@@ -117,6 +120,11 @@ if($Experimental.IsPresent -and !($Mono.IsPresent)) {
 $UseDryRun = "";
 if($WhatIf.IsPresent) {
     $UseDryRun = "-dryrun"
+}
+
+$UseCustomBuildSwitch = "";
+if($IsCustomPackageBuild) {
+    $UseCustomBuildSwitch = "--custom_build=true";
 }
 
 # Make sure tools folder exists
@@ -233,5 +241,5 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" -where=`"$Where`" -signing_certificate_path=`"$SigningCertificatePath`" -signing_certificate_password=`"$SigningCertificatePassword`" $UseMono $UseDryRun $UseExperimental"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" -where=`"$Where`" -signing_certificate_path=`"$SigningCertificatePath`" -signing_certificate_password=`"$SigningCertificatePassword`" $UseMono $UseDryRun $UseExperimental $UseCustomBuildSwitch"
 exit $LASTEXITCODE


### PR DESCRIPTION
## Background
When using a custom `Calamari` NuGet package, it appears that `Octopus.Server` uses two different NuGet package ids. 
- When testing the connectivity of deployment target, it searches for `Calamari`
- When executing a deployment, it searches for `Calamari.netfx`

While building out https://github.com/OctopusDeploy/Calamari/pull/688 with @lilwa29 and @miguelelvir we noted that for windows deployment targets, the `net40` NuGet package needed to be called `Calamari.netfx` to successfully deploy a custom version to a local Windows tentacle.

## Changes
Have added in an extra build parameter `IsCustomPackageBuild` for the PowerShell script, and `isCustomPackageBuild` for the cake build. The cake script will push an extra package for the `net40` package (as the runtime id is null). The effect is that the `artifacts` directory will contain both a `Calamari` and a `Calamari.netfx` package to satisfy both connectivity testing, and deployment.

## Testing
- spin up test Octo instance from https://octopus.com/docs/installation/octopus-in-container/docker-compose-linux
- configure custom package directory, and upload normal `build.ps1` to mapped directory in container
- ensure that connectivity passes, but deploy fails to a locally configured tentacle
- upload packages from `build.ps1 -IsCustomPackageBuild:1` and ensure both connectivity test and deploy succeed