### PR TITLE
Correctly parse NodeExecutor inputs

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -61,7 +61,7 @@
       <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
       <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
       <PackageReference Include="Octopus.Versioning" Version="4.3.5" />
-      <PackageReference Include="Octostache" Version="2.12.0" />
+      <PackageReference Include="Octostache" Version="2.13.0" />
       <PackageReference Include="SharpCompress" Version="0.24.0" />
       <PackageReference Include="XPath2" Version="1.0.12" />
       <PackageReference Include="YamlDotNet" Version="8.1.2" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="Octopus.Versioning" Version="4.3.5" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
-    <PackageReference Include="Octostache" Version="2.12.0" />
+    <PackageReference Include="Octostache" Version="2.13.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="Sprache" Version="2.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/source/Calamari.Shared/Util/InputSubstitution.cs
+++ b/source/Calamari.Shared/Util/InputSubstitution.cs
@@ -12,7 +12,11 @@ namespace Calamari.Util
     {
         public static string SubstituteAndEscapeAllVariablesInJson(string jsonInputs, IVariables variables, ILog log)
         {
-            var template = TemplateParser.ParseTemplate(jsonInputs);
+            if (!TemplateParser.TryParseTemplate(jsonInputs, out var template, out string error))
+            {
+                throw new CommandException($"Variable expression could not be parsed. Error: {error}");
+            }
+            
             jsonInputs = template.ToString(); // we parse the template back to string to have a consistent representation of Octostache expressions
             foreach (var templateToken in template.Tokens)
             {

--- a/source/Calamari.Shared/Util/InputSubstitution.cs
+++ b/source/Calamari.Shared/Util/InputSubstitution.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Newtonsoft.Json;
 using Octostache;
@@ -9,7 +10,7 @@ namespace Calamari.Util
 {
     public static class InputSubstitution
     {
-        public static string SubstituteAndEscapeAllVariablesInJson(string jsonInputs, IVariables variables)
+        public static string SubstituteAndEscapeAllVariablesInJson(string jsonInputs, IVariables variables, ILog log)
         {
             var template = TemplateParser.ParseTemplate(jsonInputs);
             jsonInputs = template.ToString(); // we parse the template back to string to have a consistent representation of Octostache expressions
@@ -19,7 +20,7 @@ namespace Calamari.Util
                 if (!arguments.Any()) continue; // to avoid TextToken, which doesn't need to be evaluated
                 string evaluated = variables.Evaluate(templateToken.ToString());
                 if (evaluated == templateToken.ToString())
-                    throw new CommandException($"Variable {templateToken.ToString()} could not be evaluated, check that the referenced variables exist.");
+                    log.Warn($"Expression {templateToken.ToString()} could not be evaluated, check that the referenced variables exist.");
                 jsonInputs = jsonInputs.Replace($"\"{templateToken.ToString()}\"", JsonConvert.ToString(evaluated));
             }
 

--- a/source/Calamari.Shared/Util/InputSubstitution.cs
+++ b/source/Calamari.Shared/Util/InputSubstitution.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
+using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Variables;
+using Newtonsoft.Json;
 using Octostache;
 using Octostache.Templates;
 
@@ -9,22 +11,19 @@ namespace Calamari.Util
     {
         public static string SubstituteAndEscapeAllVariablesInJson(string jsonInputs, IVariables variables)
         {
-            var tempVariableDictionaryToUseForExpandedVariables = new VariableDictionary();
             var template = TemplateParser.ParseTemplate(jsonInputs);
+            jsonInputs = template.ToString(); // we parse the template back to string to have a consistent representation of Octostache expressions
             foreach (var templateToken in template.Tokens)
             {
-                // TODO: we need change this to have a better way of escaping json string here
                 var arguments = templateToken.GetArguments();
                 if (!arguments.Any()) continue; // to avoid TextToken, which doesn't need to be evaluated
-                var variableName = templateToken.ToString()
-                                                .Replace("#{", string.Empty)
-                                                .Replace("}", string.Empty);
-                var expanded = variables.Evaluate($"#{{{variableName} | JsonEscape}}");
-                tempVariableDictionaryToUseForExpandedVariables.Add(variableName, expanded);
+                string evaluated = variables.Evaluate(templateToken.ToString());
+                if (evaluated == templateToken.ToString())
+                    throw new CommandException($"Variable {templateToken.ToString()} could not be evaluated, check that the referenced variables exist.");
+                jsonInputs = jsonInputs.Replace($"\"{templateToken.ToString()}\"", JsonConvert.ToString(evaluated));
             }
 
-            var evaluatedJson = tempVariableDictionaryToUseForExpandedVariables.Evaluate(jsonInputs);
-            return evaluatedJson;
+            return jsonInputs;
         }
     }
 }

--- a/source/Calamari.Shared/Util/InputSubstitution.cs
+++ b/source/Calamari.Shared/Util/InputSubstitution.cs
@@ -20,10 +20,8 @@ namespace Calamari.Util
             jsonInputs = template.ToString(); // we parse the template back to string to have a consistent representation of Octostache expressions
             foreach (var templateToken in template.Tokens)
             {
-                var arguments = templateToken.GetArguments();
-                if (!arguments.Any()) continue; // to avoid TextToken, which doesn't need to be evaluated
                 string evaluated = variables.Evaluate(templateToken.ToString());
-                if (evaluated == templateToken.ToString())
+                if (templateToken.GetArguments().Any() && evaluated == templateToken.ToString())
                     log.Warn($"Expression {templateToken.ToString()} could not be evaluated, check that the referenced variables exist.");
                 jsonInputs = jsonInputs.Replace($"\"{templateToken.ToString()}\"", JsonConvert.ToString(evaluated));
             }

--- a/source/Calamari.Tests/Fixtures/Util/InputSubstitutionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/InputSubstitutionFixture.cs
@@ -65,6 +65,16 @@ namespace Calamari.Tests.Fixtures.Util
             InputSubstitution.SubstituteAndEscapeAllVariablesInJson(jsonInputs, variables, log);
             log.Received().Warn(Arg.Any<string>());
         }
+        
+        [Test]
+        public void InvalidVariableExpressionFails()
+        {
+            var variables = new CalamariVariables
+            {
+            };
+            string jsonInputs = "{\"package\":{\"extractedToPath\":\"#{Octopus.Action.Package[package]...ExtractedPath}\"}}";
+            Assert.Throws<CommandException>(() => InputSubstitution.SubstituteAndEscapeAllVariablesInJson(jsonInputs, variables, Substitute.For<ILog>()));
+        }
 
         CalamariVariables ParseVariables(string variableDefinitions)
         {

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -58,7 +58,7 @@ namespace Calamari.LaunchTools
                 };
 
                 var commandResult = commandLineRunner.Execute(commandLineInvocation);
-
+                
                 return commandResult.ExitCode;
             }
         }

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -7,6 +7,7 @@ using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Proxies;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Util;
@@ -19,12 +20,14 @@ namespace Calamari.LaunchTools
         readonly CommonOptions options;
         readonly IVariables variables;
         readonly ICommandLineRunner commandLineRunner;
+        readonly ILog log;
 
-        public NodeExecutor(CommonOptions options, IVariables variables, ICommandLineRunner commandLineRunner)
+        public NodeExecutor(CommonOptions options, IVariables variables, ICommandLineRunner commandLineRunner, ILog log)
         {
             this.options = options;
             this.variables = variables;
             this.commandLineRunner = commandLineRunner;
+            this.log = log;
         }
 
         protected override int ExecuteInternal(NodeInstructions instructions, params string[] args)
@@ -37,7 +40,7 @@ namespace Calamari.LaunchTools
             using (var variableFile = new TemporaryFile(Path.GetTempFileName()))
             {
                 var jsonInputs = variables.GetRaw(instructions.InputsVariable) ?? string.Empty;
-                variables.Set(instructions.InputsVariable, InputSubstitution.SubstituteAndEscapeAllVariablesInJson(jsonInputs, variables));
+                variables.Set(instructions.InputsVariable, InputSubstitution.SubstituteAndEscapeAllVariablesInJson(jsonInputs, variables, log));
 
                 var variablesAsJson = variables.CloneAndEvaluate().SaveAsString();
                 File.WriteAllBytes(variableFile.FilePath, new AesEncryption(options.InputVariables.SensitiveVariablesPassword).Encrypt(variablesAsJson));


### PR DESCRIPTION
### Background
We would like to JSON escape all evaluated variables inside of our inputs so that they can be safely passed to steps executing through Node.js. Our previous implementation did not support the many ways Octostache expressions can be written, this is an attempt to resolve this.

The way it works is quite simple:

1. Parse the Octostache template.
2. Convert the parsed template back to a string, so that there is a deterministic representation of the inputs.
3. Evaluate the variables inside.
4. `string.Replace` the variable expressions with values.

I've put in tests for most available variable expression types and they all appear to work, except one, [see here](https://github.com/OctopusDeploy/Octostache/pull/61).

```csharp
var template = TemplateParser.ParseTemplate(jsonInputs);
jsonInputs = template.ToString();
foreach (var templateToken in template.Tokens)
{
    var arguments = templateToken.GetArguments();
    if (!arguments.Any()) continue; // to avoid TextToken, which doesn't need to be evaluated
    string evaluated = variables.Evaluate(templateToken.ToString());
    jsonInputs = jsonInputs.Replace($"\"{templateToken.ToString()}\"", JsonConvert.ToString(evaluated));
}
```

### Dependencies
Octostache: https://github.com/OctopusDeploy/Octostache/pull/61