### PR TITLE
Restrict permissions on kubectl-octo.yml config file

### DIFF
--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -229,7 +229,8 @@ function setup_context {
 function configure_kubectl_path {
   export KUBECONFIG=$(get_octopusvariable "Octopus.Action.Kubernetes.KubectlConfig")
   echo "Temporary kubectl config set to $KUBECONFIG"
-  echo "" >> $KUBECONFIG
+  # create an empty file, to suppress kubectl errors about the file missing
+  echo "" > $KUBECONFIG
   chmod 600 $KUBECONFIG
 }
 

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -231,7 +231,7 @@ function configure_kubectl_path {
   echo "Temporary kubectl config set to $KUBECONFIG"
   # create an empty file, to suppress kubectl errors about the file missing
   echo "" > $KUBECONFIG
-  chmod 600 $KUBECONFIG
+  chmod u=rw,g=,o= $KUBECONFIG
 }
 
 function create_namespace {

--- a/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
+++ b/source/Calamari/Kubernetes/Scripts/KubectlBashContext.sh
@@ -230,6 +230,7 @@ function configure_kubectl_path {
   export KUBECONFIG=$(get_octopusvariable "Octopus.Action.Kubernetes.KubectlConfig")
   echo "Temporary kubectl config set to $KUBECONFIG"
   echo "" >> $KUBECONFIG
+  chmod 600 $KUBECONFIG
 }
 
 function create_namespace {


### PR DESCRIPTION
When creating the config file, we can start with it being readable/writable only by the file owner.

This will suppress warnings from tools that expect this file to have these permissions, fixing OctopusDeploy/Issues#6858.

We also initially make sure the file is empty if the file already exists, which mirrors the behaviour of the PowerShell script. As this is a temporarily created file, the file shouldn't exist, but this should clarify the intent.