### PR TITLE
Changes build to use SHA256 for timestamping

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -31,11 +31,8 @@ string nugetVersion;
 // From time to time the timestamping services go offline, let's try a few of them so our builds are more resilient
 var timestampUrls = new string[]
 {
-    "http://timestamp.globalsign.com/scripts/timestamp.dll",
-    "http://www.startssl.com/timestamp",
-    "http://timestamp.comodoca.com/rfc3161",
-    "http://timestamp.verisign.com/scripts/timstamp.dll",
-    "http://tsa.starfieldtech.com"
+    "http://timestamp.digicert.com?alg=sha256",
+	"http://timestamp.comodoca.com"
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -32,7 +32,7 @@ string nugetVersion;
 var timestampUrls = new string[]
 {
     "http://timestamp.digicert.com?alg=sha256",
-	"http://timestamp.comodoca.com"
+    "http://timestamp.comodoca.com"
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -356,7 +356,9 @@ private void TimeStampFiles(IEnumerable<FilePath> files)
     {
         var timestampArguments = new ProcessArgumentBuilder()
             .Append($"timestamp")
-            .Append("/tr").AppendQuoted(url);
+            .Append("/tr").AppendQuoted(url)
+            .Append("/td").Append("sha256");
+            
         foreach (var file in files)
         {
             timestampArguments.AppendQuoted(file.FullPath);


### PR DESCRIPTION
Changes Calamari to use sha256 when timestamping.

This brings the Calamari build in line with the Octopus Server build changes done in https://github.com/OctopusDeploy/OctopusDeploy/commit/7ace77a166385361bb31e91f1bac537a9db134e4#diff-72db529222c5975fac485f635b06c3fb1ec198d202d95e473e8b0f04872560a2L73-L77