### PR TITLE
K8S: Add Pod Service Account authentication

### DIFF
--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -127,7 +127,7 @@ function setup_context {
     kubectl config set-cluster octocluster --server=$Octopus_K8S_ClusterUrl
     
     if [[ -z $Octopus_K8s_Server_Cert_From_Path ]]; then
-      kubectl config set-cluster octocluster --insecure-skip-tls-verify=$SkipTlsVerification
+      kubectl config set-cluster octocluster --insecure-skip-tls-verify=$Octopus_K8S_SkipTlsVerification
     else
       kubectl config set-cluster octocluster --certificate-authority=$Octopus_K8s_Server_Cert_Path
     fi

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -12,6 +12,10 @@ Octopus_K8S_Client_Cert_Pem=$(get_octopusvariable "${Octopus_K8S_Client_Cert}.Ce
 Octopus_K8S_Client_Cert_Key=$(get_octopusvariable "${Octopus_K8S_Client_Cert}.PrivateKeyPem")
 Octopus_K8S_Server_Cert=$(get_octopusvariable "Octopus.Action.Kubernetes.CertificateAuthority")
 Octopus_K8S_Server_Cert_Pem=$(get_octopusvariable "${Octopus_K8S_Server_Cert}.CertificatePem")
+Octopus_K8s_Server_Cert_Path=$(get_octopusvariable "Octopus.Action.Kubernetes.PodServiceAccountTokenPath")
+Octopus_K8s_Pod_Service_Account_Token_Path=$(get_octopusvariable "Octopus.Action.Kubernetes.PodServiceAccountTokenPath")
+echo >&2 $Octopus_K8s_Server_Cert_Path
+echo >&2 $Octopus_K8s_Pod_Service_Account_Token_Path
 
 function check_app_exists {
 	command -v $1 > /dev/null 2>&1
@@ -71,7 +75,7 @@ function setup_context {
     exit 1
   fi
 
-  if [[ -z $Octopus_AccountType && -z $Octopus_K8S_Client_Cert && ${Octopus_EKS_Use_Instance_Role,,} != "true" ]]; then
+  if [[ -z $Octopus_AccountType && -z $Octopus_K8S_Client_Cert && -z $Octopus_K8s_Pod_Service_Account_Token_Path && ${Octopus_EKS_Use_Instance_Role,,} != "true" ]]; then
     echo >&2 "Kubernetes account type or certificate is missing"
     exit 1
   fi

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -131,7 +131,7 @@ function setup_context {
       K8S_Azure_Cluster+="-admin"
     fi
     kubectl config set-context $K8S_Azure_Cluster --namespace=$Octopus_K8S_Namespace
-  elif [[ $IsUsingPodServiceAccount ]]; then
+  elif [[ $IsUsingPodServiceAccount == "true" ]]; then
     kubectl config set-cluster octocluster --server=$Octopus_K8S_ClusterUrl
     
     if [[ -z $Octopus_K8s_Server_Cert_From_Path ]]; then

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -74,7 +74,7 @@ function setup_context {
   fi
   
   if [[ -z $Octopus_AccountType && -z $Octopus_K8S_Client_Cert && ${Octopus_EKS_Use_Instance_Role,,} != "true" ]]; then
-    if (-z $Octopus_K8s_Pod_Service_Account_Token_Path && -z $Octopus_K8s_Server_Cert_Path) then
+    if [[ -z $Octopus_K8s_Pod_Service_Account_Token_Path && -z $Octopus_K8s_Server_Cert_Path ]] then
       echo >&2 "Kubernetes account type or certificate is missing"
       exit 1
     fi

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -14,8 +14,6 @@ Octopus_K8S_Server_Cert=$(get_octopusvariable "Octopus.Action.Kubernetes.Certifi
 Octopus_K8S_Server_Cert_Pem=$(get_octopusvariable "${Octopus_K8S_Server_Cert}.CertificatePem")
 Octopus_K8s_Server_Cert_Path=$(get_octopusvariable "Octopus.Action.Kubernetes.CertificateAuthorityPath")
 Octopus_K8s_Pod_Service_Account_Token_Path=$(get_octopusvariable "Octopus.Action.Kubernetes.PodServiceAccountTokenPath")
-echo >&2 $Octopus_K8s_Server_Cert_Path
-echo >&2 $Octopus_K8s_Pod_Service_Account_Token_Path
 
 function check_app_exists {
 	command -v $1 > /dev/null 2>&1
@@ -75,9 +73,15 @@ function setup_context {
     exit 1
   fi
 
-  if [[ -z $Octopus_AccountType && -z $Octopus_K8S_Client_Cert && -z $Octopus_K8s_Pod_Service_Account_Token_Path && ${Octopus_EKS_Use_Instance_Role,,} != "true" ]]; then
-    echo >&2 "Kubernetes account type or certificate is missing"
-    exit 1
+  if [[ -z $Octopus_AccountType && -z $Octopus_K8S_Client_Cert && ${Octopus_EKS_Use_Instance_Role,,} != "true" ]]; then
+    if (-z $Octopus_K8s_Pod_Service_Account_Token_Path && -z Octopus_K8s_Server_Cert_Path) then
+      echo >&2 "Kubernetes account type or certificate is missing"
+      exit 1
+    fi
+    Octopus_K8s_Pod_Service_Account_Token=$(cat ${Octopus_K8s_Pod_Service_Account_Token_Path})
+    Octopus_K8s_Server_Cert=$(cat ${Octopus_K8s_Server_Cert_Path})
+    echo >&2 "${Octopus_K8s_Pod_Service_Account_Token}"
+    echo >&2 "${Octopus_K8s_Server_Cert}"
   fi
 
   if [[ -z $Octopus_K8S_Namespace ]]; then

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -79,10 +79,13 @@ function setup_context {
       exit 1
     fi
     
-    Octopus_K8s_Pod_Service_Account_Token=$(cat ${Octopus_K8s_Pod_Service_Account_Token_Path} | base64 $base64_args)
-    Octopus_K8s_Server_Cert=$(cat ${Octopus_K8s_Server_Cert_Path} | base64 $base64_args)
-    if [[ -z $Octopus_K8s_Pod_Service_Account_Token || -z $Octopus_K8s_Server_Cert ]]; then
-      echo >&2 "Pod service token file or certificate authority file is missing"
+    Octopus_K8s_Pod_Service_Account_Token=$(cat ${Octopus_K8s_Pod_Service_Account_Token_Path})
+    Octopus_K8s_Server_Cert=$(cat ${Octopus_K8s_Server_Cert_Path})
+    if [[ -z $Octopus_K8s_Pod_Service_Account_Token ]]; then
+      echo >&2 "Pod service token file not found"
+      exit 1
+    elif [[ -z $Octopus_K8s_Server_Cert ]]; then
+      echo >&2 "Certificate authority file not found"
       exit 1
     else
       IsUsingPodServiceAccount=true

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -14,6 +14,9 @@ Octopus_K8S_Server_Cert=$(get_octopusvariable "Octopus.Action.Kubernetes.Certifi
 Octopus_K8S_Server_Cert_Pem=$(get_octopusvariable "${Octopus_K8S_Server_Cert}.CertificatePem")
 Octopus_K8s_Server_Cert_Path=$(get_octopusvariable "Octopus.Action.Kubernetes.CertificateAuthorityPath")
 Octopus_K8s_Pod_Service_Account_Token_Path=$(get_octopusvariable "Octopus.Action.Kubernetes.PodServiceAccountTokenPath")
+Octopus_K8s_Pod_Service_Account_Token=""
+Octopus_K8s_Server_Cert_From_Path=""
+IsUsingPodServiceAccount=false
 
 function check_app_exists {
 	command -v $1 > /dev/null 2>&1
@@ -79,8 +82,13 @@ function setup_context {
       exit 1
     fi
     
-    Octopus_K8s_Pod_Service_Account_Token=$(cat ${Octopus_K8s_Pod_Service_Account_Token_Path})
-    Octopus_K8s_Server_Cert_From_Path=$(cat ${Octopus_K8s_Server_Cert_Path})
+    if [[ ! -z $Octopus_K8s_Pod_Service_Account_Token_Path ]]; then
+      Octopus_K8s_Pod_Service_Account_Token=$(cat ${Octopus_K8s_Pod_Service_Account_Token_Path})
+    fi
+    if [[ ! -z $Octopus_K8s_Server_Cert_Path ]]; then
+      Octopus_K8s_Server_Cert_From_Path=$(cat ${Octopus_K8s_Server_Cert_Path})
+    fi
+    
     if [[ -z $Octopus_K8s_Pod_Service_Account_Token ]]; then
       echo >&2 "Pod service token file not found"
       exit 1

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -12,7 +12,7 @@ Octopus_K8S_Client_Cert_Pem=$(get_octopusvariable "${Octopus_K8S_Client_Cert}.Ce
 Octopus_K8S_Client_Cert_Key=$(get_octopusvariable "${Octopus_K8S_Client_Cert}.PrivateKeyPem")
 Octopus_K8S_Server_Cert=$(get_octopusvariable "Octopus.Action.Kubernetes.CertificateAuthority")
 Octopus_K8S_Server_Cert_Pem=$(get_octopusvariable "${Octopus_K8S_Server_Cert}.CertificatePem")
-Octopus_K8s_Server_Cert_Path=$(get_octopusvariable "Octopus.Action.Kubernetes.PodServiceAccountTokenPath")
+Octopus_K8s_Server_Cert_Path=$(get_octopusvariable "Octopus.Action.Kubernetes.CertificateAuthorityPath")
 Octopus_K8s_Pod_Service_Account_Token_Path=$(get_octopusvariable "Octopus.Action.Kubernetes.PodServiceAccountTokenPath")
 echo >&2 $Octopus_K8s_Server_Cert_Path
 echo >&2 $Octopus_K8s_Pod_Service_Account_Token_Path

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -128,7 +128,7 @@ function setup_context {
     kubectl config set-context $K8S_Azure_Cluster --namespace=$Octopus_K8S_Namespace
   elif [[ $IsUsingPodServiceAccount ]]; then
     echo "Creating kubectl context to $Octopus_K8S_ClusterUrl (namespace $Octopus_K8S_Namespace) using Pod Service Account"
-    kubectl config set-cluster octocluster --server=$Octopus_K8S_ClusterUrl --certificate-authority=${Octopus_K8s_Server_Cert_Path}
+    kubectl config set-cluster octocluster --server=$Octopus_K8S_ClusterUrl --certificate-authority=$Octopus_K8s_Server_Cert_Path
     kubectl config set-context octocontext --user=octouser --cluster=octocluster --namespace=$Octopus_K8S_Namespace
     kubectl config use-context octocontext
     kubectl config set-credentials octouser --token=$Octopus_K8s_Pod_Service_Account_Token

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -74,7 +74,7 @@ function setup_context {
   fi
   
   if [[ -z $Octopus_AccountType && -z $Octopus_K8S_Client_Cert && ${Octopus_EKS_Use_Instance_Role,,} != "true" ]]; then
-    if [[ -z $Octopus_K8s_Pod_Service_Account_Token_Path && -z $Octopus_K8s_Server_Cert_Path ]] then
+    if [[ -z $Octopus_K8s_Pod_Service_Account_Token_Path && -z $Octopus_K8s_Server_Cert_Path ]]; then
       echo >&2 "Kubernetes account type or certificate is missing"
       exit 1
     fi

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -197,7 +197,7 @@ function SetupContext {
 			$K8S_Azure_Cluster += "-admin"
 		}
 		& $Kubectl_Exe config set-context $K8S_Azure_Cluster --namespace=$K8S_Namespace
-	} elseif() {
+	} elseif($IsUsingPodServiceAccount -eq $true) {
 	  Write-Verbose "$Kubectl_Exe config set-cluster octocluster --server=$K8S_ClusterUrl --certificate-authority=$Octopus_K8s_Server_Cert_Path"
     & $Kubectl_Exe config set-cluster octocluster --server=$K8S_ClusterUrl --certificate-authority=$Octopus_K8s_Server_Cert_Path
 

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -152,16 +152,13 @@ function SetupContext {
 		if([string]::IsNullOrEmpty($Octopus_K8s_Pod_Service_Account_Token)){
 		  Write-Error "Pod service token file not found"
       Exit 1
-		} elseif([string]::IsNullOrEmpty($Octopus_K8s_Server_Cert)){
-      Write-Error "Certificate authority file not found"
-      Exit 1
-    } else {
+		} else {
       $IsUsingPodServiceAccount = $true
     }
 	}
 
 	if([string]::IsNullOrEmpty($K8S_Namespace)){
-		Write-Verbose "No namespace provded. Using default"
+		Write-Verbose "No namespace provided. Using default"
 		$K8S_Namespace="default"
 	}
 
@@ -187,19 +184,24 @@ function SetupContext {
 		$K8S_Azure_Cluster=$OctopusParameters["Octopus.Action.Kubernetes.AksClusterName"]
 		$K8S_Azure_Admin=$OctopusParameters["Octopus.Action.Kubernetes.AksAdminLogin"]
 		Write-Host "Creating kubectl context to AKS Cluster in resource group $K8S_Azure_Resource_Group called $K8S_Azure_Cluster (namespace $K8S_Namespace) using a AzureServicePrincipal"
-		if ([string]::IsNullOrEmpty($K8S_Azure_Admin) -or -not $K8S_Azure_Admin -ieq "true")
-		{
+		if ([string]::IsNullOrEmpty($K8S_Azure_Admin) -or -not $K8S_Azure_Admin -ieq "true") {
 			& az aks get-credentials --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $env:KUBECONFIG --overwrite-existing
-		}
-		else
-		{
+		} else {
 			& az aks get-credentials --admin --resource-group $K8S_Azure_Resource_Group --name $K8S_Azure_Cluster --file $env:KUBECONFIG --overwrite-existing
 			$K8S_Azure_Cluster += "-admin"
 		}
 		& $Kubectl_Exe config set-context $K8S_Azure_Cluster --namespace=$K8S_Namespace
 	} elseif($IsUsingPodServiceAccount -eq $true) {
-	  Write-Verbose "$Kubectl_Exe config set-cluster octocluster --server=$K8S_ClusterUrl --certificate-authority=$Octopus_K8s_Server_Cert_Path"
-    & $Kubectl_Exe config set-cluster octocluster --server=$K8S_ClusterUrl --certificate-authority=$Octopus_K8s_Server_Cert_Path
+	  Write-Verbose "$Kubectl_Exe config set-cluster octocluster --server=$K8S_ClusterUrl"
+    & $Kubectl_Exe config set-cluster octocluster --server=$K8S_ClusterUrl
+    
+    if([string]::IsNullOrEmpty($Octopus_K8s_Server_Cert)){
+      Write-Verbose "$Kubectl_Exe config set-cluster octocluster --insecure-skip-tls-verify=$K8S_SkipTlsVerification"
+      & $Kubectl_Exe config set-cluster octocluster --insecure-skip-tls-verify=$K8S_SkipTlsVerification
+    } else {
+      Write-Verbose "$Kubectl_Exe config set-cluster octocluster --certificate-authority=$Octopus_K8s_Server_Cert_Path"
+      & $Kubectl_Exe config set-cluster octocluster --certificate-authority=$Octopus_K8s_Server_Cert_Path
+    }
 
     Write-Verbose "$Kubectl_Exe config set-context octocontext --user=octouser --cluster=octocluster --namespace=$K8S_Namespace"
     & $Kubectl_Exe config set-context octocontext --user=octouser --cluster=octocluster --namespace=$K8S_Namespace
@@ -207,6 +209,7 @@ function SetupContext {
     Write-Verbose "$Kubectl_Exe config use-context octocontext"
     & $Kubectl_Exe config use-context octocontext
     
+    Write-Host "Creating kubectl context to $K8S_ClusterUrl (namespace $K8S_Namespace) using a Pod Service Account Token"
     Write-Verbose "$Kubectl_Exe config set-credentials octouser --token=$Octopus_K8s_Pod_Service_Account_Token"
     & $Kubectl_Exe config set-credentials octouser --token=$Octopus_K8s_Pod_Service_Account_Token
 	} else {
@@ -253,8 +256,7 @@ function SetupContext {
 			# Inline the certificate as base64 encoded data
 			Write-Verbose "$Kubectl_Exe config set clusters.octocluster.certificate-authority-data <server-cert-pem>"
 			& $Kubectl_Exe config set clusters.octocluster.certificate-authority-data $([Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($K8S_Server_Cert_Pem)))
-		}
-		else {
+		} else {
 			Write-Verbose "$Kubectl_Exe config set-cluster octocluster --insecure-skip-tls-verify=$K8S_SkipTlsVerification"
 			& $Kubectl_Exe config set-cluster octocluster --insecure-skip-tls-verify=$K8S_SkipTlsVerification
 		}
@@ -297,9 +299,7 @@ function SetupContext {
 			Add-Content -NoNewline -Path $env:KUBECONFIG -Value "        - `"token`"`n"
 			Add-Content -NoNewline -Path $env:KUBECONFIG -Value "        - `"-i`"`n"
 			Add-Content -NoNewline -Path $env:KUBECONFIG -Value "        - `"$K8S_ClusterName`""
-		}
-		elseif ([string]::IsNullOrEmpty($K8S_Client_Cert)) {
-
+		} elseif ([string]::IsNullOrEmpty($K8S_Client_Cert)) {
 			Write-Error "Account Type $K8S_AccountType is currently not valid for kubectl contexts"
 			Exit 1
 		}
@@ -315,18 +315,14 @@ function ConfigureKubeCtlPath {
 
 function CreateNamespace {
 	if (-not [string]::IsNullOrEmpty($K8S_Namespace)) {
-
-		try
-		{
+		try {
 			# We need to continue if "kubectl get namespace" fails
 			$backupErrorActionPreference = $script:ErrorActionPreference
 			$script:ErrorActionPreference = "Continue"
 
 			# Attempt to get the outputs. This will fail if none are defined.
 			$outputResult = & $Kubectl_Exe get namespace $K8S_Namespace 2> $null
-		}
-		finally
-		{
+		} finally {
 			# Restore the default setting
 			$script:ErrorActionPreference = $backupErrorActionPreference
 

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -31,6 +31,8 @@ $K8S_Server_Cert = $OctopusParameters["Octopus.Action.Kubernetes.CertificateAuth
 $K8S_Server_Cert_Pem = $OctopusParameters["$($K8S_Server_Cert).CertificatePem"]
 $Octopus_K8s_Server_Cert_Path = $OctopusParameters["Octopus.Action.Kubernetes.CertificateAuthorityPath"]
 $Octopus_K8s_Pod_Service_Account_Token_Path = $OctopusParameters["Octopus.Action.Kubernetes.PodServiceAccountTokenPath"]
+$Octopus_K8s_Pod_Service_Account_Token = ""
+$Octopus_K8s_Server_Cert = ""
 $IsUsingPodServiceAccount = $false
 $Kubectl_Exe=GetKubectl
 
@@ -146,9 +148,13 @@ function SetupContext {
 	    Write-Error "Kubernetes account type or certificate is missing"
     	Exit 1
 	  }
+		if (![string]::IsNullOrEmpty($Octopus_K8s_Pod_Service_Account_Token_Path)) {
+		  $Octopus_K8s_Pod_Service_Account_Token = Get-Content -Path $Octopus_K8s_Pod_Service_Account_Token_Path
+		}
+		if (![string]::IsNullOrEmpty($Octopus_K8s_Server_Cert_Path)) {
+		  $Octopus_K8s_Server_Cert = Get-Content -Path $Octopus_K8s_Server_Cert_Path
+		}
 		
-		$Octopus_K8s_Pod_Service_Account_Token = Get-Content -Path $Octopus_K8s_Pod_Service_Account_Token_Path
-		$Octopus_K8s_Server_Cert = Get-Content -Path $Octopus_K8s_Server_Cert_Path
 		if([string]::IsNullOrEmpty($Octopus_K8s_Pod_Service_Account_Token)){
 		  Write-Error "Pod service token file not found"
       Exit 1


### PR DESCRIPTION
# Background

When running a worker as a container in a Kubernetes cluster, it is possible to connect back to the parent cluster using the service account token and cluster certificate files mounted as files in the pod. 

This allows Kubernetes workers to manage the cluster they are deployed to without sending down any additional credentials.

This PR is to implement the ability to use Pod Service Account as a mean of authentication when creating Kubernetes deployment targets. The details of this changes can be found in the pitch document below.

Pitch document: https://docs.google.com/document/d/1Psj5saZqhBDlEhbn6s361X_HXWk4jA9EEaqyGaeWyLI/edit#heading=h.eeq4erbzkzf8

Octopus Server PR: https://github.com/OctopusDeploy/OctopusDeploy/pull/8637

# Results

The script `KubectlPowershellContext.ps1` and `KubectlBashContext.sh` is updated to create a valid context using the information of the Pod Service Account.

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites
- [x ] I have considered informing or consulting the right people, e.g.: 
  - For changes to the execution pipeline: [`#topic-execution`](https://octopusdeploy.slack.com/archives/C3KT1DFSM)
  - For other changes, consider the other `#topic-...` channels
- [x ] I have considered whether this should be a patch or wait for a minor.
- [x ] I have considered appropriate testing for my change.