### PR TITLE
Backported: restrict tests to mono version 5.14.0 or lower

### DIFF
--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/CSharpScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/CSharpScriptEngineFixture.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using Calamari.Common.Features.Scripting.ScriptCS;
 using Calamari.Common.Plumbing.FileSystem;
-using Calamari.Integration.FileSystem;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
 
@@ -11,7 +10,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
     public class CSharpScriptEngineFixture : ScriptEngineFixtureBase
     {
         [Category(TestCategory.ScriptingSupport.ScriptCS)]
-        [Test, RequiresMonoVersion400OrAbove, RequiresDotNet45]
+        [Test, RequiresMonoVersion400OrAbove, RequiresDotNet45, RequiresMonoVersionBefore(5, 14, 0)]
         public void CSharpDecryptsVariables()
         {
             using (var scriptFile = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "cs")))

--- a/source/Calamari.Tests/Fixtures/RequiresMonoVersionBefore.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresMonoVersionBefore.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Calamari.Common.Plumbing.Extensions;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace Calamari.Tests.Fixtures
+{
+    public class RequiresMonoVersionBefore : TestAttribute, ITestAction
+    {
+        private readonly int major;
+        private readonly int minor;
+        private readonly int build;
+
+        public RequiresMonoVersionBefore(int major, int minor, int build)
+        {
+            this.major = major;
+            this.minor = minor;
+            this.build = build;
+        }
+
+        public void BeforeTest(ITest testDetails)
+        {
+            if (ScriptingEnvironment.IsRunningOnMono() && (ScriptingEnvironment.GetMonoVersion() >= new Version(major, minor, build)))
+            {
+                Assert.Ignore($"Requires a Mono version before {major}.{minor}.{build}");
+            }
+        }
+
+        public void AfterTest(ITest testDetails)
+        {
+        }
+
+        public ActionTargets Targets { get; set; }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using Calamari.Deployment;
-using Calamari.Integration.FileSystem;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
-using Octostache;
 
 namespace Calamari.Tests.Fixtures.ScriptCS
 {
@@ -13,7 +10,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
     [Category(TestCategory.ScriptingSupport.ScriptCS)]
     public class ScriptCSFixture : CalamariFixture
     {
-        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
+        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove, RequiresMonoVersionBefore(5, 14, 0)]
         public void ShouldPrintEncodedVariable()
         {
             var (output, _) = RunScript("PrintEncodedVariable.csx");
@@ -22,7 +19,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
             output.AssertOutput("##octopus[setVariable name='RG9ua2V5' value='S29uZw==']");
         }
         
-        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
+        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove, RequiresMonoVersionBefore(5, 14, 0)]
         public void ShouldPrintSensitiveVariable()
         {
             var (output, _) = RunScript("PrintSensitiveVariable.csx");
@@ -31,7 +28,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
             output.AssertOutput("##octopus[setVariable name='UGFzc3dvcmQ=' value='Y29ycmVjdCBob3JzZSBiYXR0ZXJ5IHN0YXBsZQ==' sensitive='VHJ1ZQ==']");
         }
 
-        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
+        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove, RequiresMonoVersionBefore(5, 14, 0)]
         public void ShouldCreateArtifact()
         {
             var (output, _) = RunScript("CreateArtifact.csx");
@@ -41,7 +38,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
             output.AssertOutput("name='bXlGaWxlLnR4dA==' length='MTAw']");
         }
         
-        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
+        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove, RequiresMonoVersionBefore(5, 14, 0)]
         public void ShouldUpdateProgress()
         {
             var (output, _) = RunScript("UpdateProgress.csx");
@@ -50,7 +47,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
             output.AssertOutput("##octopus[progress percentage='NTA=' message='SGFsZiBXYXk=']");
         }
 
-        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
+        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove, RequiresMonoVersionBefore(5, 14, 0)]
         public void ShouldCallHello()
         {
             var (output, _) = RunScript("Hello.csx", new Dictionary<string, string>()
@@ -67,7 +64,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
             output.AssertProcessNameAndId("scriptcs");
         }
 
-        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove]
+        [Test, RequiresDotNet45, RequiresMonoVersion400OrAbove, RequiresMonoVersionBefore(5, 14, 0)]
         public void ShouldCallHelloWithSensitiveVariable()
         {
             var (output, _) = RunScript("Hello.csx", new Dictionary<string, string>()


### PR DESCRIPTION
# Background
[The Debian - Mono 5.14.0 Test](https://build.octopushq.com/buildConfiguration/OctopusDeploy_CalamariNetCore_MonoTesting_TestDebianMono5181/2180503) are only compatible with Mono version 5.14.0 or lower. When running on Mono version 5.14.0 or higher, we would like to ignore these tests.
This change have been implemented in `master`. This PR is to backport the change to release `2020.6` so that these tests will not fail when we apply patches to `2020.6` branch.
More info is in [this Slack thread](https://octopusdeploy.slack.com/archives/C012VMX1YMQ/p1617082094111100).