### PR TITLE
Trying to improve reliability of S3 tests

### DIFF
--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -41,11 +41,11 @@ namespace Calamari.Tests.AWS
         static JsonSerializerSettings GetEnrichedSerializerSettings()
         {
             return JsonSerialization.GetDefaultSerializerSettings()
-                                    .Tee(x =>
-                                         {
-                                             x.Converters.Add(new FileSelectionsConverter());
-                                             x.ContractResolver = new CamelCasePropertyNamesContractResolver();
-                                         });
+                .Tee(x =>
+                {
+                    x.Converters.Add(new FileSelectionsConverter());
+                    x.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                });
         }
 
         public S3Fixture()
@@ -64,7 +64,6 @@ namespace Calamari.Tests.AWS
                                 {
                                     await client.DeleteObjectAsync(bucketName, s3Object.Key);
                                 }
-
                                 await client.DeleteBucketAsync(bucketName);
                             });
         }
@@ -115,20 +114,20 @@ namespace Calamari.Tests.AWS
             var prefix = Upload("Package2", fileSelections);
 
             await Validate(async client =>
-                           {
-                               await client.GetObjectAsync(bucketName, $"{prefix}Wild/Things/TextFile2.txt");
-                               try
-                               {
-                                   await client.GetObjectAsync(bucketName, $"{prefix}Wild/Ignore/TextFile1.txt");
-                               }
-                               catch (AmazonS3Exception e)
-                               {
-                                   if (e.StatusCode != HttpStatusCode.NotFound)
-                                   {
-                                       throw;
-                                   }
-                               }
-                           });
+            {
+                await client.GetObjectAsync(bucketName, $"{prefix}Wild/Things/TextFile2.txt");
+                try
+                {
+                    await client.GetObjectAsync(bucketName, $"{prefix}Wild/Ignore/TextFile1.txt");
+                }
+                catch (AmazonS3Exception e)
+                {
+                    if (e.StatusCode != HttpStatusCode.NotFound)
+                    {
+                        throw;
+                    }
+                }
+            });
         }
 
         [Test]
@@ -191,22 +190,22 @@ namespace Calamari.Tests.AWS
 
         IDictionary<string, string> specialHeaders = new Dictionary<string, string>()
         {
-            { "Cache-Control", "max-age=123" },
-            { "Content-Disposition", "some disposition" },
-            { "Content-Encoding", "some-encoding" },
-            { "Content-Type", "application/html" },
-            { "Expires", DateTime.UtcNow.AddDays(1).ToString("r") }, // Need to use RFC1123 format to match how the request is serialized
-            { "x-amz-website-redirect-location", "/anotherPage.html" },
+            {"Cache-Control", "max-age=123"},
+            {"Content-Disposition", "some disposition"},
+            {"Content-Encoding", "some-encoding"},
+            {"Content-Type", "application/html"},
+            {"Expires", DateTime.UtcNow.AddDays(1).ToString("r")}, // Need to use RFC1123 format to match how the request is serialized
+            {"x-amz-website-redirect-location", "/anotherPage.html"},
         };
 
         IDictionary<string, string> userDefinedMetadata = new Dictionary<string, string>()
         {
-            { "Expect", "some-expect" },
-            { "Content-MD5", "somemd5" },
-            { "Content-Length", "12345" },
-            { "x-amz-tagging", "sometag" },
-            { "x-amz-storage-class", "GLACIER" },
-            { "x-amz-meta", "somemeta" }
+            {"Expect", "some-expect"},
+            {"Content-MD5", "somemd5"},
+            {"Content-Length", "12345"},
+            {"x-amz-tagging", "sometag"},
+            {"x-amz-storage-class", "GLACIER"},
+            {"x-amz-meta", "somemeta"}
         };
 
         [Test]
