### PR TITLE
Merge release/2020.6 into release/2021.1

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -31,11 +31,8 @@ string nugetVersion;
 // From time to time the timestamping services go offline, let's try a few of them so our builds are more resilient
 var timestampUrls = new string[]
 {
-    "http://timestamp.globalsign.com/scripts/timestamp.dll",
-    "http://www.startssl.com/timestamp",
-    "http://timestamp.comodoca.com/rfc3161",
-    "http://timestamp.verisign.com/scripts/timstamp.dll",
-    "http://tsa.starfieldtech.com"
+    "http://timestamp.digicert.com?alg=sha256",
+    "http://timestamp.comodoca.com"
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -356,7 +353,9 @@ private void TimeStampFiles(IEnumerable<FilePath> files)
     {
         var timestampArguments = new ProcessArgumentBuilder()
             .Append($"timestamp")
-            .Append("/tr").AppendQuoted(url);
+            .Append("/tr").AppendQuoted(url)
+            .Append("/td").Append("sha256");
+
         foreach (var file in files)
         {
             timestampArguments.AppendQuoted(file.FullPath);

--- a/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlEventStreamClassifier.cs
@@ -189,6 +189,9 @@ namespace Calamari.Common.Features.StructuredVariables
                     }
 
                     break;
+                case Comment c:
+                    classifiedNode = new YamlNode<Comment>(c, stack.GetPath());
+                    break;
             }
 
             return classifiedNode ?? new YamlNode<ParsingEvent>(ev, stack.GetPath());

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.JsonFileOutput/Acme.JsonFileOutput.nuspec
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.JsonFileOutput/Acme.JsonFileOutput.nuspec
@@ -12,7 +12,6 @@
     <language>en-US</language>
   </metadata>
    <files>
-    <file src="**\*.*" target="" exclude="*.csproj"/>
     <file src="**/*.*" target="" exclude="*.csproj"/>
   </files>
 </package>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Package/Acme.Package.nuspec
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Package/Acme.Package.nuspec
@@ -12,7 +12,6 @@
     <language>en-US</language>
   </metadata>
    <files>
-    <file src="**\*.*" target="" exclude="*.csproj"/>
     <file src="**/*.*" target="" exclude="*.csproj"/>
   </files>
 </package>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.PackageBilingual/Acme.PackageBilingual.nuspec
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.PackageBilingual/Acme.PackageBilingual.nuspec
@@ -12,7 +12,6 @@
     <language>en-US</language>
   </metadata>
    <files>
-    <file src="**\*.*" target="" exclude="*.csproj"/>
     <file src="**/*.*" target="" exclude="*.csproj"/>
   </files>
 </package>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Service/Acme.Service.nuspec
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Service/Acme.Service.nuspec
@@ -12,7 +12,6 @@
     <language>en-US</language>
   </metadata>
   <files>
-    <file src="**\*.*" target="" exclude="*.csproj;bin/**;obj/**"/>
     <file src="**/*.*" target="" exclude="*.csproj;bin/**;obj/**"/>
   </files>
 </package>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/Acme.StructuredConfigFiles.nuspec
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/Acme.StructuredConfigFiles.nuspec
@@ -12,7 +12,6 @@
     <language>en-US</language>
   </metadata>
    <files>
-    <file src="**\*.*" target="" exclude="*.csproj"/>
     <file src="**/*.*" target="" exclude="*.csproj"/>
   </files>
 </package>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web.Tests/Acme.Web.Tests.Nix.nuspec
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web.Tests/Acme.Web.Tests.Nix.nuspec
@@ -11,7 +11,6 @@
     <licenseUrl>https://github.com/OctopusDeploy/Calamari/blob/master/LICENSE.txt</licenseUrl>
   </metadata>
   <files>
-    <file src="**\*.*" target="" exclude="*.csproj;*.ps1;bin/**;obj/**"/>
     <file src="**/*.*" target="" exclude="*.csproj;*.ps1;bin/**;obj/**"/>
   </files>
 </package>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web.Tests/Acme.Web.Tests.nuspec
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web.Tests/Acme.Web.Tests.nuspec
@@ -11,7 +11,6 @@
     <licenseUrl>https://github.com/OctopusDeploy/Calamari/blob/master/LICENSE.txt</licenseUrl>
   </metadata>
   <files>
-    <file src="**\*.*" target="" exclude="*.csproj;*.sh;bin/**;obj/**"/>
     <file src="**/*.*" target="" exclude="*.csproj;*.sh;bin/**;obj/**"/>
   </files>
 </package>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Acme.Web.Nix.nuspec
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Acme.Web.Nix.nuspec
@@ -11,7 +11,6 @@
     <licenseUrl>https://github.com/OctopusDeploy/Calamari/blob/master/LICENSE.txt</licenseUrl>
   </metadata>
   <files>
-    <file src="**\*.*" target="" exclude="*.csproj;*.ps1;bin/**;obj/**"/>
     <file src="**/*.*" target="" exclude="*.csproj;*.ps1;bin/**;obj/**"/>
   </files>
 </package>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Acme.Web.nuspec
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Acme.Web.nuspec
@@ -11,7 +11,6 @@
     <licenseUrl>https://github.com/OctopusDeploy/Calamari/blob/master/LICENSE.txt</licenseUrl>
   </metadata>
   <files>
-    <file src="**\*.*" target="" exclude="*.csproj;*.sh;bin/**;obj/**"/>
     <file src="**/*.*" target="" exclude="*.csproj;*.sh;bin/**;obj/**"/>
   </files>
 </package>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/DumpArgs/DumpArgs.nuspec
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/DumpArgs/DumpArgs.nuspec
@@ -12,7 +12,6 @@
     <language>en-US</language>
   </metadata>
   <files>
-    <file src="**\*.*" target="" exclude="*.csproj;bin/**;obj/**"/>
     <file src="**/*.*" target="" exclude="*.csproj;bin/**;obj/**"/>
   </files>
 </package>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Octopus.Sample.AzureCloudService/Octopus.Sample.AzureCloudService.nuspec
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Octopus.Sample.AzureCloudService/Octopus.Sample.AzureCloudService.nuspec
@@ -10,7 +10,6 @@
     <licenseUrl>http://tempuri.org/</licenseUrl>
   </metadata>
    <files>
-    <file src="**\*.*" target="" exclude="*.csproj"/>
     <file src="**/*.*" target="" exclude="*.csproj"/>
   </files>
 </package>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/PackageBuilder.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/PackageBuilder.cs
@@ -28,7 +28,7 @@ namespace Calamari.Tests.Fixtures.Deployment.Packages
             var nugetCommandLine = "dotnet";
 
             var target = GetNixFileOrDefault(packageDirectory, name, ".csproj");
-#endif                 
+#endif
 
             var output = Path.Combine(Path.GetTempPath(), "CalamariTestPackages");
             Directory.CreateDirectory(output);
@@ -74,8 +74,8 @@ namespace Calamari.Tests.Fixtures.Deployment.Packages
             else
             {
                 var path = Path.Combine(filePath, filePrefix + ".Nix" + fileSuffix);
-                return File.Exists(path) 
-                    ? path 
+                return File.Exists(path)
+                    ? path
                     : GetWindowsOrDefaultPath();
             }
 
@@ -90,7 +90,7 @@ namespace Calamari.Tests.Fixtures.Deployment.Packages
         static string AddFileToPackage(string packageDirectory)
         {
             var indexFilePath = Path.Combine(packageDirectory, "index.html");
-            var content = 
+            var content =
 "<!DOCTYPE html>\n" +
 "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n" +
 "<head>\n" +

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
@@ -90,7 +90,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
 
                 var packages = store.GetNearestPackages("Acme.Web", new SemanticVersion("1.1.1.1"));
 
-                CollectionAssert.AreEquivalent(new[] {"1.0.0.1"}, packages.Select(c => c.Version.ToString()));
+                CollectionAssert.AreEquivalent(new[] { "1.0.0.1" }, packages.Select(c => c.Version.ToString()));
             }
         }
 
