### PR TITLE
Wrapped kubeConfig

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
@@ -1,4 +1,4 @@
-[Verbose] "chmod" u=rw,g=,o= <path>kubectl-octo.yml
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
@@ -8,6 +8,6 @@
 [Verbose] "az" account set --subscription azSubscriptionId
 [Info] Successfully authenticated with the Azure CLI
 [Info] Creating kubectl context to AKS Cluster in resource group clusterRG called asCluster (namespace calamari-testing) using a AzureServicePrincipal
-[Verbose] "az" aks get-credentials --resource-group clusterRG --name asCluster --file <path>kubectl-octo.yml --overwrite-existing
+[Verbose] "az" aks get-credentials --resource-group clusterRG --name asCluster --file "<path>kubectl-octo.yml" --overwrite-existing
 [Verbose] "kubectl" config set-context asCluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
@@ -1,4 +1,4 @@
-[Verbose] "chmod" u=rw,g=,o= <path>kubectl-octo.yml
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
 [Verbose] "az" cloud set --name AzureCloud

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
@@ -7,6 +7,6 @@
 [Verbose] "az" account set --subscription azSubscriptionId
 [Info] Successfully authenticated with the Azure CLI
 [Info] Creating kubectl context to AKS Cluster in resource group clusterRG called asCluster (namespace calamari-testing) using a AzureServicePrincipal
-[Verbose] "az" aks get-credentials --resource-group clusterRG --name asCluster --file <path>kubectl-octo.yml --overwrite-existing --admin
+[Verbose] "az" aks get-credentials --resource-group clusterRG --name asCluster --file "<path>kubectl-octo.yml" --overwrite-existing --admin
 [Verbose] "kubectl" config set-context asCluster-admin --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
@@ -1,4 +1,4 @@
-[Verbose] "chmod" u=rw,g=,o= <path>kubectl-octo.yml
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable.approved.txt
@@ -1,3 +1,3 @@
-[Verbose] "chmod" u=rw,g=,o= <path>\kubectl-octo.yml
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>\kubectl-octo.yml
 [Error] The custom kubectl location of mykubectl does not exist. See https://g.octopushq.com/KubernetesTarget for more information.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileDoesNotExist.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileDoesNotExist.approved.txt
@@ -1,3 +1,3 @@
-[Verbose] "chmod" u=rw,g=,o= <path>kubectl-octo.yml
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Error] The custom kubectl location of mykubectl does not exist. See https://g.octopushq.com/KubernetesTarget for more information.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS.approved.txt
@@ -1,4 +1,4 @@
-[Verbose] "chmod" u=rw,g=,o= <path>kubectl-octo.yml
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithUsernamePassword.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithUsernamePassword.approved.txt
@@ -1,4 +1,4 @@
-[Verbose] "chmod" u=rw,g=,o= <path>kubectl-octo.yml
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
@@ -233,7 +233,7 @@ namespace Calamari.Tests.KubernetesFixtures
             var wrapper = CreateWrapper();
             TestScript(wrapper, "Test-Script");
         }
