### PR TITLE
Fixes kubernetes powershell azure auth to work with Powershell Core

### DIFF
--- a/source/Calamari.Tests/Fixtures/RequiresPowerShell5Attribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresPowerShell5Attribute.cs
@@ -1,0 +1,19 @@
+﻿using Calamari.Common.Plumbing.Extensions;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace Calamari.Tests.Fixtures
+{
+    public class RequiresPowerShell5OrLowerAttribute : NUnitAttribute, IApplyToTest
+    {
+        public void ApplyToTest(Test test)
+        {
+            if (ScriptingEnvironment.SafelyGetPowerShellVersion().Major > 5)
+            {
+                test.RunState = RunState.Skipped;
+                test.Properties.Set(PropertyNames.SkipReason, "This test requires PowerShell 5 or older.");
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/RequiresPowerShellCoreAttribute.cs
+++ b/source/Calamari.Tests/Fixtures/RequiresPowerShellCoreAttribute.cs
@@ -1,0 +1,19 @@
+﻿using Calamari.Common.Plumbing.Extensions;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace Calamari.Tests.Fixtures
+{
+    public class RequiresPowerShellCoreAttribute : NUnitAttribute, IApplyToTest
+    {
+        public void ApplyToTest(Test test)
+        {
+            if (ScriptingEnvironment.SafelyGetPowerShellVersion().Major < 6)
+            {
+                test.RunState = RunState.Skipped;
+                test.Properties.Set(PropertyNames.SkipReason, "This test requires PowerShell Core (6) or newer.");
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -8,6 +8,7 @@ using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes;
+using Calamari.Tests.Fixtures;
 using Calamari.Tests.Helpers;
 using FluentAssertions;
 using NUnit.Framework;
@@ -42,6 +43,7 @@ namespace Calamari.Tests.KubernetesFixtures
 
         [Test]
         [Category(TestCategory.CompatibleOS.OnlyWindows)]
+        [RequiresPowerShell5OrLower]
         public void WindowsPowershellKubeCtlScripts()
         {
             SetTestClusterVariables();
@@ -52,6 +54,8 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [RequiresNonFreeBSDPlatform]
+        [RequiresPowerShellCore]
         public void PowershellCoreKubeCtlScripts()
         {
             SetTestClusterVariables();
@@ -63,6 +67,7 @@ namespace Calamari.Tests.KubernetesFixtures
 
         [Test]
         [Category(TestCategory.CompatibleOS.OnlyNix)]
+        [RequiresNonFreeBSDPlatform]
         public void BashKubeCtlScripts()
         {
             SetTestClusterVariables();

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -45,6 +45,7 @@ namespace Calamari.Tests.KubernetesFixtures
         public void WindowsPowershellKubeCtlScripts()
         {
             SetTestClusterVariables();
+            Variables.Set(ScriptVariables.Syntax, ScriptSyntax.PowerShell.ToString());
             Variables.Set(PowerShellVariables.Edition, "Desktop");
             var wrapper = new KubernetesContextScriptWrapper(Variables);
             TestScript(wrapper, "Test-Script.ps1");
@@ -54,6 +55,7 @@ namespace Calamari.Tests.KubernetesFixtures
         public void PowershellCoreKubeCtlScripts()
         {
             SetTestClusterVariables();
+            Variables.Set(ScriptVariables.Syntax, ScriptSyntax.PowerShell.ToString());
             Variables.Set(PowerShellVariables.Edition, "Core");
             var wrapper = new KubernetesContextScriptWrapper(Variables);
             TestScript(wrapper, "Test-Script.ps1");
@@ -64,6 +66,7 @@ namespace Calamari.Tests.KubernetesFixtures
         public void BashKubeCtlScripts()
         {
             SetTestClusterVariables();
+            Variables.Set(ScriptVariables.Syntax, ScriptSyntax.Bash.ToString());
             var wrapper = new KubernetesContextScriptWrapper(Variables);
             TestScript(wrapper, "Test-Script.sh");
         }
@@ -92,8 +95,8 @@ namespace Calamari.Tests.KubernetesFixtures
         CalamariResult ExecuteScript(IScriptWrapper wrapper, string scriptName, IVariables variables)
         {
             var runner = new TestCommandLineRunner(ConsoleLog.Instance, variables);
-            wrapper.NextWrapper = new TerminalScriptWrapper(new PowerShellScriptExecutor(), variables);
-            var result = wrapper.ExecuteScript(new Script(scriptName), ScriptSyntax.PowerShell, runner, new Dictionary<string, string>());
+            var engine = new ScriptEngine(new[] { wrapper });
+            var result = engine.Execute(new Script(scriptName), variables, runner, new Dictionary<string, string>());
             return new CalamariResult(result.ExitCode, runner.Output);
         }
     }

--- a/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/KubectlPowershellContext.ps1
@@ -51,55 +51,102 @@ function EnsureDirectoryExists([string] $path)
 	New-Item -ItemType Directory -Force -Path $path *>$null
 }
 
-function ConnectAzAccount {
+function Get-AzureRmModuleInstalled {
+	return $null -ne (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
+}
+
+function Get-AzModuleInstalled {
+	return $null -ne (Get-Command "Connect-AzAccount" -ErrorAction SilentlyContinue)
+}
+
+function Get-RunningInPowershellCore {
+	return $PSVersionTable.PSVersion.Major -gt 5
+}
+
+function Initialize-AzureRmContext {
+    
 	# Authenticate via Service Principal
 	$securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
 	$creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
 
-	if(Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
-	{
-		# Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-		Disable-AzureRMContextAutosave -Scope Process
+	# Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+	Write-Host "##octopus[stdout-verbose]"
+	Disable-AzureRMContextAutosave -Scope Process
+	Write-Host "##octopus[stdout-default]"
 
-		$AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
-		if (!$AzureEnvironment)
-		{
-			Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-			exit -2
-		}
-
-		Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
-
-		# Force any output generated to be verbose in Octopus logs.
-		Write-Host "##octopus[stdout-verbose]"
-		Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-		Write-Host "##octopus[stdout-default]"
+	$AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
+	if (!$AzureEnvironment) {
+		Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+		exit 2
 	}
-	elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
-	{
-		if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
-		{
-			# Turn on AzureRm aliasing
-			# See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
-			Enable-AzureRmAlias -Scope Process
+
+	Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
+
+	# Force any output generated to be verbose in Octopus logs.
+	Write-Host "##octopus[stdout-verbose]"
+	Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+	Write-Host "##octopus[stdout-default]"
+}
+
+function Initialize-AzContext {
+    
+	# Authenticate via Service Principal
+	$securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
+	$creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
+
+	if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue)) {
+		Write-Verbose "Enabling AzureRM aliasing"
+
+		# Turn on AzureRm aliasing
+		# See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
+		Enable-AzureRmAlias -Scope Process
+	}
+
+	# Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+	Write-Host "##octopus[stdout-verbose]"
+	Disable-AzContextAutosave -Scope Process
+	Write-Host "##octopus[stdout-default]"
+
+	$AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
+	if (!$AzureEnvironment) {
+		Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+		exit 2
+	}
+
+	Write-Verbose "Az Modules: Authenticating with Service Principal"
+
+	# Force any output generated to be verbose in Octopus logs.
+	Write-Host "##octopus[stdout-verbose]"
+	Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+	Write-Host "##octopus[stdout-default]"
+}
+
+function ConnectAzAccount {
+	# Depending on which version of Powershell we are running under will change which module context we want to initialize.            
+	#   Powershell Core: Check Az then AzureRM (provide a warning and do nothing if AzureRM is installed)
+	#   Windows Powershell: Check AzureRM then Az
+	#
+	# If a module is installed (e.g. AzureRM) then testing for it causes the module to be loaded along with its various assemblies
+	# and dependencies. If we then test for the other module (e.g. Az) then it also loads it's module and assemblies which then
+	# creates havoc when you try and call any context methods such as Disable-AzContextAutosave due to version differences etc. 
+	# For this reason we'll only test the module we prefer and then if it exists initialize it and not the other one.
+	if (Get-RunningInPowershellCore) {
+		if (Get-AzModuleInstalled) {
+			Initialize-AzContext
 		}
-
-		# Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-		Disable-AzContextAutosave -Scope Process
-
-		$AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
-		if (!$AzureEnvironment)
-		{
-			Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-			exit -2
+		elseif (Get-AzureRmModuleInstalled) {
+			# AzureRM is not supported on powershell core
+			Write-Warning "AzureRM module is not compatible with Powershell Core, authentication will not be performed with AzureRM"
+		}                
+	}            
+	else { 
+		# Windows Powershell
+		if (Get-AzureRmModuleInstalled) {
+			Initialize-AzureRmContext
 		}
-
-		Write-Verbose "Az Modules: Authenticating with Service Principal"
-
-		# Force any output generated to be verbose in Octopus logs.
-		Write-Host "##octopus[stdout-verbose]"
-		Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-		Write-Host "##octopus[stdout-default]"
+		elseif (Get-AzModuleInstalled) {
+			Initialize-AzContext
+		}
 	}
 
 	If (!$OctopusDisableAzureCLI -or $OctopusDisableAzureCLI -like [Boolean]::FalseString) {


### PR DESCRIPTION
This PR changes the Kubernetes Azure authentication so it can work with Powershell Core. This is the same set of changes as https://github.com/OctopusDeploy/Sashimi.AzureScripting/pull/9 but for the kubernetes context. It initializes the Az context instead of the AzureRM context when running on Powershell Core and adds a warning if AzureRM is present (but Az isn't), so that scripts can run in powershell core if the worker has AzureRM installed. 