### PR TITLE
Skip tests on FreeBSD/Mono.

### DIFF
--- a/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
@@ -65,12 +65,16 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         }
 
 #if USE_NUGET_V2_LIBS
+        const string SkipFreeBsdBecause = "performance on Mono+FreeBSD fluctuates significantly";
+
         // We only support the specification of HTTP timeouts on V3 nuget endpoints in
         // .NET framework. V2 nuget endpoints and .net core runtimes execute entirely
         // different codepaths that don't give us an easy way to allow users to specify 
         // timeouts.
+
         [Test]
         [NonParallelizable]
+        [RequiresNonFreeBSDPlatform(SkipFreeBsdBecause)]
         public void TimesOutIfAValidTimeoutIsDefinedInVariables()
         {
             RunNugetV3TimeoutTest("00:00:01", TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
@@ -78,6 +82,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
 
         [Test]
         [NonParallelizable]
+        [RequiresNonFreeBSDPlatform(SkipFreeBsdBecause)]
         public void IgnoresTheTimeoutIfAnInvalidTimeoutIsDefinedInVariables()
         {
             RunNugetV3TimeoutTest("this is not a valid timespan", TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
@@ -85,6 +90,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
 
         [Test]
         [NonParallelizable]
+        [RequiresNonFreeBSDPlatform(SkipFreeBsdBecause)]
         public void DoesNotTimeOutIfTheServerRespondsBeforeTheTimeout()
         {
             RunNugetV3TimeoutTest("00:01:00", TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));

--- a/source/Calamari.Tests/Fixtures/RequiresNonFreeBSDPlatformAttribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresNonFreeBSDPlatformAttribute.cs
@@ -8,12 +8,30 @@ namespace Calamari.Tests.Fixtures
 {
     public class RequiresNonFreeBSDPlatformAttribute : NUnitAttribute, IApplyToTest
     {
+        readonly string reason;
+
+        public RequiresNonFreeBSDPlatformAttribute()
+        {
+            
+        }
+
+        public RequiresNonFreeBSDPlatformAttribute(string reason)
+        {
+            this.reason = reason;
+        }
+        
         public void ApplyToTest(Test test)
         {
             if (ScriptingEnvironment.IsRunningOnMono() && (Environment.GetEnvironmentVariable("TEAMCITY_BUILDCONF_NAME")?.Contains("FreeBSD") ?? false))
             {
+                var skipReason = "This test does not run on FreeBSD";
+                if (!string.IsNullOrWhiteSpace(reason))
+                {
+                    skipReason += $" because {reason}";
+                }
+                
                 test.RunState = RunState.Skipped;
-                test.Properties.Set(PropertyNames.SkipReason, "This test does not run on FreeBSD");
+                test.Properties.Set(PropertyNames.SkipReason, skipReason);
             }
         }
     }


### PR DESCRIPTION
This PR skips some tests on FreeBSD/Mono because:

- The case for supporting Mono is weakening
- The performance of `HttpListener` on Mono/FreeBSD seems to be significantly different to other platforms and runtimes.