### PR TITLE
Adding transform commands

### DIFF
--- a/source/Calamari.Common/Features/Behaviours/StructuredConfigurationVariablesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/StructuredConfigurationVariablesBehaviour.cs
@@ -24,7 +24,7 @@ namespace Calamari.Common.Features.Behaviours
 
         public Task Execute(RunningDeployment context)
         {
-            structuredConfigVariablesService.ReplaceVariables(context);
+            structuredConfigVariablesService.ReplaceVariables(context.CurrentDirectory);
 
             return this.CompletedTask();
         }

--- a/source/Calamari.Common/Features/Behaviours/SubstituteInFilesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/SubstituteInFilesBehaviour.cs
@@ -24,7 +24,7 @@ namespace Calamari.Common.Features.Behaviours
 
         public Task Execute(RunningDeployment context)
         {
-            substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(context);
+            substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(context.CurrentDirectory);
             return this.CompletedTask();
         }
     }

--- a/source/Calamari.Common/Features/ConfigurationTransforms/ITransformFileLocator.cs
+++ b/source/Calamari.Common/Features/ConfigurationTransforms/ITransformFileLocator.cs
@@ -6,6 +6,6 @@ namespace Calamari.Common.Features.ConfigurationTransforms
 {
     public interface ITransformFileLocator
     {
-        IEnumerable<string> DetermineTransformFileNames(string sourceFile, XmlConfigTransformDefinition transformation, bool diagnosticLoggingEnabled, RunningDeployment deployment);
+        IEnumerable<string> DetermineTransformFileNames(string sourceFile, XmlConfigTransformDefinition transformation, bool diagnosticLoggingEnabled, string currentDirectory);
     }
 }

--- a/source/Calamari.Common/Features/ConfigurationTransforms/TransformFileLocator.cs
+++ b/source/Calamari.Common/Features/ConfigurationTransforms/TransformFileLocator.cs
@@ -22,7 +22,7 @@ namespace Calamari.Common.Features.ConfigurationTransforms
             this.log = log;
         }
 
