### PR TITLE
Changes AWS and Kubernetes context tests so test execution can be controlled in CI

### DIFF
--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixture.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 
 namespace Calamari.Tests.AWS.CloudFormation
 {
-    [TestFixture]
+    [TestFixture, Explicit]
     public class CloudFormationFixture
     {
         private string StackName;

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixture.cs
@@ -8,7 +8,8 @@ using NUnit.Framework;
 
 namespace Calamari.Tests.AWS.CloudFormation
 {
-    [TestFixture, Explicit]
+    [TestFixture]
+    [Category(TestCategory.RunOnceOnWindowsAndLinux)]
     public class CloudFormationFixture
     {
         private string StackName;

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 namespace Calamari.Tests.AWS.CloudFormation
 {
-    [TestFixture]
+    [TestFixture, Explicit]
     public class CloudFormationVariableReplacementFixture
     {
         private string StackName;

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
@@ -7,7 +7,8 @@ using NUnit.Framework;
 
 namespace Calamari.Tests.AWS.CloudFormation
 {
-    [TestFixture, Explicit]
+    [TestFixture]
+    [Category(TestCategory.RunOnceOnWindowsAndLinux)]
     public class CloudFormationVariableReplacementFixture
     {
         private string StackName;

--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -34,7 +34,8 @@ using Octostache;
 
 namespace Calamari.Tests.AWS
 {
-    [TestFixture, Explicit]
+    [TestFixture]
+    [Category(TestCategory.RunOnceOnWindowsAndLinux)]
     public class S3Fixture
     {
         private const string BucketName = "octopus-e2e-tests";

--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -34,7 +34,7 @@ using Octostache;
 
 namespace Calamari.Tests.AWS
 {
-    [TestFixture]
+    [TestFixture, Explicit]
     public class S3Fixture
     {
         private const string BucketName = "octopus-e2e-tests";

--- a/source/Calamari.Tests/Helpers/TestCategory.cs
+++ b/source/Calamari.Tests/Helpers/TestCategory.cs
@@ -21,5 +21,6 @@ namespace Calamari.Tests.Helpers
         }
         
         public const string PlatformAgnostic = "PlatformAgnostic";
+        public const string RunOnceOnWindowsAndLinux = "RunOnceOnWindowsAndLinux";
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
@@ -9,6 +9,7 @@ using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Kubernetes;
+using Calamari.Tests.Helpers;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -16,7 +17,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.KubernetesFixtures
 {
     [TestFixture]
-    [Explicit]
+    [Category(TestCategory.RunOnceOnWindowsAndLinux)]
     public class KubernetesContextScriptWrapperLiveFixture: KubernetesContextScriptWrapperLiveFixtureBase
     {
         InstallTools installTools;


### PR DESCRIPTION
This PR marks tests that were added/enabled in #729 as Explicit as we are getting rate limited by AWS when running them all the time. We are going to run them explicitly against one Linux and one Windows test run as this will give us enough coverage and hopefully then we won't have any issues.