### PR TITLE
Fixes proxy handling for netcore builds of Calamari (#754)

### DIFF
--- a/source/Calamari.Common/Plumbing/Proxies/ProxySettingsInitializer.cs
+++ b/source/Calamari.Common/Plumbing/Proxies/ProxySettingsInitializer.cs
@@ -21,9 +21,7 @@ namespace Calamari.Common.Plumbing.Proxies
                     proxyPassword
                 );
 
-            bool useDefaultProxy;
-            if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy),
-                out useDefaultProxy))
+            if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy), out var useDefaultProxy))
                 useDefaultProxy = true;
 
             if (useDefaultProxy)

--- a/source/Calamari.Common/Plumbing/Proxies/SystemWebProxyRetriever.cs
+++ b/source/Calamari.Common/Plumbing/Proxies/SystemWebProxyRetriever.cs
@@ -10,15 +10,17 @@ namespace Calamari.Common.Plumbing.Proxies
     {
         public static Maybe<IWebProxy> GetSystemWebProxy()
         {
-            //Only try to retrieve the system proxy on windows + .Net full
-#if NETFRAMEWORK
             try
             {
                 var TestUri = new Uri("http://test9c7b575efb72442c85f706ef1d64afa6.com");
 
                 var systemWebProxy = WebRequest.GetSystemWebProxy();
 
-                return systemWebProxy.GetProxy(TestUri).Host != TestUri.Host
+                var proxyUri = systemWebProxy.GetProxy(TestUri);
+
+                if (proxyUri == null) return Maybe<IWebProxy>.None;
+
+                return proxyUri.Host != TestUri.Host
                     ? systemWebProxy.AsSome()
                     : Maybe<IWebProxy>.None;
             }
@@ -26,7 +28,7 @@ namespace Calamari.Common.Plumbing.Proxies
             {
                 /*
                  Ignore this exception. It is probably just an inability to get the IE proxy settings. e.g.
-                 
+
                  Unhandled Exception: System.Net.Sockets.SocketException: The requested service provider could not be loaded or initialized
                    at System.Net.SafeCloseSocketAndEvent.CreateWSASocketWithEvent(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, Boolean autoReset, Boolean signaled)
                    at System.Net.NetworkAddressChangePolled..ctor()
@@ -38,16 +40,12 @@ namespace Calamari.Common.Plumbing.Proxies
                    at System.Net.WebRequest.GetSystemWebProxy()
                    at Calamari.Integration.Proxies.ProxyInitializer.InitializeDefaultProxy()
                    at Calamari.Program.Execute(String[] args)
-                   at Calamari.Program.Main(String[] args)                 
+                   at Calamari.Program.Main(String[] args)
                  */
 
                 Log.Error("Failed to get the system proxy settings. Calamari will not use any proxy settings.");
                 return Maybe<IWebProxy>.None;
             }
-#else
-                Log.Verbose("Unable to get the system proxy settings due to not running under .Net Framework. Calamari will not use any proxy settings.");
-                return Maybe<IWebProxy>.None;
-#endif
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/WindowsScriptProxyFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/WindowsScriptProxyFixtureBase.cs
@@ -118,31 +118,19 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
 
         void AssertUnauthenticatedSystemProxyUsedWithException(CalamariResult output, string bypassedUrl)
         {
-#if !NETCORE
             AssertUnauthenticatedSystemProxyUsed(output);
             if (TestWebRequestDefaultProxy)
                 output.AssertPropertyValue("ProxyBypassed", bypassedUrl);
-#else
-            base.AssertNoProxyChanges(output);
-#endif
         }
 
         void AssertUnauthenticatedSystemProxyUsed(CalamariResult output)
         {
-#if !NETCORE
             AssertUnauthenticatedProxyUsed(output);
-#else
-            base.AssertNoProxyChanges(output);
-#endif
         }
-        
+
         void AssertAuthenticatedSystemProxyUsed(CalamariResult output)
         {
-#if !NETCORE
             AssertAuthenticatedProxyUsed(output);
-#else
-            base.AssertNoProxyChanges(output);
-#endif
         }
     }
 }


### PR DESCRIPTION
# Overview

This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.2.

Change: OctopusDeploy/Calamari#754

Issue: OctopusDeploy/Issues#6941