### PR TITLE
Update Calamari.Tests to net461

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -191,7 +191,7 @@ Task("PackTests")
 {
     var actions = new List<Action>();
 
-    actions.Add(() => Zip("./source/Calamari.Tests/bin/Release/net452/", Path.Combine(artifactsDir, "Binaries.zip")));
+    actions.Add(() => Zip("./source/Calamari.Tests/bin/Release/net461/", Path.Combine(artifactsDir, "Binaries.zip")));
 
     // Create a Zip for each runtime for testing
 	foreach(var rid in GetProjectRuntimeIds(@".\source\Calamari.Tests\Calamari.Tests.csproj"))

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -12,7 +12,7 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -20,7 +20,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);NETCORE;AWS;AZURE_CORE;JAVA_SUPPORT</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <DefineConstants>$(DefineConstants);NETFX;AWS;IIS_SUPPORT;USE_NUGET_V2_LIBS;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT;WINDOWS_USER_ACCOUNT_SUPPORT;WINDOWS_REGISTRY_SUPPORT</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
@@ -219,7 +219,7 @@
     <CreateItem Include="@(PackageDefinitions)" Condition="'%(Name)' == 'ScriptCS'">
       <Output TaskParameter="Include" ItemName="ScriptCSRef" />
     </CreateItem>
-    <CreateItem Include="@(PackageDefinitions)" Condition=" '$(TargetFramework)' == 'net452' And '%(Name)' == 'NuGet.CommandLine'">
+    <CreateItem Include="@(PackageDefinitions)" Condition=" '$(TargetFramework)' == 'net461' And '%(Name)' == 'NuGet.CommandLine'">
       <Output TaskParameter="Include" ItemName="NuGetCommandLineRef" />
     </CreateItem>
     <PropertyGroup>
@@ -234,11 +234,11 @@
       <FSharpFilesExe Condition="'$(TargetFramework)' == 'netcoreapp3.1'" Include="$(FSharpCompilerToolsExe)" />
       <ScriptCSFiles Include="$(ScriptCS)" />
       <ScriptCSFilesExe Condition="'$(TargetFramework)' == 'netcoreapp3.1'" Include="$(ScriptCSExe)" />
-      <NuGetFiles Include="$(NuGetCommandLine)" Condition=" '$(TargetFramework)' == 'net452'" />
+      <NuGetFiles Include="$(NuGetCommandLine)" Condition=" '$(TargetFramework)' == 'net461'" />
     </ItemGroup>
     <Copy SourceFiles="@(FSharpFiles)" DestinationFolder="$(OutDir)/FSharp/" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(ScriptCSFiles)" DestinationFolder="$(OutDir)/ScriptCS/" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(NuGetFiles)" DestinationFolder="$(OutDir)/NuGet/" SkipUnchangedFiles="true" Condition="'$(TargetFramework)' == 'net452'" />
+    <Copy SourceFiles="@(NuGetFiles)" DestinationFolder="$(OutDir)/NuGet/" SkipUnchangedFiles="true" Condition="'$(TargetFramework)' == 'net461'" />
     <Exec Command="chmod +x %(FSharpFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <Exec Command="chmod +x %(ScriptCSFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <Copy SourceFiles="@(FSharpFiles)" DestinationFolder="$(PublishDir)/FSharp/" Condition="'$(PublishDir)' != ''" />

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
@@ -75,6 +75,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [Test]
         [NonParallelizable]
         [RequiresNonFreeBSDPlatform(SkipFreeBsdBecause)]
+        [RequiresMinimumMonoVersion(5, 12, 0, Description = "HttpClient 4.3.2 broken on Mono - https://xamarin.github.io/bugzilla-archives/60/60315/bug.html#c7")]
         public void TimesOutIfAValidTimeoutIsDefinedInVariables()
         {
             RunNugetV3TimeoutTest("00:00:01", TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
@@ -83,6 +84,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [Test]
         [NonParallelizable]
         [RequiresNonFreeBSDPlatform(SkipFreeBsdBecause)]
+        [RequiresMinimumMonoVersion(5, 12, 0, Description = "HttpClient 4.3.2 broken on Mono - https://xamarin.github.io/bugzilla-archives/60/60315/bug.html#c7")]
         public void IgnoresTheTimeoutIfAnInvalidTimeoutIsDefinedInVariables()
         {
             RunNugetV3TimeoutTest("this is not a valid timespan", TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
@@ -91,6 +93,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [Test]
         [NonParallelizable]
         [RequiresNonFreeBSDPlatform(SkipFreeBsdBecause)]
+        [RequiresMinimumMonoVersion(5, 12, 0, Description = "HttpClient 4.3.2 broken on Mono - https://xamarin.github.io/bugzilla-archives/60/60315/bug.html#c7")]
         public void DoesNotTimeOutIfTheServerRespondsBeforeTheTimeout()
         {
             RunNugetV3TimeoutTest("00:01:00", TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -142,6 +142,7 @@ namespace Calamari.Tests.Fixtures.PackageDownload
 
         [Test]
         [RequiresMonoVersion480OrAboveForTls12]
+        [RequiresMinimumMonoVersion(5, 12, 0, Description = "HttpClient 4.3.2 broken on Mono - https://xamarin.github.io/bugzilla-archives/60/60315/bug.html#c7")]
         public void ShouldDownloadPackageWithRepositoryMetadata()
         {
             var result = DownloadPackage(NuGetFeed.PackageId, NuGetFeed.Version.ToString(), NuGetFeed.Id, NuGetFeedUri);


### PR DESCRIPTION
As part of the package retention changes #team-fire-and-motion are making, we want to add convention test(s) to Calamari. For this we're taking a similar approach to OctopusServer, which uses `Best.Conventional`. However the current `Calamari.Tests` project isn't compatible as it's running `net452`. This PR updates `Calamari.Tests` to `net461`.

## How to review
The main change in this PR is in `Calamari.Tests.csproj`. All `.cs` files are test fixture changes which have been excluded from running on Mono <5.12.0 due to HttpClient issues

(Old PR which this has been split from: https://github.com/OctopusDeploy/Calamari/pull/791)