### PR TITLE
Enable Structured Variable Replacement for CloudFormation

### DIFF
--- a/source/Calamari.Aws/Commands/DeployAwsCloudFormationCommand.cs
+++ b/source/Calamari.Aws/Commands/DeployAwsCloudFormationCommand.cs
@@ -13,7 +13,9 @@ using Calamari.Aws.Util;
 using Calamari.CloudAccounts;
 using Calamari.Commands;
 using Calamari.Common.Commands;
+using Calamari.Common.Features.Behaviours;
 using Calamari.Common.Features.Packages;
+using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Plumbing.Deployment;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
@@ -68,6 +70,8 @@ namespace Calamari.Aws.Commands
             string RoleArnProvider (RunningDeployment x) => x.Variables[AwsSpecialVariables.CloudFormation.RoleArn];
             var iamCapabilities = JsonConvert.DeserializeObject<List<string>>(variables.Get(AwsSpecialVariables.IamCapabilities, "[]"));
             var tags = JsonConvert.DeserializeObject<List<KeyValuePair<string, string>>>(variables.Get(AwsSpecialVariables.CloudFormation.Tags, "[]"));
+            var allFileFormatReplacers = FileFormatVariableReplacers.BuildAllReplacers(fileSystem, log);
+            var structuredConfigVariablesService = new StructuredConfigVariablesService(allFileFormatReplacers, variables, fileSystem, log);
 
             CloudFormationTemplate TemplateFactory()
             {
@@ -87,6 +91,7 @@ namespace Calamari.Aws.Commands
             {
                 new LogAwsUserInfoConvention(environment),
                 new DelegateInstallConvention(d => extractPackage.ExtractToStagingDirectory(pathToPackage)),
+                new StructuredConfigurationVariablesConvention(new StructuredConfigurationVariablesBehaviour(structuredConfigVariablesService)),
 
                 //Create or Update the stack using changesets
                 new AggregateInstallationConvention(

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixture.cs
@@ -3,34 +3,22 @@ using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Amazon.CloudFormation;
-using Amazon.CloudFormation.Model;
 using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Logging;
 #if AWS
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Net;
 using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
 using Calamari.Aws.Commands;
 using Calamari.Aws.Deployment;
 using Calamari.Aws.Integration.CloudFormation;
-using Calamari.Aws.Integration.S3;
-using Calamari.Aws.Serialization;
-using Calamari.Integration.FileSystem;
-using Calamari.Serialization;
-using Calamari.Tests.Fixtures.Deployment.Packages;
 using Calamari.Tests.Helpers;
 using FluentAssertions;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using NUnit.Framework;
-using Octopus.CoreUtilities.Extensions;
-using Octostache;
 
-namespace Calamari.Tests.AWS
+namespace Calamari.Tests.AWS.CloudFormation
 {
     [TestFixture, Explicit]
     public class CloudFormationFixture
@@ -41,20 +29,15 @@ namespace Calamari.Tests.AWS
         [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public async Task CreateOrUpdateCloudFormationTemplate()
         {
-            var template = $@"
-{{
-    ""Resources"": {{
-        ""{StackName}"": {{
-            ""Type"": ""AWS::S3::Bucket"",
-            ""Properties"": {{ 
-                ""BucketName"": {StackName}
-            }}
-        }}
-    }}
-}}";
+            var template = GetBasicS3Template(StackName);
+
+            var templateFilePath = Path.GetTempFileName();
+            var variables = new CalamariVariables();
+            File.WriteAllText(templateFilePath, template);
+
             try
             {
-                DeployTemplate(StackName, template);
+                DeployTemplate(StackName, templateFilePath, variables);
 
                 await ValidateStackExists(StackName, true);
 
@@ -72,8 +55,7 @@ namespace Calamari.Tests.AWS
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Error occurred while attempting to delete stack {StackName} -> {e}." +
-                              $"{Environment.NewLine} Test resources may not have been deleted, please check the AWS console for the status of the stack.");
+                    Log.Error($"Error occurred while attempting to delete stack {StackName} -> {e}." + $"{Environment.NewLine} Test resources may not have been deleted, please check the AWS console for the status of the stack.");
                 }
             }
         }
@@ -82,27 +64,34 @@ namespace Calamari.Tests.AWS
         [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public async Task DeleteCloudFormationStack()
         {
-            var template = $@"
-{{
-    ""Resources"": {{
-        ""{StackName}"": {{
-            ""Type"": ""AWS::S3::Bucket"",
-            ""Properties"": {{ 
-                ""BucketName"": {StackName}
-            }}
-        }}
-    }}
-}}";
-            DeployTemplate(StackName, template);
+            var template = GetBasicS3Template(StackName);
+            var templateFilePath = Path.GetTempFileName();
+            var variables = new CalamariVariables();
+            File.WriteAllText(templateFilePath, template);
+
+            DeployTemplate(StackName, templateFilePath, variables);
             DeleteStack(StackName);
             await ValidateStackExists(StackName, false);
         }
 
-        void ValidateS3(Action<AmazonS3Client> execute)
+        public static string GetBasicS3Template(string stackName)
         {
-            var credentials = new BasicAWSCredentials(
-                Environment.GetEnvironmentVariable("AWS_Calamari_Access"),
-                Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
+            return $@"
+    {{
+        ""Resources"": {{
+            ""{stackName}"": {{
+                ""Type"": ""AWS::S3::Bucket"",
+                ""Properties"": {{ 
+                    ""BucketName"": {stackName}
+                }}
+            }}
+        }}
+    }}";
+        }
+
+        public static void ValidateS3(Action<AmazonS3Client> execute)
+        {
+            var credentials = new BasicAWSCredentials(Environment.GetEnvironmentVariable("AWS_Calamari_Access"), Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
             var config = new AmazonS3Config { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.APSoutheast1 };
             using (var client = new AmazonS3Client(credentials, config))
             {
@@ -113,18 +102,16 @@ namespace Calamari.Tests.AWS
         async Task ValidateStackExists(string stackName, bool shouldExist)
         {
             await ValidateCloudFormation(async (client) =>
-            {
-                Func<IAmazonCloudFormation> clientFactory = () => client;
-                var stackStatus = await clientFactory.StackExistsAsync(new StackArn(stackName), Aws.Deployment.Conventions.StackStatus.DoesNotExist);
-                stackStatus.Should().Be(shouldExist ? Aws.Deployment.Conventions.StackStatus.Completed : Aws.Deployment.Conventions.StackStatus.DoesNotExist);
-            });
+                                         {
+                                             Func<IAmazonCloudFormation> clientFactory = () => client;
+                                             var stackStatus = await clientFactory.StackExistsAsync(new StackArn(stackName), Aws.Deployment.Conventions.StackStatus.DoesNotExist);
+                                             stackStatus.Should().Be(shouldExist ? Aws.Deployment.Conventions.StackStatus.Completed : Aws.Deployment.Conventions.StackStatus.DoesNotExist);
+                                         });
         }
 
-        async Task ValidateCloudFormation(Func<AmazonCloudFormationClient, Task> execute)
+        public static async Task ValidateCloudFormation(Func<AmazonCloudFormationClient, Task> execute)
         {
-            var credentials = new BasicAWSCredentials(
-                Environment.GetEnvironmentVariable("AWS_Calamari_Access"),
-                Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
+            var credentials = new BasicAWSCredentials(Environment.GetEnvironmentVariable("AWS_Calamari_Access"), Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
             var config = new AmazonCloudFormationConfig { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.APSoutheast1 };
             using (var client = new AmazonCloudFormationClient(credentials, config))
             {
@@ -132,18 +119,14 @@ namespace Calamari.Tests.AWS
             }
         }
 
-        void DeployTemplate(string resourceName, string template)
+        public static void DeployTemplate(string resourceName, string templateFilePath, IVariables variables)
         {
             var variablesFile = Path.GetTempFileName();
-            var variables = new CalamariVariables();
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
             variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_Calamari_Access"));
             variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
             variables.Set("Octopus.Action.Aws.Region", RegionEndpoint.APSoutheast1.SystemName);
             variables.Save(variablesFile);
-
-            var templateFilePath = Path.GetTempFileName();
-            File.WriteAllText(templateFilePath, template);
 
             using (var templateFile = new TemporaryFile(templateFilePath))
             using (new TemporaryFile(variablesFile))
@@ -151,22 +134,24 @@ namespace Calamari.Tests.AWS
                 var log = new InMemoryLog();
                 var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
                 var command = new DeployCloudFormationCommand(
-                    log,
-                    variables,
-                    fileSystem,
-                    new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log)
-                );
-                var result = command.Execute(new[] {
+                                                              log,
+                                                              variables,
+                                                              fileSystem,
+                                                              new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log)
+                                                             );
+                var result = command.Execute(new[]
+                {
                     "--template", $"{templateFile.FilePath}",
                     "--variables", $"{variablesFile}",
                     "--stackName", resourceName,
-                    "--waitForCompletion", "true"});
+                    "--waitForCompletion", "true"
+                });
 
                 result.Should().Be(0);
             }
         }
 
-        void DeleteStack(string stackName)
+        public static void DeleteStack(string stackName)
         {
             var variablesFile = Path.GetTempFileName();
             var variables = new CalamariVariables();
@@ -182,12 +167,14 @@ namespace Calamari.Tests.AWS
                 var log = new InMemoryLog();
                 var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
                 var command = new DeleteCloudFormationCommand(
-                    log,
-                    variables
-                );
-                var result = command.Execute(new[] {
+                                                              log,
+                                                              variables
+                                                             );
+                var result = command.Execute(new[]
+                {
                     "--variables", $"{variablesFile}",
-                    "--waitForCompletion", "true"});
+                    "--waitForCompletion", "true"
+                });
 
                 result.Should().Be(0);
             }

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixture.cs
@@ -1,21 +1,9 @@
-﻿using Calamari.Common.Features.Packages;
-using Calamari.Common.Features.Processes;
-using Calamari.Common.Plumbing.FileSystem;
-using Calamari.Common.Plumbing.Variables;
-using Amazon.CloudFormation;
+﻿using Calamari.Common.Plumbing.Variables;
 using System.Threading.Tasks;
-using Calamari.Common.Plumbing.Logging;
 #if AWS
 using System;
 using System.IO;
-using Amazon;
-using Amazon.Runtime;
-using Amazon.S3;
-using Calamari.Aws.Commands;
-using Calamari.Aws.Deployment;
-using Calamari.Aws.Integration.CloudFormation;
 using Calamari.Tests.Helpers;
-using FluentAssertions;
 using NUnit.Framework;
 
 namespace Calamari.Tests.AWS.CloudFormation
@@ -29,34 +17,19 @@ namespace Calamari.Tests.AWS.CloudFormation
         [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public async Task CreateOrUpdateCloudFormationTemplate()
         {
-            var template = GetBasicS3Template(StackName);
-
-            var templateFilePath = Path.GetTempFileName();
-            var variables = new CalamariVariables();
-            File.WriteAllText(templateFilePath, template);
+            var templateFilePath = CloudFormationFixtureHelpers.WriteTemplateFile(CloudFormationFixtureHelpers.GetBasicS3Template(StackName));
 
             try
             {
-                DeployTemplate(StackName, templateFilePath, variables);
+                CloudFormationFixtureHelpers.DeployTemplate(StackName, templateFilePath, new CalamariVariables());
 
-                await ValidateStackExists(StackName, true);
+                await CloudFormationFixtureHelpers.ValidateStackExists(StackName, true);
 
-                ValidateS3(client =>
-                {
-                    // Bucket can be created successfully
-                    client.GetBucketLocation(StackName);
-                });
+                await CloudFormationFixtureHelpers.ValidateS3BucketExists(StackName);
             }
             finally
             {
-                try
-                {
-                    DeleteStack(StackName);
-                }
-                catch (Exception e)
-                {
-                    Log.Error($"Error occurred while attempting to delete stack {StackName} -> {e}." + $"{Environment.NewLine} Test resources may not have been deleted, please check the AWS console for the status of the stack.");
-                }
+                CloudFormationFixtureHelpers.CleanupStack(StackName);
             }
         }
 
@@ -64,121 +37,13 @@ namespace Calamari.Tests.AWS.CloudFormation
         [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public async Task DeleteCloudFormationStack()
         {
-            var template = GetBasicS3Template(StackName);
-            var templateFilePath = Path.GetTempFileName();
-            var variables = new CalamariVariables();
-            File.WriteAllText(templateFilePath, template);
+            var templateFilePath = CloudFormationFixtureHelpers.WriteTemplateFile(CloudFormationFixtureHelpers.GetBasicS3Template(StackName));
 
-            DeployTemplate(StackName, templateFilePath, variables);
-            DeleteStack(StackName);
-            await ValidateStackExists(StackName, false);
+            CloudFormationFixtureHelpers.DeployTemplate(StackName, templateFilePath, new CalamariVariables());
+            CloudFormationFixtureHelpers.DeleteStack(StackName);
+            await CloudFormationFixtureHelpers.ValidateStackExists(StackName, false);
         }
 
-        public static string GetBasicS3Template(string stackName)
-        {
-            return $@"
-    {{
-        ""Resources"": {{
-            ""{stackName}"": {{
-                ""Type"": ""AWS::S3::Bucket"",
-                ""Properties"": {{ 
-                    ""BucketName"": {stackName}
-                }}
-            }}
-        }}
-    }}";
-        }
-
-        public static void ValidateS3(Action<AmazonS3Client> execute)
-        {
-            var credentials = new BasicAWSCredentials(Environment.GetEnvironmentVariable("AWS_Calamari_Access"), Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
-            var config = new AmazonS3Config { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.APSoutheast1 };
-            using (var client = new AmazonS3Client(credentials, config))
-            {
-                execute(client);
-            }
-        }
-
-        async Task ValidateStackExists(string stackName, bool shouldExist)
-        {
-            await ValidateCloudFormation(async (client) =>
-                                         {
-                                             Func<IAmazonCloudFormation> clientFactory = () => client;
-                                             var stackStatus = await clientFactory.StackExistsAsync(new StackArn(stackName), Aws.Deployment.Conventions.StackStatus.DoesNotExist);
-                                             stackStatus.Should().Be(shouldExist ? Aws.Deployment.Conventions.StackStatus.Completed : Aws.Deployment.Conventions.StackStatus.DoesNotExist);
-                                         });
-        }
-
-        public static async Task ValidateCloudFormation(Func<AmazonCloudFormationClient, Task> execute)
-        {
-            var credentials = new BasicAWSCredentials(Environment.GetEnvironmentVariable("AWS_Calamari_Access"), Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
-            var config = new AmazonCloudFormationConfig { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.APSoutheast1 };
-            using (var client = new AmazonCloudFormationClient(credentials, config))
-            {
-                await execute(client);
-            }
-        }
-
-        public static void DeployTemplate(string resourceName, string templateFilePath, IVariables variables)
-        {
-            var variablesFile = Path.GetTempFileName();
-            variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
-            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_Calamari_Access"));
-            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
-            variables.Set("Octopus.Action.Aws.Region", RegionEndpoint.APSoutheast1.SystemName);
-            variables.Save(variablesFile);
-
-            using (var templateFile = new TemporaryFile(templateFilePath))
-            using (new TemporaryFile(variablesFile))
-            {
-                var log = new InMemoryLog();
-                var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-                var command = new DeployCloudFormationCommand(
-                                                              log,
-                                                              variables,
-                                                              fileSystem,
-                                                              new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log)
-                                                             );
-                var result = command.Execute(new[]
-                {
-                    "--template", $"{templateFile.FilePath}",
-                    "--variables", $"{variablesFile}",
-                    "--stackName", resourceName,
-                    "--waitForCompletion", "true"
-                });
-
-                result.Should().Be(0);
-            }
-        }
-
-        public static void DeleteStack(string stackName)
-        {
-            var variablesFile = Path.GetTempFileName();
-            var variables = new CalamariVariables();
-            variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
-            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_Calamari_Access"));
-            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
-            variables.Set("Octopus.Action.Aws.Region", RegionEndpoint.APSoutheast1.SystemName);
-            variables.Set(AwsSpecialVariables.CloudFormation.StackName, stackName);
-            variables.Save(variablesFile);
-
-            using (new TemporaryFile(variablesFile))
-            {
-                var log = new InMemoryLog();
-                var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-                var command = new DeleteCloudFormationCommand(
-                                                              log,
-                                                              variables
-                                                             );
-                var result = command.Execute(new[]
-                {
-                    "--variables", $"{variablesFile}",
-                    "--waitForCompletion", "true"
-                });
-
-                result.Should().Be(0);
-            }
-        }
     }
 }
 #endif

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.Runtime;
+using Amazon;
+using Amazon.S3;
+using Calamari.Aws.Commands;
+using Calamari.Aws.Deployment;
+using Calamari.Aws.Integration.CloudFormation;
+using Calamari.Common.Features.Packages;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Tests.Helpers;
+using FluentAssertions;
+
+namespace Calamari.Tests.AWS.CloudFormation
+{
+    public static class CloudFormationFixtureHelpers
+    {
+        
+        public static string GetBasicS3Template(string stackName)
+        {
+            return $@"
+    {{
+        ""Resources"": {{
+            ""{stackName}"": {{
+                ""Type"": ""AWS::S3::Bucket"",
+                ""Properties"": {{ 
+                    ""BucketName"": {stackName}
+                }}
+            }}
+        }}
+    }}";
+        }
+
+        public static string WriteTemplateFile(string template)
+        {
+            var templateFilePath = Path.GetTempFileName();
+            File.WriteAllText(templateFilePath, template);
+            return templateFilePath;
+        }
+
+        public static async Task ValidateS3BucketExists(string stackName)
+        {
+            await ValidateS3(async client =>
+            {
+                await client.GetBucketLocationAsync(stackName);
+            });
+        }
+
+        public static async Task ValidateS3(Func<AmazonS3Client, Task> execute)
+        {
+            var credentials = new BasicAWSCredentials(Environment.GetEnvironmentVariable("AWS_Calamari_Access"), Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
+            var config = new AmazonS3Config { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.APSoutheast1 };
+            using (var client = new AmazonS3Client(credentials, config))
+            {
+                await execute(client);
+            }
+        }
+
+        public static async Task ValidateStackExists(string stackName, bool shouldExist)
+        {
+            await ValidateCloudFormation(async (client) =>
+            {
+                Func<IAmazonCloudFormation> clientFactory = () => client;
+                var stackStatus = await clientFactory.StackExistsAsync(new StackArn(stackName), Aws.Deployment.Conventions.StackStatus.DoesNotExist);
+                stackStatus.Should().Be(shouldExist ? Aws.Deployment.Conventions.StackStatus.Completed : Aws.Deployment.Conventions.StackStatus.DoesNotExist);
+            });
+        }
+
+        static async Task ValidateCloudFormation(Func<AmazonCloudFormationClient, Task> execute)
+        {
+            var credentials = new BasicAWSCredentials(Environment.GetEnvironmentVariable("AWS_Calamari_Access"), Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
+            var config = new AmazonCloudFormationConfig { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.APSoutheast1 };
+            using (var client = new AmazonCloudFormationClient(credentials, config))
+            {
+                await execute(client);
+            }
+        }
+
+        public static void DeployTemplate(string resourceName, string templateFilePath, IVariables variables)
+        {
+            var variablesFile = Path.GetTempFileName();
+            variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
+            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_Calamari_Access"));
+            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
+            variables.Set("Octopus.Action.Aws.Region", RegionEndpoint.APSoutheast1.SystemName);
+            variables.Save(variablesFile);
+
+            using (var templateFile = new TemporaryFile(templateFilePath))
+            using (new TemporaryFile(variablesFile))
+            {
+                var log = new InMemoryLog();
+                var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+                var command = new DeployCloudFormationCommand(
+                    log,
+                    variables,
+                    fileSystem,
+                    new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log)
+                );
+                var result = command.Execute(new[]
+                {
+                    "--template", $"{templateFile.FilePath}",
+                    "--variables", $"{variablesFile}",
+                    "--stackName", resourceName,
+                    "--waitForCompletion", "true"
+                });
+
+                result.Should().Be(0);
+            }
+        }
+
+        public static void CleanupStack(string stackName)
+        {
+            try
+            {
+                DeleteStack(stackName);
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Error occurred while attempting to delete stack {stackName} -> {e}." + 
+                          $"{Environment.NewLine} Test resources may not have been deleted, please check the AWS console for the status of the stack.");
+            }
+        }
+
+        public static void DeleteStack(string stackName)
+        {
+            var variablesFile = Path.GetTempFileName();
+            var variables = new CalamariVariables();
+            variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
+            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_Calamari_Access"));
+            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
+            variables.Set("Octopus.Action.Aws.Region", RegionEndpoint.APSoutheast1.SystemName);
+            variables.Set(AwsSpecialVariables.CloudFormation.StackName, stackName);
+            variables.Save(variablesFile);
+
+            using (new TemporaryFile(variablesFile))
+            {
+                var log = new InMemoryLog();
+                var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+                var command = new DeleteCloudFormationCommand(
+                                                              log,
+                                                              variables
+                                                             );
+                var result = command.Execute(new[]
+                {
+                    "--variables", $"{variablesFile}",
+                    "--waitForCompletion", "true"
+                });
+
+                result.Should().Be(0);
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
@@ -1,13 +1,8 @@
 ﻿#if AWS
 using System;
-using System.IO;
 using System.Threading.Tasks;
-using Amazon.CloudFormation;
-using Calamari.Aws.Integration.CloudFormation;
-using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Tests.Helpers;
-using FluentAssertions;
 using NUnit.Framework;
 
 namespace Calamari.Tests.AWS.CloudFormation
@@ -22,10 +17,7 @@ namespace Calamari.Tests.AWS.CloudFormation
         [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public async Task CreateCloudFormationWithStructuredVariableReplacement()
         {
-            var template = CloudFormationFixture.GetBasicS3Template(StackName);
-            
-            var templateFilePath = Path.GetTempFileName();
-            File.WriteAllText(templateFilePath, template);
+            var templateFilePath = CloudFormationFixtureHelpers.WriteTemplateFile(CloudFormationFixtureHelpers.GetBasicS3Template(StackName));
             
             var variables = new CalamariVariables();
             variables.Set(KnownVariables.Package.EnabledFeatures, "Octopus.Features.JsonConfigurationVariables");
@@ -34,32 +26,12 @@ namespace Calamari.Tests.AWS.CloudFormation
             
             try
             {
-                CloudFormationFixture.DeployTemplate(StackName, templateFilePath, variables);
-
-                await CloudFormationFixture.ValidateCloudFormation(async (client) =>
-                {
-                    Func<IAmazonCloudFormation> clientFactory = () => client;
-                    var stackStatus = await clientFactory.StackExistsAsync(new StackArn(StackName), Aws.Deployment.Conventions.StackStatus.DoesNotExist);
-                    stackStatus.Should().Be(Aws.Deployment.Conventions.StackStatus.Completed);
-                });
-
-                CloudFormationFixture.ValidateS3(client =>
-                {
-                    // Bucket with replaced name was created successfully
-                    client.GetBucketLocation(ReplacedName);
-                });
+                CloudFormationFixtureHelpers.DeployTemplate(StackName, templateFilePath, variables);
+                await CloudFormationFixtureHelpers.ValidateS3BucketExists(ReplacedName);
             }
             finally
             {
-                try
-                {
-                    CloudFormationFixture.DeleteStack(StackName);
-                }
-                catch (Exception e)
-                {
-                    Log.Error($"Error occurred while attempting to delete stack {StackName} -> {e}." + 
-                              $"{Environment.NewLine} Test resources may not have been deleted, please check the AWS console for the status of the stack.");
-                }
+                CloudFormationFixtureHelpers.CleanupStack(StackName);
             }
         }
     }

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
@@ -1,0 +1,165 @@
+﻿#if AWS
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.CloudFormation;
+using Amazon.Runtime;
+using Amazon.S3;
+using Calamari.Aws.Commands;
+using Calamari.Aws.Deployment;
+using Calamari.Aws.Integration.CloudFormation;
+using Calamari.Common.Features.Packages;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Tests.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.AWS.CloudFormation
+{
+    [TestFixture, Explicit]
+    public class CloudFormationVariableReplacementFixture
+    {
+        private const string StackName = "octopuse2ecftests";
+        private const string ReplacedName = "octopuse2e-replaced";
+
+        [Test]
+        [Category(TestCategory.CompatibleOS.OnlyWindows)]
+        public async Task CreateCloudFormationWithStructuredVariableReplacement()
+        {
+            var template = $@"
+{{
+    ""Resources"": {{
+        ""{StackName}"": {{
+            ""Type"": ""AWS::S3::Bucket"",
+            ""Properties"": {{ 
+                ""BucketName"": {StackName}
+            }}
+        }}
+    }}
+}}";
+            try
+            {
+                DeployTemplate(StackName, template);
+
+                await ValidateCloudFormation(async (client) =>
+                {
+                    Func<IAmazonCloudFormation> clientFactory = () => client;
+                    var stackStatus = await clientFactory.StackExistsAsync(new StackArn(StackName), Aws.Deployment.Conventions.StackStatus.DoesNotExist);
+                    stackStatus.Should().Be(Aws.Deployment.Conventions.StackStatus.Completed);
+                });
+
+                ValidateS3(client =>
+                {
+                    // Bucket with replaced name was created successfully
+                    client.GetBucketLocation(ReplacedName);
+                });
+            }
+            finally
+            {
+                try
+                {
+                    DeleteStack(StackName);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Error occurred while attempting to delete stack {StackName} -> {e}." + 
+                              $"{Environment.NewLine} Test resources may not have been deleted, please check the AWS console for the status of the stack.");
+                }
+            }
+        }
+
+        void ValidateS3(Action<AmazonS3Client> execute)
+        {
+            var credentials = new BasicAWSCredentials(
+                Environment.GetEnvironmentVariable("AWS_Calamari_Access"),
+                Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
+            var config = new AmazonS3Config { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.APSoutheast1 };
+            using (var client = new AmazonS3Client(credentials, config))
+            {
+                execute(client);
+            }
+        }
+
+        async Task ValidateCloudFormation(Func<AmazonCloudFormationClient, Task> execute)
+        {
+            var credentials = new BasicAWSCredentials(
+                Environment.GetEnvironmentVariable("AWS_Calamari_Access"),
+                Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
+            var config = new AmazonCloudFormationConfig { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.APSoutheast1 };
+            using (var client = new AmazonCloudFormationClient(credentials, config))
+            {
+                await execute(client);
+            }
+        }
+
+        void DeployTemplate(string resourceName, string template)
+        {
+            var templateFilePath = Path.GetTempFileName();
+            var variablesFile = Path.GetTempFileName();
+            var variables = new CalamariVariables();
+            variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
+            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_Calamari_Access"));
+            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
+            variables.Set("Octopus.Action.Aws.Region", RegionEndpoint.APSoutheast1.SystemName);
+            variables.Set(KnownVariables.Package.EnabledFeatures, "Octopus.Features.JsonConfigurationVariables");
+            variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, templateFilePath);
+            variables.Set($"Resources:{StackName}:Properties:BucketName", ReplacedName);
+            variables.Save(variablesFile);
+
+            File.WriteAllText(templateFilePath, template);
+
+            using (var templateFile = new TemporaryFile(templateFilePath))
+            using (new TemporaryFile(variablesFile))
+            {
+                var log = new InMemoryLog();
+                var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+                var command = new DeployCloudFormationCommand(
+                    log,
+                    variables,
+                    fileSystem,
+                    new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log)
+                );
+                var result = command.Execute(new[]
+                {
+                    "--template", $"{templateFile.FilePath}",
+                    "--variables", $"{variablesFile}",
+                    "--stackName", resourceName,
+                    "--waitForCompletion", "true"
+                });
+
+                result.Should().Be(0);
+            }
+        }
+
+        void DeleteStack(string stackName)
+        {
+            var variablesFile = Path.GetTempFileName();
+            var variables = new CalamariVariables();
+            variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
+            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_Calamari_Access"));
+            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
+            variables.Set("Octopus.Action.Aws.Region", RegionEndpoint.APSoutheast1.SystemName);
+            variables.Set(AwsSpecialVariables.CloudFormation.StackName, stackName);
+            variables.Save(variablesFile);
+
+            using (new TemporaryFile(variablesFile))
+            {
+                var log = new InMemoryLog();
+                var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+                var command = new DeleteCloudFormationCommand(log, variables);
+                var result = command.Execute(new[]
+                {
+                    "--variables", $"{variablesFile}",
+                    "--waitForCompletion", "true"
+                });
+
+                result.Should().Be(0);
+            }
+        }
+    }
+}
+#endif

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
@@ -2,16 +2,8 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Amazon;
 using Amazon.CloudFormation;
-using Amazon.Runtime;
-using Amazon.S3;
-using Calamari.Aws.Commands;
-using Calamari.Aws.Deployment;
 using Calamari.Aws.Integration.CloudFormation;
-using Calamari.Common.Features.Packages;
-using Calamari.Common.Features.Processes;
-using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Tests.Helpers;
@@ -30,29 +22,28 @@ namespace Calamari.Tests.AWS.CloudFormation
         [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public async Task CreateCloudFormationWithStructuredVariableReplacement()
         {
-            var template = $@"
-{{
-    ""Resources"": {{
-        ""{StackName}"": {{
-            ""Type"": ""AWS::S3::Bucket"",
-            ""Properties"": {{ 
-                ""BucketName"": {StackName}
-            }}
-        }}
-    }}
-}}";
+            var template = CloudFormationFixture.GetBasicS3Template(StackName);
+            
+            var templateFilePath = Path.GetTempFileName();
+            File.WriteAllText(templateFilePath, template);
+            
+            var variables = new CalamariVariables();
+            variables.Set(KnownVariables.Package.EnabledFeatures, "Octopus.Features.JsonConfigurationVariables");
+            variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, templateFilePath);
+            variables.Set($"Resources:{StackName}:Properties:BucketName", ReplacedName);
+            
             try
             {
-                DeployTemplate(StackName, template);
+                CloudFormationFixture.DeployTemplate(StackName, templateFilePath, variables);
 
-                await ValidateCloudFormation(async (client) =>
+                await CloudFormationFixture.ValidateCloudFormation(async (client) =>
                 {
                     Func<IAmazonCloudFormation> clientFactory = () => client;
                     var stackStatus = await clientFactory.StackExistsAsync(new StackArn(StackName), Aws.Deployment.Conventions.StackStatus.DoesNotExist);
                     stackStatus.Should().Be(Aws.Deployment.Conventions.StackStatus.Completed);
                 });
 
-                ValidateS3(client =>
+                CloudFormationFixture.ValidateS3(client =>
                 {
                     // Bucket with replaced name was created successfully
                     client.GetBucketLocation(ReplacedName);
@@ -62,102 +53,13 @@ namespace Calamari.Tests.AWS.CloudFormation
             {
                 try
                 {
-                    DeleteStack(StackName);
+                    CloudFormationFixture.DeleteStack(StackName);
                 }
                 catch (Exception e)
                 {
                     Log.Error($"Error occurred while attempting to delete stack {StackName} -> {e}." + 
                               $"{Environment.NewLine} Test resources may not have been deleted, please check the AWS console for the status of the stack.");
                 }
-            }
-        }
-
-        void ValidateS3(Action<AmazonS3Client> execute)
-        {
-            var credentials = new BasicAWSCredentials(
-                Environment.GetEnvironmentVariable("AWS_Calamari_Access"),
-                Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
-            var config = new AmazonS3Config { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.APSoutheast1 };
-            using (var client = new AmazonS3Client(credentials, config))
-            {
-                execute(client);
-            }
-        }
-
-        async Task ValidateCloudFormation(Func<AmazonCloudFormationClient, Task> execute)
-        {
-            var credentials = new BasicAWSCredentials(
-                Environment.GetEnvironmentVariable("AWS_Calamari_Access"),
-                Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
-            var config = new AmazonCloudFormationConfig { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.APSoutheast1 };
-            using (var client = new AmazonCloudFormationClient(credentials, config))
-            {
-                await execute(client);
-            }
-        }
-
-        void DeployTemplate(string resourceName, string template)
-        {
-            var templateFilePath = Path.GetTempFileName();
-            var variablesFile = Path.GetTempFileName();
-            var variables = new CalamariVariables();
-            variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
-            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_Calamari_Access"));
-            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
-            variables.Set("Octopus.Action.Aws.Region", RegionEndpoint.APSoutheast1.SystemName);
-            variables.Set(KnownVariables.Package.EnabledFeatures, "Octopus.Features.JsonConfigurationVariables");
-            variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, templateFilePath);
-            variables.Set($"Resources:{StackName}:Properties:BucketName", ReplacedName);
-            variables.Save(variablesFile);
-
-            File.WriteAllText(templateFilePath, template);
-
-            using (var templateFile = new TemporaryFile(templateFilePath))
-            using (new TemporaryFile(variablesFile))
-            {
-                var log = new InMemoryLog();
-                var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-                var command = new DeployCloudFormationCommand(
-                    log,
-                    variables,
-                    fileSystem,
-                    new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log)
-                );
-                var result = command.Execute(new[]
-                {
-                    "--template", $"{templateFile.FilePath}",
-                    "--variables", $"{variablesFile}",
-                    "--stackName", resourceName,
-                    "--waitForCompletion", "true"
-                });
-
-                result.Should().Be(0);
-            }
-        }
-
-        void DeleteStack(string stackName)
-        {
-            var variablesFile = Path.GetTempFileName();
-            var variables = new CalamariVariables();
-            variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
-            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_Calamari_Access"));
-            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_Calamari_Secret"));
-            variables.Set("Octopus.Action.Aws.Region", RegionEndpoint.APSoutheast1.SystemName);
-            variables.Set(AwsSpecialVariables.CloudFormation.StackName, stackName);
-            variables.Save(variablesFile);
-
-            using (new TemporaryFile(variablesFile))
-            {
-                var log = new InMemoryLog();
-                var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-                var command = new DeleteCloudFormationCommand(log, variables);
-                var result = command.Execute(new[]
-                {
-                    "--variables", $"{variablesFile}",
-                    "--waitForCompletion", "true"
-                });
-
-                result.Should().Be(0);
             }
         }
     }


### PR DESCRIPTION
This PR enables the Structured Variable Replacement feature for CloudFormation deployments.

The included test creates a Stack from a template, performs variable replacement for the name of an S3 bucket, and verifies that the bucket with the replaced name can be found. 

The test can be made to fail by removing the `s3-full-access` permission from the user in IAM.