### PR TITLE
Apply structured configuration variables for files that don't use well known extensions

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/FileFormatVariableReplacers.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/FileFormatVariableReplacers.cs
@@ -9,9 +9,11 @@ namespace Calamari.Common.Features.StructuredVariables
         {
             return new IFileFormatVariableReplacer[]
             {
+                // For files that don't have well known extensions (like `.xml`, `.yaml`, etc.)
+                // these replacers should appear here in the order we want to test them against such files
                 new JsonFormatVariableReplacer(fileSystem, log),
-                new YamlFormatVariableReplacer(fileSystem, log),
                 new XmlFormatVariableReplacer(fileSystem, log),
+                new YamlFormatVariableReplacer(fileSystem, log),
                 new PropertiesFormatVariableReplacer(fileSystem, log)
             };
         }

--- a/source/Calamari.Testing/Calamari.Testing.csproj
+++ b/source/Calamari.Testing/Calamari.Testing.csproj
@@ -1,11 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net452;netstandard2.1</TargetFrameworks>
         <Nullable>enable</Nullable>
         <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <LangVersion>default</LangVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
+        <TargetFrameworks>net452;netstandard2.1</TargetFrameworks>
+    </PropertyGroup>
+    <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInJsonFileWithANonJsonExtension.approved.json
+++ b/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInJsonFileWithANonJsonExtension.approved.json
@@ -1,0 +1,3 @@
+{
+  "key": "new-value"
+}

--- a/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInJsonFileWithFileExtensionForOtherSupportedConfigFormat.approved.json
+++ b/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInJsonFileWithFileExtensionForOtherSupportedConfigFormat.approved.json
@@ -1,3 +1,3 @@
-<document>
-  <key>new-value</key>
-</document>
+{
+  "key": "new-value"
+}

--- a/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInJsonFileWithFileExtensionForOtherSupportedConfigFormat.approved.json
+++ b/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInJsonFileWithFileExtensionForOtherSupportedConfigFormat.approved.json
@@ -1,0 +1,3 @@
+<document>
+  <key>new-value</key>
+</document>

--- a/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInPropertiesFileWithANonPropertiesExtension.approved.properties
+++ b/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInPropertiesFileWithANonPropertiesExtension.approved.properties
@@ -1,0 +1,3 @@
+@ -- this makes this file invalid yaml
+debug:false
+port:80

--- a/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInXmlFileWithANonXmlExtension.approved.xml
+++ b/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInXmlFileWithANonXmlExtension.approved.xml
@@ -1,0 +1,3 @@
+<document>
+  <key>new-value</key>
+</document>

--- a/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInYamlFileWithANonYamlExtension.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/Deployment/Approved/DeployPackageWithStructuredConfigurationFixture.ShouldPerformReplacementInYamlFileWithANonYamlExtension.approved.yaml
@@ -1,0 +1,1 @@
+key: new-value

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using Assent;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
@@ -20,6 +20,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         const string PropertiesFileName = "config.properties";
         const string MalformedFileName = "malformed.file";
         const string XmlFileNameWithNonXmlExtension = "xml.config";
+        const string XmlFileNameWithJsonExtension = "xml.json";
         const string YamlFileNameWithNonYamlExtension = "yaml.config";
         const string PropertiesFileNameWithNonPropertiesExtension = "properties.config";
         const string PropertiesFileNameWithYamlExtension = "properties.yaml";
@@ -406,6 +407,21 @@ namespace Calamari.Tests.Fixtures.Deployment
                 var result = DeployPackage(file.FilePath);
                 result.AssertFailure();
                 result.AssertErrorOutput("The file could not be parsed as Yaml");
+            }
+        }
+
+        [Test]
+        public void FailsAndWarnsIfFileWithAJsonExtensionContainsValidNonJsonContent()
+        {
+            using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
+            {
+                Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
+                Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, XmlFileNameWithJsonExtension);
+                Variables.Set("key", "new-value");
+
+                var result = DeployPackage(file.FilePath);
+                result.AssertFailure();
+                result.AssertErrorOutput("The file could not be parsed as Json");
             }
         }
 

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
@@ -332,7 +332,8 @@ namespace Calamari.Tests.Fixtures.Deployment
 
                 var extractedPackageUpdatedXmlFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, XmlFileNameWithNonXmlExtension));
 
