### PR TITLE
Handle concurrent usages of the package retention journal

### DIFF
--- a/source/Calamari.Tests/Fixtures/PackageRetention/JournalEntryFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageRetention/JournalEntryFixture.cs
@@ -18,7 +18,7 @@ namespace Calamari.Tests.Fixtures.PackageRetention
         {
             var thePackage = new PackageIdentity("Package", "1.0");
             var theDeployment = new ServerTaskId("Deployment-1");
-            var journal = new Journal(new InMemoryJournalRepository(), Substitute.For<ILog>());
+            var journal = new Journal(new InMemoryJournalRepositoryFactory(), Substitute.For<ILog>());
 
             journal.RegisterPackageUse(thePackage, theDeployment);
 
@@ -30,7 +30,7 @@ namespace Calamari.Tests.Fixtures.PackageRetention
         {
             var thePackage = new PackageIdentity("Package", "1.0");
             var theDeployment = new ServerTaskId("Deployment-1");
-            var journal = new Journal(new InMemoryJournalRepository(), Substitute.For<ILog>());
+            var journal = new Journal(new InMemoryJournalRepositoryFactory(), Substitute.For<ILog>());
 
             journal.RegisterPackageUse(thePackage, theDeployment);
             journal.DeregisterPackageUse(thePackage, theDeployment);
@@ -45,7 +45,7 @@ namespace Calamari.Tests.Fixtures.PackageRetention
             var deploymentOne = new ServerTaskId("Deployment-1");
             var deploymentTwo = new ServerTaskId("Deployment-2");
 
-            var journal = new Journal(new InMemoryJournalRepository(), Substitute.For<ILog>());
+            var journal = new Journal(new InMemoryJournalRepositoryFactory(), Substitute.For<ILog>());
             journal.RegisterPackageUse(thePackage, deploymentOne);
             journal.RegisterPackageUse(thePackage, deploymentTwo);
             journal.DeregisterPackageUse(thePackage, deploymentOne);
@@ -60,7 +60,7 @@ namespace Calamari.Tests.Fixtures.PackageRetention
             var deploymentOne = new ServerTaskId("Deployment-1");
             var deploymentTwo = new ServerTaskId("Deployment-2");
 
-            var journal = new Journal(new InMemoryJournalRepository(), Substitute.For<ILog>());
+            var journal = new Journal(new InMemoryJournalRepositoryFactory(), Substitute.For<ILog>());
             journal.RegisterPackageUse(thePackage, deploymentOne);
             journal.RegisterPackageUse(thePackage, deploymentTwo);
             journal.DeregisterPackageUse(thePackage, deploymentOne);
@@ -75,7 +75,7 @@ namespace Calamari.Tests.Fixtures.PackageRetention
             var thePackage = new PackageIdentity("Package", "1.0");
             var deploymentOne = new ServerTaskId("Deployment-1");
 
-            var journal = new Journal(new InMemoryJournalRepository(), Substitute.For<ILog>());
+            var journal = new Journal(new InMemoryJournalRepositoryFactory(), Substitute.For<ILog>());
             journal.RegisterPackageUse(thePackage, deploymentOne);
 
             Assert.AreEqual(1, journal.GetUsage(thePackage).Count());
@@ -88,7 +88,7 @@ namespace Calamari.Tests.Fixtures.PackageRetention
             var package2 = new PackageIdentity("Package2", "1.0");
             var theDeployment = new ServerTaskId("Deployment-1");
 
-            var journal = new Journal(new InMemoryJournalRepository(), Substitute.For<ILog>());
+            var journal = new Journal(new InMemoryJournalRepositoryFactory(), Substitute.For<ILog>());
             journal.RegisterPackageUse(package1, theDeployment);
             journal.RegisterPackageUse(package2, theDeployment);
 
@@ -103,7 +103,7 @@ namespace Calamari.Tests.Fixtures.PackageRetention
             var deploymentOne = new ServerTaskId("Deployment-1");
             var deploymentTwo = new ServerTaskId("Deployment-2");
 
-            var journal = new Journal(new InMemoryJournalRepository(), Substitute.For<ILog>());
+            var journal = new Journal(new InMemoryJournalRepositoryFactory(), Substitute.For<ILog>());
             journal.RegisterPackageUse(thePackage, deploymentOne);
             journal.RegisterPackageUse(thePackage, deploymentTwo);
 
@@ -117,7 +117,7 @@ namespace Calamari.Tests.Fixtures.PackageRetention
             var thePackage = new PackageIdentity("Package", "1.0");
             var deploymentOne = new ServerTaskId("Deployment-1");
 
-            var journal = new Journal(new InMemoryJournalRepository(), Substitute.For<ILog>());
+            var journal = new Journal(new InMemoryJournalRepositoryFactory(), Substitute.For<ILog>());
             journal.RegisterPackageUse(thePackage, deploymentOne);
             journal.DeregisterPackageUse(thePackage, deploymentOne);
 

--- a/source/Calamari.Tests/Fixtures/PackageRetention/Repository/InMemoryJournalRepository.cs
+++ b/source/Calamari.Tests/Fixtures/PackageRetention/Repository/InMemoryJournalRepository.cs
@@ -39,5 +39,10 @@ namespace Calamari.Tests.Fixtures.PackageRetention.Repository
         {
             //This does nothing in the in-memory implementation
         }
+
+        public void Dispose()
+        {
+            //This does nothing in the in-memory implementation
+        }
     }
 }

