### PR TITLE
Revert deletion of `Calamari.CloudAccounts.AzureAccountVariables`

### DIFF
--- a/source/Calamari.CloudAccounts/AzureAccountVariables.cs
+++ b/source/Calamari.CloudAccounts/AzureAccountVariables.cs
@@ -1,0 +1,14 @@
+namespace Calamari.CloudAccounts
+{
+    public static class AzureAccountVariables
+    {
+        public static readonly string Environment = "Octopus.Action.Azure.Environment";
+        public static readonly string AccountVariable = "Octopus.Action.AzureAccount.Variable";
+        public static readonly string SubscriptionId = "Octopus.Action.Azure.SubscriptionId";
+        public static readonly string ClientId = "Octopus.Action.Azure.ClientId";   
+        public static readonly string TenantId = "Octopus.Action.Azure.TenantId";
+        public static readonly string Password = "Octopus.Action.Azure.Password";
+        public static readonly string ResourceManagementEndPoint = "Octopus.Action.Azure.ResourceManagementEndPoint";
+        public static readonly string ActiveDirectoryEndPoint = "Octopus.Action.Azure.ActiveDirectoryEndPoint";
+    }
+}


### PR DESCRIPTION
The `Calamari.CloudAccounts.AzureAccountVariables` class was cleaned up as part of fixing OctopusDeploy/Calamari#723 but it is still [being used in `Calamari.Terraform@10.x`](https://github.com/OctopusDeploy/Sashimi.Terraform/blob/10.2.2/source/Calamari/Behaviours/TerraformDeployBehaviour.cs#L135-L141). This PR reverts the deletion in lieu of a more principled solution.