@@ -104,11 +104,11 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         private string CreatePackage(string version, bool oldCacheFormat = false)
         {
             var sourcePackage = PackageBuilder.BuildSamplePackage("Acme.Web", version, true);
-            
+
             var destinationPath = Path.Combine(PackagePath, oldCacheFormat
                 ? $"Acme.Web.{version}.nupkg-fd55edc5-9b36-414b-a2d0-4a2deeb6b2ec"
                 : PackageName.ToCachedFileName("Acme.Web", new SemanticVersion(version), ".nupkg"));
-            
+
             if (File.Exists(destinationPath))
                 File.Delete(destinationPath);
 

--- a/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
@@ -68,7 +68,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
         public void ShouldCallHelloWithSensitiveVariable()
         {
             var (output, _) = RunScript("Hello.csx", new Dictionary<string, string>()
-            { ["Name"] = "NameToEncrypt" }, sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
+                { ["Name"] = "NameToEncrypt" }, sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
 
             output.AssertSuccess();
             output.AssertOutput("Hello NameToEncrypt");
@@ -78,7 +78,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
         public void ShouldConsumeParametersWithQuotes()
         {
             var (output, _) = RunScript("Parameters.csx", new Dictionary<string, string>()
-            { [SpecialVariables.Action.Script.ScriptParameters] = "-- \"Para meter0\" Parameter1" });
+                { [SpecialVariables.Action.Script.ScriptParameters] = "-- \"Para meter0\" Parameter1" });
 
             output.AssertSuccess();
             output.AssertOutput("Parameters Para meter0Parameter1");
@@ -88,7 +88,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
         public void ShouldConsumeParametersWithoutParametersPrefix()
         {
             var (output, _) = RunScript("Parameters.csx", new Dictionary<string, string>()
-            { [SpecialVariables.Action.Script.ScriptParameters] = "Parameter0 Parameter1" });
+                { [SpecialVariables.Action.Script.ScriptParameters] = "Parameter0 Parameter1" });
 
             output.AssertSuccess();
             output.AssertOutput("Parameters Parameter0Parameter1");

--- a/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
@@ -68,7 +68,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
         public void ShouldCallHelloWithSensitiveVariable()
         {
             var (output, _) = RunScript("Hello.csx", new Dictionary<string, string>()
-                {["Name"] = "NameToEncrypt"}, sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
+            { ["Name"] = "NameToEncrypt" }, sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
 
             output.AssertSuccess();
             output.AssertOutput("Hello NameToEncrypt");
@@ -78,7 +78,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
         public void ShouldConsumeParametersWithQuotes()
         {
             var (output, _) = RunScript("Parameters.csx", new Dictionary<string, string>()
-                { [SpecialVariables.Action.Script.ScriptParameters] = "-- \"Para meter0\" Parameter1" });
+            { [SpecialVariables.Action.Script.ScriptParameters] = "-- \"Para meter0\" Parameter1" });
 
             output.AssertSuccess();
             output.AssertOutput("Parameters Para meter0Parameter1");
@@ -88,7 +88,7 @@ namespace Calamari.Tests.Fixtures.ScriptCS
         public void ShouldConsumeParametersWithoutParametersPrefix()
         {
             var (output, _) = RunScript("Parameters.csx", new Dictionary<string, string>()
-                { [SpecialVariables.Action.Script.ScriptParameters] = "Parameter0 Parameter1" });
+            { [SpecialVariables.Action.Script.ScriptParameters] = "Parameter0 Parameter1" });
 
             output.AssertSuccess();
             output.AssertOutput("Parameters Parameter0Parameter1");

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
@@ -1,18 +1,20 @@
-﻿platform: x64
-environment:
-  matrix:
-  - DC: dmd
-    # DVersion: nightly
-    arch: x64
-  - DC: dmd
-    # DVersion: nightly
-    arch: x86
-    # - DC: dmd
-    #   DVersion: beta
-    #   arch: x64  
-  - DC: dmd
-    DVersion: stable
-    arch: x86
+﻿# block at start
+platform: x64
+# block at top level
+environment: # inline at top level
+  matrix: # inline at nested level
+    - DC: dmd
+      # DVersion: nightly
+      arch: x64
+    - DC: dmd
+      # DVersion: nightly
+      arch: x86
+      # - DC: dmd
+      #   DVersion: beta
+      #   arch: x64  
+    - DC: dmd # inline at value
+      DVersion: stable # inline at replaced value
+      arch: x86
 skip_tags: false
 branches:
   only:

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
@@ -1,6 +1,8 @@
+# block at start
 platform: x64
-environment:
-  matrix:
+# block at top level
+environment: # inline at top level
+  matrix: # inline at nested level
   - DC: dmd
     # DVersion: nightly
     arch: x64
@@ -10,8 +12,8 @@ environment:
     # - DC: dmd
     #   DVersion: beta
     #   arch: x64  
-  - DC: dmd
-    DVersion: beta
+  - DC: dmd # inline at value
+    DVersion: beta # inline at replaced value
     arch: x86
 skip_tags: false
 branches:


### PR DESCRIPTION
This PR merges release/2020.6 into release/2021.1 to capture fixes from https://github.com/OctopusDeploy/Calamari/pull/732