### PR TITLE
Removed unnecessary data masking

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -43,7 +43,6 @@ namespace Calamari.Common.Features.Scripting.Bash
             var builder = new StringBuilder(BootstrapScriptTemplate);
             var encryptedVariables = EncryptVariables(variables);
             builder.Replace("#### VariableDeclarations ####", string.Join(LinuxNewLine, GetVariableSwitchConditions(encryptedVariables)));
-            builder.Replace("#### SensitiveValueMasks ####", string.Join(LinuxNewLine, GetSensitiveValueMasks(encryptedVariables)));
 
             using (var file = new FileStream(configurationFile, FileMode.CreateNew, FileAccess.Write))
             using (var writer = new StreamWriter(file, Encoding.ASCII))
@@ -54,15 +53,6 @@ namespace Calamari.Common.Features.Scripting.Bash
 
             File.SetAttributes(configurationFile, FileAttributes.Hidden);
             return configurationFile;
-        }
-
-        static IEnumerable<string> GetSensitiveValueMasks(IEnumerable<EncryptedVariable> variables)
-        {
-            foreach (var variable in variables)
-            {
-                yield return $@"__mask_sensitive_value ""{variable.EncryptedValue}""";
-                yield return $@"__mask_sensitive_value ""{variable.Iv}""";
-            }
         }
 
         static IList<EncryptedVariable> EncryptVariables(IVariables variables)

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -34,7 +34,6 @@ function __mask_sensitive_value
 }
 
 __mask_sensitive_value $sensitiveVariableKey
-#### SensitiveValueMasks ####
 
 # -----------------------------------------------------------------------------
 # Function to decrypt a sensitive variable


### PR DESCRIPTION
In https://github.com/OctopusDeploy/Calamari/pull/679, we introduced data masking for the encryption key, encrypted values and IVs. However, we don't need to mask the encrypted values and IVs in bash scripts since the encryption key is already masked. In fact, this extra data masking was exacerbating another issue: https://github.com/OctopusDeploy/Issues/issues/6676


This PR removes the masking for the encrypted values and IVs. Security discussion validating the change in this PR approach: https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1606274985345900

Task: https://trello.com/c/oaYjphI2/4023-calamari-bootstrapper-script-encrypts-all-variables

# Before https://github.com/OctopusDeploy/Calamari/pull/679

Running a script with 

```
set -x

echo $(get_octopusvariable "MySensitiveValue")
```

## Log excerpt
**Encryption key, encrypted value and IV are all unmasked**

```
01:37:44   Error    |       +++ echo liFugi5AQPBZRfcmnAMdyHLMu3+dbJE2NL5tdvegH9I=
01:37:44   Error    |       +++ openssl enc -a -A -d -aes-128-cbc -nosalt -K DD50A80A9FB07B6C057A9DA86614F6F1 -iv CCA4E8AA809D95662417A5950A9F29D4
01:37:44   Error    |       ++ echo ********
01:37:44   Info     |       ********
```

## Decryption of sensitive value based on log output

![image](https://user-images.githubusercontent.com/1892715/102032192-dee05580-3e03-11eb-8501-2e0c8a39a6e7.png)

# After https://github.com/OctopusDeploy/Calamari/pull/679
**Encryption key, encrypted value, and IV are all masked**

## Log Excerpt

```
12:00:18   Error    |       +++ echo ********
12:00:18   Error    |       +++ openssl enc -a -A -d -aes-128-cbc -nosalt -K ******** -iv ********
12:00:18   Error    |       ++ echo ********
12:00:18   Info     |       ********
```

# After this PR

## Log Excerpt

**The encryption key is masked**

```
11:54:54   Error    |       +++ echo DuwCEpr1v7xhOpkmB4dcdPFOjVeotNK3JbLkgg8cqLg=
11:54:54   Error    |       +++ openssl enc -a -A -d -aes-128-cbc -nosalt -K ******** -iv E69C2B3E2A5257FCED256B859B91CA7D
11:54:54   Error    |       ++ echo ********
11:54:54   Info     |       ********
```