-                // NOSHIP: Assert that it logs that it tried json first
+                result.AssertOutput("The file will be tried as multiple formats and will be treated as the first format that can be successfully parsed");
+                result.AssertOutput("couldn't be parsed as Json");
                 this.Assent(extractedPackageUpdatedXmlFile, TestEnvironment.AssentXmlConfiguration);
             }
         }
@@ -351,7 +352,9 @@ namespace Calamari.Tests.Fixtures.Deployment
 
                 var extractedPackageUpdatedYamlFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, YamlFileNameWithNonYamlExtension));
 
-                // noship: assert that it tried json, xml and json first
+                result.AssertOutput("The file will be tried as multiple formats and will be treated as the first format that can be successfully parsed");
+                result.AssertOutput("couldn't be parsed as Json");
+                result.AssertOutput("couldn't be parsed as Xml");
                 this.Assent(extractedPackageUpdatedYamlFile, TestEnvironment.AssentYamlConfiguration);
             }
         }
@@ -371,7 +374,10 @@ namespace Calamari.Tests.Fixtures.Deployment
 
                 var extractedPackageUpdatedPropertiesFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, PropertiesFileNameWithNonPropertiesExtension));
 
-                // noship: assert that it tried json, xml and yaml first
+                result.AssertOutput("The file will be tried as multiple formats and will be treated as the first format that can be successfully parsed");
+                result.AssertOutput("couldn't be parsed as Json");
+                result.AssertOutput("couldn't be parsed as Xml");
+                result.AssertOutput("couldn't be parsed as Yaml");
                 this.Assent(extractedPackageUpdatedPropertiesFile, TestEnvironment.AssentPropertiesConfiguration);
             }
         }

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using Assent;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
@@ -18,14 +18,13 @@ namespace Calamari.Tests.Fixtures.Deployment
         const string JsonFileNameWithAnXmlExtension = "json.xml";
         const string ConfigFileName = "values.config";
         const string PropertiesFileName = "config.properties";
-        const string MalformedFileName = "malformed.file";
+        const string MalformedFileName = "malformed.json";
         const string XmlFileNameWithNonXmlExtension = "xml.config";
         const string XmlFileNameWithJsonExtension = "xml.json";
         const string YamlFileNameWithNonYamlExtension = "yaml.config";
         const string PropertiesFileNameWithNonPropertiesExtension = "properties.config";
         const string PropertiesFileNameWithYamlExtension = "properties.yaml";
         const string YamlFileNameWithXmlExtension = "yaml.xml";
-
 
         [SetUp]
         public override void SetUp()

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
@@ -261,7 +261,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
-        public void FailsIfAFileFailsToParseWhenThereAreManyGlobs()
+        public void FailsIfAFileFailsToParseWhenThereAreMultipleTargetFiles()
         {
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployPackageWithStructuredConfigurationFixture.cs
@@ -22,7 +22,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         const string XmlFileNameWithNonXmlExtension = "xml.config";
         const string YamlFileNameWithNonYamlExtension = "yaml.config";
         const string PropertiesFileNameWithNonPropertiesExtension = "properties.config";
-        const string XmlFileNameWithYamlExtension = "xml.yaml";
+        const string PropertiesFileNameWithYamlExtension = "properties.yaml";
         const string YamlFileNameWithXmlExtension = "yaml.xml";
 
 
@@ -330,7 +330,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
 
-                var extractedPackageUpdatedXmlFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, XmlFileName));
+                var extractedPackageUpdatedXmlFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, XmlFileNameWithNonXmlExtension));
 
                 // NOSHIP: Assert that it logs that it tried json first
                 this.Assent(extractedPackageUpdatedXmlFile, TestEnvironment.AssentXmlConfiguration);
@@ -349,7 +349,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
 
-                var extractedPackageUpdatedYamlFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, YamlFileName));
+                var extractedPackageUpdatedYamlFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, YamlFileNameWithNonYamlExtension));
 
                 // noship: assert that it tried json, xml and json first
                 this.Assent(extractedPackageUpdatedYamlFile, TestEnvironment.AssentYamlConfiguration);
@@ -369,7 +369,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
 
-                var extractedPackageUpdatedPropertiesFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, PropertiesFileName));
+                var extractedPackageUpdatedPropertiesFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, PropertiesFileNameWithNonPropertiesExtension));
 
                 // noship: assert that it tried json, xml and yaml first
                 this.Assent(extractedPackageUpdatedPropertiesFile, TestEnvironment.AssentPropertiesConfiguration);
