### PR TITLE
Renames the script modules responsible for creating dynamic targets

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -145,7 +145,7 @@ function remove-octopustarget {
 	echo "##octopus[delete-target machine='$(encode_servicemessagevalue "$1")']"
 }
 
-function create_steppackagetarget() (
+function new_octopustarget() (
   parameters=""
 
   while :

--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -165,7 +165,7 @@ function Remove-OctopusTarget([string] $targetIdOrName)
 	Write-Host "##octopus[delete-target $($parameters)]"
 }
 
-function New-StepPackageTarget
+function New-OctopusTarget
 {
 	[CmdletBinding()]
 	param(


### PR DESCRIPTION
The existing naming for the script modules responsible for creating dynamic targets were somewhat confusing for users.

This PR updates the names of the modules to:

PS: `New-OctopusTarget`
Bash: `new_octopustarget()`

Which should be easier for people to understand the intent of. 