### PR TITLE
Add support for deployment target inputs

### DIFF
--- a/source/Calamari.Tests/Fixtures/Manifest/ExecuteManifestCommandFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Manifest/ExecuteManifestCommandFixture.cs
@@ -68,6 +68,7 @@ namespace Calamari.Tests.Fixtures.Manifest
                     { nameof(NodeInstructions.NodePathVariable), toolRoot },
                     { nameof(NodeInstructions.TargetPathVariable), "TargetPathVariable_Value" },
                     { nameof(NodeInstructions.InputsVariable), "no_empty" },
+                    { nameof(NodeInstructions.DeploymentTargetInputsVariable), "deploymentTargetInputs" },
                 };
 
                 var result = ExecuteCommand(variables, "Calamari.Tests");
@@ -77,6 +78,7 @@ namespace Calamari.Tests.Fixtures.Manifest
                 result.AssertOutput("Hello from my custom node!");
                 result.AssertOutput(string.Join(Path.Combine("BootstrapperPathVariable_Value", "bootstrapper.js"),
                                                 Path.Combine("TargetPathVariable_Value", "executor.js")));
+                result.AssertOutput(nameof(NodeInstructions.DeploymentTargetInputsVariable));
             }
         }
 

--- a/source/Calamari.Tests/Fixtures/Manifest/InstructionBuilder.cs
+++ b/source/Calamari.Tests/Fixtures/Manifest/InstructionBuilder.cs
@@ -45,7 +45,8 @@ namespace Calamari.Tests.Fixtures.Manifest
                                                                        BootstrapperPathVariable = nameof(NodeInstructions.BootstrapperPathVariable),
                                                                        NodePathVariable = nameof(NodeInstructions.NodePathVariable),
                                                                        TargetPathVariable = nameof(NodeInstructions.TargetPathVariable),
-                                                                       InputsVariable = nameof(NodeInstructions.InputsVariable)
+                                                                       InputsVariable = nameof(NodeInstructions.InputsVariable),
+                                                                       DeploymentTargetInputsVariable = nameof(NodeInstructions.DeploymentTargetInputsVariable)
                                                                    },
                                                                    JsonSerialization.GetDefaultSerializerSettings())
             });

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -49,7 +49,8 @@ namespace Calamari.LaunchTools
                                                                                 variableFile.FilePath,
                                                                                 options.InputVariables.SensitiveVariablesPassword,
                                                                                 AesEncryption.SaltRaw,
-                                                                                instructions.InputsVariable))
+                                                                                instructions.InputsVariable,
+                                                                                instructions.DeploymentTargetInputsVariable))
                 {
                     WorkingDirectory = runningDeployment.CurrentDirectory,
                     OutputToLog = true,
@@ -80,8 +81,8 @@ namespace Calamari.LaunchTools
 
         static string BuildNodePath(string pathToNode) => CalamariEnvironment.IsRunningOnWindows ? Path.Combine(pathToNode, "node.exe") : Path.Combine(pathToNode, "bin", "node");
 
-        static string BuildArgs(string pathToBootstrapper, string pathToStepPackage, string pathToSensitiveVariables, string sensitiveVariablesSecret, string salt, string inputsKey) =>
-            $"\"{pathToBootstrapper}\" \"{pathToStepPackage}\" \"{pathToSensitiveVariables}\" \"{sensitiveVariablesSecret}\" \"{salt}\" \"{inputsKey}\"";
+        static string BuildArgs(string pathToBootstrapper, string pathToStepPackage, string pathToSensitiveVariables, string sensitiveVariablesSecret, string salt, string inputsKey, string deploymentTargetInputsKey) =>
+            $"\"{pathToBootstrapper}\" \"{pathToStepPackage}\" \"{pathToSensitiveVariables}\" \"{sensitiveVariablesSecret}\" \"{salt}\" \"{inputsKey}\" \"{deploymentTargetInputsKey}\"";
     }
 
     public class NodeInstructions
@@ -90,5 +91,7 @@ namespace Calamari.LaunchTools
         public string TargetPathVariable { get; set; }
         public string BootstrapperPathVariable { get; set; }
         public string InputsVariable { get; set; }
+        
+        public string DeploymentTargetInputsVariable { get; set; }
     }
 }


### PR DESCRIPTION
Adding support for the additional parameter to be passed to our steps bootstrapper, containing the key to deployment target inputs in the variables property bag.

API PR: https://github.com/OctopusDeploy/step-api/pull/25
Bootstrapper PR: https://github.com/OctopusDeploy/step-bootstrapper/pull/4