### PR TITLE
Named packages support

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -61,7 +61,7 @@
       <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
       <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
       <PackageReference Include="Octopus.Versioning" Version="4.3.5" />
-      <PackageReference Include="Octostache" Version="2.10.0" />
+      <PackageReference Include="Octostache" Version="2.11.1-ray-support-square-2" />
       <PackageReference Include="SharpCompress" Version="0.24.0" />
       <PackageReference Include="XPath2" Version="1.0.12" />
       <PackageReference Include="YamlDotNet" Version="8.1.2" />

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -61,7 +61,7 @@
       <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
       <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
       <PackageReference Include="Octopus.Versioning" Version="4.3.5" />
-      <PackageReference Include="Octostache" Version="2.11.1-ray-support-square-2" />
+      <PackageReference Include="Octostache" Version="2.12.0" />
       <PackageReference Include="SharpCompress" Version="0.24.0" />
       <PackageReference Include="XPath2" Version="1.0.12" />
       <PackageReference Include="YamlDotNet" Version="8.1.2" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="Octopus.Versioning" Version="4.3.5" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
-    <PackageReference Include="Octostache" Version="2.11.1-ray-support-square-2" />
+    <PackageReference Include="Octostache" Version="2.12.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="Sprache" Version="2.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="Octopus.Versioning" Version="4.3.5" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
-    <PackageReference Include="Octostache" Version="2.10.0" />
+    <PackageReference Include="Octostache" Version="2.11.1-ray-support-square-2" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="Sprache" Version="2.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/source/Calamari.Shared/Util/InputSubstitution.cs
+++ b/source/Calamari.Shared/Util/InputSubstitution.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using Calamari.Common.Plumbing.Variables;
+using Octostache;
+using Octostache.Templates;
+
+namespace Calamari.Util
+{
+    public static class InputSubstitution
+    {
+        public static string SubstituteAndEscapeAllVariablesInJson(string jsonInputs, IVariables variables)
+        {
+            var tempVariableDictionaryToUseForExpandedVariables = new VariableDictionary();
+            var template = TemplateParser.ParseTemplate(jsonInputs);
+            foreach (var templateToken in template.Tokens)
+            {
+                // TODO: we need change this to have a better way of escaping json string here
+                var arguments = templateToken.GetArguments();
+                if (!arguments.Any()) continue; // to avoid TextToken, which doesn't need to be evaluated
+                var variableName = templateToken.ToString()
+                                                .Replace("#{", string.Empty)
+                                                .Replace("}", string.Empty);
+                var expanded = variables.Evaluate($"#{{{variableName} | JsonEscape}}");
+                tempVariableDictionaryToUseForExpandedVariables.Add(variableName, expanded);
+            }
+
+            var evaluatedJson = tempVariableDictionaryToUseForExpandedVariables.Evaluate(jsonInputs);
+            return evaluatedJson;
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Manifest/ExecuteManifestCommandFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Manifest/ExecuteManifestCommandFixture.cs
@@ -81,48 +81,6 @@ namespace Calamari.Tests.Fixtures.Manifest
                 result.AssertOutput(nameof(NodeInstructions.DeploymentTargetInputsVariable));
             }
         }
-        
-        [Test]
-        public void WithNamedPackageInstructions()
-        {
-            var instructions =
-                InstructionBuilder
-                    .Create()
-                    .WithCalamariInstruction("test-calamari-instruction")
-                    .WithNodeInstruction()
-                    .AsString();
-
-            using (var temporaryDirectory = TemporaryDirectory.Create())
-            {
-                var generatedApplicationPath = CodeGenerator.GenerateConsoleApplication("node", temporaryDirectory.DirectoryPath);
-                var toolRoot = Path.Combine(temporaryDirectory.DirectoryPath, "app");
-                var destinationPath =
-                    CalamariEnvironment.IsRunningOnWindows ? toolRoot : Path.Combine(toolRoot, "bin");
-
-                DirectoryEx.Copy(generatedApplicationPath, destinationPath);
-
-                var inputs = "{\"containerNameOverride\":\"payload\",\"package\":{\"extractedToPath\":\"#{Octopus.Action.Package[package].ExtractedPath}\"},\"target\":{\"files\":[]}}";
-                var variables = new VariableDictionary
-                {
-                    { SpecialVariables.Execution.Manifest, instructions },
-                    { nameof(NodeInstructions.BootstrapperPathVariable), "BootstrapperPathVariable_Value" },
-                    { nameof(NodeInstructions.NodePathVariable), toolRoot },
-                    { nameof(NodeInstructions.TargetPathVariable), "TargetPathVariable_Value" },
-                    { nameof(NodeInstructions.InputsVariable), inputs },
-                    { nameof(NodeInstructions.DeploymentTargetInputsVariable), "deploymentTargetInputs" },
-                    { "Octopus.Action.Package[package].ExtractedPath", "C:\\OctopusTest\\Api Test\\1\\Octopus-Primary\\Work\\20210804020317-7-11\\package" },
-                };
-
-                var result = ExecuteCommand(variables, "Calamari.Tests");
-
-                result.AssertSuccess();
-                result.AssertOutput("Hello from TestCommand");
-                result.AssertOutput("Hello from my custom node!");
-                result.AssertOutput(string.Join(Path.Combine("BootstrapperPathVariable_Value", "bootstrapper.js"),
-                                                Path.Combine("TargetPathVariable_Value", "executor.js")));
-                result.AssertOutput(nameof(NodeInstructions.DeploymentTargetInputsVariable));
-            }
-        }
 
         CalamariResult ExecuteCommand(VariableDictionary variables, string extensions = "")
         {

--- a/source/Calamari.Tests/Fixtures/Util/InputSubstitutionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/InputSubstitutionFixture.cs
@@ -1,0 +1,26 @@
+﻿using Calamari.Util;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Tests.Fixtures.Util
+{
+    [TestFixture]
+    public class InputSubstitutionFixture
+    {
+        [Test]
+        public void VariablesInJsonInputsShouldBeEvaluated()
+        {
+            var variables = new CalamariVariables
+            {
+                { "Octopus.Action.Package[package].ExtractedPath", "C:\\OctopusTest\\Api Test\\1\\Octopus-Primary\\Work\\20210804020317-7-11\\package" },
+            };
+            var jsonInputs = "{\"containerNameOverride\":\"payload\",\"package\":{\"extractedToPath\":\"#{Octopus.Action.Package[package].ExtractedPath}\"},\"target\":{\"files\":[]}}";
+            var evaluatedInputs = InputSubstitution.SubstituteAndEscapeAllVariablesInJson(jsonInputs, variables);
+
+            var expectedEvaluatedInputs = "{\"containerNameOverride\":\"payload\",\"package\":{\"extractedToPath\":\"C:\\\\OctopusTest\\\\Api Test\\\\1\\\\Octopus-Primary\\\\Work\\\\20210804020317-7-11\\\\package\"},\"target\":{\"files\":[]}}";
+            Assert.AreEqual(evaluatedInputs, expectedEvaluatedInputs);
+        }
+    }
+}

--- a/source/Calamari/Commands/ExecuteManifestCommand.cs
+++ b/source/Calamari/Commands/ExecuteManifestCommand.cs
@@ -58,6 +58,8 @@ namespace Calamari.Commands
                 throw new CommandException("The execution manifest must have at least one instruction.");
             }
 
+            // TODO: refactor this to use an instruction transformer. ExtractPackageInstructionTransformer
+            // https://octopusdeploy.slack.com/archives/C028E35JZH6/p1628135757073500?thread_ts=1628135383.073000&cid=C028E35JZH6
             var conventions = new List<IConvention>
             {
                 new StageScriptPackagesConvention(string.Empty, fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner)),

--- a/source/Calamari/Commands/ExecuteManifestCommand.cs
+++ b/source/Calamari/Commands/ExecuteManifestCommand.cs
@@ -4,8 +4,13 @@ using System.Linq;
 using Autofac.Features.Metadata;
 using Calamari.Commands.Support;
 using Calamari.Common.Commands;
+using Calamari.Common.Features.Packages;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment;
+using Calamari.Deployment.Conventions;
 using Calamari.LaunchTools;
 using Calamari.Serialization;
 using Newtonsoft.Json;
@@ -17,13 +22,20 @@ namespace Calamari.Commands
     {
         readonly IVariables variables;
         readonly IEnumerable<Meta<ILaunchTool, LaunchToolMeta>> executionTools;
+        private readonly ICalamariFileSystem fileSystem;
+        private readonly ILog log;
+        private readonly ICommandLineRunner commandLineRunner;
 
-        public ExecuteManifestCommand(
-            IVariables variables,
-            IEnumerable<Meta<ILaunchTool, LaunchToolMeta>> executionTools)
+        public ExecuteManifestCommand(IVariables variables,
+            IEnumerable<Meta<ILaunchTool, LaunchToolMeta>> executionTools,
+            ICalamariFileSystem fileSystem,
+            ILog log, ICommandLineRunner commandLineRunner)
         {
             this.variables = variables;
             this.executionTools = executionTools;
+            this.fileSystem = fileSystem;
+            this.log = log;
+            this.commandLineRunner = commandLineRunner;
         }
 
         public override int Execute(string[] commandLineArguments)
@@ -37,18 +49,31 @@ namespace Calamari.Commands
                 throw new CommandException("Execution manifest not found in variables.");
             }
 
-            var instructions = JsonConvert.DeserializeObject<Instruction[]>(contents, JsonSerialization.GetDefaultSerializerSettings());
+            var instructions =
+                JsonConvert.DeserializeObject<Instruction[]>(contents,
+                    JsonSerialization.GetDefaultSerializerSettings());
 
             if (instructions.Length == 0)
             {
                 throw new CommandException("The execution manifest must have at least one instruction.");
             }
 
+            var conventions = new List<IConvention>
+            {
+                new StageScriptPackagesConvention(string.Empty, fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner)),
+            };
+
+            var deployment = new RunningDeployment(string.Empty, variables);
+            var conventionRunner = new ConventionProcessor(deployment, conventions, log);
+
+            conventionRunner.RunConventions();
+
             foreach (var instruction in instructions)
             {
                 var tool = executionTools.First(x => x.Metadata.Tool == instruction.Launcher);
 
-                var result = tool.Value.Execute(instruction.LauncherInstructionsRaw, commandLineArguments.Skip(1).ToArray());
+                var result = tool.Value.Execute(instruction.LauncherInstructionsRaw,
+                    commandLineArguments.Skip(1).ToArray());
 
                 if (result != 0)
                 {

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -32,7 +32,6 @@ namespace Calamari.LaunchTools
 
         protected override int ExecuteInternal(NodeInstructions instructions, params string[] args)
         {
-            Thread.Sleep(20000);
             var pathToNode = variables.Get(instructions.NodePathVariable);
             var pathToStepPackage = variables.Get(instructions.TargetPathVariable);
             var pathToBootstrapper = variables.Get(instructions.BootstrapperPathVariable);

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing;
@@ -11,8 +10,6 @@ using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Proxies;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Util;
-using Octostache;
-using Octostache.Templates;
 
 namespace Calamari.LaunchTools
 {
@@ -32,7 +29,6 @@ namespace Calamari.LaunchTools
 
         protected override int ExecuteInternal(NodeInstructions instructions, params string[] args)
         {
-            Thread.Sleep(20000);
             var pathToNode = variables.Get(instructions.NodePathVariable);
             var pathToStepPackage = variables.Get(instructions.TargetPathVariable);
             var pathToBootstrapper = variables.Get(instructions.BootstrapperPathVariable);

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing;
@@ -30,6 +32,7 @@ namespace Calamari.LaunchTools
 
         protected override int ExecuteInternal(NodeInstructions instructions, params string[] args)
         {
+            Thread.Sleep(20000);
             var pathToNode = variables.Get(instructions.NodePathVariable);
             var pathToStepPackage = variables.Get(instructions.TargetPathVariable);
             var pathToBootstrapper = variables.Get(instructions.BootstrapperPathVariable);
@@ -70,8 +73,10 @@ namespace Calamari.LaunchTools
             var template = TemplateParser.ParseTemplate(rawJson);
             foreach (var templateToken in template.Tokens)
             {
-                var variableName = String.Join(".", templateToken.GetArguments());
-                var expanded = variables.Evaluate($"#{{ {variableName} | JsonEscape }}");
+                var variableName = templateToken.ToString()
+                                                .Replace("#{", string.Empty)
+                                                .Replace("}", string.Empty);
+                var expanded = variables.Evaluate($"#{{{variableName} | JsonEscape}}");
                 tempVariableDictionaryToUseForExpandedVariables.Add(variableName, expanded);
             }
 

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -73,6 +73,9 @@ namespace Calamari.LaunchTools
             var template = TemplateParser.ParseTemplate(rawJson);
             foreach (var templateToken in template.Tokens)
             {
+                // TODO: we need change this to have a better way of escaping json string here
+                var arguments = templateToken.GetArguments();
+                if (!arguments.Any()) continue; // to avoid TextToken, which doesn't need to be evaluated
                 var variableName = templateToken.ToString()
                                                 .Replace("#{", string.Empty)
                                                 .Replace("}", string.Empty);


### PR DESCRIPTION
This PR added:
- A temporary change in `ExecuteManifestCommand` to enable package extraction for named packages.
- A temporary change in `NodeExecutor` to allow variables with square brackets to be evaluated by `Octostache`.