### PR TITLE
Fixes issues with YAML structured replacement and inline comments

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
@@ -189,6 +189,9 @@ namespace Calamari.Common.Features.StructuredVariables
                     }
 
                     break;
+                case Comment c:
+                    classifiedNode = new YamlNode<Comment>(c, stack.GetPath());
+                    break;
             }
 
             return classifiedNode ?? new YamlNode<ParsingEvent>(ev, stack.GetPath());

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -92,6 +92,8 @@ namespace Calamari.Common.Features.StructuredVariables
                             else if (node is YamlNode<SequenceStart> sequenceStart
                                      && variablesByKey.TryGetValue(sequenceStart.Path, out var sequenceReplacement))
                                 structureWeAreReplacing = (sequenceStart, sequenceReplacement());
+                            else if (node is YamlNode<Comment> comment && comment.Event.IsInline)
+                                structureWeAreReplacing = (comment, null);
                             else
                                 outputEvents.Add(node.Event);
                         }
@@ -115,6 +117,13 @@ namespace Calamari.Common.Features.StructuredVariables
                                 outputEvents.AddRange(ParseFragment(structureWeAreReplacing.Value.replacementValue,
                                                                     sequenceStart.Event.Anchor,
                                                                     sequenceStart.Event.Tag));
+                                structureWeAreReplacing = null;
+                            }
+                            else if ((node is YamlNode<MappingStart> || node is YamlNode<SequenceStart>) 
+                                     && structureWeAreReplacing.Value.startEvent is YamlNode<Comment> comment)
+                            {
+                                outputEvents.Add(node.Event);
+                                outputEvents.Add(structureWeAreReplacing.Value.startEvent.Event);
                                 structureWeAreReplacing = null;
                             }
                         }

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -124,8 +124,8 @@ namespace Calamari.Common.Features.StructuredVariables
                             {
                                 // We aren't doing any replacement here, YamlDotNet gives us the comment and the
                                 // mapping/sequence start element in a different order to what we would expect
-                                // (comment first, start element second), so we are flipping them back to the
-                                // other way around so the output is correct.
+                                // (comment first, start element second instead of the other way around),
+                                // so we are flipping them back to the other way around so the output is correct.
                                 outputEvents.Add(node.Event);
                                 outputEvents.Add(structureWeAreReplacing.Value.startEvent.Event);
                                 structureWeAreReplacing = null;

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -122,6 +122,10 @@ namespace Calamari.Common.Features.StructuredVariables
                             else if ((node is YamlNode<MappingStart> || node is YamlNode<SequenceStart>) 
                                      && structureWeAreReplacing.Value.startEvent is YamlNode<Comment> comment)
                             {
+                                // We aren't doing any replacement here, YamlDotNet gives us the comment and the
+                                // mapping/sequence start element in a different order to what we would expect
+                                // (comment first, start element second), so we are flipping them back to the
+                                // other way around so the output is correct.
                                 outputEvents.Add(node.Event);
                                 outputEvents.Add(structureWeAreReplacing.Value.startEvent.Event);
                                 structureWeAreReplacing = null;

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -119,8 +119,8 @@ namespace Calamari.Common.Features.StructuredVariables
                                                                     sequenceStart.Event.Tag));
                                 structureWeAreReplacing = null;
                             }
-                            else if ((node is YamlNode<MappingStart> || node is YamlNode<SequenceStart>) 
-                                     && structureWeAreReplacing.Value.startEvent is YamlNode<Comment> comment)
+                            else if ((node is YamlNode<MappingStart> || node is YamlNode<SequenceStart>)
+                                     && structureWeAreReplacing.Value.startEvent is YamlNode<Comment>)
                             {
                                 // We aren't doing any replacement here, YamlDotNet gives us the comment and the
                                 // mapping/sequence start element in a different order to what we would expect
@@ -128,6 +128,14 @@ namespace Calamari.Common.Features.StructuredVariables
                                 // so we are flipping them back to the other way around so the output is correct.
                                 outputEvents.Add(node.Event);
                                 outputEvents.Add(structureWeAreReplacing.Value.startEvent.Event);
+                                structureWeAreReplacing = null;
+                            }
+                            else if (structureWeAreReplacing.Value.startEvent is YamlNode<Comment>)
+                            {
+                                // Comment after any other type of element, just put in the order in which they
+                                // were given to us
+                                outputEvents.Add(structureWeAreReplacing.Value.startEvent.Event);
+                                outputEvents.Add(node.Event);                                
                                 structureWeAreReplacing = null;
                             }
                         }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
@@ -1,18 +1,20 @@
-﻿platform: x64
-environment:
-  matrix:
-  - DC: dmd
-    # DVersion: nightly
-    arch: x64
-  - DC: dmd
-    # DVersion: nightly
-    arch: x86
-    # - DC: dmd
-    #   DVersion: beta
-    #   arch: x64  
-  - DC: dmd
-    DVersion: stable
-    arch: x86
+﻿# block at start
+platform: x64
+# block at top level
+environment: # inline at top level
+  matrix: # inline at nested level
+    - DC: dmd
+      # DVersion: nightly
+      arch: x64
+    - DC: dmd
+      # DVersion: nightly
+      arch: x86
+      # - DC: dmd
+      #   DVersion: beta
+      #   arch: x64  
+    - DC: dmd
+      DVersion: stable
+      arch: x86
 skip_tags: false
 branches:
   only:

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
@@ -12,8 +12,8 @@ environment: # inline at top level
       # - DC: dmd
       #   DVersion: beta
       #   arch: x64  
-    - DC: dmd
-      DVersion: stable
+    - DC: dmd # inline at value
+      DVersion: stable # inline at replaced value
       arch: x86
 skip_tags: false
 branches:

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
@@ -1,6 +1,8 @@
+# block at start
 platform: x64
-environment:
-  matrix:
+# block at top level
+environment: # inline at top level
+  matrix: # inline at nested level
   - DC: dmd
     # DVersion: nightly
     arch: x64

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
@@ -12,8 +12,8 @@ environment: # inline at top level
     # - DC: dmd
     #   DVersion: beta
     #   arch: x64  
-  - DC: dmd
-    DVersion: beta
+  - DC: dmd # inline at value
+    DVersion: beta # inline at replaced value
     arch: x86
 skip_tags: false
 branches:


### PR DESCRIPTION
This PR fixes issues reported in https://github.com/OctopusDeploy/Issues/issues/6905 where performing structure replacement of a yaml file containing inline comments on a mapping or sequence starting element would cause the output to be invalid.

Also adds a couple of more block comments to the test case to increase coverage.