-        public IEnumerable<string> DetermineTransformFileNames(string sourceFile, XmlConfigTransformDefinition transformation, bool diagnosticLoggingEnabled, RunningDeployment deployment)
+        public IEnumerable<string> DetermineTransformFileNames(string sourceFile, XmlConfigTransformDefinition transformation, bool diagnosticLoggingEnabled, string currentDirectory)
         {
             var defaultTransformFileName = DetermineTransformFileName(sourceFile, transformation, true);
             var transformFileName = DetermineTransformFileName(sourceFile, transformation, false);
@@ -52,7 +52,7 @@ namespace Calamari.Common.Features.ConfigurationTransforms
             {
                 foreach (var transformFile in enumerateFiles)
                 {
-                    var sourceFileName = GetSourceFileName(sourceFile, transformation, transformFileName, transformFile, deployment);
+                    var sourceFileName = GetSourceFileName(sourceFile, transformation, transformFileName, transformFile, currentDirectory);
 
                     if (transformation.Advanced && !transformation.IsSourceWildcard &&
                         !string.Equals(transformation.SourcePattern, sourceFileName, StringComparison.OrdinalIgnoreCase))
@@ -97,12 +97,12 @@ namespace Calamari.Common.Features.ConfigurationTransforms
         }
 
         private string GetSourceFileName(string sourceFile, XmlConfigTransformDefinition transformation,
-            string transformFileName, string transformFile, RunningDeployment deployment)
+            string transformFileName, string transformFile, string currentDirectory)
         {
             var sourcePattern = transformation.SourcePattern ?? "";
             if (Path.IsPathRooted(transformFileName) && sourcePattern.StartsWith("." + Path.DirectorySeparatorChar))
             {
-                var path = fileSystem.GetRelativePath(deployment.CurrentDirectory, sourceFile);
+                var path = fileSystem.GetRelativePath(currentDirectory, sourceFile);
                 return "." + path.Substring(path.IndexOf(Path.DirectorySeparatorChar));
             }
 

--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -25,8 +24,8 @@ namespace Calamari.Common.Features.StructuredVariables
         public StructuredConfigVariablesService(
             IFileFormatVariableReplacer[] replacers,
             IVariables variables,
-        ICalamariFileSystem fileSystem,
-                            ILog log)
+            ICalamariFileSystem fileSystem,
+            ILog log)
         {
             this.fileSystem = fileSystem;
             this.log = log;
@@ -89,7 +88,10 @@ namespace Calamari.Common.Features.StructuredVariables
 
         IEnumerable<IFileFormatVariableReplacer>? GetParsersWhenOnlyPerformingJsonReplacement(string filePath, bool onlyPerformJsonReplacement)
         {
-            if (!onlyPerformJsonReplacement) return null;
+            if (!onlyPerformJsonReplacement)
+            {
+                return null;
+            }
 
             log.Verbose($"The {ActionVariables.StructuredConfigurationFallbackFlag} flag is set. The file at "
                         + $"{filePath} will be parsed as JSON.");
@@ -99,7 +101,10 @@ namespace Calamari.Common.Features.StructuredVariables
         IEnumerable<IFileFormatVariableReplacer>? GetParsersBasedOnFileName(string filePath)
         {
             var guessedParserBasedOnFileName = allReplacers.FirstOrDefault(r => r.IsBestReplacerForFileName(filePath));
-            if (guessedParserBasedOnFileName == null) return null;
+            if (guessedParserBasedOnFileName == null)
+            {
+                return null;
+            }
 
             var guessedParserMessage = $"The file at {filePath} matches a known filename pattern, and will be "
                                        + $"treated as {guessedParserBasedOnFileName.FileFormatName}.";
@@ -124,7 +129,7 @@ namespace Calamari.Common.Features.StructuredVariables
 
             // Order so that the json replacer comes first
             yield return jsonReplacer;
-            foreach (var replacer in allReplacers.Except(new [] { jsonReplacer }))
+            foreach (var replacer in allReplacers.Except(new[] { jsonReplacer }))
             {
                 yield return replacer;
             }

--- a/source/Calamari.Common/Features/Substitutions/ISubstituteInFiles.cs
+++ b/source/Calamari.Common/Features/Substitutions/ISubstituteInFiles.cs
@@ -1,12 +1,11 @@
 using System;
 using System.Collections.Generic;
-using Calamari.Common.Commands;
 
 namespace Calamari.Common.Features.Substitutions
 {
     public interface ISubstituteInFiles
     {
-        void SubstituteBasedSettingsInSuppliedVariables(RunningDeployment deployment);
-        void Substitute(RunningDeployment deployment, IList<string> filesToTarget, bool warnIfFileNotFound = true);
+        void SubstituteBasedSettingsInSuppliedVariables(string currentDirectory);
+        void Substitute(string currentDirectory, IList<string> filesToTarget, bool warnIfFileNotFound = true);
     }
 }

--- a/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
@@ -9,7 +9,8 @@ namespace Calamari.Common.Plumbing.Extensions
     public class AesEncryption
     {
         const int PasswordSaltIterations = 1000;
-        static readonly byte[] PasswordPaddingSalt = Encoding.UTF8.GetBytes("Octopuss");
+        public const string SaltRaw = "Octopuss";
+        static readonly byte[] PasswordPaddingSalt = Encoding.UTF8.GetBytes(SaltRaw);
         static readonly byte[] IvPrefix = Encoding.UTF8.GetBytes("IV__");
 
         static readonly Random RandomGenerator = new Random();

--- a/source/Calamari.Shared/Deployment/ConventionProcessor.cs
+++ b/source/Calamari.Shared/Deployment/ConventionProcessor.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using Calamari.Commands.Support;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Deployment.Conventions;
@@ -66,7 +64,7 @@ namespace Calamari.Deployment
                 throw;
             }
         }
-        
+
 
         void RunInstallConventions()
         {
@@ -74,7 +72,7 @@ namespace Calamari.Deployment
             {
                 convention.Install(deployment);
 
-                if (deployment.Variables.GetFlag(SpecialVariables.Action.SkipRemainingConventions))
+                if (deployment.Variables.GetFlag(Common.Plumbing.Variables.KnownVariables.Action.SkipRemainingConventions))
                 {
                     break;
                 }
@@ -93,7 +91,7 @@ namespace Calamari.Deployment
         {
             foreach (var convention in conventions.OfType<IRollbackConvention>())
             {
-                if (deployment.Variables.GetFlag(SpecialVariables.Action.SkipRemainingConventions))
+                if (deployment.Variables.GetFlag(Common.Plumbing.Variables.KnownVariables.Action.SkipRemainingConventions))
                 {
                     break;
                 }

--- a/source/Calamari.Shared/Deployment/Conventions/AggregateInstallationConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/AggregateInstallationConvention.cs
@@ -23,7 +23,7 @@ namespace Calamari.Deployment.Conventions
             foreach (var convention in conventions)
             {
                 convention.Install(deployment);
-                if (deployment.Variables.GetFlag(SpecialVariables.Action.SkipRemainingConventions))
+                if (deployment.Variables.GetFlag(Common.Plumbing.Variables.KnownVariables.Action.SkipRemainingConventions))
                 {
                     break;
                 }

--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -105,7 +105,6 @@ namespace Calamari.Deployment
 
         public static class Action
         {
-            public const string SkipRemainingConventions = "Octopus.Action.SkipRemainingConventions";
             public const string FailScriptOnErrorOutput = "Octopus.Action.FailScriptOnErrorOutput";
 
             public static class IisWebSite

--- a/source/Calamari.Tests/Fixtures/ConfigurationTransforms/ConfigurationTransformTestCaseBuilder.cs
+++ b/source/Calamari.Tests/Fixtures/ConfigurationTransforms/ConfigurationTransformTestCaseBuilder.cs
@@ -125,7 +125,7 @@ namespace Calamari.Tests.Fixtures.ConfigurationTransforms
             var deployment = new RunningDeployment(null, deploymentVariables);
 
             const bool diagnosticLoggingEnabled = false;
-            var result = transformFileLocator.DetermineTransformFileNames(sourceFile, transform, diagnosticLoggingEnabled, deployment).ToArray();
+            var result = transformFileLocator.DetermineTransformFileNames(sourceFile, transform, diagnosticLoggingEnabled, deployment.CurrentDirectory).ToArray();
             return result;
         }
 

--- a/source/Calamari.Tests/Fixtures/Conventions/ConfigurationVariablesConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConfigurationVariablesConventionFixture.cs
@@ -3,7 +3,6 @@ using Calamari.Common.Features.Behaviours;
 using Calamari.Common.Features.ConfigurationVariables;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
-using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
 using Calamari.Tests.Helpers;
 using NSubstitute;
@@ -36,7 +35,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         [Test]
         public void ShouldNotRunIfFeatureNotEnabled()
         {
-            var convention = new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, replacer, new InMemoryLog()));
+            var convention = new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, deployment.Variables, replacer, new InMemoryLog()));
             convention.Install(deployment);
             replacer.DidNotReceiveWithAnyArgs().ModifyConfigurationFile(null, null);
         }
@@ -46,7 +45,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             deployment.Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.ConfigurationVariables);
             deployment.Variables.Set(KnownVariables.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings, "false");
-            var convention = new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, replacer, new InMemoryLog()));
+            var convention = new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, deployment.Variables,replacer, new InMemoryLog()));
             convention.Install(deployment);
             replacer.DidNotReceiveWithAnyArgs().ModifyConfigurationFile(null, null);
         }
