### PR TITLE
Fixing the context name with Azure admin login

### DIFF
--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -180,7 +180,6 @@ function SetupContext {
 			& az aks get-credentials --admin --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $env:KUBECONFIG --overwrite-existing
 			& $Kubectl_Exe config set-context "$($K8S_Azure_Cluster)-admin" --namespace=$K8S_Namespace
 		}
-
 	} else {
 		Write-Verbose "$Kubectl_Exe config set-cluster octocluster --server=$K8S_ClusterUrl"
 		& $Kubectl_Exe config set-cluster octocluster --server=$K8S_ClusterUrl

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -173,12 +173,14 @@ function SetupContext {
 		if ([string]::IsNullOrEmpty($K8S_Azure_Admin) -or -not $K8S_Azure_Admin -ieq "true")
 		{
 			& az aks get-credentials --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $env:KUBECONFIG --overwrite-existing
+			& $Kubectl_Exe config set-context $K8S_Azure_Cluster --namespace=$K8S_Namespace
 		}
 		else
 		{
 			& az aks get-credentials --admin --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $env:KUBECONFIG --overwrite-existing
+			& $Kubectl_Exe config set-context "$($K8S_Azure_Cluster)-admin" --namespace=$K8S_Namespace
 		}
-		& $Kubectl_Exe config set-context $K8S_Azure_Cluster --namespace=$K8S_Namespace
+
 	} else {
 		Write-Verbose "$Kubectl_Exe config set-cluster octocluster --server=$K8S_ClusterUrl"
 		& $Kubectl_Exe config set-cluster octocluster --server=$K8S_ClusterUrl


### PR DESCRIPTION
When logging in with an Azure admin account, the context name is the cluster name plus "-admin".

This PR updates an issue where the default namespace is not updated in the correct Kubernetes context for an admin login.