### PR TITLE
Support AWS IMDSv2

### DIFF
--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -18,7 +18,9 @@ namespace Calamari.CloudAccounts
     /// </summary>
     public class AwsEnvironmentGeneration
     {
+        const string TokenUri = "http://169.254.169.254/latest/api/token";
         const string RoleUri = "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
+        const string MetadataHeaderToken = "X-aws-ec2-metadata-token";
 
         readonly ILog log;
         readonly Func<Task<bool>> verifyLogin;
@@ -157,6 +159,7 @@ namespace Calamari.CloudAccounts
                     string payload;
                     using (var client = new HttpClient())
                     {
+                        client.DefaultRequestHeaders.Add(MetadataHeaderToken, await GetIMDSv2Token());
                         var instanceRole = await client.GetStringAsync(RoleUri);
 
                         payload = await client.GetStringAsync($"{RoleUri}{instanceRole}");
@@ -179,6 +182,19 @@ namespace Calamari.CloudAccounts
                         "a role assigned to it. " +
                         $"For more information visit {log.FormatLink("https://g.octopushq.com/AwsCloudFormationDeploy#aws-login-error-0003")}", ex);
                 }
+            }
+        }
+
+        /// <summary>
+        /// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+        /// </summary>
+        /// <returns>A token to be used with any IMDS request</returns>
+        async Task<string> GetIMDSv2Token()
+        {
+            using (var client = new HttpClient())
+            {
+                var body = await client.PutAsync(RoleUri, null);
+                return await body.Content.ReadAsStringAsync();
             }
         }
 

--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -193,7 +193,7 @@ namespace Calamari.CloudAccounts
         {
             using (var client = new HttpClient())
             {
-                var body = await client.PutAsync(RoleUri, null);
+                var body = await client.PutAsync(TokenUri, null);
                 return await body.Content.ReadAsStringAsync();
             }
         }

--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -21,6 +21,7 @@ namespace Calamari.CloudAccounts
         const string TokenUri = "http://169.254.169.254/latest/api/token";
         const string RoleUri = "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
         const string MetadataHeaderToken = "X-aws-ec2-metadata-token";
+        const string MetadataHeaderTTL = "X-aws-ec2-metadata-token-ttl-seconds";
 
         readonly ILog log;
         readonly Func<Task<bool>> verifyLogin;
@@ -193,6 +194,7 @@ namespace Calamari.CloudAccounts
         {
             using (var client = new HttpClient())
             {
+                client.DefaultRequestHeaders.Add(MetadataHeaderTTL, "60");
                 var body = await client.PutAsync(TokenUri, null);
                 return await body.Content.ReadAsStringAsync();
             }


### PR DESCRIPTION
IMDSv2 is a new security layer added to the EC2 metadata endpoint. It is documented here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.

Essentially all it requires is the generation of a token to be used with any subsequent IMDS API call. The only API calls we make are to get the EC2 IAM role.