-        
+
         [Test]
         public void AuthorisingWithGoogleCloudAccount()
         {

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -89,12 +89,17 @@ namespace Calamari.Tests.KubernetesFixtures
         protected void TestScript(IScriptWrapper wrapper, string scriptName)
         {
             using (var dir = TemporaryDirectory.Create())
-            using (var temp = new TemporaryFile(Path.Combine(dir.DirectoryPath, $"{scriptName}.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
             {
-                File.WriteAllText(temp.FilePath, "kubectl cluster-info");
+                var folderPath = Path.Combine(dir.DirectoryPath, "Folder with spaces");
 
-                var output = ExecuteScript(wrapper, temp.FilePath);
-                output.AssertSuccess();
+                using (var temp = new TemporaryFile(Path.Combine(folderPath, $"{scriptName}.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
+                {
+                    Directory.CreateDirectory(folderPath);
+                    File.WriteAllText(temp.FilePath, "kubectl cluster-info");
+
+                    var output = ExecuteScript(wrapper, temp.FilePath);
+                    output.AssertSuccess();
+                }
             }
         }
     }

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -693,7 +693,7 @@ namespace Calamari.Kubernetes
 
                 if (scriptSyntax == ScriptSyntax.Bash)
                 {
-                    ExecuteCommand("chmod", LogType.Verbose, "u=rw,g=,o=", kubeConfig);
+                    ExecuteCommand("chmod", LogType.Verbose, "u=rw,g=,o=", $"\"{kubeConfig}\"");
                 }
 
                 log.Verbose($"Temporary kubectl config set to {kubeConfig}");

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -183,7 +183,7 @@ namespace Calamari.Kubernetes
 
                 var isUsingGoogleCloudAuth = accountType == "GoogleCloudAccount" || useVmServiceAccount;
                 var isUsingAzureServicePrincipalAuth = accountType == "AzureServicePrincipal";
-                
+
                 if (!isUsingAzureServicePrincipalAuth && !isUsingGoogleCloudAuth && string.IsNullOrEmpty(clusterUrl))
                 {
                     log.Error("Kubernetes cluster URL is missing");
@@ -253,9 +253,9 @@ namespace Calamari.Kubernetes
                         log.Error("Could not find gcloud. Make sure gcloud is on the PATH.");
                         return false;
                     }
-                    
+
                     ConfigureGcloudAccount(useVmServiceAccount);
-                    SetupContextForGoogleCloudAccount(kubeConfig, @namespace);
+                    SetupContextForGoogleCloudAccount(@namespace);
                 }
                 else
                 {
@@ -491,7 +491,7 @@ namespace Calamari.Kubernetes
                     "--name",
                     azureCluster,
                     "--file",
-                    kubeConfig,
+                    $"\"{kubeConfig}\"",
                     "--overwrite-existing"
                 });
                 if (azureAdmin)
@@ -508,7 +508,7 @@ namespace Calamari.Kubernetes
                                       $"--namespace={@namespace}");
             }
 
-            void SetupContextForGoogleCloudAccount(string kubeConfig, string @namespace)
+            void SetupContextForGoogleCloudAccount(string @namespace)
             {
                 var gkeClusterName = variables.Get(SpecialVariables.GkeClusterName);
                 var zone = variables.Get("Octopus.Action.GoogleCloud.Zone");
@@ -522,7 +522,7 @@ namespace Calamari.Kubernetes
                     gkeClusterName,
                     $"--zone={zone}"
                 });
-                
+
                 ExecuteCommand(gcloud, LogType.Info, arguments.ToArray());
                 ExecuteKubectlCommand("config",
                                       "set-context",
@@ -551,7 +551,7 @@ namespace Calamari.Kubernetes
                 gcloud = CalamariEnvironment.IsRunningOnWindows
                     ? ExecuteCommandAndReturnOutput("where", "gcloud.cmd").FirstOrDefault()
                     : ExecuteCommandAndReturnOutput("which", "gcloud").FirstOrDefault();
-                
+
                 if (string.IsNullOrEmpty(gcloud))
                 {
                     return false;
@@ -637,7 +637,7 @@ namespace Calamari.Kubernetes
                 {
                     environmentVars.Add("CLOUDSDK_COMPUTE_ZONE", zone);
                 }
-                
+
                 if (!useVmServiceAccount)
                 {
                     var accountVariable = variables.Get("Octopus.Action.GoogleCloudAccount.Variable");
@@ -672,14 +672,14 @@ namespace Calamari.Kubernetes
                 {
                     log.Verbose("Bypassing authentication with gcloud");
                 }
-                
+
                 if (variables.GetFlag("Octopus.Action.GoogleCloud.ImpersonateServiceAccount"))
                 {
                     var impersonationEmails = variables.Get("Octopus.Action.GoogleCloud.ServiceAccountEmails");
                     if (!string.IsNullOrEmpty(impersonationEmails))
                         environmentVars.Add("CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT", impersonationEmails);
                 }
-                
+
             }
 
             string ConfigureCliExecution()


### PR DESCRIPTION
Ensure that `kubeConfig` is wrapped inside double quotes to have a valid path when running in Linux. 

This change will fix the failing tests in `Gate: Steps Test` which have been occurring since we merged GCP changes for K8s. The remote tests with this change have been run successfully. 

The successful build is in here: https://build.octopushq.com/buildConfiguration/OctopusDeploy_OctopusServer_TestOrchestration_GateStepsTests?buildTypeTab=overview&branch=&mode=builds