@@ -232,42 +231,41 @@ namespace Calamari.Tests.AWS
             var prefix = Upload("Package1", fileSelections);
 
             await Validate(async client =>
-                           {
-                               var response = await client.GetObjectAsync(bucketName, $"{prefix}Extra/JavaScript.js");
-                               var headers = response.Headers;
-                               var metadata = response.Metadata;
+            {
+                var response = await client.GetObjectAsync(bucketName, $"{prefix}Extra/JavaScript.js");
+                var headers = response.Headers;
+                var metadata = response.Metadata;
 
-                               foreach (var specialHeader in specialHeaders)
-                               {
-                                   if (specialHeader.Key == "Expires")
-                                   {
-                                       //There's a serialization bug in Json.Net that ends up changing the time to local.
-                                       //Fix this assertion once that's done.
-                                       var expectedDate = DateTime.Parse(specialHeader.Value.TrimEnd('Z')).ToUniversalTime();
-                                       response.Expires.Should().Be(expectedDate);
-                                   }
-                                   else if (specialHeader.Key == "x-amz-website-redirect-location")
-                                   {
-                                       response.WebsiteRedirectLocation.Should().Be(specialHeader.Value);
-                                   }
-                                   else
-                                       headers[specialHeader.Key].Should().Be(specialHeader.Value);
-                               }
+                foreach (var specialHeader in specialHeaders)
+                {
+                    if (specialHeader.Key == "Expires")
+                    {
+                        //There's a serialization bug in Json.Net that ends up changing the time to local.
+                        //Fix this assertion once that's done.
+                        var expectedDate = DateTime.Parse(specialHeader.Value.TrimEnd('Z')).ToUniversalTime();
+                        response.Expires.Should().Be(expectedDate);
+                    }
+                    else if (specialHeader.Key == "x-amz-website-redirect-location")
+                    {
+                        response.WebsiteRedirectLocation.Should().Be(specialHeader.Value);
+                    }
+                    else
+                        headers[specialHeader.Key].Should().Be(specialHeader.Value);
+                }
 
-                               foreach (var userMetadata in userDefinedMetadata)
-                                   metadata["x-amz-meta-" + userMetadata.Key.ToLowerInvariant()]
-                                       .Should()
-                                       .Be(userMetadata.Value);
+                foreach (var userMetadata in userDefinedMetadata)
+                    metadata["x-amz-meta-" + userMetadata.Key.ToLowerInvariant()]
+                        .Should().Be(userMetadata.Value);
 
-                               response.TagCount.Should().Be(1);
-                           });
+                response.TagCount.Should().Be(1);
+            });
         }
 
         async Task Validate(Func<AmazonS3Client, Task> execute)
         {
             var credentials = new BasicAWSCredentials(Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Access"),
-                                                      Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Secret"));
-            var config = new AmazonS3Config { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.GetBySystemName(region) };
+                Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Secret"));
+            var config = new AmazonS3Config {AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.GetBySystemName(region)};
             using (var client = new AmazonS3Client(credentials, config))
             {
                 await execute(client);
@@ -279,17 +277,17 @@ namespace Calamari.Tests.AWS
             var bucketKeyPrefix = $"calamaritest/{Guid.NewGuid():N}/";
 
             fileSelections.ForEach(properties =>
-                                   {
-                                       if (properties is S3MultiFileSelectionProperties multiFileSelectionProperties)
-                                       {
-                                           multiFileSelectionProperties.BucketKeyPrefix = bucketKeyPrefix;
-                                       }
+            {
+                if (properties is S3MultiFileSelectionProperties multiFileSelectionProperties)
+                {
+                    multiFileSelectionProperties.BucketKeyPrefix = bucketKeyPrefix;
+                }
 
-                                       if (properties is S3SingleFileSelectionProperties singleFileSelectionProperties)
-                                       {
-                                           singleFileSelectionProperties.BucketKeyPrefix = bucketKeyPrefix;
-                                       }
-                                   });
+                if (properties is S3SingleFileSelectionProperties singleFileSelectionProperties)
+                {
+                    singleFileSelectionProperties.BucketKeyPrefix = bucketKeyPrefix;
+                }
+            });
 
             var variablesFile = Path.GetTempFileName();
             var variables = new CalamariVariables();
@@ -298,7 +296,7 @@ namespace Calamari.Tests.AWS
             variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Secret"));
             variables.Set("Octopus.Action.Aws.Region", region);
             variables.Set(AwsSpecialVariables.S3.FileSelections,
-                          JsonConvert.SerializeObject(fileSelections, GetEnrichedSerializerSettings()));
+                JsonConvert.SerializeObject(fileSelections, GetEnrichedSerializerSettings()));
             if (customVariables != null) variables.Merge(customVariables);
             variables.Save(variablesFile);
 
@@ -310,19 +308,17 @@ namespace Calamari.Tests.AWS
                 var log = new InMemoryLog();
                 var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
                 var command = new UploadAwsS3Command(
-                                                     log,
-                                                     variables,
-                                                     fileSystem,
-                                                     new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem), variables),
-                                                     new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log)
-                                                    );
-                var result = command.Execute(new[]
-                {
+                    log,
+                    variables,
+                    fileSystem,
+                    new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem), variables),
+                    new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log)
+                );
+                var result = command.Execute(new[] {
                     "--package", $"{package.FilePath}",
                     "--variables", $"{variablesFile}",
                     "--bucket", bucketName,
-                    "--targetMode", S3TargetMode.FileSelections.ToString()
-                });
+                    "--targetMode", S3TargetMode.FileSelections.ToString()});
 
                 result.Should().Be(0);
             }


### PR DESCRIPTION
This PR is changing the S3 tests to try and improve reliability.

Currently, the S3 tests regularly fail when it is trying to validate the second file on a multi-file upload to s3.
With the error that the S3 bucket does not exists, even though it successfully validated a file in the same bucket earlier in the test.
The change is to separate the validate calls to see if that improves the reliability of the test.