### PR TITLE
Adds input variable key to node bootstrapper invocation

### DIFF
--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -39,7 +39,12 @@ namespace Calamari.LaunchTools
                 var variablesAsJson = variables.CloneAndEvaluate().SaveAsString();
                 File.WriteAllBytes(variableFile.FilePath, new AesEncryption(options.InputVariables.SensitiveVariablesPassword).Encrypt(variablesAsJson));
                 var commandLineInvocation = new CommandLineInvocation(BuildNodePath(pathToNode),
-                                                                      BuildArgs(Path.Combine(pathToBootstrapper, "bootstrapper.js"), Path.Combine(pathToStepPackage, instructions.TargetEntryPoint), variableFile.FilePath, options.InputVariables.SensitiveVariablesPassword))
+                                                                      BuildArgs(
+                                                                                Path.Combine(pathToBootstrapper, "bootstrapper.js"),
+                                                                                Path.Combine(pathToStepPackage, instructions.TargetEntryPoint),
+                                                                                variableFile.FilePath,
+                                                                                options.InputVariables.SensitiveVariablesPassword,
+                                                                                instructions.InputsVariable))
                 {
                     WorkingDirectory = runningDeployment.CurrentDirectory,
                     OutputToLog = true,
@@ -53,8 +58,8 @@ namespace Calamari.LaunchTools
 
         static string BuildNodePath(string pathToNode) => CalamariEnvironment.IsRunningOnWindows ? Path.Combine(pathToNode, "node.exe") : Path.Combine(pathToNode, "bin", "node");
 
-        static string BuildArgs(string pathToBootstrapper, string pathToStepPackage, string pathToSensitiveVariables, string sensitiveVariablesSecret) =>
-            $"\"{pathToBootstrapper}\" \"{pathToStepPackage}\" \"{pathToSensitiveVariables}\" {sensitiveVariablesSecret}";
+        static string BuildArgs(string pathToBootstrapper, string pathToStepPackage, string pathToSensitiveVariables, string sensitiveVariablesSecret, string inputsKey) =>
+            $"\"{pathToBootstrapper}\" \"{pathToStepPackage}\" \"{pathToSensitiveVariables}\" \"{sensitiveVariablesSecret}\" \"{inputsKey}\"";
     }
 
     public class NodeInstructions
@@ -63,5 +68,6 @@ namespace Calamari.LaunchTools
         public string TargetPathVariable { get; set; }
         public string BootstrapperPathVariable { get; set; }
         public string TargetEntryPoint { get; set; }
+        public string InputsVariable { get; }
     }
 }


### PR DESCRIPTION
This PR provides the glue between https://github.com/OctopusDeploy/OctopusDeploy/pull/8588 and https://github.com/OctopusDeploy/step-package-azurestorage/pull/1, ensuring the input variable key supplied by Server on the execution manifest is passed through to the node bootstrapper.