### PR TITLE
Fixed: GKE deployments do not use custom namespace (#769)

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenBothZoneAndRegionAreProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenBothZoneAndRegionAreProvided.approved.txt
@@ -5,5 +5,5 @@
 [Verbose] Successfully authenticated with gcloud
 [Info] Creating kubectl context to GKE Cluster called gke-cluster-name (namespace calamari-testing) using a Google Cloud Account
 [Verbose] "gcloud" container clusters get-credentials gke-cluster-name --zone=gke-zone
-[Verbose] "kubectl" config set-context gke-cluster-name --namespace=calamari-testing --request-timeout=1m
+[Verbose] "kubectl" config set-context --current --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenRegionIsProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenRegionIsProvided.approved.txt
@@ -5,5 +5,5 @@
 [Verbose] Successfully authenticated with gcloud
 [Info] Creating kubectl context to GKE Cluster called gke-cluster-name (namespace calamari-testing) using a Google Cloud Account
 [Verbose] "gcloud" container clusters get-credentials gke-cluster-name --region=gke-region
-[Verbose] "kubectl" config set-context gke-cluster-name --namespace=calamari-testing --request-timeout=1m
+[Verbose] "kubectl" config set-context --current --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenZoneIsProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenZoneIsProvided.approved.txt
@@ -5,5 +5,5 @@
 [Verbose] Successfully authenticated with gcloud
 [Info] Creating kubectl context to GKE Cluster called gke-cluster-name (namespace calamari-testing) using a Google Cloud Account
 [Verbose] "gcloud" container clusters get-credentials gke-cluster-name --zone=gke-zone
-[Verbose] "kubectl" config set-context gke-cluster-name --namespace=calamari-testing --request-timeout=1m
+[Verbose] "kubectl" config set-context --current --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -539,7 +539,7 @@ namespace Calamari.Kubernetes
                 ExecuteCommand(gcloud, arguments.ToArray());
                 ExecuteKubectlCommand("config",
                                       "set-context",
-                                      gkeClusterName,
+                                      "--current",
                                       $"--namespace={@namespace}");
             }
 


### PR DESCRIPTION
Merging the fix (https://github.com/OctopusDeploy/Calamari/pull/769) from 2021.2 to master