### PR TITLE
Add a configurable timeout for nuget V3 in netfx.

### DIFF
--- a/source/Calamari.Common/Plumbing/Variables/KnownVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/KnownVariables.cs
@@ -13,7 +13,7 @@ namespace Calamari.Common.Plumbing.Variables
         public static readonly string DeleteScriptsOnCleanup = "OctopusDeleteScriptsOnCleanup";
         public static readonly string AppliedXmlConfigTransforms = "OctopusAppliedXmlConfigTransforms";
 
-        public static readonly string NetfxNugetHttpTimeout = "OctopusNetfxNugetHttpTimeout";
+        public static readonly string NugetHttpTimeout = "OctopusNugetHttpTimeout";
         
         public static class Action
         {

--- a/source/Calamari.Common/Plumbing/Variables/KnownVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/KnownVariables.cs
@@ -13,6 +13,8 @@ namespace Calamari.Common.Plumbing.Variables
         public static readonly string DeleteScriptsOnCleanup = "OctopusDeleteScriptsOnCleanup";
         public static readonly string AppliedXmlConfigTransforms = "OctopusAppliedXmlConfigTransforms";
 
+        public static readonly string NetfxNugetHttpTimeout = "OctopusNetfxNugetHttpTimeout";
+        
         public static class Action
         {
             public const string SkipJournal = "Octopus.Action.SkipJournal";

--- a/source/Calamari.Shared/Integration/Packages/Download/NuGetPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/NuGetPackageDownloader.cs
@@ -107,7 +107,7 @@ namespace Calamari.Integration.Packages.Download
 
             var fullPathToDownloadTo = Path.Combine(cacheDirectory, PackageName.ToCachedFileName(packageId, version, ".nupkg"));
 
-            var httpTimeoutMilliseconds = variables.GetInt32(KnownVariables.NetfxNugetHttpTimeout) ?? 0;
+            var httpTimeoutMilliseconds = variables.GetInt32(KnownVariables.NugetHttpTimeout) ?? 0;
             var httpTimeout = TimeSpan.FromMilliseconds(httpTimeoutMilliseconds);
             
             var downloader = new InternalNuGetPackageDownloader(fileSystem, variables);

--- a/source/Calamari.Shared/Integration/Packages/Download/NuGetPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/NuGetPackageDownloader.cs
@@ -107,9 +107,6 @@ namespace Calamari.Integration.Packages.Download
 
             var fullPathToDownloadTo = Path.Combine(cacheDirectory, PackageName.ToCachedFileName(packageId, version, ".nupkg"));
 
-            var httpTimeoutMilliseconds = variables.GetInt32(KnownVariables.NugetHttpTimeout) ?? 0;
-            var httpTimeout = TimeSpan.FromMilliseconds(httpTimeoutMilliseconds);
-            
             var downloader = new InternalNuGetPackageDownloader(fileSystem, variables);
             downloader.DownloadPackage(packageId,
                 version,

--- a/source/Calamari.Shared/Integration/Packages/Download/NuGetPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/NuGetPackageDownloader.cs
@@ -7,6 +7,7 @@ using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Packages.NuGet;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
 using Calamari.Integration.Packages.NuGet;
 using Octopus.Versioning;
 using PackageName = Calamari.Common.Features.Packages.PackageName;
@@ -27,11 +28,13 @@ namespace Calamari.Integration.Packages.Download
 
         readonly ICalamariFileSystem fileSystem;
         readonly IFreeSpaceChecker freeSpaceChecker;
+        readonly IVariables variables;
 
-        public NuGetPackageDownloader(ICalamariFileSystem fileSystem, IFreeSpaceChecker freeSpaceChecker)
+        public NuGetPackageDownloader(ICalamariFileSystem fileSystem, IFreeSpaceChecker freeSpaceChecker, IVariables variables)
         {
             this.fileSystem = fileSystem;
             this.freeSpaceChecker = freeSpaceChecker;
+            this.variables = variables;
         }
 
         public PackagePhysicalFileMetadata DownloadPackage(
@@ -104,7 +107,10 @@ namespace Calamari.Integration.Packages.Download
 
             var fullPathToDownloadTo = Path.Combine(cacheDirectory, PackageName.ToCachedFileName(packageId, version, ".nupkg"));
 
-            var downloader = new InternalNuGetPackageDownloader(fileSystem);
+            var httpTimeoutMilliseconds = variables.GetInt32(KnownVariables.NetfxNugetHttpTimeout) ?? 0;
+            var httpTimeout = TimeSpan.FromMilliseconds(httpTimeoutMilliseconds);
+            
+            var downloader = new InternalNuGetPackageDownloader(fileSystem, variables);
             downloader.DownloadPackage(packageId,
                 version,
                 feedUri,

--- a/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
@@ -58,7 +58,7 @@ namespace Calamari.Integration.Packages.Download
                     downloader = new MavenPackageDownloader(fileSystem, freeSpaceChecker);
                     break;
                 case FeedType.NuGet:
-                    downloader = new NuGetPackageDownloader(fileSystem, freeSpaceChecker);
+                    downloader = new NuGetPackageDownloader(fileSystem, freeSpaceChecker, variables);
                     break;
                 case FeedType.GitHub:
                     downloader = new GitHubPackageDownloader(log, fileSystem, freeSpaceChecker);

--- a/source/Calamari.Shared/Integration/Packages/NuGet/InternalNuGetPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/InternalNuGetPackageDownloader.cs
@@ -104,13 +104,13 @@ namespace Calamari.Integration.Packages.NuGet
             // V2 feed
             else
             {
-                WarnIfHttpTimeoutIsUnsupported();
+                WarnIfHttpTimeoutHasBeenSet();
                 NuGetV2Downloader.DownloadPackage(packageId, version.ToString(), feedUri, feedCredentials, targetFilePath);
             }
 #else
             else
             {
-                WarnIfHttpTimeoutIsUnsupported();
+                WarnIfHttpTimeoutHasBeenSet();
                 NuGetV3LibDownloader.DownloadPackage(packageId, version, feedUri, feedCredentials, targetFilePath);
             }
 #endif
@@ -147,7 +147,7 @@ namespace Calamari.Integration.Packages.NuGet
 
 #endif
         
-        void WarnIfHttpTimeoutIsUnsupported()
+        void WarnIfHttpTimeoutHasBeenSet()
         {
             if (variables.IsSet(KnownVariables.NugetHttpTimeout))
             {

--- a/source/Calamari.Shared/Integration/Packages/NuGet/InternalNuGetPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/InternalNuGetPackageDownloader.cs
@@ -13,7 +13,7 @@ namespace Calamari.Integration.Packages.NuGet
 {
     public class InternalNuGetPackageDownloader
     {
-        private readonly ICalamariFileSystem fileSystem;
+        readonly ICalamariFileSystem fileSystem;
         readonly IVariables variables;
 
         public InternalNuGetPackageDownloader(ICalamariFileSystem fileSystem, IVariables variables)

--- a/source/Calamari.Shared/Integration/Packages/NuGet/InternalNuGetPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/InternalNuGetPackageDownloader.cs
@@ -153,7 +153,7 @@ namespace Calamari.Integration.Packages.NuGet
             {
                 Log.Warn(
                     $"A Nuget HTTP timeout was set via the '{KnownVariables.NugetHttpTimeout}' variable. "
-                    + "This variable is not supported for this Nuget repository on this version of .NET."
+                    + "This variable is only supported when running on .NET Framework."
                 );
             }
         }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
 using Calamari.Common.Plumbing.FileSystem;
-using Calamari.Integration.FileSystem;
+using Calamari.Common.Plumbing.Variables;
 using Calamari.Integration.Packages.NuGet;
 using NSubstitute;
 using NUnit.Framework;
@@ -21,9 +21,10 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var feedCredentials = new CredentialCache();
             var targetFilePath = "FakeTargetFilePath";
             var filesystem = Substitute.For<ICalamariFileSystem>();
+            var variables = new CalamariVariables();
 
             var calledCount = 0;
-            var downloader = new InternalNuGetPackageDownloader(filesystem);
+            var downloader = new InternalNuGetPackageDownloader(filesystem, variables);
             downloader.DownloadPackage(packageId, version, feedUri, feedCredentials, targetFilePath, maxDownloadAttempts: 5, downloadAttemptBackoff: TimeSpan.Zero, action: (arg1, arg2, arg3, arg4, arg5) =>
             {
                 calledCount++;
@@ -44,11 +45,12 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var feedCredentials = new CredentialCache();
             var targetFilePath = "FakeTargetFilePath";
             var filesystem = Substitute.For<ICalamariFileSystem>();
+            var variables = new CalamariVariables();
 
             var calledCount = 0;
             Assert.Throws<Exception>(() =>
             {
-                var downloader = new InternalNuGetPackageDownloader(filesystem);
+                var downloader = new InternalNuGetPackageDownloader(filesystem, variables);
                 downloader.DownloadPackage(packageId, version, feedUri, feedCredentials, targetFilePath, maxDownloadAttempts: maxDownloadAttempts, downloadAttemptBackoff: TimeSpan.Zero,
                     action: (arg1, arg2, arg3, arg4, arg5) =>
                     {

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Net;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Integration.Packages.NuGet;
+using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Versioning;
@@ -61,5 +63,76 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
 
             return calledCount;
         }
+
+#if USE_NUGET_V2_LIBS
+        [Test]
+        public void TimesOutIfAValidTimeoutIsDefinedInVariables()
+        {
+            RunTimeoutTest("00:00:01", TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void IgnoresTheTimeoutIfAnInvalidTimeoutIsDefinedInVariables()
+        {
+            RunTimeoutTest("this is not a valid timespan", TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
+        }
+
+        [Test]
+        public void DoesNotTimeOutIfNoTimeoutIsDefinedInVariables()
+        {
+            RunTimeoutTest(null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void DoesNotTimeOutIfTheServerRespondsBeforeTheTimeout()
+        {
+            RunTimeoutTest("00:01:00", TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+        }
+
+        void RunTimeoutTest(string timeoutInVariables, TimeSpan serverResponseTime, TimeSpan estimatedTimeout)
+        {
+            using (var server = new TestHttpServer(9001, serverResponseTime))
+            {
+                var packageId = "FakePackageId";
+                var version = VersionFactory.CreateSemanticVersion(1, 2, 3);
+                var feedCredentials = new CredentialCache();
+                var targetFilePath = "FakeTargetFilePath";
+                var filesystem = Substitute.For<ICalamariFileSystem>();
+                var v3NugetUri = new Uri(server.BaseUrl + "/index.json");
+                var variables = new CalamariVariables();
+
+                if (timeoutInVariables != null)
+                {
+                    variables[KnownVariables.NetfxNugetHttpTimeout] = timeoutInVariables;
+                }
+                
+                var downloader = new InternalNuGetPackageDownloader(filesystem, variables);
+
+                var stopwatch = new Stopwatch();
+                
+                Action invocation = () =>
+                {
+                    stopwatch.Start();
+                    downloader.DownloadPackage(
+                        packageId,
+                        version,
+                        v3NugetUri,
+                        feedCredentials,
+                        targetFilePath,
+                        maxDownloadAttempts: 1,
+                        downloadAttemptBackoff: TimeSpan.Zero
+                    );
+                    stopwatch.Stop();
+                };
+
+                invocation.Should()
+                          .ThrowExactly<Exception>();
+
+                stopwatch.Elapsed
+                    .Should()
+                    .BeCloseTo(estimatedTimeout, TimeSpan.FromSeconds(0.5));
+            }
+        }
+#endif
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Net;
 using Calamari.Common.Plumbing.FileSystem;
@@ -65,25 +65,33 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         }
 
 #if USE_NUGET_V2_LIBS
+        // We only support the specification of HTTP timeouts on V3 nuget endpoints in
+        // .NET framework. V2 nuget endpoints and .net core runtimes execute entirely
+        // different codepaths that don't give us an easy way to allow users to specify 
+        // timeouts.
         [Test]
+        [NonParallelizable]
         public void TimesOutIfAValidTimeoutIsDefinedInVariables()
         {
             RunNugetV3TimeoutTest("00:00:01", TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
         }
 
         [Test]
+        [NonParallelizable]
         public void IgnoresTheTimeoutIfAnInvalidTimeoutIsDefinedInVariables()
         {
             RunNugetV3TimeoutTest("this is not a valid timespan", TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
         }
 
         [Test]
+        [NonParallelizable]
         public void DoesNotTimeOutIfNoTimeoutIsDefinedInVariables()
         {
             RunNugetV3TimeoutTest(null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
         }
 
         [Test]
+        [NonParallelizable]
         public void DoesNotTimeOutIfTheServerRespondsBeforeTheTimeout()
         {
             RunNugetV3TimeoutTest("00:01:00", TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
@@ -68,28 +68,28 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [Test]
         public void TimesOutIfAValidTimeoutIsDefinedInVariables()
         {
-            RunTimeoutTest("00:00:01", TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
+            RunNugetV3TimeoutTest("00:00:01", TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
         }
 
         [Test]
         public void IgnoresTheTimeoutIfAnInvalidTimeoutIsDefinedInVariables()
         {
-            RunTimeoutTest("this is not a valid timespan", TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
+            RunNugetV3TimeoutTest("this is not a valid timespan", TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
         }
 
         [Test]
         public void DoesNotTimeOutIfNoTimeoutIsDefinedInVariables()
         {
-            RunTimeoutTest(null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+            RunNugetV3TimeoutTest(null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
         }
 
         [Test]
         public void DoesNotTimeOutIfTheServerRespondsBeforeTheTimeout()
         {
-            RunTimeoutTest("00:01:00", TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+            RunNugetV3TimeoutTest("00:01:00", TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
         }
 
-        void RunTimeoutTest(string timeoutInVariables, TimeSpan serverResponseTime, TimeSpan estimatedTimeout)
+        void RunNugetV3TimeoutTest(string timeoutInVariables, TimeSpan serverResponseTime, TimeSpan estimatedTimeout)
         {
             using (var server = new TestHttpServer(9001, serverResponseTime))
             {
@@ -103,7 +103,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
 
                 if (timeoutInVariables != null)
                 {
-                    variables[KnownVariables.NetfxNugetHttpTimeout] = timeoutInVariables;
+                    variables[KnownVariables.NugetHttpTimeout] = timeoutInVariables;
                 }
                 
                 var downloader = new InternalNuGetPackageDownloader(filesystem, variables);

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/TestHttpServer.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/TestHttpServer.cs
@@ -1,0 +1,45 @@
+﻿#if USE_NUGET_V2_LIBS
+using System;
+using System.Net;
+using System.Threading;
+
+namespace Calamari.Tests.Fixtures.Integration.Packages
+{
+    public class TestHttpServer : IDisposable
+    {
+        readonly HttpListener listener;
+        
+        public int Port { get; }
+        public TimeSpan ResponseTime { get; }
+
+        public string BaseUrl => $"http://localhost:{Port}";
+
+        public TestHttpServer(int port, TimeSpan responseTime)
+        {
+            Port = port;
+            ResponseTime = responseTime;
+            listener = new HttpListener
+            {
+                Prefixes = { BaseUrl + "/" }
+            };
+
+            listener.Start();
+            listener.BeginGetContext(OnRequest, listener);
+        }
+
+        void OnRequest(IAsyncResult result)
+        {
+            var context = listener.EndGetContext(result);
+            Thread.Sleep(ResponseTime);
+            var response = context.Response;
+            response.StatusCode = 200;
+            response.OutputStream.Close();
+        }
+        
+        public void Dispose()
+        {
+            listener.Stop();
+        }
+    }
+}
+#endif


### PR DESCRIPTION
# Background
A customer has experienced issues with nuget package downloads hanging indefinitely. The component that is hanging is `NuGetV3Downloader`. This component is only used for .NET framework builds of Calamari - .NET core builds execute a different codepath.

# Results
This PR adds a new Calamari variable `OctopusNugetHttpTimeout` that allows for this timeout to be configured. If the variable is not set, Calamari retains the current behaviour of waiting indefinitely. If the variable is set, the specified timeout is used.

See https://trello.com/c/yloKEZtR/3927-intermittent-hanging-with-acquire-packages