@@ -56,7 +55,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             deployment.Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.ConfigurationVariables);
             deployment.Variables.Set(KnownVariables.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings, "true");
-            var convention = new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, replacer, new InMemoryLog()));
+            var convention = new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, deployment.Variables,replacer, new InMemoryLog()));
             convention.Install(deployment);
             replacer.Received().ModifyConfigurationFile("C:\\App\\MyApp\\Web.config", deployment.Variables);
             replacer.Received().ModifyConfigurationFile("C:\\App\\MyApp\\Web.Release.config", deployment.Variables);

--- a/source/Calamari.Tests/Fixtures/Conventions/StructuredConfigurationVariablesConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/StructuredConfigurationVariablesConventionFixture.cs
@@ -29,7 +29,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             var convention = new StructuredConfigurationVariablesConvention(new StructuredConfigurationVariablesBehaviour(service));
             convention.Install(deployment);
-            service.DidNotReceiveWithAnyArgs().ReplaceVariables(deployment);
+            service.DidNotReceiveWithAnyArgs().ReplaceVariables(deployment.CurrentDirectory);
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace Calamari.Tests.Fixtures.Conventions
         {
             var convention = new StructuredConfigurationVariablesConvention(new StructuredConfigurationVariablesBehaviour(service));
             convention.Install(deployment);
-            service.DidNotReceiveWithAnyArgs().ReplaceVariables(deployment);
+            service.DidNotReceiveWithAnyArgs().ReplaceVariables(deployment.CurrentDirectory);
         }
 
         [Test]
