### PR TITLE
Unset impersonate_service_account when not in use

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount.approved.txt
@@ -3,9 +3,7 @@
 [Verbose] Authenticating to gcloud with key file
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"
 [Verbose] Successfully authenticated with gcloud
-[Verbose] "gcloud" config unset auth/impersonate_service_account
 [Info] Creating kubectl context to GKE Cluster called gke-cluster-name (namespace calamari-testing) using a Google Cloud Account
-[Verbose] "gcloud" config set project gke-project
 [Verbose] "gcloud" container clusters get-credentials gke-cluster-name --zone=gke-zone
 [Verbose] "kubectl" config set-context gke-cluster-name --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount.approved.txt
@@ -3,6 +3,7 @@
 [Verbose] Authenticating to gcloud with key file
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"
 [Verbose] Successfully authenticated with gcloud
+[Verbose] "gcloud" config unset auth/impersonate_service_account
 [Info] Creating kubectl context to GKE Cluster called gke-cluster-name (namespace calamari-testing) using a Google Cloud Account
 [Verbose] "gcloud" config set project gke-project
 [Verbose] "gcloud" container clusters get-credentials gke-cluster-name --zone=gke-zone

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -511,19 +511,9 @@ namespace Calamari.Kubernetes
             void SetupContextForGoogleCloudAccount(string kubeConfig, string @namespace)
             {
                 var gkeClusterName = variables.Get(SpecialVariables.GkeClusterName);
-                var project = variables.Get("Octopus.Action.GoogleCloud.Project");
                 var zone = variables.Get("Octopus.Action.GoogleCloud.Zone");
                 log.Info($"Creating kubectl context to GKE Cluster called {gkeClusterName} (namespace {@namespace}) using a Google Cloud Account");
 
-                if (!string.IsNullOrEmpty(project))
-                {
-                    ExecuteCommand(gcloud,
-                                   LogType.Info,
-                                   "config",
-                                   "set",
-                                   "project",
-                                   project);
-                }
                 var arguments = new List<string>(new[]
                 {
                     "container",
@@ -687,23 +677,7 @@ namespace Calamari.Kubernetes
                 {
                     var impersonationEmails = variables.Get("Octopus.Action.GoogleCloud.ServiceAccountEmails");
                     if (!string.IsNullOrEmpty(impersonationEmails))
-                    {
-                        ExecuteCommand(gcloud,
-                                       LogType.Info, 
-                                       "config",
-                                       "set",
-                                       "auth/impersonate_service_account",
-                                       impersonationEmails);
-                        log.Verbose("Impersonation emails set.");
-                    }
-                }
-                else
-                {
-                    ExecuteCommand(gcloud,
-                                   LogType.Info, 
-                                   "config",
-                                   "unset",
-                                   "auth/impersonate_service_account");
+                        environmentVars.Add("CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT", impersonationEmails);
                 }
                 
             }


### PR DESCRIPTION
When running K8s deployment target health check using Octopus worker, I notice that sometimes the `auth/impersonate_service_account` value is not reset.
When we select an account to impersonate we set the impersonate email to `auth/impersonate_service_account`. This value maybe hanged around and may affect other processes which don't want to impersonate another account.

This PR is to ensure when `ImpersonateServiceAccount` is set to `false`, we will explicitly unset the `auth/impersonate_service_account` value.