### PR TITLE
Allow go durations for the helm timeout value

### DIFF
--- a/source/Calamari.Shared/Util/GoDurationParser.cs
+++ b/source/Calamari.Shared/Util/GoDurationParser.cs
@@ -1,0 +1,20 @@
+using System.Text.RegularExpressions;
+
+namespace Calamari.Util
+{
+    public static class GoDurationParser
+    {
+        /// <summary>
+        /// https://golang.org/pkg/time/#ParseDuration
+        /// A duration string is a possibly signed sequence of decimal numbers, each with optional fraction
+        /// and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"),
+        /// "ms", "s", "m", "h". 
+        /// </summary>
+        static readonly Regex DurationRegex = new Regex(@"[+-]?(\d+(\.\d+)?(ns|us|µs|ms|s|m|h)?)+");
+        
+        public static bool ValidateTimeout(string timeout)
+        {
+            return DurationRegex.IsMatch(timeout);
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/GoDurationParserFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/GoDurationParserFixture.cs
@@ -1,12 +1,11 @@
-using System.Text.RegularExpressions;
-using Calamari.Kubernetes.Conventions;
+using Calamari.Util;
 using FluentAssertions;
 using NUnit.Framework;
 
 namespace Calamari.Tests.KubernetesFixtures
 {
     [TestFixture]
-    public class HelmValidationFixture
+    public class GoDurationParserFixture
     {
         [TestCase("100")]
         [TestCase("100s")]
@@ -18,7 +17,7 @@ namespace Calamari.Tests.KubernetesFixtures
         [TestCase("2h45m")]
         public void ValidateTimeouts(string timeout)
         {
-            HelmUpgradeConvention.ValidateTimeout(timeout).Should().BeTrue();
+            GoDurationParser.ValidateTimeout(timeout).Should().BeTrue();
         }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/HelmValidationFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmValidationFixture.cs
@@ -1,0 +1,24 @@
+using System.Text.RegularExpressions;
+using Calamari.Kubernetes.Conventions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures
+{
+    [TestFixture]
+    public class HelmValidationFixture
+    {
+        [TestCase("100")]
+        [TestCase("100s")]
+        [TestCase("100us")]
+        [TestCase("100µs")]
+        [TestCase("100m10s")]
+        [TestCase("300ms")]
+        [TestCase("-1.5h")]
+        [TestCase("2h45m")]
+        public void ValidateTimeouts(string timeout)
+        {
+            HelmUpgradeConvention.ValidateTimeout(timeout).Should().BeTrue();
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -19,13 +19,6 @@ namespace Calamari.Kubernetes.Conventions
 {
     public class HelmUpgradeConvention : IInstallConvention
     {
-        /// <summary>
-        /// https://golang.org/pkg/time/#ParseDuration
-        /// A duration string is a possibly signed sequence of decimal numbers, each with optional fraction
-        /// and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"),
-        /// "ms", "s", "m", "h". 
-        /// </summary>
-        const string DurationRegex = @"[+-]?(\d+(\.\d+)?(ns|us|µs|ms|s|m|h)?)+";
         readonly ILog log;
         readonly IScriptEngine scriptEngine;
         readonly ICommandLineRunner commandLineRunner;
@@ -202,17 +195,12 @@ namespace Calamari.Kubernetes.Conventions
             
             var timeout = deployment.Variables.Get(SpecialVariables.Helm.Timeout);
             
-            if (!ValidateTimeout(timeout))
+            if (!GoDurationParser.ValidateTimeout(timeout))
             {
                 throw new CommandException($"Timeout period is not a valid duration: {timeout}");
             }
 
             sb.Append($" --timeout \"{timeout}\"");
-        }
-
-        public static bool ValidateTimeout(string timeout)
-        {
-            return new Regex(DurationRegex).IsMatch(timeout);
         }
 
         static void SetTillerTimeoutParameter(RunningDeployment deployment, StringBuilder sb)

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -194,10 +194,6 @@ namespace Calamari.Kubernetes.Conventions
             if (!deployment.Variables.IsSet(SpecialVariables.Helm.Timeout)) return;
             
             var timeout = deployment.Variables.Get(SpecialVariables.Helm.Timeout);
-            if (!int.TryParse(timeout, out _))
-            {
-                throw new CommandException($"Timeout period is not a valid integer: {timeout}");
-            }
 
             sb.Append($" --timeout \"{timeout}\"");
         }


### PR DESCRIPTION
Helm 3 has moved to a duration field for the `--timeout` parameter. This PR updates the validation to allow a Go duration field to be provided.

The associated unit tests validate the timeout field parsing.

Fixes https://github.com/OctopusDeploy/Issues/issues/6820

