### PR TITLE
Reverting change from

### DIFF
--- a/source/Calamari.Common/Features/Behaviours/ConfigurationVariablesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/ConfigurationVariablesBehaviour.cs
@@ -26,7 +26,8 @@ namespace Calamari.Common.Features.Behaviours
 
         public bool IsEnabled(RunningDeployment context)
         {
-            return context.Variables.IsFeatureEnabled(KnownVariables.Features.ConfigurationVariables);
+            return context.Variables.IsFeatureEnabled(KnownVariables.Features.ConfigurationVariables) &&
+                context.Variables.GetFlag(KnownVariables.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings);
         }
 
         public Task Execute(RunningDeployment context)

--- a/source/Calamari.Common/Plumbing/Variables/KnownVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/KnownVariables.cs
@@ -50,6 +50,7 @@ namespace Calamari.Common.Plumbing.Variables
             public static readonly string EnabledFeatures = "Octopus.Action.EnabledFeatures";
             public static readonly string UpdateIisWebsite = "Octopus.Action.Package.UpdateIisWebsite";
             public static readonly string UpdateIisWebsiteName = "Octopus.Action.Package.UpdateIisWebsiteName";
+            public static readonly string AutomaticallyUpdateAppSettingsAndConnectionStrings = "Octopus.Action.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings";
             public static readonly string JsonConfigurationVariablesEnabled = "Octopus.Action.Package.JsonConfigurationVariablesEnabled";
             public static readonly string JsonConfigurationVariablesTargets = "Octopus.Action.Package.JsonConfigurationVariablesTargets";
             public static readonly string AutomaticallyRunConfigurationTransformationFiles = "Octopus.Action.Package.AutomaticallyRunConfigurationTransformationFiles";

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfigurationVariablesConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfigurationVariablesConventionFixture.cs
@@ -34,8 +34,18 @@ namespace Calamari.Tests.Fixtures.Conventions
         }
 
         [Test]
-        public void ShouldNotRunIfVariableNotSet()
+        public void ShouldNotRunIfFeatureNotEnabled()
         {
+            var convention = new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, replacer, new InMemoryLog()));
+            convention.Install(deployment);
+            replacer.DidNotReceiveWithAnyArgs().ModifyConfigurationFile(null, null);
+        }
+
+        [Test]
+        public void ShouldNotRunIfConfiguredToNotReplace()
+        {
+            deployment.Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.ConfigurationVariables);
+            deployment.Variables.Set(KnownVariables.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings, "false");
             var convention = new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, replacer, new InMemoryLog()));
             convention.Install(deployment);
             replacer.DidNotReceiveWithAnyArgs().ModifyConfigurationFile(null, null);
@@ -45,6 +55,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         public void ShouldFindAndCallDeployScripts()
         {
             deployment.Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.ConfigurationVariables);
+            deployment.Variables.Set(KnownVariables.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings, "true");
             var convention = new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, replacer, new InMemoryLog()));
             convention.Install(deployment);
             replacer.Received().ModifyConfigurationFile("C:\\App\\MyApp\\Web.config", deployment.Variables);

--- a/source/Calamari.Tests/NewPipeline/PipelineCommandFixture.cs
+++ b/source/Calamari.Tests/NewPipeline/PipelineCommandFixture.cs
@@ -156,6 +156,7 @@ namespace Calamari.Tests.NewPipeline
                                         .WithArrange(context =>
                                                      {
                                                          context.Variables.Add(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.ConfigurationTransforms + "," + KnownVariables.Features.ConfigurationVariables);
+                                                         context.Variables.Add(KnownVariables.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings, "true");
                                                          context.Variables.Add("Environment", "Test");
                                                          context.WithFilesToCopy(tempPath.DirectoryPath);
                                                      })


### PR DESCRIPTION
It seems this [commit](https://github.com/OctopusDeploy/Calamari/commit/3be1bb8972751efd66cc6c4d462b01ecfec84f1e#diff-f04b9cd38dc8ebf07cccf7285ab1843179ce7ebf0a69107a0ccde7595e077a7d) inadvertently meant that disabling `Replace entries in config files` did not
take effect.

Closes https://github.com/OctopusDeploy/Issues/issues/6633