### PR TITLE
Fixes proxy handling for netcore builds of Calamari

### DIFF
--- a/source/Calamari.Common/Plumbing/Proxies/ProxySettingsInitializer.cs
+++ b/source/Calamari.Common/Plumbing/Proxies/ProxySettingsInitializer.cs
@@ -21,9 +21,7 @@ namespace Calamari.Common.Plumbing.Proxies
                     proxyPassword
                 );
 
-            bool useDefaultProxy;
-            if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy),
-                out useDefaultProxy))
+            if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy), out var useDefaultProxy))
                 useDefaultProxy = true;
 
             if (useDefaultProxy)

--- a/source/Calamari.Common/Plumbing/Proxies/SystemWebProxyRetriever.cs
+++ b/source/Calamari.Common/Plumbing/Proxies/SystemWebProxyRetriever.cs
@@ -16,7 +16,11 @@ namespace Calamari.Common.Plumbing.Proxies
 
                 var systemWebProxy = WebRequest.GetSystemWebProxy();
 
-                return systemWebProxy.GetProxy(TestUri)?.Host != TestUri.Host
+                var proxyUri = systemWebProxy.GetProxy(TestUri);
+
+                if (proxyUri == null) return Maybe<IWebProxy>.None;
+
+                return proxyUri.Host != TestUri.Host
                     ? systemWebProxy.AsSome()
                     : Maybe<IWebProxy>.None;
             }

--- a/source/Calamari.Common/Plumbing/Proxies/SystemWebProxyRetriever.cs
+++ b/source/Calamari.Common/Plumbing/Proxies/SystemWebProxyRetriever.cs
@@ -10,8 +10,6 @@ namespace Calamari.Common.Plumbing.Proxies
     {
         public static Maybe<IWebProxy> GetSystemWebProxy()
         {
-            //Only try to retrieve the system proxy on windows + .Net full
-#if NETFRAMEWORK
             try
             {
                 var TestUri = new Uri("http://test9c7b575efb72442c85f706ef1d64afa6.com");
@@ -26,7 +24,7 @@ namespace Calamari.Common.Plumbing.Proxies
             {
                 /*
                  Ignore this exception. It is probably just an inability to get the IE proxy settings. e.g.
-                 
+
                  Unhandled Exception: System.Net.Sockets.SocketException: The requested service provider could not be loaded or initialized
                    at System.Net.SafeCloseSocketAndEvent.CreateWSASocketWithEvent(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, Boolean autoReset, Boolean signaled)
                    at System.Net.NetworkAddressChangePolled..ctor()
@@ -38,16 +36,12 @@ namespace Calamari.Common.Plumbing.Proxies
                    at System.Net.WebRequest.GetSystemWebProxy()
                    at Calamari.Integration.Proxies.ProxyInitializer.InitializeDefaultProxy()
                    at Calamari.Program.Execute(String[] args)
-                   at Calamari.Program.Main(String[] args)                 
+                   at Calamari.Program.Main(String[] args)
                  */
 
                 Log.Error("Failed to get the system proxy settings. Calamari will not use any proxy settings.");
                 return Maybe<IWebProxy>.None;
             }
-#else
-                Log.Verbose("Unable to get the system proxy settings due to not running under .Net Framework. Calamari will not use any proxy settings.");
-                return Maybe<IWebProxy>.None;
-#endif
         }
     }
 }

--- a/source/Calamari.Common/Plumbing/Proxies/SystemWebProxyRetriever.cs
+++ b/source/Calamari.Common/Plumbing/Proxies/SystemWebProxyRetriever.cs
@@ -16,7 +16,7 @@ namespace Calamari.Common.Plumbing.Proxies
 
                 var systemWebProxy = WebRequest.GetSystemWebProxy();
 
