### PR TITLE
fix: shift encryption key out of scope of user bash scripts

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -116,7 +116,7 @@ namespace Calamari.Common.Features.Scripting.Bash
                 writer.NewLine = LinuxNewLine;
                 writer.WriteLine("#!/bin/bash");
                 writer.WriteLine("source \"$(pwd)/" + Path.GetFileName(configurationFile) + "\"");
-                writer.WriteLine("shift");
+                writer.WriteLine("shift"); // Shift the variable decryption key out of scope of the user script (see: https://github.com/OctopusDeploy/Calamari/pull/773)
                 writer.WriteLine("source \"$(pwd)/" + Path.GetFileName(script.File) + "\" " + script.Parameters);
                 writer.Flush();
             }

--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -116,6 +116,7 @@ namespace Calamari.Common.Features.Scripting.Bash
                 writer.NewLine = LinuxNewLine;
                 writer.WriteLine("#!/bin/bash");
                 writer.WriteLine("source \"$(pwd)/" + Path.GetFileName(configurationFile) + "\"");
+                writer.WriteLine("shift");
                 writer.WriteLine("source \"$(pwd)/" + Path.GetFileName(script.File) + "\" " + script.Parameters);
                 writer.Flush();
             }

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -57,20 +57,17 @@ namespace Calamari.Tests.Fixtures.Bash
                 { [SpecialVariables.Action.Script.ScriptParameters] = "\"Para meter0\" 'Para meter1'" });
 
             output.AssertSuccess();
-            output.AssertOutput("Parameters Para meter0Para meter1");
+            output.AssertOutput("Parameters ($1='Para meter0' $2='Para meter1'");
         }
         
         [Test]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldNotHaveDecryptionKeyInScopeOfUserScript()
+        public void ShouldNotReceiveParametersIfNoneProvided()
         {
-            var (output, _) = RunScript("parameters.sh", new Dictionary<string, string>()
-                                            { ["Name"] = "NameToEncrypt", [SpecialVariables.Action.Script.ScriptParameters] = "" }, 
-                                            sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
+            var (output, _) = RunScript("parameters.sh", sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
 
             output.AssertSuccess();
-            output.AssertOutput("Parameters ");
-            output.AssertNoOutputMatches(@"Parameters ([A-Z0-9])+");
+            output.AssertOutput("Parameters ($1='' $2='')");
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Calamari.Deployment;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
@@ -57,6 +58,19 @@ namespace Calamari.Tests.Fixtures.Bash
 
             output.AssertSuccess();
             output.AssertOutput("Parameters Para meter0Para meter1");
+        }
+        
+        [Test]
+        [RequiresBashDotExeIfOnWindows]
+        public void ShouldNotHaveDecryptionKeyInScopeOfUserScript()
+        {
+            var (output, _) = RunScript("parameters.sh", new Dictionary<string, string>()
+                                            { ["Name"] = "NameToEncrypt", [SpecialVariables.Action.Script.ScriptParameters] = "" }, 
+                                            sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
+
+            output.AssertSuccess();
+            output.AssertOutput("Parameters ");
+            output.AssertNoOutputMatches(@"Parameters ([A-Z0-9])+");
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/Bash/Scripts/parameters.sh
+++ b/source/Calamari.Tests/Fixtures/Bash/Scripts/parameters.sh
@@ -1,2 +1,2 @@
 ﻿#!/bin/bash
-echo "Parameters $1$2"
+echo "Parameters (\$1='$1' \$2='$2')"

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -208,18 +208,27 @@ namespace Calamari.Tests.KubernetesFixtures
                                             string destination)
         {
             var zipPath = Path.Combine(Path.GetTempPath(), fileName);
+            var downloadUrl = UriCombine(downloadBaseUrl, fileName);
             using (new TemporaryFile(zipPath))
             {
-                await Download(zipPath, client, $"{downloadBaseUrl}{fileName}");
+                await Download(zipPath, client, downloadUrl);
 
                 ZipFile.ExtractToDirectory(zipPath, destination);
             }
         }
-        
+
+        static string UriCombine(string downloadBaseUrl, string fileName)
+        {
+            if (downloadBaseUrl.Last() != '/')
+                downloadBaseUrl += '/';
+            
+            return $"{downloadBaseUrl}{fileName}";
+        }
+
         static async Task DownloadGcloud(string fileName,
-                                            HttpClient client,
-                                            string downloadUrl,
-                                            string destination)
+                                         HttpClient client,
+                                         string downloadUrl,
+                                         string destination)
         {
             var zipPath = Path.Combine(Path.GetTempPath(), fileName);
             using (new TemporaryFile(zipPath))


### PR DESCRIPTION
# Background
The "Run a Script" step generates a number of supporting scripts on the target machine in the leadup to step execution. These include a top-level script that orchestrates, and a couple of scripts that provide octopus-specific functions that step authors can use, for example to access variables, publish artefacts etc. 

There is a top-level bootstrapper script generated, which looks something like this:
```
#!/bin/bash
source "$(pwd)/Bootstrap.57cb81bc-5.script.sh"
source "$(pwd)/script.sh" "command" "arguments" "from" "step" "definition"
```

When Calamari executes the step, a decryption key is the single argument to the bootstrapper script. The command executed on the target looks something like this, assuming the decryption key is `AE001BC55GAC29800B`
`/bin/bash "top-level-script.sh" "AE001BC55GAC29800B"`

The resulting bash process has a single argument, $1 = "AE001BC55GAC29800B"

# Problem
If no script arguments are defined by the user to be passed to their script, `source`ing `script.sh` results in the decryption key being available to the user script as `$1`, which will be masked if echo'd as console output.

This was discovered by a user accidentally, who was attempting to pass a first argument of `#{Octopus.Release.Id}` to a script in a Runbook. ReleaseId doesn't exist in a runbook, and the leading `#` resulted in all further arguments being bash-commented out. This effectively leads to a bootstrapping script that looks like this:

```
#!/bin/bash
source "$(pwd)/Bootstrap.57cb81bc-5.script.sh"
source "$(pwd)/script.sh" #{Octopus.Release.Id} "anything following commented out from a Bash perspective"
```

The user's script was then echo'ing `$1`, which they thought should be empty, but was printing out masked characters unexpectedly.

# Solution
Without making too much potentially dangerous change to how scripts get executed, which could have pretty far-reaching consequences, this change uses the `shift` bash command to "shift" the decryption key out of the scope in which the user's script is executed. 

Because the user script's arguments are set directly in the bootstrapper script when it's generated, there should be no impact on things when arguments are explicitly provided.