@@ -46,7 +46,7 @@ namespace Calamari.Tests.Fixtures.Conventions
             var convention = new StructuredConfigurationVariablesConvention(new StructuredConfigurationVariablesBehaviour(service));
             deployment.Variables.Add(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
             convention.Install(deployment);
-            service.Received().ReplaceVariables(deployment);
+            service.Received().ReplaceVariables(deployment.CurrentDirectory);
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Conventions/SubstituteInFilesFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/SubstituteInFilesFixture.cs
@@ -43,7 +43,7 @@ namespace Calamari.Tests.Fixtures.Conventions
 
             var substituter = Substitute.For<IFileSubstituter>();
             new SubstituteInFiles(new InMemoryLog(), fileSystem, substituter, variables)
-                .SubstituteBasedSettingsInSuppliedVariables(deployment);
+                .SubstituteBasedSettingsInSuppliedVariables(deployment.CurrentDirectory);
 
             substituter.Received().PerformSubstitution(Path.Combine(StagingDirectory, actualMatch), variables);
         }

--- a/source/Calamari.Tests/Fixtures/Manifest/ExecuteManifestCommandFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Manifest/ExecuteManifestCommandFixture.cs
@@ -68,6 +68,7 @@ namespace Calamari.Tests.Fixtures.Manifest
                     { nameof(NodeInstructions.NodePathVariable), toolRoot },
                     { nameof(NodeInstructions.TargetEntryPoint), "TargetEntryPoint_Value" },
                     { nameof(NodeInstructions.TargetPathVariable), "TargetPathVariable_Value" },
+                    { nameof(NodeInstructions.InputsVariable), "no_empty" },
                 };
 
                 var result = ExecuteCommand(variables, "Calamari.Tests");

--- a/source/Calamari.Tests/Fixtures/Manifest/ExecuteManifestCommandFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Manifest/ExecuteManifestCommandFixture.cs
@@ -75,8 +75,8 @@ namespace Calamari.Tests.Fixtures.Manifest
 
                 result.AssertSuccess();
                 result.AssertOutput("Hello from TestCommand");
-                result.AssertOutput(string.Join(Environment.NewLine, "Hello from my custom node!",
-                                                Path.Combine("BootstrapperPathVariable_Value", "bootstrapper.js"),
+                result.AssertOutput("Hello from my custom node!");
+                result.AssertOutput(string.Join(Path.Combine("BootstrapperPathVariable_Value", "bootstrapper.js"),
                                                 Path.Combine("TargetPathVariable_Value", "TargetEntryPoint")));
             }
         }

--- a/source/Calamari.Tests/Fixtures/Manifest/InstructionBuilder.cs
+++ b/source/Calamari.Tests/Fixtures/Manifest/InstructionBuilder.cs
@@ -45,7 +45,8 @@ namespace Calamari.Tests.Fixtures.Manifest
                                                                        BootstrapperPathVariable = nameof(NodeInstructions.BootstrapperPathVariable),
                                                                        NodePathVariable = nameof(NodeInstructions.NodePathVariable),
                                                                        TargetEntryPoint = nameof(NodeInstructions.TargetEntryPoint),
-                                                                       TargetPathVariable = nameof(NodeInstructions.TargetPathVariable)
+                                                                       TargetPathVariable = nameof(NodeInstructions.TargetPathVariable),
+                                                                       InputsVariable = nameof(NodeInstructions.InputsVariable)
                                                                    },
                                                                    JsonSerialization.GetDefaultSerializerSettings())
             });

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
@@ -40,23 +40,23 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             replacer.IsBestReplacerForFileName(Arg.Any<string>()).Returns(true);
 
             var log = new InMemoryLog();
-            var service = new StructuredConfigVariablesService(new []
-            {
-                replacer
-            }, fileSystem, log);
-
             var variables = new CalamariVariables();
             variables.Set(ActionVariables.AdditionalPaths, AdditionalPath);
             variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
             variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, FileName);
             variables.Set(PackageVariables.CustomInstallationDirectory, CurrentPath);
 
