### PR TITLE
Authenticated GitHub package download

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
@@ -43,12 +43,18 @@ namespace Calamari.Integration.Packages.Download
             this.variables = variables;
         }
 
-        public PackagePhysicalFileMetadata DownloadPackage(string packageId, IVersion version, string feedId, Uri feedUri,
-            ICredentials feedCredentials, bool forcePackageDownload, int maxDownloadAttempts, TimeSpan downloadAttemptBackoff)
+        public PackagePhysicalFileMetadata DownloadPackage(string packageId,
+                                                           IVersion version,
+                                                           string feedId,
+                                                           Uri feedUri,
+                                                           string? username,
+                                                           string? password,
+                                                           bool forcePackageDownload,
+                                                           int maxDownloadAttempts,
+                                                           TimeSpan downloadAttemptBackoff)
         {
             //Always try re-pull image, docker engine can take care of the rest
             var fullImageName = GetFullImageName(packageId, version, feedUri);
-            var (username, password) = ExtractCredentials(feedCredentials, feedUri);
 
             var feedHost = GetFeedHost(feedUri);
             PerformPull(username, password, fullImageName, feedHost);
@@ -122,19 +128,6 @@ namespace Calamari.Integration.Packages.Download
 
             return (hash, size);
         }
-
-
-        (string? username, string? password) ExtractCredentials(ICredentials feedCredentials, Uri feedUri)
-        {
-            if (feedCredentials == null)
-            {
-                return (null, null);
-            }
-
-            var creds = feedCredentials.GetCredential(feedUri, "basic");
-            return (creds.UserName, creds.Password);
-        }
-
 
         string GetFetchScript()
         {

--- a/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
@@ -190,7 +190,7 @@ namespace Calamari.Integration.Packages.Download
                     {
                         client.CachePolicy = new RequestCachePolicy(RequestCacheLevel.CacheIfAvailable);
                         client.Headers.Set(HttpRequestHeader.UserAgent, GetUserAgent());
-                        client.Credentials = feedCredentials;
+                        client.Headers.Set(HttpRequestHeader.Authorization, GetAuthorization(feedCredentials, uri));
                         client.DownloadFileWithProgress(uri, tempPath, (progress, total) => log.Progress(progress, $"Downloading {packageId} v{version}"));
 
                         DeNestContents(tempPath, localDownloadName);
@@ -216,7 +216,7 @@ namespace Calamari.Integration.Packages.Download
                     client.CachePolicy = new RequestCachePolicy(RequestCacheLevel.BypassCache);
                     client.Headers.Set(HttpRequestHeader.UserAgent, GetUserAgent());
                     client.Headers.Set("Accept", "application/vnd.github.v3+json");
-                    client.Credentials = feedCredentials;
+                    client.Headers.Set(HttpRequestHeader.Authorization, GetAuthorization(feedCredentials, uri));
                     using (var readStream = client.OpenRead(uri))
                     {
                         var reader =
@@ -236,6 +236,11 @@ namespace Calamari.Integration.Packages.Download
 
                 throw;
             }
+        }
+
+        string GetAuthorization(ICredentials feedCredentials, string uri)
+        {
+            return String.Concat("token ", feedCredentials.GetCredential(new Uri(uri), "token").Password);
         }
 
         void VerifyRateLimit(HttpWebResponse response)

--- a/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
@@ -35,8 +35,15 @@ namespace Calamari.Integration.Packages.Download
             endpointProxy = new HelmEndpointProxy(client);
         }
 
-        public PackagePhysicalFileMetadata DownloadPackage(string packageId, IVersion version, string feedId, Uri feedUri,
-            ICredentials feedCredentials, bool forcePackageDownload, int maxDownloadAttempts, TimeSpan downloadAttemptBackoff)
+        public PackagePhysicalFileMetadata DownloadPackage(string packageId,
+                                                           IVersion version,
+                                                           string feedId,
+                                                           Uri feedUri,
+                                                           string? feedUsername,
+                                                           string? feedPassword,
+                                                           bool forcePackageDownload,
+                                                           int maxDownloadAttempts,
+                                                           TimeSpan downloadAttemptBackoff)
         {
             var cacheDirectory = PackageDownloaderUtils.GetPackageRoot(feedId);
             fileSystem.EnsureDirectoryExists(cacheDirectory);
@@ -51,7 +58,9 @@ namespace Calamari.Integration.Packages.Download
                 }
             }
 
