### PR TITLE
Added WaitForDebugger variable, and code to do just that.

### DIFF
--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -21,7 +21,6 @@ using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Proxies;
 using Calamari.Common.Plumbing.Variables;
-using Octopus.Versioning;
 
 namespace Calamari.Common
 {

--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -59,8 +59,7 @@ namespace Calamari.Common
                 using var container = builder.Build();
                 container.Resolve<VariableLogger>().LogVariables();
 
-                #if DEBUG
-
+#if DEBUG
                 var waitForDebugger = container.Resolve<IVariables>().Get(KnownVariables.Calamari.WaitForDebugger);
 
                 if (string.Equals(waitForDebugger, "true", StringComparison.CurrentCultureIgnoreCase))
@@ -73,8 +72,7 @@ namespace Calamari.Common
                         Thread.Sleep(100);
                     }
                 }
-
-                #endif
+#endif
 
                 return ResolveAndExecuteCommand(container, options);
             }

--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Autofac;
 using Autofac.Core;
 using Autofac.Core.Registration;
@@ -19,6 +21,7 @@ using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Proxies;
 using Calamari.Common.Plumbing.Variables;
+using Octopus.Versioning;
 
 namespace Calamari.Common
 {
@@ -53,12 +56,24 @@ namespace Calamari.Common
 
                 var builder = new ContainerBuilder();
                 ConfigureContainer(builder, options);
-                using (var container = builder.Build())
-                {
-                    container.Resolve<VariableLogger>().LogVariables();
 
-                    return ResolveAndExecuteCommand(container, options);
+                using var container = builder.Build();
+                container.Resolve<VariableLogger>().LogVariables();
+
+                var waitForDebugger = container.Resolve<IVariables>().Get(KnownVariables.Calamari.WaitForDebugger);
+
+                if (string.Equals(waitForDebugger, "true", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    using var proc = Process.GetCurrentProcess();
+                    Log.Info($"Waiting for debugger to attach... (PID: {proc.Id})");
+
+                    while (!Debugger.IsAttached)
+                    {
+                        Thread.Sleep(100);
+                    }
                 }
+
+                return ResolveAndExecuteCommand(container, options);
             }
             catch (Exception ex)
             {

--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -60,6 +60,8 @@ namespace Calamari.Common
                 using var container = builder.Build();
                 container.Resolve<VariableLogger>().LogVariables();
 
+                #if DEBUG
+
                 var waitForDebugger = container.Resolve<IVariables>().Get(KnownVariables.Calamari.WaitForDebugger);
 
                 if (string.Equals(waitForDebugger, "true", StringComparison.CurrentCultureIgnoreCase))
@@ -72,6 +74,8 @@ namespace Calamari.Common
                         Thread.Sleep(100);
                     }
                 }
+
+                #endif
 
                 return ResolveAndExecuteCommand(container, options);
             }

--- a/source/Calamari.Common/Plumbing/Variables/KnownVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/KnownVariables.cs
@@ -32,6 +32,11 @@ namespace Calamari.Common.Plumbing.Variables
             }
         }
 
+        public static class Calamari
+        {
+            public const string WaitForDebugger = "Octopus.Calamari.WaitForDebugger";
+        }
+
         public static class Release
         {
             public static readonly string Number = "Octopus.Release.Number";

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -29,6 +29,9 @@
     <DefineConstants>$(DefineConstants);IIS_SUPPORT;WINDOWS_CERTIFICATE_STORE_SUPPORT</DefineConstants>
     <PlatformTarget>anycpu</PlatformTarget>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+  </PropertyGroup>
   <!--
 	The net452 build is the one that pulls in the AWS and Azure extensions. We treat
 	this build as the "Cloud" build.


### PR DESCRIPTION
This PR makes debugging Calamari a nicer experience out of the box.

If you add an `Octopus.Calamari.WaitForDebugger` variable to a project and set its value to 'true', then point the `Octopus.Calamari.Executable` variable to an appropriate exe, Calamari will wait for a debugger to attach before any commands are run:

![image](https://user-images.githubusercontent.com/46470837/130701057-9f6d0608-e19d-45d2-baab-0e724fc53e93.png)


![image](https://user-images.githubusercontent.com/46470837/130701023-fdae4289-a046-42e9-801b-d4ceb5251915.png)

This should work cross platform.

Thanks to @TomPeters for basically all of the code, if I'm being honest 😄 