+            var service = new StructuredConfigVariablesService(new []
+            {
+                replacer
+            }, variables, fileSystem, log);
+
             var deployment = new RunningDeployment(CurrentPath, variables)
             {
                 CurrentDirectoryProvider = DeploymentWorkingDirectory.CustomDirectory
             };
 
-            service.ReplaceVariables(deployment);
+            service.ReplaceVariables(deployment.CurrentDirectory);
 
             replacerAssertions?.Invoke(replacer);
             logAssertions?.Invoke(log);

--- a/source/Calamari/Commands/ConfigurationTransformsCommand.cs
+++ b/source/Calamari/Commands/ConfigurationTransformsCommand.cs
@@ -1,18 +1,18 @@
 ﻿using System;
 using Calamari.Commands.Support;
 using Calamari.Common.Commands;
-using Calamari.Common.Features.Substitutions;
+using Calamari.Common.Features.Behaviours;
 using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Commands
 {
-    [Command("substitute-in-files")]
-    public class SubstituteInFilesCommand : Command
+    [Command("configuration-transforms")]
+    public class ConfigurationTransformsCommand : Command
     {
-        readonly ISubstituteInFiles substituteInFiles;
+        readonly ConfigurationTransformsBehaviour substituteInFiles;
         readonly string targetPath;
 
-        public SubstituteInFilesCommand(IVariables variables, ISubstituteInFiles substituteInFiles)
+        public ConfigurationTransformsCommand(IVariables variables, ConfigurationTransformsBehaviour substituteInFiles)
         {
             targetPath = variables.Get(PackageVariables.Output.InstallationDirectoryPath, String.Empty);
             this.substituteInFiles = substituteInFiles;
@@ -20,7 +20,7 @@ namespace Calamari.Commands
 
         public override int Execute(string[] commandLineArguments)
         {
-            substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(targetPath);
+            substituteInFiles.DoTransforms(targetPath);
             return 0;
         }
     }

--- a/source/Calamari/Commands/ConfigurationVariablesCommand.cs
+++ b/source/Calamari/Commands/ConfigurationVariablesCommand.cs
@@ -1,18 +1,18 @@
 ﻿using System;
 using Calamari.Commands.Support;
 using Calamari.Common.Commands;
-using Calamari.Common.Features.Substitutions;
+using Calamari.Common.Features.Behaviours;
 using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Commands
 {
-    [Command("substitute-in-files")]
-    public class SubstituteInFilesCommand : Command
+    [Command("configuration-variables")]
+    public class ConfigurationVariablesCommand : Command
     {
-        readonly ISubstituteInFiles substituteInFiles;
+        readonly ConfigurationVariablesBehaviour substituteInFiles;
         readonly string targetPath;
 
-        public SubstituteInFilesCommand(IVariables variables, ISubstituteInFiles substituteInFiles)
+        public ConfigurationVariablesCommand(IVariables variables, ConfigurationVariablesBehaviour substituteInFiles)
         {
             targetPath = variables.Get(PackageVariables.Output.InstallationDirectoryPath, String.Empty);
             this.substituteInFiles = substituteInFiles;
@@ -20,7 +20,7 @@ namespace Calamari.Commands
 
         public override int Execute(string[] commandLineArguments)
         {
-            substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(targetPath);
+            substituteInFiles.DoTransforms(targetPath);
             return 0;
         }
     }

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -76,7 +76,7 @@ namespace Calamari.Commands
 
             var replacer = new ConfigurationVariablesReplacer(variables, log);
             var allFileFormatReplacers = FileFormatVariableReplacers.BuildAllReplacers(fileSystem, log);
-            var structuredConfigVariablesService = new StructuredConfigVariablesService(allFileFormatReplacers, fileSystem, log);
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(allFileFormatReplacers, variables, fileSystem, log);
             var configurationTransformer = ConfigurationTransformer.FromVariables(variables, log);
             var transformFileLocator = new TransformFileLocator(fileSystem, log);
             var embeddedResources = new AssemblyEmbeddedResources();
@@ -101,8 +101,8 @@ namespace Calamari.Commands
                 new PackagedScriptConvention(new PreDeployPackagedScriptBehaviour(log, fileSystem, scriptEngine, commandLineRunner)),
                 new FeatureConvention(DeploymentStages.AfterPreDeploy, featureClasses, fileSystem, scriptEngine, commandLineRunner, embeddedResources),
                 new SubstituteInFilesConvention(new SubstituteInFilesBehaviour(substituteInFiles)),
-                new ConfigurationTransformsConvention(new ConfigurationTransformsBehaviour(fileSystem, configurationTransformer, transformFileLocator, log)),
-                new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, replacer, log)),
+                new ConfigurationTransformsConvention(new ConfigurationTransformsBehaviour(fileSystem, variables, configurationTransformer, transformFileLocator, log)),
+                new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, variables, replacer, log)),
                 new StructuredConfigurationVariablesConvention(new StructuredConfigurationVariablesBehaviour(structuredConfigVariablesService)),
                 new CopyPackageToCustomInstallationDirectoryConvention(fileSystem),
                 new FeatureConvention(DeploymentStages.BeforeDeploy, featureClasses, fileSystem, scriptEngine, commandLineRunner, embeddedResources),

