### PR TITLE
NGINX output is now captured as verbose messages

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
+++ b/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
@@ -34,10 +34,10 @@ fi
 
 echo "Validating nginx configuration"
 echo "##octopus[stdout-verbose]"
-sudo nginx -t
+sudo nginx -t 2>&1
 echo "##octopus[stdout-default]"
 
 echo "Reloading nginx configuration"
 echo "##octopus[stdout-verbose]"
-sudo nginx -s reload
+sudo nginx -s reload 2>&1
 echo "##octopus[stdout-default]"

--- a/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
+++ b/source/Calamari/Scripts/Octopus.Features.Nginx_AfterDeploy.sh
@@ -13,11 +13,11 @@ trap 'echo "Removing temporary folder ${nginxTempDir}..." && sudo rm -rf $nginxT
 nginxConfRoot=${nginxConfDir:-/etc/nginx/conf.d}
 
 echo "Clearing the existing locations dir"
-for dir in $nginxTempDir/conf/* 
-do 
+for dir in $nginxTempDir/conf/*
+do
     fixedDir=${dir##*/}
     if [[ -d "$dir" && ! -L "$dir" && -d "$nginxConfRoot/$fixedDir" ]]
-    then         
+    then
         sudo rm -rf $nginxConfRoot/$fixedDir
     fi
 done
@@ -33,7 +33,11 @@ if [ -d "$nginxTempDir/ssl" ]; then
 fi
 
 echo "Validating nginx configuration"
+echo "##octopus[stdout-verbose]"
 sudo nginx -t
+echo "##octopus[stdout-default]"
 
 echo "Reloading nginx configuration"
+echo "##octopus[stdout-verbose]"
 sudo nginx -s reload
+echo "##octopus[stdout-default]"


### PR DESCRIPTION
Nginx writes many diagnostic messages to the error stream, which Octopus will highlight in red. This makes them look like errors when they are actually expected output.

This PR captures the nginx output as verbose and redirects std err to std out.

# Before

![image](https://user-images.githubusercontent.com/160104/118069338-59c78f80-b3e7-11eb-8fe7-5937a78df420.png)

# After

![image](https://user-images.githubusercontent.com/160104/118069371-6b109c00-b3e7-11eb-91dd-2fd847f8b618.png)

![image](https://user-images.githubusercontent.com/160104/118069573-c478cb00-b3e7-11eb-9727-5dcebcf26178.png)

