### PR TITLE
K8s - Redirect command outputs based on ExitCode

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount.approved.txt
@@ -4,6 +4,6 @@
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"
 [Verbose] Successfully authenticated with gcloud
 [Info] Creating kubectl context to GKE Cluster called gke-cluster-name (namespace calamari-testing) using a Google Cloud Account
-[Verbose] "gcloud" container clusters get-credentials gke-cluster-name --zone=gke-zone
+[Verbose] "gcloud" container clusters get-credentials gke-cluster-name
 [Verbose] "kubectl" config set-context gke-cluster-name --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -322,7 +322,8 @@ namespace Calamari.Tests.KubernetesFixtures
         {
             public CommandResult Execute(CommandLineInvocation invocation)
             {
-                invocation.AdditionalInvocationOutputSink?.WriteInfo(Path.GetFileNameWithoutExtension(invocation.Arguments));
+                if (new string[] { "kubectl", "az", "gcloud", "kubectl.exe", "az.cmd", "gcloud.cmd" }.Contains(invocation.Arguments)) 
+                    invocation.AdditionalInvocationOutputSink?.WriteInfo(Path.GetFileNameWithoutExtension(invocation.Arguments));
                 return new CommandResult(invocation.ToString(), 0);
             }
         }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -322,6 +322,7 @@ namespace Calamari.Tests.KubernetesFixtures
         {
             public CommandResult Execute(CommandLineInvocation invocation)
             {
+                // We only want to output executable string. eg. ExecuteCommandAndReturnOutput("where", "kubectl.exe")
                 if (new string[] { "kubectl", "az", "gcloud", "kubectl.exe", "az.cmd", "gcloud.cmd" }.Contains(invocation.Arguments)) 
                     invocation.AdditionalInvocationOutputSink?.WriteInfo(Path.GetFileNameWithoutExtension(invocation.Arguments));
                 return new CommandResult(invocation.ToString(), 0);

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -511,6 +511,7 @@ namespace Calamari.Kubernetes
             void SetupContextForGoogleCloudAccount(string @namespace)
             {
                 var gkeClusterName = variables.Get(SpecialVariables.GkeClusterName);
+                var region = variables.Get("Octopus.Action.GoogleCloud.Region");
                 var zone = variables.Get("Octopus.Action.GoogleCloud.Zone");
                 log.Info($"Creating kubectl context to GKE Cluster called {gkeClusterName} (namespace {@namespace}) using a Google Cloud Account");
 
@@ -519,10 +520,18 @@ namespace Calamari.Kubernetes
                     "container",
                     "clusters",
                     "get-credentials",
-                    gkeClusterName,
-                    $"--zone={zone}"
+                    gkeClusterName
                 });
 
+                if (!string.IsNullOrEmpty(zone))
+                {
+                    arguments.Add($"--zone={zone}");
+                }
+                else if (!string.IsNullOrEmpty(region))
+                {
+                    arguments.Add($"--region={region}");
+                }
+                    
                 ExecuteCommand(gcloud, LogType.Info, arguments.ToArray());
                 ExecuteKubectlCommand("config",
                                       "set-context",

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -511,8 +511,6 @@ namespace Calamari.Kubernetes
             void SetupContextForGoogleCloudAccount(string @namespace)
             {
                 var gkeClusterName = variables.Get(SpecialVariables.GkeClusterName);
-                var region = variables.Get("Octopus.Action.GoogleCloud.Region");
-                var zone = variables.Get("Octopus.Action.GoogleCloud.Zone");
                 log.Info($"Creating kubectl context to GKE Cluster called {gkeClusterName} (namespace {@namespace}) using a Google Cloud Account");
 
                 var arguments = new List<string>(new[]
@@ -522,15 +520,6 @@ namespace Calamari.Kubernetes
                     "get-credentials",
                     gkeClusterName
                 });
-
-                if (!string.IsNullOrEmpty(zone))
-                {
-                    arguments.Add($"--zone={zone}");
-                }
-                else if (!string.IsNullOrEmpty(region))
-                {
-                    arguments.Add($"--region={region}");
-                }
                     
                 ExecuteCommand(gcloud, LogType.Info, arguments.ToArray());
                 ExecuteKubectlCommand("config",

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -755,11 +755,8 @@ namespace Calamari.Kubernetes
             {
                 invocation.EnvironmentVars = environmentVars;
                 invocation.WorkingDirectory = workingDirectory;
-                invocation.OutputAsVerbose = false;
-                invocation.OutputToLog = false;
-
-                var captureCommandOutput = new CaptureCommandOutput();
-                invocation.AdditionalInvocationOutputSink = captureCommandOutput;
+                invocation.OutputAsVerbose = logType == LogType.Verbose;
+                invocation.OutputToLog = logType == LogType.Info;
 
                 if (logType != LogType.None)
                 {
@@ -769,25 +766,6 @@ namespace Calamari.Kubernetes
                 }
 
                 var result = commandLineRunner.Execute(invocation);
-
-                foreach (var message in captureCommandOutput.Messages)
-                {
-                    if (result.ExitCode == 0)
-                    {
-                        log.Verbose(message.Text);
-                        continue;
-                    }
-
-                    switch (message.Level)
-                    {
-                        case Level.Info:
-                            log.Verbose(message.Text);
-                            break;
-                        case Level.Error:
-                            log.Error(message.Text);
-                            break;
-                    }
-                }
 
                 return result;
             }
@@ -807,42 +785,24 @@ namespace Calamari.Kubernetes
                 var result = commandLineRunner.Execute(invocation);
 
                 return result.ExitCode == 0
-                    ? captureCommandOutput.Messages.Where(m => m.Level == Level.Info).Select(m => m.Text).ToArray()
+                    ? captureCommandOutput.Text
                     : Enumerable.Empty<string>();
             }
 
             class CaptureCommandOutput : ICommandInvocationOutputSink
             {
-                private List<Message> messages = new List<Message>();
+                List<string> lines = new List<string>();
 
-                public List<Message> Messages => messages;
+                public IList<string> Text => lines;
 
                 public void WriteInfo(string line)
                 {
-                    Messages.Add(new Message(Level.Info, line));
+                    lines.Add(line);
                 }
 
                 public void WriteError(string line)
                 {
-                    Messages.Add(new Message(Level.Error, line));
                 }
-            }
-
-            class Message
-            {
-                public Level Level { get; }
-                public string Text { get; }
-                public Message(Level level, string text)
-                {
-                    Level = level;
-                    Text = text;
-                }
-            }
-
-            enum Level
-            {
-                Info,
-                Error
             }
 
             enum LogType

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -837,13 +837,6 @@ namespace Calamari.Kubernetes
                 Info,
                 Error
             }
-
-            enum LogType
-            {
-                None,
-                Verbose,
-                Info
-            }
         }
     }
 }

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -520,7 +520,7 @@ namespace Calamari.Kubernetes
                     "get-credentials",
                     gkeClusterName
                 });
-                    
+
                 ExecuteCommand(gcloud, arguments.ToArray());
                 ExecuteKubectlCommand("config",
                                       "set-context",


### PR DESCRIPTION
- Redirect command outputs based on ExitCode
- Removed `--zone` argument when getting GKE credentials because zone value is already set to Environment variable