--- a/source/Calamari/Commands/ExecuteManifestCommand.cs
+++ b/source/Calamari/Commands/ExecuteManifestCommand.cs
@@ -50,7 +50,15 @@ namespace Calamari.Commands
 
                 var result = tool.Value.Execute(instruction.LauncherInstructionsRaw, commandLineArguments.Skip(1).ToArray());
 
-                if (result != 0) return result;
+                if (result != 0)
+                {
+                    return result;
+                }
+
+                if (variables.GetFlag(KnownVariables.Action.SkipRemainingConventions))
+                {
+                    break;
+                }
             }
 
             return 0;

--- a/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
+++ b/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
@@ -74,7 +74,7 @@ namespace Calamari.Commands.Java
             var semaphore = SemaphoreFactory.Get();
             var journal = new DeploymentJournal(fileSystem, semaphore, variables);
             var allFileFormatReplacers = FileFormatVariableReplacers.BuildAllReplacers(fileSystem, log);
-            var structuredConfigVariablesService = new StructuredConfigVariablesService(allFileFormatReplacers, fileSystem, log);
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(allFileFormatReplacers, variables, fileSystem, log);
             var jarTools = new JarTool(commandLineRunner, log, variables);
             var packageExtractor = new JarPackageExtractor(jarTools);
             var embeddedResources = new AssemblyEmbeddedResources();

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -67,7 +67,7 @@ namespace Calamari.Commands
             var transformFileLocator = new TransformFileLocator(fileSystem, log);
             var replacer = new ConfigurationVariablesReplacer(variables, log);
             var allFileFormatReplacers = FileFormatVariableReplacers.BuildAllReplacers(fileSystem, log);
-            var structuredConfigVariablesService = new StructuredConfigVariablesService(allFileFormatReplacers, fileSystem, log);
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(allFileFormatReplacers, variables, fileSystem, log);
 
             ValidateArguments();
             WriteVariableScriptToFile();
@@ -76,11 +76,11 @@ namespace Calamari.Commands
             {
                 new StageScriptPackagesConvention(packageFile, fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner)),
                 // Substitute the script source file
-                new DelegateInstallConvention(d => substituteInFiles.Substitute(d, ScriptFileTargetFactory(d).ToList())),
+                new DelegateInstallConvention(d => substituteInFiles.Substitute(d.CurrentDirectory, ScriptFileTargetFactory(d).ToList())),
                 // Substitute any user-specified files
                 new SubstituteInFilesConvention(new SubstituteInFilesBehaviour(substituteInFiles)),
-                new ConfigurationTransformsConvention(new ConfigurationTransformsBehaviour(fileSystem, configurationTransformer, transformFileLocator, log)),
-                new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, replacer, log)),
+                new ConfigurationTransformsConvention(new ConfigurationTransformsBehaviour(fileSystem, variables, configurationTransformer, transformFileLocator, log)),
+                new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, variables, replacer, log)),
                 new StructuredConfigurationVariablesConvention(new StructuredConfigurationVariablesBehaviour(structuredConfigVariablesService)),
                 new ExecuteScriptConvention(scriptEngine, commandLineRunner)
             };

