### PR TITLE
Support java package types via CombinedPackageExtractor

### DIFF
--- a/source/Calamari.Common/Features/Packages/CombinedPackageExtractor.cs
+++ b/source/Calamari.Common/Features/Packages/CombinedPackageExtractor.cs
@@ -2,8 +2,11 @@
 using System.IO;
 using System.Linq;
 using Calamari.Common.Commands;
+using Calamari.Common.Features.Packages.Java;
 using Calamari.Common.Features.Packages.NuGet;
+using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Common.Features.Packages
 {
@@ -15,7 +18,7 @@ namespace Calamari.Common.Features.Packages
     {
         readonly IPackageExtractor[] extractors;
 
-        public CombinedPackageExtractor(ILog log)
+        public CombinedPackageExtractor(ILog log, IVariables variables, ICommandLineRunner commandLineRunner)
         {
             extractors = new IPackageExtractor[]
             {
@@ -24,7 +27,8 @@ namespace Calamari.Common.Features.Packages
                 new TarGzipPackageExtractor(log),
                 new TarBzipPackageExtractor(log),
                 new ZipPackageExtractor(log),
-                new TarPackageExtractor(log)
+                new TarPackageExtractor(log),
+                new JarPackageExtractor(new JarTool(commandLineRunner, log, variables))
             };
         }
 

--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Calamari.Common.Features.Packages;
+using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;

--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -242,7 +242,7 @@ namespace Calamari.Tests.AWS
                     variables,
                     fileSystem,
                     new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem), variables),
-                    new ExtractPackage(new CombinedPackageExtractor(log), fileSystem, variables, log)
+                    new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log)
                 );
                 var result = command.Execute(new[] { 
                     "--package", $"{package.FilePath}", 

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
@@ -3,12 +3,16 @@ using System.IO;
 using System.Linq;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Variables;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Packages;
+using Calamari.Testing.Helpers;
 using Calamari.Tests.Fixtures.Deployment.Packages;
-using Calamari.Tests.Helpers;
+using Calamari.Tests.Fixtures.Manifest;
 using NUnit.Framework;
 using Octopus.Versioning.Semver;
+using InMemoryLog = Calamari.Tests.Helpers.InMemoryLog;
+using TestEnvironment = Calamari.Tests.Helpers.TestEnvironment;
 
 namespace Calamari.Tests.Fixtures.Integration.FileSystem
 {
@@ -46,8 +50,8 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             using (new TemporaryFile(CreatePackage("2.0.0.2")))
             {
                 var store = new PackageStore(
-                    new CombinedPackageExtractor(new InMemoryLog()),
-                    CalamariPhysicalFileSystem.GetPhysicalFileSystem()
+                     CreatePackageExtractor(),
+                     CalamariPhysicalFileSystem.GetPhysicalFileSystem()
                     );
 
                 var packages = store.GetNearestPackages("Acme.Web", new SemanticVersion(1, 1, 1, 1));
@@ -63,7 +67,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             using (new TemporaryFile(CreatePackage("1.0.0.1", true)))
             {
                 var store = new PackageStore(
-                    new CombinedPackageExtractor(new InMemoryLog()),
+                    CreatePackageExtractor(),
                     CalamariPhysicalFileSystem.GetPhysicalFileSystem()
                 );
 
@@ -80,7 +84,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             using (new TemporaryFile(CreateEmptyFile("1.0.0.2")))
             {
                 var store = new PackageStore(
-                    new CombinedPackageExtractor(new InMemoryLog()),
+                    CreatePackageExtractor(),
                     CalamariPhysicalFileSystem.GetPhysicalFileSystem()
                 );
 
@@ -110,6 +114,15 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
 
             File.Move(sourcePackage, destinationPath);
             return destinationPath;
+        }
+
+        ICombinedPackageExtractor CreatePackageExtractor()
+        {
+            var log = new InMemoryLog();
+            var variables = new CalamariVariables();
+            var commandLineRunner = new TestCommandLineRunner(log, variables);
+
+            return new CombinedPackageExtractor(log, variables, commandLineRunner);
         }
     }
 }

--- a/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
@@ -124,14 +124,15 @@ namespace Calamari.Tests.Java.Fixtures.Deployment
 
         protected void DeployPackage(string packageName, IVariables variables)
         {
+            var commandLineRunner = new CommandLineRunner(log, variables); 
             var command = new DeployJavaArchiveCommand(
                 log,
                 new ScriptEngine(Enumerable.Empty<IScriptWrapper>()),
                 variables,
                 fileSystem,
-                new CommandLineRunner(log, variables),
+                commandLineRunner,
                 new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem), variables),
-                new ExtractPackage(new CombinedPackageExtractor(log), fileSystem, variables, log)
+                new ExtractPackage(new CombinedPackageExtractor(log, variables, commandLineRunner), fileSystem, variables, log)
             );
             returnCode = command.Execute(new[] { "--archive", $"{packageName}" });
         }

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -74,7 +74,7 @@ namespace Calamari.Commands
 
             var conventions = new List<IConvention>
             {
-                new StageScriptPackagesConvention(packageFile, fileSystem, new CombinedPackageExtractor(log)),
+                new StageScriptPackagesConvention(packageFile, fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner)),
                 // Substitute the script source file
                 new DelegateInstallConvention(d => substituteInFiles.Substitute(d, ScriptFileTargetFactory(d).ToList())),
                 // Substitute any user-specified files

--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -69,7 +69,7 @@ namespace Calamari.Kubernetes.Commands
             var conventions = new List<IConvention>
             {
                 new DelegateInstallConvention(d => extractPackage.ExtractToStagingDirectory(pathToPackage)),
-                new StageScriptPackagesConvention(null, fileSystem, new CombinedPackageExtractor(log), true),
+                new StageScriptPackagesConvention(null, fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner), true),
                 new ConfiguredScriptConvention(new PreDeployConfiguredScriptBehaviour(log, fileSystem, scriptEngine, commandLineRunner)),
                 // Any values.yaml files in any packages referenced by the step will automatically have variable substitution applied (we won't log a warning if these aren't present)
                 new DelegateInstallConvention(d => substituteInFiles.Substitute(d, DefaultValuesFiles().ToList(), false)),


### PR DESCRIPTION
Today, java packages are only supported by the [DeployJavaArchiveCommand](https://github.com/OctopusDeploy/Calamari/blob/master/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs) which explicitly uses the `JarPackageExtractor` class.  

In the newer model of inheriting from `PipelineCommand`, this isn't an option.  

This PR extends the `CombinedPackageExtractor` to use the `JarPackageExtractor` for the appropriate java file types (`.jar`, `.war`, `.ear`)

The immediate need for this is to allow the [AzureAppService](https://github.com/OctopusDeploy/Sashimi.AzureAppService/blob/main/source/Calamari/Behaviors/AzureAppServiceBehaviour.cs) step to support deploying java apps.

