### PR TITLE
adding code to suppress write-progress breaking output on linux

### DIFF
--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -201,13 +201,13 @@ namespace Calamari.Common.Features.Scripting.WindowsPowerShell
             return commandArguments.ToString();
         }
 
-        string GetDisplayProgressCommand(IVariables variables)
+        static string GetDisplayProgressCommand(IVariables variables)
         {
             var powerShellProgressPreferenceArg = variables[PowerShellVariables.OutputPowerShellProgress];
             
-            int.TryParse(powerShellProgressPreferenceArg, out var processArgAsInt);
-            bool.TryParse(powerShellProgressPreferenceArg, out var processArgAsBool);
-            if (processArgAsInt > 0 || processArgAsBool)
+            int.TryParse(powerShellProgressPreferenceArg, out var powerShellProgressPreferenceArgAsInt);
+            bool.TryParse(powerShellProgressPreferenceArg, out var powerShellProgressPreferenceArgAsBool);
+            if (powerShellProgressPreferenceArgAsInt > 0 || powerShellProgressPreferenceArgAsBool)
             {
                 return "$ProgressPreference = 'Continue';";
             }

--- a/source/Calamari.Common/Plumbing/Variables/PowerShellVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/PowerShellVariables.cs
@@ -10,6 +10,7 @@ namespace Calamari.Common.Plumbing.Variables
         public static readonly string UserName = "Octopus.Action.PowerShell.UserName";
         public static readonly string Password = "Octopus.Action.PowerShell.Password";
         public static readonly string Edition = "Octopus.Action.PowerShell.Edition";
+        public static readonly string OutputPowerShellProgress = "Octopus.Action.PowerShell.OutputPowerShellProgress";
 
         public static class PSDebug
         {

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
@@ -595,21 +595,21 @@ namespace Calamari.Tests.Fixtures.PowerShell
         }
         
         [Test]
-        [TestCase("true", 1)]
-        [TestCase("false", 0)]
-        [TestCase("1", 1)]
-        [TestCase("0", 0)]
-        [TestCase(null, 0)]
-        public void ScriptWithPowerShellProgressAndOverrideOutputVariableDefinedCorrectlyWritesExpectedWarningAfter(string progressVariable, int expectedOutputCount)
+        [TestCase("true", "Continue")]
+        [TestCase("false", "SilentlyContinue")]
+        [TestCase("1", "Continue")]
+        [TestCase("0", "SilentlyContinue")]
+        [TestCase(null, "SilentlyContinue")]
+        public void ScriptWithPowerShellProgressAndOverrideOutputVariableDefinedCorrectlySetProgressPreferenceVariable(string progressVariable, string expectedOutput)
         {
             var additionalVariables = new Dictionary<string, string>
             {
                 [PowerShellVariables.OutputPowerShellProgress] = progressVariable
             };
-            var (output, _) = RunPowerShellScript("PowerShellProgress.ps1", additionalVariables);
+            var (output, _) = RunPowerShellScript("PowerShellProgressPreferenceCheck.ps1", additionalVariables);
 
             output.AssertSuccess();
-            output.CapturedOutput.AllMessages.Where(x => x.EndsWith(" ##octopus[stdout-warning]")).Should().HaveCount(expectedOutputCount);
+            output.AssertOutput($"ProgressPreference = {expectedOutput}");
         }
 
         static bool IsRunningOnUnixLikeEnvironment => CalamariEnvironment.IsRunningOnNix || CalamariEnvironment.IsRunningOnMac;
@@ -651,7 +651,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
             }
         }
 
-        (CalamariResult result, IVariables variables) RunPowerShellScript(string scriptName,
+        protected (CalamariResult result, IVariables variables) RunPowerShellScript(string scriptName,
             Dictionary<string, string> additionalVariables = null,
             Dictionary<string, string> additionalParameters = null,
             string sensitiveVariablesPassword = null)

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
@@ -584,6 +584,33 @@ namespace Calamari.Tests.Fixtures.PowerShell
             output.AssertOutput(string.Join(Environment.NewLine, "45", "226", "128", "147"));
             AssertPowerShellEdition(output);
         }