--- a/source/Calamari/Commands/StructuredConfigVariablesCommand.cs
+++ b/source/Calamari/Commands/StructuredConfigVariablesCommand.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Calamari.Commands.Support;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.StructuredVariables;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Commands
+{
+    [Command("structured-config-variables")]
+    public class StructuredConfigVariablesCommand : Command
+    {
+        readonly IStructuredConfigVariablesService structuredConfigVariablesService;
+        readonly string targetPath;
+
+        public StructuredConfigVariablesCommand(IVariables variables, IStructuredConfigVariablesService structuredConfigVariablesService)
+        {
+            targetPath = variables.Get(PackageVariables.Output.InstallationDirectoryPath, String.Empty);
+            this.structuredConfigVariablesService = structuredConfigVariablesService;
+        }
+
+        public override int Execute(string[] commandLineArguments)
+        {
+            structuredConfigVariablesService.ReplaceVariables(targetPath);
+            return 0;
+        }
+    }
+}

--- a/source/Calamari/Deployment/Conventions/AlreadyInstalledConvention.cs
+++ b/source/Calamari/Deployment/Conventions/AlreadyInstalledConvention.cs
@@ -40,7 +40,7 @@ namespace Calamari.Deployment.Conventions
                 log.Info("The package has already been installed on this machine, so installation will be skipped.");
                 log.SetOutputVariableButDoNotAddToVariables(PackageVariables.Output.InstallationDirectoryPath, previous.ExtractedTo);
                 log.SetOutputVariableButDoNotAddToVariables(PackageVariables.Output.DeprecatedInstallationDirectoryPath, previous.ExtractedTo);
-                deployment.Variables.Set(SpecialVariables.Action.SkipRemainingConventions, "true");
+                deployment.Variables.Set(KnownVariables.Action.SkipRemainingConventions, "true");
                 deployment.SkipJournal = true;
             }
         }

--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -72,9 +72,9 @@ namespace Calamari.Kubernetes.Commands
                 new StageScriptPackagesConvention(null, fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner), true),
                 new ConfiguredScriptConvention(new PreDeployConfiguredScriptBehaviour(log, fileSystem, scriptEngine, commandLineRunner)),
                 // Any values.yaml files in any packages referenced by the step will automatically have variable substitution applied (we won't log a warning if these aren't present)
-                new DelegateInstallConvention(d => substituteInFiles.Substitute(d, DefaultValuesFiles().ToList(), false)),
+                new DelegateInstallConvention(d => substituteInFiles.Substitute(d.CurrentDirectory, DefaultValuesFiles().ToList(), false)),
                 // Any values files explicitly specified by the user will also have variable substitution applied
-                new DelegateInstallConvention(d => substituteInFiles.Substitute(d, ExplicitlySpecifiedValuesFiles().ToList(), true)),
+                new DelegateInstallConvention(d => substituteInFiles.Substitute(d.CurrentDirectory, ExplicitlySpecifiedValuesFiles().ToList(), true)),
                 new ConfiguredScriptConvention(new DeployConfiguredScriptBehaviour(log, fileSystem, scriptEngine, commandLineRunner)),
                 new HelmUpgradeConvention(log, scriptEngine, commandLineRunner, fileSystem),
                 new ConfiguredScriptConvention(new PostDeployConfiguredScriptBehaviour(log, fileSystem, scriptEngine, commandLineRunner))

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -81,7 +81,7 @@ namespace Calamari.LaunchTools
         static string BuildNodePath(string pathToNode) => CalamariEnvironment.IsRunningOnWindows ? Path.Combine(pathToNode, "node.exe") : Path.Combine(pathToNode, "bin", "node");
 
         static string BuildArgs(string pathToBootstrapper, string pathToStepPackage, string pathToSensitiveVariables, string sensitiveVariablesSecret, string salt, string inputsKey) =>
-            $"\"{pathToBootstrapper}\" \"{pathToStepPackage}\" \"{pathToSensitiveVariables}\" \"{sensitiveVariablesSecret}\" \"{salt}\" \"{inputsKey}\"";
+            $"--input-type=module \"{pathToBootstrapper}\" \"{pathToStepPackage}\" \"{pathToSensitiveVariables}\" \"{sensitiveVariablesSecret}\" \"{salt}\" \"{inputsKey}\"";
     }
 
     public class NodeInstructions

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -69,6 +69,6 @@ namespace Calamari.LaunchTools
         public string TargetPathVariable { get; set; }
         public string BootstrapperPathVariable { get; set; }
         public string TargetEntryPoint { get; set; }
