### PR TITLE
Merging NuGet partial fix from release 2021.2 to master

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/NuGet/NuGetServiceTypes.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NuGetServiceTypes.cs
@@ -9,8 +9,9 @@ namespace Calamari.Integration.Packages.NuGet
         public static readonly string Version300beta = "/3.0.0-beta";
         public static readonly string Version300 = "/3.0.0";
         public static readonly string Version340 = "/3.4.0";
+        public static readonly string Version360 = "/3.6.0";
 
-        public static readonly string[] RegistrationsBaseUrl = { "RegistrationsBaseUrl" + Version340, "RegistrationsBaseUrl" + Version300beta };
+        public static readonly string[] RegistrationsBaseUrl = { "RegistrationsBaseUrl" + Version360, "RegistrationsBaseUrl" + Version340, "RegistrationsBaseUrl" + Version300beta };
         public static readonly string PackageBaseAddress = "PackageBaseAddress" + Version300;
     }
 }

--- a/source/Calamari.Tests/Fixtures/PackageDownload/NuGetFeedSupport/Calamari.Tests.Fixtures.PackageDownload.NuGetFeedSupport.nuspec
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/NuGetFeedSupport/Calamari.Tests.Fixtures.PackageDownload.NuGetFeedSupport.nuspec
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Calamari.Tests.Fixtures.PackageDownload.NuGetFeedSupport</id>
+        <version>0.0.0</version>
+        <authors>Octopus Deploy</authors>
+        <owners>octopus-deploy</owners>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Test Package for Calamari NuGet Integration Tests</description>
+        <copyright>Copyright ©2021 Octopus Deploy</copyright>
+        <dependencies />
+    </metadata>
+    <files>
+        <file src="Readme.md" target="" />
+    </files>
+</package>

--- a/source/Calamari.Tests/Fixtures/PackageDownload/NuGetFeedSupport/Readme.md
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/NuGetFeedSupport/Readme.md
@@ -1,0 +1,3 @@
+# Calamari.Tests.Fixtures.PackageDownload.NuGetFeedSupport
+
+This package exists purely to support Integration Tests of Calamari's NuGet package download functionality.