+        
+        [Test]
+        public void ScriptWithPowerShellProgressCorrectlyWritesWarningAfter()
+        {
+            var (output, _) = RunPowerShellScript("PowerShellProgress.ps1");
+
+            output.AssertSuccess();
+            output.CapturedOutput.AllMessages.Where(x => x.EndsWith(" ##octopus[stdout-warning]")).Should().HaveCount(0);
+        }
+        
+        [Test]
+        [TestCase("true", 1)]
+        [TestCase("false", 0)]
+        [TestCase("1", 1)]
+        [TestCase("0", 0)]
+        [TestCase(null, 0)]
+        public void ScriptWithPowerShellProgressAndOverrideOutputVariableDefinedCorrectlyWritesExpectedWarningAfter(string progressVariable, int expectedOutputCount)
+        {
+            var additionalVariables = new Dictionary<string, string>
+            {
+                [PowerShellVariables.OutputPowerShellProgress] = progressVariable
+            };
+            var (output, _) = RunPowerShellScript("PowerShellProgress.ps1", additionalVariables);
+
+            output.AssertSuccess();
+            output.CapturedOutput.AllMessages.Where(x => x.EndsWith(" ##octopus[stdout-warning]")).Should().HaveCount(expectedOutputCount);
+        }
 
         static bool IsRunningOnUnixLikeEnvironment => CalamariEnvironment.IsRunningOnNix || CalamariEnvironment.IsRunningOnMac;
 

--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/PowerShellProgress.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/PowerShellProgress.ps1
@@ -1,0 +1,3 @@
+﻿Write-Warning "This should log as a warning"
+Write-Progress -Activity "Progress" -PercentComplete 100
+Write-Warning "This should also log as a warning"

--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/PowerShellProgressPreferenceCheck.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/PowerShellProgressPreferenceCheck.ps1
@@ -1,0 +1,1 @@
+﻿Write-Host "ProgressPreference = ${ProgressPreference}"


### PR DESCRIPTION
# Background

When the "Run a Script" is running a PowerShell script that contains a call to a cmdlet or contains a `Write-Progress` call breaks the following line if it contains an Octopus marker like ##octopus[stdout-warning]. It appears that `Write-Progress` does not put a trailing newline character which means the marker is not treated correctly.

This only happens on Linux-based OS (including macOS). You can see below this script when runs on a Windows worker always parses the output correctly.

You can read more about [Write-Progess](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/write-progress?view=powershell-7.1) and [$ProgressPreference](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.1#progresspreference) in the Microsoft documentation.

# Problem

The following PowerShell script is a small repro of the issue mention above.

```PowerShell

Write-Warning "This should log as a warning"
Write-Progress -Activity "Progress" -PercentComplete 100
Write-Warning "This should also log as a warning"

```

## Before

Prior to the fix, this is what is shown in the output in Octopus when the step that ran the code block on a Linux worker is below.

<img width="1454" alt="Screen Shot 2021-09-21 at 11 34 48 am" src="https://user-images.githubusercontent.com/88302625/134099433-9a2a5599-5010-4426-9cb0-50757c27a209.png">

## After

The output in Octopus is now parsing the second warning correctly

<img width="1458" alt="Screen Shot 2021-09-21 at 11 35 28 am" src="https://user-images.githubusercontent.com/88302625/134099453-c6e45869-4cbb-4c64-8521-69af73252942.png">

# Solution

This has been resolved by adding the following line to the PowerShell bootstrap script so that the provided user script is run `"$ProgressPreference = 'SilentlyContinue';"` by default.

The PR also adds a new Octopus Variable that can be set `Octopus.Action.PowerShell.OutputPowerShellProgress` to true and this will set `"$ProgressPreference = 'Continue';"` instead of `'SilentlyContinue'` this would allow any script that actually requires `$ProgressPreference` to be run with the default value of `'Continue'`.