-            var package = GetChartDetails(feedUri, feedCredentials,  packageId, CancellationToken.None);
+            var feedCredentials = GetFeedCredentials(feedUsername, feedPassword);
+
+            var package = GetChartDetails(feedUri, feedCredentials, packageId, CancellationToken.None);
 
             if (string.IsNullOrEmpty(package.PackageId))
             {
@@ -163,6 +172,16 @@ namespace Calamari.Integration.Packages.Download
             }
 
             return null;
+        }
+        
+        static ICredentials GetFeedCredentials(string? feedUsername, string? feedPassword)
+        {
+            ICredentials credentials = CredentialCache.DefaultNetworkCredentials;
+            if (!String.IsNullOrWhiteSpace(feedUsername))
+            {
+                credentials = new NetworkCredential(feedUsername, feedPassword);
+            }
+            return credentials;
         }
     }
 }

--- a/source/Calamari.Shared/Integration/Packages/Download/IPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/IPackageDownloader.cs
@@ -13,14 +13,14 @@ namespace Calamari.Integration.Packages.Download
         /// <summary>
         /// Downloads the given file to the local cache.
         /// </summary>
-        PackagePhysicalFileMetadata DownloadPackage(
-            string packageId,
-            IVersion version,
-            string feedId,
-            Uri feedUri,
-            ICredentials feedCredentials,
-            bool forcePackageDownload,
-            int maxDownloadAttempts,
-            TimeSpan downloadAttemptBackoff);
+        PackagePhysicalFileMetadata DownloadPackage(string packageId,
+                                                    IVersion version,
+                                                    string feedId,
+                                                    Uri feedUri,
+                                                    string? feedUsername,
+                                                    string? feedPassword,
+                                                    bool forcePackageDownload,
+                                                    int maxDownloadAttempts,
+                                                    TimeSpan downloadAttemptBackoff);
     }
 }

--- a/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
@@ -41,15 +41,15 @@ namespace Calamari.Integration.Packages.Download
             this.freeSpaceChecker = freeSpaceChecker;
         }
 
-        public PackagePhysicalFileMetadata DownloadPackage(
-            string packageId,
-            IVersion version,
-            string feedId,
-            Uri feedUri,
-            ICredentials feedCredentials,
-            bool forcePackageDownload,
-            int maxDownloadAttempts,
-            TimeSpan downloadAttemptBackoff)
+        public PackagePhysicalFileMetadata DownloadPackage(string packageId,
+                                                           IVersion version,
+                                                           string feedId,
+                                                           Uri feedUri,
+                                                           string? feedUsername,
+                                                           string? feedPassword,
+                                                           bool forcePackageDownload,
+                                                           int maxDownloadAttempts,
+                                                           TimeSpan downloadAttemptBackoff)
         {
             ServicePointManager.SecurityProtocol |= (SecurityProtocolType)3072;
             var cacheDirectory = PackageDownloaderUtils.GetPackageRoot(feedId);
@@ -68,7 +68,7 @@ namespace Calamari.Integration.Packages.Download
             return DownloadPackage(packageId,
                 version,
                 feedUri,
-                feedCredentials,
+                GetFeedCredentials(feedUsername, feedPassword),
                 cacheDirectory,
                 maxDownloadAttempts,
                 downloadAttemptBackoff);
@@ -349,6 +349,16 @@ namespace Calamari.Integration.Packages.Download
                     .Select(node => node.SelectSingleNode("./*[local-name()='value']")?.InnerText)
                     .FirstOrDefault() ??
                 defaultVersion;
+        }
+        
+        static ICredentials GetFeedCredentials(string? feedUsername, string? feedPassword)
+        {
+            ICredentials credentials = CredentialCache.DefaultNetworkCredentials;
+            if (!String.IsNullOrWhiteSpace(feedUsername))
+            {
+                credentials = new NetworkCredential(feedUsername, feedPassword);
+            }
+            return credentials;
         }
     }
 }

--- a/source/Calamari.Shared/Integration/Packages/Download/NuGetPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/NuGetPackageDownloader.cs
@@ -37,15 +37,15 @@ namespace Calamari.Integration.Packages.Download
             this.variables = variables;
         }
 
