### PR TITLE
Rename package retention journal if contents are invalid

### DIFF
--- a/source/Calamari.Tests/Fixtures/PackageRetention/JsonJournalRepositoryFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageRetention/JsonJournalRepositoryFixture.cs
@@ -1,6 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Calamari.Common.Features.Processes.Semaphores;
-using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment.PackageRetention.Repositories;
 using Calamari.Tests.Fixtures.Integration.FileSystem;
@@ -38,7 +39,7 @@ namespace Calamari.Tests.Fixtures.PackageRetention
             var variables = Substitute.For<IVariables>();
             variables.Get(KnownVariables.Calamari.PackageRetentionJournalPath).Returns(journalPath);
 
-            var repository = new JsonJournalRepository(TestCalamariPhysicalFileSystem.GetPhysicalFileSystem(), Substitute.For<ISemaphoreFactory>(), variables);
+            var repository = new JsonJournalRepository(TestCalamariPhysicalFileSystem.GetPhysicalFileSystem(), Substitute.For<ISemaphoreFactory>(), variables, Substitute.For<ILog>());
 
             repository.Commit();
             Assert.IsTrue(File.Exists(journalPath));
@@ -53,12 +54,29 @@ namespace Calamari.Tests.Fixtures.PackageRetention
             variables.Get(KnownVariables.Calamari.PackageRetentionJournalPath).Returns((string) null);
             variables.Get(TentacleVariables.Agent.TentacleHome).Returns(homeDir);
 
-            var repository = new JsonJournalRepository(TestCalamariPhysicalFileSystem.GetPhysicalFileSystem(), Substitute.For<ISemaphoreFactory>(), variables);
+            var repository = new JsonJournalRepository(TestCalamariPhysicalFileSystem.GetPhysicalFileSystem(), Substitute.For<ISemaphoreFactory>(), variables, Substitute.For<ILog>());
 
             var expectedPath = Path.Combine(homeDir, JsonJournalRepository.DefaultJournalName);
 
             repository.Commit();
             Assert.IsTrue(File.Exists(expectedPath));
+        }
+
+        [Test]
+        public void WhenThereIsAnErrorReadingTheJournal_ThenTheJournalIsRenamed()
+        {
+            const string invalidJson = @"[{""a"",}]";
+            var journalPath = Path.Combine(TentacleHome, "PackageRetentionJournal.json");
+
+            File.WriteAllText(journalPath, invalidJson);
+
+            var variables = Substitute.For<IVariables>();
+            variables.Get(KnownVariables.Calamari.PackageRetentionJournalPath).Returns(journalPath);
+
+            // Load()
+            var repository = new JsonJournalRepository(TestCalamariPhysicalFileSystem.GetPhysicalFileSystem(), Substitute.For<ISemaphoreFactory>(), variables, Substitute.For<ILog>());
+
+            Directory.GetFiles(TentacleHome, "PackageRetentionJournal_*.json").Length.Should().Be(1);
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/PackageRetention/JsonJournalRepositoryFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageRetention/JsonJournalRepositoryFixture.cs
@@ -73,7 +73,6 @@ namespace Calamari.Tests.Fixtures.PackageRetention
             var variables = Substitute.For<IVariables>();
             variables.Get(KnownVariables.Calamari.PackageRetentionJournalPath).Returns(journalPath);
 
-            // Load()
             var repository = new JsonJournalRepository(TestCalamariPhysicalFileSystem.GetPhysicalFileSystem(), Substitute.For<ISemaphoreFactory>(), variables, Substitute.For<ILog>());
 
             Directory.GetFiles(TentacleHome, "PackageRetentionJournal_*.json").Length.Should().Be(1);

--- a/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepository.cs
+++ b/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepository.cs
@@ -79,7 +79,7 @@ namespace Calamari.Deployment.PackageRetention.Repositories
                 else
                 {
                     var journalFileName = journalPath.Substring(0, journalPath.LastIndexOf(".", StringComparison.Ordinal));
-                    var backupJournalPath = $"{journalFileName}_{DateTimeOffset.UtcNow:yyyyMMddTHHmmss}.json"; // PackageRetentionJournal_20210101T120000.json
+                    var backupJournalPath = $"{journalFileName}_{DateTimeOffset.UtcNow:yyyyMMddTHHmmss}.json"; // eg. PackageRetentionJournal_20210101T120000.json
 
                     log.Warn($"The existing package retention journal file {journalPath} could not be read. The file will be renamed to {backupJournalPath}. A new journal will be created.");
                     File.Move(journalPath, backupJournalPath);


### PR DESCRIPTION
This PR adds a check when reading from the journal file on whether the contents are valid json or not. If not, the old file is renamed to `<OLDNAME>_<DATETIME>.json` where `<DATETIME>` is the current datetime.

## How to test

1. Start Octopus server
2. Add a Tentacle
3. Add a package to the built-in feed (or use one from an external feed)
3. Add a "Transfer a package" step, select the package and specify a transfer destination
4. Set up project variables to debug Calamari (Mark's [guide here](https://trello.com/c/jS95BzZ3/10-how-do-i-debug-calamari))
4. Create a release and deploy it
5. Attach Calamari (make sure to build) to the process
6. `PackageRetentionJournal.json` should be created in the root directory of the tentacle
7. Open the file location of the tentacle and locate `PackageRetentionJournal.json`
8. Edit it to be invalid json eg. remove the closing `]`
9. Re-deploy the release w/ attaching Calamari
10. A backup `.json` file should be created and the `PackageRetentionJournal.json` will be restored to valid json. The log should look something like this:
![image](https://user-images.githubusercontent.com/11970672/141048701-4c942a72-eb0a-4a13-92ac-630b64fc27ec.png)


I'll probably tear this PR down and make a new one when the filepath changes are merged in, since this change relies on some functionality from that change (location of the file, unit test file)