-        public string InputsVariable { get; }
+        public string InputsVariable { get; set; }
     }
 }

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -81,7 +81,7 @@ namespace Calamari.LaunchTools
         static string BuildNodePath(string pathToNode) => CalamariEnvironment.IsRunningOnWindows ? Path.Combine(pathToNode, "node.exe") : Path.Combine(pathToNode, "bin", "node");
 
         static string BuildArgs(string pathToBootstrapper, string pathToStepPackage, string pathToSensitiveVariables, string sensitiveVariablesSecret, string salt, string inputsKey) =>
-            $"--input-type=module \"{pathToBootstrapper}\" \"{pathToStepPackage}\" \"{pathToSensitiveVariables}\" \"{sensitiveVariablesSecret}\" \"{salt}\" \"{inputsKey}\"";
+            $"\"{pathToBootstrapper}\" \"{pathToStepPackage}\" \"{pathToSensitiveVariables}\" \"{sensitiveVariablesSecret}\" \"{salt}\" \"{inputsKey}\"";
     }
 
     public class NodeInstructions

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -44,6 +44,7 @@ namespace Calamari.LaunchTools
                                                                                 Path.Combine(pathToStepPackage, instructions.TargetEntryPoint),
                                                                                 variableFile.FilePath,
                                                                                 options.InputVariables.SensitiveVariablesPassword,
+                                                                                "Octopuss",
                                                                                 instructions.InputsVariable))
                 {
                     WorkingDirectory = runningDeployment.CurrentDirectory,
@@ -58,8 +59,8 @@ namespace Calamari.LaunchTools
 
         static string BuildNodePath(string pathToNode) => CalamariEnvironment.IsRunningOnWindows ? Path.Combine(pathToNode, "node.exe") : Path.Combine(pathToNode, "bin", "node");
 
-        static string BuildArgs(string pathToBootstrapper, string pathToStepPackage, string pathToSensitiveVariables, string sensitiveVariablesSecret, string inputsKey) =>
-            $"\"{pathToBootstrapper}\" \"{pathToStepPackage}\" \"{pathToSensitiveVariables}\" \"{sensitiveVariablesSecret}\" \"{inputsKey}\"";
+        static string BuildArgs(string pathToBootstrapper, string pathToStepPackage, string pathToSensitiveVariables, string sensitiveVariablesSecret, string salt, string inputsKey) =>
+            $"\"{pathToBootstrapper}\" \"{pathToStepPackage}\" \"{pathToSensitiveVariables}\" \"{sensitiveVariablesSecret}\" \"{salt}\" \"{inputsKey}\"";
     }
 
     public class NodeInstructions

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -44,7 +44,7 @@ namespace Calamari.LaunchTools
                                                                                 Path.Combine(pathToStepPackage, instructions.TargetEntryPoint),
                                                                                 variableFile.FilePath,
                                                                                 options.InputVariables.SensitiveVariablesPassword,
-                                                                                Guid.NewGuid().ToString("N"),
+                                                                                AesEncryption.SaltRaw,
                                                                                 instructions.InputsVariable))
                 {
                     WorkingDirectory = runningDeployment.CurrentDirectory,

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -44,7 +44,7 @@ namespace Calamari.LaunchTools
                                                                                 Path.Combine(pathToStepPackage, instructions.TargetEntryPoint),
                                                                                 variableFile.FilePath,
                                                                                 options.InputVariables.SensitiveVariablesPassword,
-                                                                                "Octopuss",
+                                                                                Guid.NewGuid().ToString("N"),
                                                                                 instructions.InputsVariable))
                 {
                     WorkingDirectory = runningDeployment.CurrentDirectory,


### PR DESCRIPTION
This is so that we can use them individually for step packages.

I have converted the following behaviours to commands:
- `SubstituteInFilesBehaviour`
- `ConfigurationTransformsBehaviour`
- `ConfigurationVariablesBehaviour`
- `StructuredConfigurationVariablesBehaviour`
           
The majority of the work was to refactor the current implementations, so they do not depend on `RunningDeployment` which does not exist in raw `ICommand` implementations.

We are also honouring `SkipRemainingConventions` flag 