-        public PackagePhysicalFileMetadata DownloadPackage(
-            string packageId,
-            IVersion version,
-            string feedId,
-            Uri feedUri,
-            ICredentials feedCredentials,
-            bool forcePackageDownload,
-            int maxDownloadAttempts,
-            TimeSpan downloadAttemptBackoff)
+        public PackagePhysicalFileMetadata DownloadPackage(string packageId,
+                                                           IVersion version,
+                                                           string feedId,
+                                                           Uri feedUri,
+                                                           string? feedUsername,
+                                                           string? feedPassword,
+                                                           bool forcePackageDownload,
+                                                           int maxDownloadAttempts,
+                                                           TimeSpan downloadAttemptBackoff)
         {
             var cacheDirectory = PackageDownloaderUtils.GetPackageRoot(feedId);
             fileSystem.EnsureDirectoryExists(cacheDirectory);
@@ -63,7 +63,7 @@ namespace Calamari.Integration.Packages.Download
             return DownloadPackage(packageId,
                 version,
                 feedUri,
-                feedCredentials,
+                GetFeedCredentials(feedUsername, feedPassword),
                 cacheDirectory,
                 maxDownloadAttempts,
                 downloadAttemptBackoff);
@@ -139,6 +139,16 @@ namespace Calamari.Integration.Packages.Download
                     pkg.Version,
                     string.Join(", ", dependencies.Select(dependency => $"{dependency.Id}")),
                     WhyAmINotAllowedToUseDependencies);
+        }
+        
+        static ICredentials GetFeedCredentials(string? feedUsername, string? feedPassword)
+        {
+            ICredentials credentials = CredentialCache.DefaultNetworkCredentials;
+            if (!String.IsNullOrWhiteSpace(feedUsername))
+            {
+                credentials = new NetworkCredential(feedUsername, feedPassword);
+            }
+            return credentials;
         }
     }
 }

--- a/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
@@ -40,16 +40,16 @@ namespace Calamari.Integration.Packages.Download
             this.variables = variables;
         }
 
-        public PackagePhysicalFileMetadata DownloadPackage(
-            string packageId,
-            IVersion version,
-            string feedId,
-            Uri feedUri,
-            FeedType feedType,
-            ICredentials feedCredentials,
-            bool forcePackageDownload,
-            int maxDownloadAttempts,
-            TimeSpan downloadAttemptBackoff)
+        public PackagePhysicalFileMetadata DownloadPackage(string packageId,
+                                                           IVersion version,
+                                                           string feedId,
+                                                           Uri feedUri,
+                                                           FeedType feedType,
+                                                           string feedUsername,
+                                                           string feedPassword,
+                                                           bool forcePackageDownload,
+                                                           int maxDownloadAttempts,
+                                                           TimeSpan downloadAttemptBackoff)
         {
             IPackageDownloader? downloader = null;
             switch (feedType)
@@ -80,7 +80,8 @@ namespace Calamari.Integration.Packages.Download
                 version,
                 feedId,
                 feedUri,
-                feedCredentials,
+                feedUsername,
+                feedPassword,
                 forcePackageDownload,
                 maxDownloadAttempts,
                 downloadAttemptBackoff);

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
@@ -46,7 +46,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var downloader = GetDownloader();
             var pkg = downloader.DownloadPackage("alpine",
                 new SemanticVersion("3.6.5"), "docker-feed",
-                new Uri(DockerHubFeedUri), null, true, 1,
+                new Uri(DockerHubFeedUri), null, null, true, 1,
                 TimeSpan.FromSeconds(3));
 
             Assert.AreEqual("alpine", pkg.PackageId);
@@ -66,7 +66,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                 version,
                 "docker-feed",
                 new Uri(DockerHubFeedUri),
-                new NetworkCredential(DockerTestUsername, DockerTestPassword),
+                DockerTestUsername, DockerTestPassword,
                 true,
                 1,
                 TimeSpan.FromSeconds(3));
@@ -85,7 +85,8 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                 new SemanticVersion("1.1"),
                 "docker-feed",
                 new Uri(AuthFeedUri),
-                new NetworkCredential(FeedUsername, FeedPassword), true, 1,
+                FeedUsername, FeedPassword,
+                true, 1,
                 TimeSpan.FromSeconds(3));
 
             Assert.AreEqual("octopus-echo", pkg.PackageId);