--- a/source/Calamari.Tests/Fixtures/PackageDownload/NuGetFeedSupportFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/NuGetFeedSupportFixture.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Calamari.Common.Features.Packages;
+using Calamari.Tests.Helpers;
+using NUnit.Framework;
+using Octopus.Versioning;
+
+namespace Calamari.Tests.Fixtures.PackageDownload
+{
+    [TestFixture]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
+    
+    public class NuGetFeedVersionSupportFixture : CalamariFixture
+    {
+        const string FeedzV2UriEnvironmentVariable = "CALAMARI_FEEDZV2URI";
+        const string FeedzV3UriEnvironmentVariable = "CALAMARI_FEEDZV3URI";
+        const string ArtifactoryV2UriEnvironmentVariable = "CALAMARI_ARTIFACTORYV2URI";
+        const string ArtifactoryV3FeedUriEnvironmentVariable = "CALAMARI_ARTIFACTORYV3URI";
+        
+        const string TestNuGetPackageId = "Calamari.Tests.Fixtures.PackageDownload.NuGetFeedSupport";
+
+        // TODO: Packages here were generated using the nuspec file in the .\NuGetFeedSupport folder
+        // Right now, they have been manually uploaded to the feedz.io and Artifactory repositories below.
+        // In future, we should ensure this test fixture sets its own data up from scratch before running
+        // and tears it down on completion, rather than relying on external state as it currently does.
+
+        static readonly string FeedzNuGetV2FeedUrl = Environment.GetEnvironmentVariable(FeedzV2UriEnvironmentVariable);
+        static readonly string FeedzNuGetV3FeedUrl = Environment.GetEnvironmentVariable(FeedzV3UriEnvironmentVariable);
+        static readonly string ArtifactoryNuGetV2FeedUrl = Environment.GetEnvironmentVariable(ArtifactoryV2UriEnvironmentVariable);
+        static readonly string ArtifactoryNuGetV3FeedUrl = Environment.GetEnvironmentVariable(ArtifactoryV3FeedUriEnvironmentVariable);
+        
+        static readonly string TentacleHome = TestEnvironment.GetTestPath("Fixtures", "PackageDownload");
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (!Directory.Exists(TentacleHome))
+                Directory.CreateDirectory(TentacleHome);
+
+            Directory.SetCurrentDirectory(TentacleHome);
+
+            Environment.SetEnvironmentVariable("TentacleHome", TentacleHome);
+            Console.WriteLine("TentacleHome is set to: " + TentacleHome);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            var downloadPath = TestEnvironment.GetTestPath(TentacleHome, "Files");
+            
+            if (Directory.Exists(downloadPath))
+                Directory.Delete(downloadPath, true);
+            Environment.SetEnvironmentVariable("TentacleHome", null);
+        }
+        
+        [Test]
+        [TestCaseSource(nameof(FeedzNuGet2SupportedVersionStrings))]
+        public void ShouldSupportFeedzNuGetVersion2Feeds(string versionString)
+        {
+            var calamariResult = DownloadPackage(TestNuGetPackageId, versionString, "nuget-local", FeedzNuGetV2FeedUrl);
+            calamariResult.AssertSuccess();
+        }
+        
+        [Test]
+        [TestCaseSource(nameof(FeedzNuGet2SupportedVersionStrings))]
+        [TestCaseSource(nameof(FeedzNuGet3SupportedVersionStrings))]
+        public void ShouldSupportFeedzNuGetVersion3Feeds(string versionString)
+        {
+            var calamariResult = DownloadPackage(TestNuGetPackageId, versionString, "nuget-local", FeedzNuGetV3FeedUrl);
+            
+            calamariResult.AssertSuccess();
+        }
+        
+        [Test]
+        [TestCaseSource(nameof(ArtifactoryNuGet3SupportedVersionStrings))]
+        [TestCaseSource(nameof(ArtifactoryNuGet2SupportedVersionStrings))]
+        [Platform("Net-4.5")]
+        public void ArtifactoryShouldSupportNuGetVersion3Feeds(string versionString)
+        {
+            var calamariResult = DownloadPackage(TestNuGetPackageId,  versionString, "nuget-local", ArtifactoryNuGetV3FeedUrl);
+            calamariResult.AssertSuccess();
+        }
+        
+        [Test]
+        [TestCaseSource(nameof(ArtifactoryNuGet2SupportedVersionStrings))]
+        public void ArtifactoryShouldSupportNuGetVersion2Feeds(string versionString)
+        {
+            var calamariResult = DownloadPackage(TestNuGetPackageId,  versionString, "nuget-local", ArtifactoryNuGetV2FeedUrl);
+            calamariResult.AssertSuccess();
+        }
+
+       
+
+        public static IEnumerable<TestCaseData> FeedzNuGet2SupportedVersionStrings
+        {
+            get
+            {
+                yield return new TestCaseData("1.0.0");
+                yield return new TestCaseData("1.4.92").SetDescription("Multi-digit Patch Version");
+                yield return new TestCaseData("2.0.0-beta").SetDescription("SemVer 1.0 beta pre-release");
+            }
+        }
+
+        public static IEnumerable<TestCaseData> FeedzNuGet3SupportedVersionStrings
+        {
+            get
+            {
+
+                yield return new TestCaseData("2.0.0-beta+abcd16bd").SetDescription("Pre-release version with metadata");
+                yield return new TestCaseData("2.0.0-beta.1+abcd16bd").SetDescription("Pre-release version with dot suffix and metadata");
+                yield return new TestCaseData("2.0.0-beta.2").SetDescription("Pre-release version with dot suffix");
+                yield return new TestCaseData("2.0.0-beta.2.1").SetDescription("Pre-release version with double-dot suffix");
+            }
+        }
+        public static IEnumerable<TestCaseData> ArtifactoryNuGet2SupportedVersionStrings
+        {
+            get
+            {
+                yield return new TestCaseData("1.0.0").SetDescription("Pre-release version with metadata");
+            }
+        }
+
+        public static IEnumerable<TestCaseData> ArtifactoryNuGet3SupportedVersionStrings
+        {
+            get
+            {
+                yield return new TestCaseData("1.0.0-alpha.3+metadata").SetDescription("Pre-release version with dot suffix and metadata");
+            }
+        }
+        
+        CalamariResult DownloadPackage(string packageId, string packageVersion, string feedId, string feedUri, string feedUsername = "", string feedPassword = "")
+        {
+            var calamari = Calamari()
+                           .Action("download-package")
+                           .Argument("packageId", packageId)
+                           .Argument("packageVersion", packageVersion)
+                           .Argument("packageVersionFormat", VersionFormat.Semver)
+                           .Argument("feedId", feedId)
+                           .Argument("feedUri", feedUri)
+                           .Argument("feedType", FeedType.NuGet)
+                           .Argument("attempts", 1)
+                           .Argument("attemptBackoffSeconds", 0);
+
+            if (!string.IsNullOrWhiteSpace(feedUsername))
+                calamari.Argument("feedUsername", feedUsername);
+
+            if (!string.IsNullOrWhiteSpace(feedPassword))
+                calamari.Argument("feedPassword", feedPassword);
+            
+            
+            return Invoke(calamari);
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/providers.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.63.0"
+      version = "= 2.78.0" #Due to a bug with 2.79.x we are pinning to this version for now. https://github.com/Azure/AKS/issues/2584 
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
This PR is merging the following fix forward from 2021.2 release to master, original details are below.

# Background

When Calamari is instructed to download NuGet packages with a version that contains Semver metadata (+somestring) and example of this `1.0.0-alpha.3+metadata` it fails to find the package when it exists.

This relates to OctopusDeploy/Issues#6965 and is a partial fix

# Problem

There was a number of issues found while investigating this.

- With NET Full Calamari's it was choosing the wrong NuGet downloader e.g V2 downloader when it was V3 feed.
- The downloading code in Calamari does not semver packages.

## Before

![Screen Shot 2021-10-07 at 3 46 21 pm](https://user-images.githubusercontent.com/88302625/136323550-fca1f325-60a7-46b5-86d9-d55b560b94c6.png)

## After

![Screen Shot 2021-10-07 at 3 48 19 pm](https://user-images.githubusercontent.com/88302625/136323569-1101b9ac-c4e0-4d1f-b671-a7fbcc4937e8.png)

# Solution

- This PR improves detecting if the NuGet feed is V3 or V2 protocol.
- It also resolves a deadlock that was appearing in the NET 4.0 of Calamari.
- It improves the NuGet V3 downloader for NET Framework when feeds do not implement all of the protocol