--- a/source/Calamari.Tests/Fixtures/PackageRetention/Repository/InMemoryJournalRepositoryFactory.cs
+++ b/source/Calamari.Tests/Fixtures/PackageRetention/Repository/InMemoryJournalRepositoryFactory.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using Calamari.Common.Plumbing.Deployment.PackageRetention;
+using Calamari.Deployment.PackageRetention.Model;
+using Calamari.Deployment.PackageRetention.Repositories;
+
+namespace Calamari.Tests.Fixtures.PackageRetention.Repository
+{
+    public class InMemoryJournalRepositoryFactory : IJournalRepositoryFactory
+    {
+        readonly Dictionary<PackageIdentity, JournalEntry> journalEntries;
+
+        public InMemoryJournalRepositoryFactory()
+        {
+            journalEntries = new Dictionary<PackageIdentity, JournalEntry>();
+        }
+
+        public IJournalRepository CreateJournalRepository()
+        {
+            return new InMemoryJournalRepository(journalEntries);
+        }
+    }
+}

--- a/source/Calamari/Deployment/PackageRetention/Repositories/IJournalRepositoryFactory.cs
+++ b/source/Calamari/Deployment/PackageRetention/Repositories/IJournalRepositoryFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Calamari.Deployment.PackageRetention.Repositories
+{
+    public interface IJournalRepositoryFactory
+    {
+        IJournalRepository CreateJournalRepository();
+    }
+}

--- a/source/Calamari/Deployment/PackageRetention/Repositories/IJournalRespository.cs
+++ b/source/Calamari/Deployment/PackageRetention/Repositories/IJournalRespository.cs
@@ -1,9 +1,10 @@
-﻿using Calamari.Common.Plumbing.Deployment.PackageRetention;
+﻿using System;
+using Calamari.Common.Plumbing.Deployment.PackageRetention;
 using Calamari.Deployment.PackageRetention.Model;
 
 namespace Calamari.Deployment.PackageRetention.Repositories
 {
-    public interface IJournalRepository
+    public interface IJournalRepository : IDisposable
     {
         bool TryGetJournalEntry(PackageIdentity package, out JournalEntry entry);
         JournalEntry GetJournalEntry(PackageIdentity packageId);

--- a/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepositoryFactory.cs
+++ b/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepositoryFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Calamari.Common.Features.Processes.Semaphores;
 using Calamari.Common.Plumbing.FileSystem;
 
 namespace Calamari.Deployment.PackageRetention.Repositories
@@ -8,18 +9,20 @@ namespace Calamari.Deployment.PackageRetention.Repositories
         internal const string DefaultJournalName = "PackageRetentionJournal.json";
 
         readonly ICalamariFileSystem fileSystem;
+        readonly ISemaphoreFactory semaphoreFactory;
         readonly string journalPath;
 
-        public JsonJournalRepositoryFactory(ICalamariFileSystem fileSystem)
+        public JsonJournalRepositoryFactory(ICalamariFileSystem fileSystem, ISemaphoreFactory semaphoreFactory)
         {
             this.fileSystem = fileSystem;
+            this.semaphoreFactory = semaphoreFactory;
 
             this.journalPath = @"C:\Octopus\PackageJournal.json";//journalPath;
         }
 
         public IJournalRepository CreateJournalRepository()
         {
-            return new JsonJournalRepository(fileSystem, journalPath);
+            return new JsonJournalRepository(fileSystem, semaphoreFactory, journalPath);
         }
     }
 }

--- a/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepositoryFactory.cs
+++ b/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepositoryFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Calamari.Common.Plumbing.FileSystem;
+
+namespace Calamari.Deployment.PackageRetention.Repositories
+{
+    public class JsonJournalRepositoryFactory : IJournalRepositoryFactory
+    {
+        internal const string DefaultJournalName = "PackageRetentionJournal.json";
+
+        readonly ICalamariFileSystem fileSystem;
+        readonly string journalPath;
+
+        public JsonJournalRepositoryFactory(ICalamariFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+
+            this.journalPath = @"C:\Octopus\PackageJournal.json";//journalPath;
+        }
+
+        public IJournalRepository CreateJournalRepository()
+        {
+            return new JsonJournalRepository(fileSystem, journalPath);
+        }
+    }
+}

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -67,6 +67,7 @@ namespace Calamari
             builder.RegisterType<DeploymentJournalWriter>().As<IDeploymentJournalWriter>().SingleInstance();
             builder.RegisterType<PackageStore>().As<IPackageStore>().SingleInstance();
 
+            builder.RegisterInstance(SemaphoreFactory.Get()).As<ISemaphoreFactory>();
             builder.RegisterType<JsonJournalRepositoryFactory>().As<IJournalRepositoryFactory>();
             builder.RegisterType<Journal>().As<IManagePackageUse>();
 

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -67,8 +67,7 @@ namespace Calamari
             builder.RegisterType<DeploymentJournalWriter>().As<IDeploymentJournalWriter>().SingleInstance();
             builder.RegisterType<PackageStore>().As<IPackageStore>().SingleInstance();
 
-            builder.RegisterInstance(SemaphoreFactory.Get()).As<ISemaphoreFactory>();
-            builder.RegisterType<JsonJournalRepository>().As<IJournalRepository>();
+            builder.RegisterType<JsonJournalRepositoryFactory>().As<IJournalRepositoryFactory>();
             builder.RegisterType<Journal>().As<IManagePackageUse>();
 
             //Add decorator to commands with the RetentionLockingCommand attribute. Also need to include commands defined in external assemblies.


### PR DESCRIPTION
This PR re-adds the repository factory which is used to restrict access to `JsonJournalRepository` which is where the reads/writes to the journal actually occur. This implementation may change in the future but we're going with this as an initial way of handling concurrency.

`JsonJournalRepository` now implements `IDisposable` and `Journal` now retrieves a `JsonJournalRepository` via `JsonJournalRepositoryFactory.CreateJournalRepository`.

This PR doesn't include the convention test changes, and also doesn't include `JournalFixture` (I was having some issues with this on TeamCity so need to look further into it).