@@ -101,7 +102,8 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var exception = Assert.Throws<CommandException>(() => downloader.DownloadPackage("octopus-echo",
                 new SemanticVersion("1.1"), "docker-feed",
                 new Uri(AuthFeedUri),
-                new NetworkCredential(FeedUsername, "SuperDooper"), true, 1,
+                FeedUsername, "SuperDooper",
+                true, 1,
                 TimeSpan.FromSeconds(3)));
 
             StringAssert.Contains("Unable to pull Docker image", exception.Message);

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/GitHubPackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/GitHubPackageDownloadFixture.cs
@@ -53,7 +53,8 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var downloader = new GitHubPackageDownloader(new InMemoryLog(), fileSystem, freeSpaceChecker);
 
             var file = downloader.DownloadPackage("OctopusDeploy/Octostache", new SemanticVersion("2.1.8"), "feed-github",
-                new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, FeedPassword), true, 3,
+                new Uri(AuthFeedUri), FeedUsername, FeedPassword,
+                true, 3,
                 TimeSpan.FromSeconds(3));
 
             Assert.Greater(file.Size, 0);
@@ -67,13 +68,13 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var downloader = new GitHubPackageDownloader(new InMemoryLog(), fileSystem, freeSpaceChecker);
 
             var file1 = downloader.DownloadPackage("OctopusDeploy/Octostache", new SemanticVersion("2.1.7"), "feed-github",
-                new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, FeedPassword), true, 3,
+                new Uri(AuthFeedUri), FeedUsername, FeedPassword, true, 3,
                 TimeSpan.FromSeconds(3));
 
             Assert.Greater(file1.Size, 0);
 
             var file2 = downloader.DownloadPackage("OctopusDeploy/Octostache", new SemanticVersion("2.1.7"), "feed-github",
-                new Uri("https://WillFailIfInvoked"), null, false, 3,
+                new Uri("https://WillFailIfInvoked"), null, null, false, 3,
                 TimeSpan.FromSeconds(3));
 
             Assert.AreEqual(file1.FullFilePath, file1.FullFilePath);
@@ -88,7 +89,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var downloader = new GitHubPackageDownloader(new InMemoryLog(), fileSystem, freeSpaceChecker);
 
             var file = downloader.DownloadPackage("octokit/octokit.net", new SemanticVersion("0.28.0"), "feed-github",
-                new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, FeedPassword), true, 3,
+                new Uri(AuthFeedUri), FeedUsername, FeedPassword, true, 3,
                 TimeSpan.FromSeconds(3));
 
             Assert.Greater(file.Size, 0);

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
@@ -42,7 +42,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [RequiresMinimumMonoVersion(5, 12, 0, Description = "HttpClient 4.3.2 broken on Mono - https://xamarin.github.io/bugzilla-archives/60/60315/bug.html#c7")]
         public void PackageWithCredentials_Loads()
         {
-            var pkg = downloader.DownloadPackage("mychart", new SemanticVersion("0.3.7"), "helm-feed", new Uri(AuthFeedUri), new NetworkCredential(FeedUsername, FeedPassword), true, 1,
+            var pkg = downloader.DownloadPackage("mychart", new SemanticVersion("0.3.7"), "helm-feed", new Uri(AuthFeedUri), FeedUsername, FeedPassword, true, 1,
                 TimeSpan.FromSeconds(3));
             pkg.PackageId.Should().Be("mychart");
             pkg.Version.Should().Be(new SemanticVersion("0.3.7"));
@@ -55,7 +55,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         {
             var badUrl = new Uri($"https://octopusdeploy.jfrog.io/gobbelygook/{Guid.NewGuid().ToString("N")}");
             var badEndpointDownloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem());
-            Action action = () => badEndpointDownloader.DownloadPackage("something", new SemanticVersion("99.9.7"), "gobbely", new Uri(badUrl, "something.99.9.7"), new NetworkCredential(FeedUsername, FeedPassword), true, 1, TimeSpan.FromSeconds(3));
+            Action action = () => badEndpointDownloader.DownloadPackage("something", new SemanticVersion("99.9.7"), "gobbely", new Uri(badUrl, "something.99.9.7"), FeedUsername, FeedPassword, true, 1, TimeSpan.FromSeconds(3));
             action.Should().Throw<Exception>().And.Message.Should().Contain("Unable to read Helm index file").And.Contain("404");
         }
     }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/MavenPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/MavenPackageDownloaderFixture.cs
