### PR TITLE
Merge from 17.0.1 tag

### DIFF
--- a/source/Calamari.Common/Features/Substitutions/ISubstituteInFiles.cs
+++ b/source/Calamari.Common/Features/Substitutions/ISubstituteInFiles.cs
@@ -7,6 +7,6 @@ namespace Calamari.Common.Features.Substitutions
     public interface ISubstituteInFiles
     {
         void SubstituteBasedSettingsInSuppliedVariables(RunningDeployment deployment);
-        void Substitute(RunningDeployment deployment, IList<string> filesToTarget);
+        void Substitute(RunningDeployment deployment, IList<string> filesToTarget, bool warnIfFileNotFound = true);
     }
 }

--- a/source/Calamari.Common/Plumbing/FileSystem/SubstituteInFiles.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/SubstituteInFiles.cs
@@ -30,7 +30,7 @@ namespace Calamari.Common.Plumbing.FileSystem
             Substitute(deployment, filesToTarget);
         }
 
-        public void Substitute(RunningDeployment deployment, IList<string> filesToTarget)
+        public void Substitute(RunningDeployment deployment, IList<string> filesToTarget, bool warnIfFileNotFound = true)
         {
             foreach (var target in filesToTarget)
             {
@@ -38,7 +38,7 @@ namespace Calamari.Common.Plumbing.FileSystem
 
                 if (!matchingFiles.Any())
                 {
-                    if (deployment.Variables.GetFlag(PackageVariables.EnableNoMatchWarning, true))
+                    if (warnIfFileNotFound && deployment.Variables.GetFlag(PackageVariables.EnableNoMatchWarning, true))
                         log.WarnFormat("No files were found that match the substitution target pattern '{0}'", target);
 
                     continue;

--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -71,7 +71,10 @@ namespace Calamari.Kubernetes.Commands
                 new DelegateInstallConvention(d => extractPackage.ExtractToStagingDirectory(pathToPackage)),
                 new StageScriptPackagesConvention(null, fileSystem, new CombinedPackageExtractor(log), true),
                 new ConfiguredScriptConvention(new PreDeployConfiguredScriptBehaviour(log, fileSystem, scriptEngine, commandLineRunner)),
-                new DelegateInstallConvention(d => substituteInFiles.Substitute(d, FileTargetFactory().ToList())),
+                // Any values.yaml files in any packages referenced by the step will automatically have variable substitution applied (we won't log a warning if these aren't present)
+                new DelegateInstallConvention(d => substituteInFiles.Substitute(d, DefaultValuesFiles().ToList(), false)),
+                // Any values files explicitly specified by the user will also have variable substitution applied
+                new DelegateInstallConvention(d => substituteInFiles.Substitute(d, ExplicitlySpecifiedValuesFiles().ToList(), true)),
                 new ConfiguredScriptConvention(new DeployConfiguredScriptBehaviour(log, fileSystem, scriptEngine, commandLineRunner)),
                 new HelmUpgradeConvention(log, scriptEngine, commandLineRunner, fileSystem),
                 new ConfiguredScriptConvention(new PostDeployConfiguredScriptBehaviour(log, fileSystem, scriptEngine, commandLineRunner))
@@ -101,27 +104,43 @@ namespace Calamari.Kubernetes.Commands
             }
         }
 
-        IEnumerable<string> FileTargetFactory()
+        /// <summary>
+        /// Any values.yaml files in any packages referenced by the step will automatically have variable substitution applied
+        /// </summary>
+        IEnumerable<string> DefaultValuesFiles()
         {
             var packageReferenceNames = variables.GetIndexes(PackageVariables.PackageCollection);
             foreach (var packageReferenceName in packageReferenceNames)
             {
-                var packageRoot = packageReferenceName;
-                if (string.IsNullOrEmpty(packageReferenceName))
-                {
-                    packageRoot = variables.Get(PackageVariables.IndexedPackageId(packageReferenceName));
-                }
-                var sanitizedPackageReferenceName = fileSystem.RemoveInvalidFileNameChars(packageRoot ?? String.Empty);
+                yield return Path.Combine(PackageDirectory(packageReferenceName), "values.yaml");
+            }
+        }
 
-                yield return Path.Combine(sanitizedPackageReferenceName, "values.yaml");
-
+        /// <summary>
+        /// Any values files explicitly specified by the user will also have variable substitution applied
+        /// </summary>
+        IEnumerable<string> ExplicitlySpecifiedValuesFiles()
+        {
+            var packageReferenceNames = variables.GetIndexes(PackageVariables.PackageCollection);
+            foreach (var packageReferenceName in packageReferenceNames)
+            {
                 var paths = variables.GetPaths(SpecialVariables.Helm.Packages.ValuesFilePath(packageReferenceName));
 
                 foreach (var path in paths)
                 {
-                    yield return Path.Combine(sanitizedPackageReferenceName, path);
+                    yield return Path.Combine(PackageDirectory(packageReferenceName), path);
                 }
             }
+        }
+
+        string PackageDirectory(string packageReferenceName)
+        {
+            var packageRoot = packageReferenceName;
+            if (string.IsNullOrEmpty(packageReferenceName))
+            {
+                packageRoot = variables.Get(PackageVariables.IndexedPackageId(packageReferenceName ?? ""));
+            }
+            return fileSystem.RemoveInvalidFileNameChars(packageRoot ?? string.Empty);
         }
     }
 }


### PR DESCRIPTION
Octopus Server [2020.6 release](https://github.com/OctopusDeploy/OctopusDeploy/blob/45c90a963668a35d5907f5f5a419e4ae6aae2aad/source/Octopus.Server/Octopus.Server.csproj#L39) references Calamari version 17.0.1 but but the Calamari 2020.6 branch is a few commits behind the 17.0.1 tag.
This PR is to update the Calamari 2020.6 branch to match with the branch 17.0.1. 