### PR TITLE
Fixed: Calamari namespace issue when using Azure Principal Account

### DIFF
--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -107,6 +107,7 @@ function setup_context {
       az aks get-credentials --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $KUBECONFIG --overwrite-existing
     else
       az aks get-credentials --admin --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $KUBECONFIG --overwrite-existing
+      K8S_Azure_Cluster+="-admin"
     fi
     kubectl config set-context $K8S_Azure_Cluster --namespace=$Octopus_K8S_Namespace
   else

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -1,4 +1,4 @@
-﻿## Octopus Kubernetes Context script
+## Octopus Kubernetes Context script
 ## --------------------------------------------------------------------------------------
 ##
 ## This script is used to configure the default kubectl context for this step.
@@ -177,6 +177,7 @@ function SetupContext {
 		else
 		{
 			& az aks get-credentials --admin --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $env:KUBECONFIG --overwrite-existing
+			$K8S_Azure_Cluster += "-admin"
 		}
 		& $Kubectl_Exe config set-context $K8S_Azure_Cluster --namespace=$K8S_Namespace
 	} else {
@@ -316,6 +317,7 @@ CreateNamespace
 if ($K8S_OutputKubeConfig -eq $true) {
 	& $Kubectl_Exe config view
 }
+Write-Verbose "Ray changes"
 Write-Verbose "Invoking target script $OctopusKubernetesTargetScript with $OctopusKubernetesTargetScriptParameters parameters"
 Write-Host "##octopus[stdout-default]"
 

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -317,7 +317,6 @@ CreateNamespace
 if ($K8S_OutputKubeConfig -eq $true) {
 	& $Kubectl_Exe config view
 }
-Write-Verbose "Ray changes"
 Write-Verbose "Invoking target script $OctopusKubernetesTargetScript with $OctopusKubernetesTargetScriptParameters parameters"
 Write-Host "##octopus[stdout-default]"
 


### PR DESCRIPTION
# Background

Issue: https://github.com/OctopusDeploy/Issues/issues/6793

# Cause

When authenticating using `Azure Principal Account` or `"Login with Administrator Credentials"` is ticked in the K8s Deployment Target, the deployment script append a suffix `-admin` to the `AzureClusterName`.
The deployment script then sets the K8s namespace to the original `AksClusterName` (without the suffix) instead of the context being deployed.
```powershell
if ([string]::IsNullOrEmpty($K8S_Azure_Admin) -or -not $K8S_Azure_Admin -ieq "true")
{
	& az aks get-credentials --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $env:KUBECONFIG --overwrite-existing
}
else
{
	& az aks get-credentials --admin --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $env:KUBECONFIG --overwrite-existing
}
& $Kubectl_Exe config set-context $K8S_Azure_Cluster --namespace=$K8S_Namespace
```

As in the server log, we can see that the current context has a `-admin` suffix but the namespace is set to the context without the suffix.
Server log:
```
contexts: 
- context: 
    cluster: "" 
    namespace: script-test 
    user: "" 
  name: ray-test 
- context: 
    cluster: ray-test 
    user: clusterAdmin_k8syaml_ray-test 
  name: ray-test-admin 
current-context: ray-test-admin 
```

# Solution

Before running the command to set the namespace to the context, we append the suffix `-admin` to the context name if the cluster is authenticated using an `Azure Principal Account` or `"Login with Administrator Credentials"` is ticked in the K8s Deployment Target.

```powershell
if ([string]::IsNullOrEmpty($K8S_Azure_Admin) -or -not $K8S_Azure_Admin -ieq "true")
{
	& az aks get-credentials --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $env:KUBECONFIG --overwrite-existing
}
else
{
	& az aks get-credentials --admin --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $env:KUBECONFIG --overwrite-existing
	$K8S_Azure_Cluster += "-admin"
}
& $Kubectl_Exe config set-context $K8S_Azure_Cluster --namespace=$K8S_Namespace
```

# How to review this PR
Quality :heavy_check_mark:

# Pre-requisites
- [ x] I have considered informing or consulting the right people, e.g.: 
  - For changes to the execution pipeline: [`#topic-execution`](https://octopusdeploy.slack.com/archives/C3KT1DFSM)
  - For other changes, consider the other `#topic-...` channels
- [ x] I have considered whether this should be a patch or wait for a minor.
- [ x] I have considered appropriate testing for my change. (Automate testings)
      