@@ -36,7 +36,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         {
             var downloader = new MavenPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new FreeSpaceChecker(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new CalamariVariables()));
             var pkg = downloader.DownloadPackage("com.google.guava:guava", VersionFactory.CreateMavenVersion("22.0"), "feed-maven",
-                new Uri("https://repo.maven.apache.org/maven2/"), new NetworkCredential("", ""), true, 3, TimeSpan.FromSeconds(3));
+                new Uri("https://repo.maven.apache.org/maven2/"), "", "", true, 3, TimeSpan.FromSeconds(3));
 
             Assert.AreEqual("com.google.guava:guava", pkg.PackageId);
         }
@@ -48,7 +48,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         {
             var downloader = new MavenPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new FreeSpaceChecker(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new CalamariVariables()));
             var pkg = downloader.DownloadPackage("com.google.guava:guava:jar:sources", VersionFactory.CreateMavenVersion("22.0"), "feed-maven",
-                new Uri("https://repo.maven.apache.org/maven2/"), new NetworkCredential("", ""), true, 3, TimeSpan.FromSeconds(3));
+                new Uri("https://repo.maven.apache.org/maven2/"), "", "", true, 3, TimeSpan.FromSeconds(3));
 
             Assert.AreEqual("com.google.guava:guava:jar:sources", pkg.PackageId);
         }

--- a/source/Calamari/Commands/DownloadPackageCommand.cs
+++ b/source/Calamari/Commands/DownloadPackageCommand.cs
@@ -114,7 +114,8 @@ namespace Calamari.Commands
                     feedId,
                     uri,
                     feedType,
-                    GetFeedCredentials(feedUsername, feedPassword),
+                    feedUsername,
+                    feedPassword,
                     forcePackageDownload,
                     parsedMaxDownloadAttempts,
                     parsedAttemptBackoff);
@@ -131,16 +132,6 @@ namespace Calamari.Commands
             }
 
             return 0;
-        }
-
-        static ICredentials GetFeedCredentials(string feedUsername, string feedPassword)
-        {
-            ICredentials credentials = CredentialCache.DefaultNetworkCredentials;
-            if (!String.IsNullOrWhiteSpace(feedUsername))
-            {
-                credentials = new NetworkCredential(feedUsername, feedPassword);
-            }
-            return credentials;
         }
 
         // ReSharper disable UnusedParameter.Local

--- a/source/Calamari/Commands/DownloadPackageCommand.cs
+++ b/source/Calamari/Commands/DownloadPackageCommand.cs
@@ -62,10 +62,10 @@ namespace Calamari.Commands
                     }
                     versionFormat = format;
                 });
-            Options.Add("feedId=", "Id of the NuGet feed", v => feedId = v);
-            Options.Add("feedUri=", "URL to NuGet feed", v => feedUri = v);
-            Options.Add("feedUsername=", "[Optional] Username to use for an authenticated NuGet feed", v => feedUsername = v);
-            Options.Add("feedPassword=", "[Optional] Password to use for an authenticated NuGet feed", v => feedPassword = v);
+            Options.Add("feedId=", "Id of the feed", v => feedId = v);
+            Options.Add("feedUri=", "URL to feed", v => feedUri = v);
+            Options.Add("feedUsername=", "[Optional] Username to use for an authenticated feed", v => feedUsername = v);
+            Options.Add("feedPassword=", "[Optional] Password to use for an authenticated feed", v => feedPassword = v);
             Options.Add("feedType=", $"[Optional] Type of feed. Options {string.Join(", ", Enum.GetNames(typeof(FeedType)))}. Defaults to `{FeedType.NuGet}`.",
                 v =>
                 {


### PR DESCRIPTION
# Problem

Resolves OctopusDeploy/Issues#6922

The GitHub API is returning a 404 for private repositories when the download is done from the target as opposed to the server. After some investigation the root cause appears to be that the `WebClient.Credentials` property only causes the `Authorization` header to be added when a 401 response is received but the GitHub API [returns a 404 for unauthenticated requests](https://docs.github.com/en/rest/overview/troubleshooting#404-error-for-an-existing-repository). So, the credentials are never used.

# Solution

The solution here involves explicitly setting the `Authorization` header instead of relying on the Credentials behaviour.