### PR TITLE
Ensure tests fail fast and give a clear reason, when EnvVars not present

### DIFF
--- a/source/Calamari.Testing/EnvironmentVariables.cs
+++ b/source/Calamari.Testing/EnvironmentVariables.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Calamari.Common.Plumbing.Logging;
+using NUnit.Framework;
 
 namespace Calamari.Testing
 {
@@ -52,7 +53,31 @@ namespace Calamari.Testing
         AwsCloudFormationAndS3AccessKey,
 
         [EnvironmentVariable("AWS_E2E_SecretKeyId", "AWS E2E Test User Keys")]
-        AwsCloudFormationAndS3SecretKey
+        AwsCloudFormationAndS3SecretKey,
+
+        [EnvironmentVariable("CALAMARI_FEEDZV2URI", "Not LastPass; Calamari TC Config Variables")]
+        FeedzNuGetV2FeedUrl,
+
+        [EnvironmentVariable("CALAMARI_FEEDZV3URI", "Not LastPass; Calamari TC Config Variables")]
+        FeedzNuGetV3FeedUrl,
+        
+        [EnvironmentVariable("CALAMARI_ARTIFACTORYV2URI", "Not LastPass; Calamari TC Config Variables")]
+        ArtifactoryNuGetV2FeedUrl,
+
+        [EnvironmentVariable("CALAMARI_ARTIFACTORYV3URI", "Not LastPass; Calamari TC Config Variables")]
+        ArtifactoryNuGetV3FeedUrl,
+        
+        [EnvironmentVariable("CALAMARI_AUTHURI", "OctopusMyGetTester")]
+        MyGetFeedUrl,
+
+        [EnvironmentVariable("CALAMARI_AUTHUSERNAME", "OctopusMyGetTester")]
+        MyGetFeedUsername,
+
+        [EnvironmentVariable("CALAMARI_AUTHPASSWORD", "OctopusMyGetTester")]
+        MyGetFeedPassword,
+
+        [EnvironmentVariable("GOOGLECLOUD_OCTOPUSAPITESTER_JSONKEY", "GoogleCloud - OctopusAPITester")]
+        GoogleCloudJsonKeyfile
     }
 
     public static class ExternalVariables

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
@@ -15,6 +15,7 @@ using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Tests.Helpers;
 using FluentAssertions;
+using Calamari.Testing;
 
 namespace Calamari.Tests.AWS.CloudFormation
 {
@@ -56,9 +57,10 @@ namespace Calamari.Tests.AWS.CloudFormation
                 await client.GetBucketLocationAsync(stackName);
             });
         }
