### PR TITLE
Fixes issues with YAML structure configuration replacement and inline comments

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
@@ -189,6 +189,9 @@ namespace Calamari.Common.Features.StructuredVariables
                     }
 
                     break;
+                case Comment c:
+                    classifiedNode = new YamlNode<Comment>(c, stack.GetPath());
+                    break;
             }
 
             return classifiedNode ?? new YamlNode<ParsingEvent>(ev, stack.GetPath());

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
@@ -88,7 +88,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
 
                 var packages = store.GetNearestPackages("Acme.Web", new SemanticVersion("1.1.1.1"));
 
-                CollectionAssert.AreEquivalent(new[] {"1.0.0.1"}, packages.Select(c => c.Version.ToString()));
+                CollectionAssert.AreEquivalent(new[] { "1.0.0.1" }, packages.Select(c => c.Version.ToString()));
             }
         }
 

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
@@ -1,18 +1,20 @@
-﻿platform: x64
-environment:
-  matrix:
-  - DC: dmd
-    # DVersion: nightly
-    arch: x64
-  - DC: dmd
-    # DVersion: nightly
-    arch: x86
-    # - DC: dmd
-    #   DVersion: beta
-    #   arch: x64  
-  - DC: dmd
-    DVersion: stable
-    arch: x86
+﻿# block at start
+platform: x64
+# block at top level
+environment: # inline at top level
+  matrix: # inline at nested level
+    - DC: dmd
+      # DVersion: nightly
+      arch: x64
+    - DC: dmd
+      # DVersion: nightly
+      arch: x86
+      # - DC: dmd
+      #   DVersion: beta
+      #   arch: x64  
+    - DC: dmd # inline at value
+      DVersion: stable # inline at replaced value
+      arch: x86
 skip_tags: false
 branches:
   only:

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
@@ -1,6 +1,8 @@
+# block at start
 platform: x64
-environment:
-  matrix:
+# block at top level
+environment: # inline at top level
+  matrix: # inline at nested level
   - DC: dmd
     # DVersion: nightly
     arch: x64
@@ -10,8 +12,8 @@ environment:
     # - DC: dmd
     #   DVersion: beta
     #   arch: x64  
-  - DC: dmd
-    DVersion: beta
+  - DC: dmd # inline at value
+    DVersion: beta # inline at replaced value
     arch: x86
 skip_tags: false
 branches:


### PR DESCRIPTION
This PR fixes issues reported in https://github.com/OctopusDeploy/Issues/issues/6905 where performing structure replacement of a yaml file containing inline comments on a mapping or sequence starting element would cause the output to be invalid.

Also adds a couple more block comments to the test case to increase coverage.