### PR TITLE
Fixed: ExecuteManifestCommandFixture test

### DIFF
--- a/source/Calamari.Tests/Fixtures/Manifest/ExecuteManifestCommandFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Manifest/ExecuteManifestCommandFixture.cs
@@ -73,7 +73,8 @@ namespace Calamari.Tests.Fixtures.Manifest
                 var result = ExecuteCommand(variables, "Calamari.Tests");
 
                 result.AssertSuccess();
-                result.AssertOutput(string.Join(Environment.NewLine, "Hello from TestCommand", "Hello from my custom node!",
+                result.AssertOutput("Hello from TestCommand");
+                result.AssertOutput(string.Join(Environment.NewLine, "Hello from my custom node!",
                                                 Path.Combine("BootstrapperPathVariable_Value", "bootstrapper.js"),
                                                 Path.Combine("TargetPathVariable_Value", "TargetEntryPoint")));
             }


### PR DESCRIPTION
The test `WithInstructions` in `ExecuteManifestCommandFixture.cs` has been failing since [this commit](https://github.com/OctopusDeploy/Calamari/commit/95916d5534534d37bf5dcd9ff3025d8ebc72f444) was merged to `master`

The branch https://github.com/OctopusDeploy/Calamari/pull/716 doesn't contain the change from the above commit so I didn't notice this test would fail in `master`. The build in that branch was successful but after being merged to master, the release cannot be built. 

This PR is to change the way we assert the outputs in that test.