@@ -387,7 +387,7 @@ namespace Calamari.Tests.Fixtures.Deployment
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertFailure();
-                result.AssertErrorOutput("The file could not be parsed as Json");
+                result.AssertErrorOutput("The file could not be parsed as Xml");
             }
         }
 
@@ -397,12 +397,15 @@ namespace Calamari.Tests.Fixtures.Deployment
             using (var file = new TemporaryFile(PackageBuilder.BuildSamplePackage(ServiceName, ServiceVersion)))
             {
                 Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
-                Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, XmlFileNameWithYamlExtension);
+                // The content of this file can't be JSON (because JSON is a special case)
+                // It also can't be XML because XML is valid yaml
+                // We are left with making it a properties file that also happens to be invalid yaml
+                Variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, PropertiesFileNameWithYamlExtension);
                 Variables.Set("key", "new-value");
 
                 var result = DeployPackage(file.FilePath);
                 result.AssertFailure();
-                result.AssertErrorOutput("The file could not be parsed as Json");
+                result.AssertErrorOutput("The file could not be parsed as Yaml");
             }
         }
 
@@ -420,7 +423,7 @@ namespace Calamari.Tests.Fixtures.Deployment
                 var result = DeployPackage(file.FilePath);
                 result.AssertSuccess();
 
-                var extractedPackageUpdatedConfigFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, ConfigFileName));
+                var extractedPackageUpdatedConfigFile = File.ReadAllText(Path.Combine(StagingDirectory, ServiceName, ServiceVersion, JsonFileNameWithAnXmlExtension));
 
                 this.Assent(extractedPackageUpdatedConfigFile, TestEnvironment.AssentJsonConfiguration);
             }

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/json.xml
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/json.xml
@@ -1,3 +1,3 @@
-﻿<document>
-    <key>value</key>
-</document>
+﻿{
+    "key": "value"
+}

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/json.xml
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/json.xml
@@ -1,0 +1,3 @@
+﻿<document>
+    <key>value</key>
+</document>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/malformed.file
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/malformed.file
@@ -1,2 +1,0 @@
-﻿^**<<&*())(
-This file should be unparseable in every format we support

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/properties.config
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/properties.config
@@ -1,0 +1,3 @@
+@ -- this makes this file invalid yaml
+debug:true
+port:8080

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/properties.yaml
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/properties.yaml
@@ -1,0 +1,2 @@
+﻿@ -- this makes this file invalid yaml
+key:value

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/xml.config
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/xml.config
@@ -1,0 +1,3 @@
+﻿<document>
+    <key>value</key>
+</document>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/xml.json
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/xml.json
@@ -1,0 +1,3 @@
+﻿<document>
+    <key>value</key>
+</document>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/xml.yaml
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/xml.yaml
@@ -1,0 +1,3 @@
+﻿<document>
+    <key>value</key>
+</document>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/xml.yaml
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/xml.yaml
@@ -1,3 +1,0 @@
-﻿<document>
-    <key>value</key>
-</document>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/yaml.config
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/yaml.config
@@ -1,0 +1,1 @@
+﻿key: value

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/yaml.xml
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/yaml.xml
@@ -1,0 +1,1 @@
+﻿key: value


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/6683

A common use case for structured configuration variables is substituting variables in files like `web.config`. This particular type of file is usually an xml file, but does not contain a `.xml` file extension. Our current structured configuration variables feature is unable to process this file because it relies heavily on the file extension to determine which parser it should use.

This PR changes the algorithm for determining which parser to use for substituting variables in structured configuration files, such that we can substitute variables in files that don't have well known extensions.

# Before

The algorithm used to look like this
- Always try to use a JSON parser first for backwards compatibility
- If the file contents can not be parsed as JSON, then:
- If we recognised the file extension (`.xml`, `.yaml`, `.yml` or `.properties`), then additionally try to parse using the single matching parser
- else if neither the JSON nor the parser matching the file extension works, we fail the process

# After

The algorithm now looks like this
- Always try to use a JSON parser first for backwards compatibility
- If the file contents can not be parsed as JSON then:
- If we recognised the file extension (`.xml`, `.yaml`, `.yml` or `.properties`), then additionally try to parse using the single matching parser
- else if the JSON parser did not work and we did not recognise the file extension, additionally try the remaining parsers in order (xml -> yaml -> properties) until we find one that works

If you want to understand the behaviour after this change, have a close look at the tests in this PR.