+
         async Task ValidateS3(Func<AmazonS3Client, Task> execute)
         {
-            var credentials = new BasicAWSCredentials(Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Access"), Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Secret"));
+            var credentials = new BasicAWSCredentials(ExternalVariables.Get(ExternalVariable.AwsAcessKey), ExternalVariables.Get(ExternalVariable.AwsSecretKey));
             var config = new AmazonS3Config { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.GetBySystemName(region) };
             using (var client = new AmazonS3Client(credentials, config))
             {
@@ -77,7 +79,7 @@ namespace Calamari.Tests.AWS.CloudFormation
         }
         async Task ValidateCloudFormation(Func<AmazonCloudFormationClient, Task> execute)
         {
-            var credentials = new BasicAWSCredentials(Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Access"), Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Secret"));
+            var credentials = new BasicAWSCredentials(ExternalVariables.Get(ExternalVariable.AwsAcessKey), ExternalVariables.Get(ExternalVariable.AwsSecretKey));
             var config = new AmazonCloudFormationConfig { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.GetBySystemName(region) };
             using (var client = new AmazonCloudFormationClient(credentials, config))
             {
@@ -89,8 +91,8 @@ namespace Calamari.Tests.AWS.CloudFormation
         {
             var variablesFile = Path.GetTempFileName();
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
-            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Access"));
-            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Secret"));
+            variables.Set("AWSAccount.AccessKey", ExternalVariables.Get(ExternalVariable.AwsAcessKey));
+            variables.Set("AWSAccount.SecretKey", ExternalVariables.Get(ExternalVariable.AwsSecretKey));
             variables.Set("Octopus.Action.Aws.Region", region);
             variables.Save(variablesFile);
 
@@ -121,8 +123,8 @@ namespace Calamari.Tests.AWS.CloudFormation
         {
             var variablesFile = Path.GetTempFileName();
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
-            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Access"));
-            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Secret"));
+            variables.Set("AWSAccount.AccessKey", ExternalVariables.Get(ExternalVariable.AwsAcessKey));
+            variables.Set("AWSAccount.SecretKey", ExternalVariables.Get(ExternalVariable.AwsSecretKey));
             variables.Set("Octopus.Action.Aws.Region", "us-east-1");
             variables.Save(variablesFile);
 
@@ -167,8 +169,8 @@ namespace Calamari.Tests.AWS.CloudFormation
             var variablesFile = Path.GetTempFileName();
             var variables = new CalamariVariables();
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
-            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Access"));
-            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Secret"));
+            variables.Set("AWSAccount.AccessKey", ExternalVariables.Get(ExternalVariable.AwsAcessKey));
+            variables.Set("AWSAccount.SecretKey", ExternalVariables.Get(ExternalVariable.AwsSecretKey));
             variables.Set("Octopus.Action.Aws.Region", region);
             variables.Set(AwsSpecialVariables.CloudFormation.StackName, stackName);
             variables.Save(variablesFile);

--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -27,6 +27,7 @@ using Newtonsoft.Json.Serialization;
 using NUnit.Framework;
 using Octopus.CoreUtilities.Extensions;
 using Octostache;
+using Calamari.Testing;
 
 namespace Calamari.Tests.AWS
 {
@@ -341,8 +342,8 @@ namespace Calamari.Tests.AWS
         protected async Task Validate(Func<AmazonS3Client, Task> execute)
         {
             var credentials = new BasicAWSCredentials(
-                Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Access"),
-                Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Secret"));
+                ExternalVariables.Get(ExternalVariable.AwsAcessKey),
+                ExternalVariables.Get(ExternalVariable.AwsSecretKey));
 
             var config = new AmazonS3Config {AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.GetBySystemName(region)};
             
@@ -373,8 +374,8 @@ namespace Calamari.Tests.AWS
             var variables = new CalamariVariables();
 
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
-            variables.Set("AWSAccount.AccessKey", Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Access"));
-            variables.Set("AWSAccount.SecretKey", Environment.GetEnvironmentVariable("AWS_OctopusAPITester_Secret"));
+            variables.Set("AWSAccount.AccessKey", ExternalVariables.Get(ExternalVariable.AwsAcessKey));
+            variables.Set("AWSAccount.SecretKey", ExternalVariables.Get(ExternalVariable.AwsSecretKey));
             variables.Set("Octopus.Action.Aws.Region", region);
             variables.Set(AwsSpecialVariables.S3.FileSelections, JsonConvert.SerializeObject(fileSelections, GetEnrichedSerializerSettings()));
 

--- a/source/Calamari.Tests/Fixtures/PackageDownload/NuGetFeedSupportFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/NuGetFeedSupportFixture.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using Calamari.Common.Features.Packages;
+using Calamari.Testing;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
 using Octopus.Versioning;
@@ -12,12 +13,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
     [Category(TestCategory.CompatibleOS.OnlyWindows)]
     
     public class NuGetFeedVersionSupportFixture : CalamariFixture
-    {
-        const string FeedzV2UriEnvironmentVariable = "CALAMARI_FEEDZV2URI";
-        const string FeedzV3UriEnvironmentVariable = "CALAMARI_FEEDZV3URI";
-        const string ArtifactoryV2UriEnvironmentVariable = "CALAMARI_ARTIFACTORYV2URI";
-        const string ArtifactoryV3FeedUriEnvironmentVariable = "CALAMARI_ARTIFACTORYV3URI";
-        
+    {        
         const string TestNuGetPackageId = "Calamari.Tests.Fixtures.PackageDownload.NuGetFeedSupport";
 
         // TODO: Packages here were generated using the nuspec file in the .\NuGetFeedSupport folder
@@ -25,10 +21,10 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         // In future, we should ensure this test fixture sets its own data up from scratch before running
         // and tears it down on completion, rather than relying on external state as it currently does.
 
-        static readonly string FeedzNuGetV2FeedUrl = Environment.GetEnvironmentVariable(FeedzV2UriEnvironmentVariable);
-        static readonly string FeedzNuGetV3FeedUrl = Environment.GetEnvironmentVariable(FeedzV3UriEnvironmentVariable);
-        static readonly string ArtifactoryNuGetV2FeedUrl = Environment.GetEnvironmentVariable(ArtifactoryV2UriEnvironmentVariable);
-        static readonly string ArtifactoryNuGetV3FeedUrl = Environment.GetEnvironmentVariable(ArtifactoryV3FeedUriEnvironmentVariable);
+        static readonly string FeedzNuGetV2FeedUrl = ExternalVariables.Get(ExternalVariable.FeedzNuGetV2FeedUrl);
+        static readonly string FeedzNuGetV3FeedUrl = ExternalVariables.Get(ExternalVariable.FeedzNuGetV3FeedUrl);
+        static readonly string ArtifactoryNuGetV2FeedUrl = ExternalVariables.Get(ExternalVariable.ArtifactoryNuGetV2FeedUrl);
+        static readonly string ArtifactoryNuGetV3FeedUrl = ExternalVariables.Get(ExternalVariable.ArtifactoryNuGetV3FeedUrl);
         
         static readonly string TentacleHome = TestEnvironment.GetTestPath("Fixtures", "PackageDownload");
 

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -4,8 +4,7 @@ using System.IO;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.FileSystem;
-using Calamari.Integration.FileSystem;
-using Calamari.Integration.Packages;
+using Calamari.Testing;
 using Calamari.Tests.Fixtures.Deployment.Packages;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
@@ -17,19 +16,15 @@ namespace Calamari.Tests.Fixtures.PackageDownload
     [TestFixture]
     public class PackageDownloadFixture : CalamariFixture
     {
-        const string FeedUriEnvironmentVariable = "CALAMARI_AUTHURI";
-        const string FeedUsernameEnvironmentVariable = "CALAMARI_AUTHUSERNAME";
-        const string FeedPasswordEnvironmentVariable = "CALAMARI_AUTHPASSWORD";
-
         static readonly string TentacleHome = TestEnvironment.GetTestPath("Fixtures", "PackageDownload");
         static readonly string DownloadPath = TestEnvironment.GetTestPath(TentacleHome, "Files");
 
         static readonly string PublicFeedUri = "https://f.feedz.io/octopus-deploy/integration-tests/nuget/index.json";
         static readonly string NuGetFeedUri = "https://www.nuget.org/api/v2/";
 
-        private static readonly string AuthFeedUri = Environment.GetEnvironmentVariable(FeedUriEnvironmentVariable);
-        private static readonly string AuthFeedUsername = Environment.GetEnvironmentVariable(FeedUsernameEnvironmentVariable);
-        private static readonly string AuthFeedPassword = Environment.GetEnvironmentVariable(FeedPasswordEnvironmentVariable);
+        private static readonly string AuthFeedUri = ExternalVariables.Get(ExternalVariable.MyGetFeedUrl);
+        private static readonly string AuthFeedUsername = ExternalVariables.Get(ExternalVariable.MyGetFeedUsername);
+        private static readonly string AuthFeedPassword = ExternalVariables.Get(ExternalVariable.MyGetFeedPassword);
         static readonly string ExpectedPackageHash = "1e0856338eb5ada3b30903b980cef9892ebf7201";
 
         static readonly long ExpectedPackageSize = 3749;
@@ -349,7 +344,6 @@ namespace Calamari.Tests.Fixtures.PackageDownload
 
         [Test]
         [Ignore("Auth Feed Failing On Mono")]
-        [AuthenticatedTest(FeedUriEnvironmentVariable, FeedUsernameEnvironmentVariable, FeedPasswordEnvironmentVariable)]
         public void PrivateNuGetFeedShouldDownloadPackage()
         {
             var result = DownloadPackage(FeedzPackage.PackageId, FeedzPackage.Version.ToString(), FeedzPackage.Id, AuthFeedUri, AuthFeedUsername, AuthFeedPassword);
@@ -368,7 +362,6 @@ namespace Calamari.Tests.Fixtures.PackageDownload
 
         [Test]
         [Ignore("Auth Feed Failing On Mono")]
-        [AuthenticatedTest(FeedUriEnvironmentVariable, FeedUsernameEnvironmentVariable, FeedPasswordEnvironmentVariable)]
         public void PrivateNuGetFeedShouldUsePackageFromCache()
         {
             DownloadPackage(FeedzPackage.PackageId, FeedzPackage.Version.ToString(), FeedzPackage.Id, AuthFeedUri, AuthFeedUsername, AuthFeedPassword)
@@ -387,7 +380,6 @@ namespace Calamari.Tests.Fixtures.PackageDownload
 
         [Test]
         [Ignore("Auth Feed Failing On Mono")]
-        [AuthenticatedTest(FeedUriEnvironmentVariable, FeedUsernameEnvironmentVariable, FeedPasswordEnvironmentVariable)]
         public void PrivateNuGetFeedShouldByPassCacheAndDownloadPackage()
         {
             DownloadPackage(FeedzPackage.PackageId, FeedzPackage.Version.ToString(), FeedzPackage.Id, AuthFeedUri, AuthFeedUsername, AuthFeedPassword).AssertSuccess();
@@ -409,7 +401,6 @@ namespace Calamari.Tests.Fixtures.PackageDownload
 
         [Test]
         [Ignore("Auth Feed Failing On Mono")]
-        [AuthenticatedTest(FeedUriEnvironmentVariable, FeedUsernameEnvironmentVariable, FeedPasswordEnvironmentVariable)]
         public void PrivateNuGetFeedShouldFailDownloadPackageWhenInvalidCredentials()
         {
             var result = DownloadPackage(FeedzPackage.PackageId, FeedzPackage.Version.ToString(), FeedzPackage.Id, AuthFeedUri, "fake-feed-username", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");

--- a/source/Calamari.Tests/Fixtures/ProgramFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ProgramFixture.cs
@@ -25,6 +25,7 @@ namespace Calamari.Tests.Fixtures
         {
             EnvironmentHelper.SetEnvironmentVariable("OctopusCalamariWorkingDirectory", null);
             RunProgram();
+            // This usage of Environment.GetEnvironmentVariable is fine as it's not accessing a test dependency variable
             Environment.GetEnvironmentVariable("OctopusCalamariWorkingDirectory").Should().NotBeNullOrWhiteSpace();
         }
         

--- a/source/Calamari.Tests/Fixtures/Util/CrossPlatformFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/CrossPlatformFixture.cs
@@ -29,6 +29,7 @@ namespace Calamari.Tests.Fixtures.Util
         [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void TildePrefixReplacedWithHome()
         {
+            // This usage of Environment.GetEnvironmentVariable is fine as it's not accessing a test dependency variable
             var home = Environment.GetEnvironmentVariable("HOME");
             Assert.IsNotNull(home, "Expected $HOME environment variable to be set.");
 

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
@@ -9,6 +9,7 @@ using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Kubernetes;
+using Calamari.Testing;
 using Calamari.Tests.AWS;
 using Calamari.Tests.Helpers;
 using FluentAssertions;
@@ -143,18 +144,18 @@ namespace Calamari.Tests.KubernetesFixtures
             var environmentVars = new Dictionary<string, string>(env)
             {
                 { "TF_IN_AUTOMATION ", Boolean.TrueString },
-                { "AWS_ACCESS_KEY_ID", Environment.GetEnvironmentVariable("AWS_E2E_AccessKeyId") },
-                { "AWS_SECRET_ACCESS_KEY", Environment.GetEnvironmentVariable("AWS_E2E_SecretKeyId") },
+                { "AWS_ACCESS_KEY_ID", ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey) },
+                { "AWS_SECRET_ACCESS_KEY", ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey) },
                 { "AWS_DEFAULT_REGION", region },
-                { "ARM_SUBSCRIPTION_ID", Environment.GetEnvironmentVariable("Azure_OctopusAPITester_SubscriptionId") },
-                { "ARM_CLIENT_ID", Environment.GetEnvironmentVariable("Azure_OctopusAPITester_ClientId") },
-                { "ARM_CLIENT_SECRET", Environment.GetEnvironmentVariable("Azure_OctopusAPITester_Password") },
-                { "ARM_TENANT_ID", Environment.GetEnvironmentVariable("Azure_OctopusAPITester_TenantId") },
-                { "TF_VAR_aks_client_id", Environment.GetEnvironmentVariable("Azure_OctopusAPITester_ClientId") },
-                { "TF_VAR_aks_client_secret", Environment.GetEnvironmentVariable("Azure_OctopusAPITester_Password") },
+                { "ARM_SUBSCRIPTION_ID", ExternalVariables.Get(ExternalVariable.AzureSubscriptionId) },
+                { "ARM_CLIENT_ID", ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId) },
+                { "ARM_CLIENT_SECRET", ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword) },
+                { "ARM_TENANT_ID", ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId) },
+                { "TF_VAR_aks_client_id", ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId) },
+                { "TF_VAR_aks_client_secret", ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword) },
                 { "TF_VAR_tests_source_dir", testFolder },
                 { "TF_VAR_test_namespace", testNamespace },
-                { "GOOGLE_CLOUD_KEYFILE_JSON", Environment.GetEnvironmentVariable("GOOGLECLOUD_OCTOPUSAPITESTER_JSONKEY") }
+                { "GOOGLE_CLOUD_KEYFILE_JSON", ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile) }
             };
 
             var result = SilentProcessRunner.ExecuteCommand(installTools.TerraformExecutable,
@@ -226,10 +227,10 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Kubernetes.AksClusterResourceGroup", azurermResourceGroup);
             variables.Set(SpecialVariables.AksClusterName, aksClusterName);
             variables.Set("Octopus.Action.Kubernetes.AksAdminLogin", Boolean.FalseString);
-            variables.Set("Octopus.Action.Azure.SubscriptionId", Environment.GetEnvironmentVariable("Azure_OctopusAPITester_SubscriptionId"));
-            variables.Set("Octopus.Action.Azure.TenantId", Environment.GetEnvironmentVariable("Azure_OctopusAPITester_TenantId"));
-            variables.Set("Octopus.Action.Azure.Password", Environment.GetEnvironmentVariable("Azure_OctopusAPITester_Password"));
-            variables.Set("Octopus.Action.Azure.ClientId", Environment.GetEnvironmentVariable("Azure_OctopusAPITester_ClientId"));
+            variables.Set("Octopus.Action.Azure.SubscriptionId", ExternalVariables.Get(ExternalVariable.AzureSubscriptionId));
+            variables.Set("Octopus.Action.Azure.TenantId", ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId));
+            variables.Set("Octopus.Action.Azure.Password", ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword));
+            variables.Set("Octopus.Action.Azure.ClientId", ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId));
             var wrapper = CreateWrapper();
             TestScript(wrapper, "Test-Script");
         }
@@ -241,7 +242,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(SpecialVariables.GkeClusterName, gkeClusterName);
             var account = "gke_account";
             variables.Set("Octopus.Action.GoogleCloudAccount.Variable", account);
-            var jsonKey = Environment.GetEnvironmentVariable("GOOGLECLOUD_OCTOPUSAPITESTER_JSONKEY") ?? string.Empty;
+            var jsonKey = ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile);
             variables.Set($"{account}.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonKey)));
             variables.Set("Octopus.Action.GoogleCloud.Project", gkeProject);
             variables.Set("Octopus.Action.GoogleCloud.Zone", gkeLocation);

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForAmazon.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForAmazon.cs
@@ -13,18 +13,18 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         public void AuthoriseWithAmazonEC2Role()
         {
-            // This fixture is marked Explicit, so it's always ignored unless you explicitly run it.
-            // Please BYO EKS Cluster and fill in the variables below if you want to run it.
-            var eksClusterUrl = "";
-            var eksClusterName = "";
-            var eksClusterRegion = "";
-
+            // This is a special test fixture, that gets remotely executed on the cluster created by the test 
+            // Calamari.Tests.KubernetesFixtures.KubernetesContextScriptWrapperLiveFixture.UsingEc2Instance
+            // (see Terraform/EC2/ec2.kubernetes.tf and Terraform/EC2/test.sh)
+            //
+            // It's allowed to access environment variables directly because of this specialness.
+            // It's ignored from direct runs locally or on CI using the [Explicit] attribute.
             variables.Set(Deployment.SpecialVariables.Account.AccountType, "AmazonWebServicesAccount");
-            variables.Set(SpecialVariables.ClusterUrl, eksClusterUrl);
-            variables.Set(SpecialVariables.EksClusterName, eksClusterName);
+            variables.Set(SpecialVariables.ClusterUrl, Environment.GetEnvironmentVariable("AWS_CLUSTER_URL"));
+            variables.Set(SpecialVariables.EksClusterName, Environment.GetEnvironmentVariable("AWS_CLUSTER_NAME"));
             variables.Set(SpecialVariables.SkipTlsVerification, Boolean.TrueString);
             variables.Set("Octopus.Action.Aws.AssumeRole", Boolean.FalseString);
-            variables.Set("Octopus.Action.Aws.Region", eksClusterRegion);
+            variables.Set("Octopus.Action.Aws.Region", Environment.GetEnvironmentVariable("AWS_REGION"));
 
             var wrapper = CreateWrapper();
             TestScript(wrapper, "Test-Script");

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForAmazon.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForAmazon.cs
@@ -1,6 +1,7 @@
 ﻿#if NETCORE
 using System;
 using Calamari.Kubernetes;
+using Calamari.Testing;
 using NUnit.Framework;
 
 namespace Calamari.Tests.KubernetesFixtures
@@ -12,12 +13,18 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         public void AuthoriseWithAmazonEC2Role()
         {
+            // This fixture is marked Explicit, so it's always ignored unless you explicitly run it.
+            // Please BYO EKS Cluster and fill in the variables below if you want to run it.
+            var eksClusterUrl = "";
+            var eksClusterName = "";
+            var eksClusterRegion = "";
+
             variables.Set(Deployment.SpecialVariables.Account.AccountType, "AmazonWebServicesAccount");
-            variables.Set(SpecialVariables.ClusterUrl, Environment.GetEnvironmentVariable("AWS_CLUSTER_URL"));
-            variables.Set(SpecialVariables.EksClusterName, Environment.GetEnvironmentVariable("AWS_CLUSTER_NAME"));
+            variables.Set(SpecialVariables.ClusterUrl, eksClusterUrl);
+            variables.Set(SpecialVariables.EksClusterName, eksClusterName);
             variables.Set(SpecialVariables.SkipTlsVerification, Boolean.TrueString);
             variables.Set("Octopus.Action.Aws.AssumeRole", Boolean.FalseString);
-            variables.Set("Octopus.Action.Aws.Region", Environment.GetEnvironmentVariable("AWS_REGION"));
+            variables.Set("Octopus.Action.Aws.Region", eksClusterRegion);
 
             var wrapper = CreateWrapper();
             TestScript(wrapper, "Test-Script");

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -14,6 +14,7 @@ using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes;
+using Calamari.Testing;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Fixtures.Integration.FileSystem;
 using FluentAssertions;
@@ -238,7 +239,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(SpecialVariables.GkeClusterName, "gke-cluster-name");
             var account = "gke_account";
             variables.Set("Octopus.Action.GoogleCloudAccount.Variable", account);
-            var jsonKey = Environment.GetEnvironmentVariable("GOOGLECLOUD_OCTOPUSAPITESTER_JSONKEY") ?? string.Empty;
+            var jsonKey = ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile);
             variables.Set($"{account}.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonKey)));
             variables.Set("Octopus.Action.GoogleCloud.Project", "gke-project");
             variables.Set("Octopus.Action.GoogleCloud.Zone", "gke-zone");
@@ -253,7 +254,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(SpecialVariables.GkeClusterName, "gke-cluster-name");
             var account = "gke_account";
             variables.Set("Octopus.Action.GoogleCloudAccount.Variable", account);
-            var jsonKey = Environment.GetEnvironmentVariable("GOOGLECLOUD_OCTOPUSAPITESTER_JSONKEY") ?? string.Empty;
+            var jsonKey = ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile);
             variables.Set($"{account}.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonKey)));
             variables.Set("Octopus.Action.GoogleCloud.Project", "gke-project");
             variables.Set("Octopus.Action.GoogleCloud.Region", "gke-region");
@@ -268,7 +269,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(SpecialVariables.GkeClusterName, "gke-cluster-name");
             var account = "gke_account";
             variables.Set("Octopus.Action.GoogleCloudAccount.Variable", account);
-            var jsonKey = Environment.GetEnvironmentVariable("GOOGLECLOUD_OCTOPUSAPITESTER_JSONKEY") ?? string.Empty;
+            var jsonKey = ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile);
             variables.Set($"{account}.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonKey)));
             variables.Set("Octopus.Action.GoogleCloud.Project", "gke-project");
             variables.Set("Octopus.Action.GoogleCloud.Region", "gke-region");
@@ -284,7 +285,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(SpecialVariables.GkeClusterName, "gke-cluster-name");
             var account = "gke_account";
             variables.Set("Octopus.Action.GoogleCloudAccount.Variable", account);
-            var jsonKey = Environment.GetEnvironmentVariable("GOOGLECLOUD_OCTOPUSAPITESTER_JSONKEY") ?? string.Empty;
+            var jsonKey = ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile);
             variables.Set($"{account}.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonKey)));
             variables.Set("Octopus.Action.GoogleCloud.Project", "gke-project");
             var wrapper = CreateWrapper();


### PR DESCRIPTION
# Background
Our Calamari tests comprise a large number of integration-style tests that interact with external infrastructure to do their work. 

These often require credentials which we don't want to store in the source code, so they get pushed into the test context at runtime using environment variables. This works nicely for our build pipeline, as TeamCity has all the configuration and sensitive values stored appropriately. However, it means that the local test-run experience is quite poor.

There is actually some infrastructure already in the `Calamari.Testing` test infrastructure library which handles this in a pretty graceful way. Rather than directly reading the environment variables in each test, we can use the `ExternalVariables.Get` method along with a centralised register of variables our tests rely on as defined in `ExternalVariable`. Then, if a required variable is not defined, the test fails as soon as the variable is read, with a nice message that guides the (Octopus internal) user to success, like this:

```
Environment Variable `AWS_OctopusAPITester_Access` could not be found. The value can be found in the password store under `AWS - OctopusAPITester`
```

However, a number of our integration-style tests don't use these helpers, and read the variables directly with `Environment.GetEnvironmentVariable`. The result is that these tests don't fail until the variable is used, often with confusing messages such as authentication failures that take a while to reverse-work why the failure occurred. It also means the test has to wait for the call to an external service to fail (which each has their own timeouts) before the test itself fails.

# Changes

* Converts all usages of `Environment.GetEnvironmentVariable` to instead use `ExternalVariables.Get`
* Adds missing `ExternalVariable` entries

# Results
Previous failure messages (which are not always as expedient in failing as these ones, some of them take up to 4 minutes before timing out... it's all dependent on what the test is attempting to interact with)
![image](https://user-images.githubusercontent.com/730704/138023252-5edd181f-be88-4451-907d-78a584f5df64.png)

Updated failure messages:
![image](https://user-images.githubusercontent.com/730704/138023379-d386cbef-9a63-4305-a8f8-064956b450ef.png)
