### PR TITLE
Don't use a guid for the domain name

### DIFF
--- a/source/Calamari.Common/Plumbing/Proxies/ProxySettings.cs
+++ b/source/Calamari.Common/Plumbing/Proxies/ProxySettings.cs
@@ -27,7 +27,7 @@ namespace Calamari.Common.Plumbing.Proxies
 
     public class UseSystemProxySettings : IProxySettings
     {
-        static readonly Uri TestUri = new Uri("http://test9c7b575efb72442c85f706ef1d64afa6.com");
+        static readonly Uri TestUri = new Uri("http://proxytestingdomain.octopus.com");
 
         public UseSystemProxySettings(string username, string password)
         {


### PR DESCRIPTION
This can cause security software to flag as potentially domain generated algorithm

Fixes https://github.com/OctopusDeploy/Issues/issues/6821