-                return systemWebProxy.GetProxy(TestUri).Host != TestUri.Host
+                return systemWebProxy.GetProxy(TestUri)?.Host != TestUri.Host
                     ? systemWebProxy.AsSome()
                     : Maybe<IWebProxy>.None;
             }

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/WindowsScriptProxyFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/WindowsScriptProxyFixtureBase.cs
@@ -118,31 +118,19 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
 
         void AssertUnauthenticatedSystemProxyUsedWithException(CalamariResult output, string bypassedUrl)
         {
-#if !NETCORE
             AssertUnauthenticatedSystemProxyUsed(output);
             if (TestWebRequestDefaultProxy)
                 output.AssertPropertyValue("ProxyBypassed", bypassedUrl);
-#else
-            base.AssertNoProxyChanges(output);
-#endif
         }
 
         void AssertUnauthenticatedSystemProxyUsed(CalamariResult output)
         {
-#if !NETCORE
             AssertUnauthenticatedProxyUsed(output);
-#else
-            base.AssertNoProxyChanges(output);
-#endif
         }
-        
+
         void AssertAuthenticatedSystemProxyUsed(CalamariResult output)
         {
-#if !NETCORE
             AssertAuthenticatedProxyUsed(output);
-#else
-            base.AssertNoProxyChanges(output);
-#endif
         }
     }
 }


### PR DESCRIPTION
# Overview 

This PR addresses two bugs that have been identified in Calamari's proxy detection and handling code.

## Bug 1: `win-x64` Calamari does not support user default proxy

In Octopus 2021.1, a [change was made](https://github.com/OctopusDeploy/OctopusDeploy/pull/7884) that changed the way we ship Calamari to Windows targets. Previously we would ship the `netfx` version of Calamari to ALL Windows targets. From 2021.1 we have a more sophisticated way of determining whether we should send the `netfx` binary, or the `x64` netcore binary.

Calamari's proxy handling [was renovated](https://github.com/OctopusDeploy/Calamari/pull/420) mid-2019. Part of that renovation ([here](ecc9474640526e72606a26d05b3264bfbe7dccaf89680f5ee1427ff6903ba36cR13))  dealt with a limitation in dotnet core at the time - you couldn't retrieve the default user proxy if one was configured. If the `x64` version of Calamari was used, the user's default proxy would not be picked up and configured, and we would instead log a verbose message saying that no proxy was configured for that execution.

A subsequent [patch to dotnet core](https://github.com/dotnet/corefx/pull/41692) has addressed this limitation, and means you can retrieve the default system proxy in dotnet core in the same way you would from netfx.

### Fix

This PR removes the conditional compilation previously required due to the limitation in dotnet core, and ensures the default user proxy is utilised regardless of whether we are in the `netfx` binary or the `x64` binary.

## Bug 2: Calamari does not support `HTTP_PROXY` environment variable with hostname or IP address

In our Powershell Bootstrapper, there is a baked-in assumption that if the default `HTTP_PROXY` variable exists, it is a valid Uri that can be passed to the dot net `Uri` type constructor.

The value of `HTTP_PROXY` may be a hostname or IP address, optionally followed by a colon and port number, or it may be an http URL, optionally including a username and password for proxy authentication. [Source](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.defaultproxy?view=netcore-3.1).

When the value was a hostname or IP address, our bootstrapper would fail to construct a valid Uri and blow up.

### Fix

This PR makes the bootstrapper more flexible and will test the value to see if it is a valid URI, and if it is not, will instead treat it as a raw string.

It does NOT attempt to further validate the contents of the string.

## Reproducing / Testing

If you wish to reproduce or test this behaviour, on a Windows 10 x64 system:

- Install and configure a Tentacle on the machine, which will by default run under `Local System`
- Stop the tentacle service, and run it via the command line instead with `C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe" run --instance="YourTentacleInstanceName"` so that it is running in the context of you as the currently logged in user
- using [ccProxy](https://www.youngzsoft.net/ccproxy/proxy-server-download.htm) or your favourite Windows-supporting proxy, configure your default user proxy in Proxy Settings
![image](https://user-images.githubusercontent.com/2706018/127106174-c7d37c60-3abe-4efc-8c41-a9ac4666325f.png)
- Create a deployment process in Octopus with a single script step with the following contents
```
Write-Warning "======"
Invoke-WebRequest -Uri "http://ident.me" -UseBasicParsing
Write-Warning "======"
```
- Run the script step with the proxy on - the step will pass
- Run the script step with the proxy off - the step will still pass, indicating it has not used the proxy to issue the request


