### PR TITLE
Add a convention test to check for new instances of JsonJournalRepository

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Assent" Version="1.6.1" />
     <PackageReference Include="Polly" Version="5.4.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="Best.Conventional" Version="9.0.7" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
     <PackageReference Include="Markdown" Version="2.1.0" />

--- a/source/Calamari.Tests/Fixtures/Conventions/AppDomainScanner.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/AppDomainScanner.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Calamari.Tests.Fixtures.Conventions
+{
+    public static class AppDomainScanner
+    {
+        static readonly Lazy<Type[]> CalamariTypesLazy;
+
+        static AppDomainScanner()
+        {
+
+            CalamariTypesLazy = new Lazy<Type[]>(ScanForCalamariTypes);
+        }
+
+        public static IReadOnlyCollection<Type> CalamariTypes => CalamariTypesLazy.Value;
+
+        static Type[] ScanForCalamariTypes()
+        {
+            var calamariAssemblies = AppDomain.CurrentDomain.GetAssemblies().Where(IsCalamariAssembly);
+            var types = calamariAssemblies
+                .SelectMany(a =>
+                    {
+                        try
+                        {
+                            return a.DefinedTypes.ToArray();
+                        }
+                        catch (ReflectionTypeLoadException)
+                        {
+                            return Array.Empty<Type>();
+                        }
+                        catch (TypeLoadException)
+                        {
+                            return Array.Empty<Type>();
+                        }
+                    })
+                .ToArray();
+
+            return types;
+        }
+
+        static bool IsCalamariAssembly(Assembly assembly)
+        {
+            if (assembly.IsDynamic) return false;
+            return assembly.GetName().Name?.StartsWith("Calamari") ?? false;
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Conventions/ConventionSpecifications/DecompilationCache.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConventionSpecifications/DecompilationCache.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Conventional.Conventions.Cecil;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+// ReSharper disable ReplaceWithSingleCallToFirstOrDefault
+// ReSharper disable ReplaceWithSingleCallToFirst
+
+namespace Calamari.Tests.Fixtures.Conventions.ConventionSpecifications
+{
+    // Taken from Octopus.Tests.Common.Conventions.ConventionSpecifications
+    static class DecompilationCache
+    {
+        static readonly ConcurrentDictionary<string, ModuleDefinition> ModuleDefinitionsByAssemblyLocation;
+        static readonly ConcurrentDictionary<Type, TypeDefinition> TypeDefinitionsByType;
+        static readonly ConcurrentDictionary<Type, IReadOnlyCollection<Instruction>> InstructionsByType;
+        static readonly object CecilMutex; // Cecil is not internally thread-safe in some places
+
+        static DecompilationCache()
+        {
+            ModuleDefinitionsByAssemblyLocation = new ConcurrentDictionary<string, ModuleDefinition>();
+            TypeDefinitionsByType = new ConcurrentDictionary<Type, TypeDefinition>();
+            InstructionsByType = new ConcurrentDictionary<Type, IReadOnlyCollection<Instruction>>();
+            CecilMutex = new object();
+        }
+
+        public static IReadOnlyCollection<Instruction> InstructionsFor(Type type)
+        {
+            return InstructionsByType.GetOrAdd(type, GetInstructionsFor);
+        }
+
+        static IReadOnlyCollection<Instruction> GetInstructionsFor(Type type)
+        {
+            var typeDefinition = TypeDefinitionsByType.GetOrAdd(type, GetTypeDefinitionFor);
+
+            lock (CecilMutex)
+            {
+                var typeInstructions =
+                    typeDefinition
+                        .Methods
+                        .Where(method => method.HasBody)
+                        .SelectMany(method => method.Body.Instructions)
+                        .Union(
+                            typeDefinition
+                                .Methods
+                                .Where(x => x.HasAttribute<AsyncStateMachineAttribute>())
+                                .SelectMany(x => x.GetAsyncStateMachineType().Methods.Where(method => method.HasBody))
+                                .SelectMany(method => method.Body.Instructions))
+                        .Union(
+                            typeDefinition
+                                .Methods
+                                .Where(x => x.HasAttribute<IteratorStateMachineAttribute>())
+                                .SelectMany(x => x.GetIteratorStateMachineType().Methods.Where(method => method.HasBody))
+                                .SelectMany(method => method.Body.Instructions))
+                        .Distinct()
+                        .ToArray();
+
+                return typeInstructions;
+            }
+        }
+
+        public static MethodDefinition GetMethodDefinitionFor(MethodInfo method)
+        {
+            var typeDefinition = GetTypeDefinitionFor(method.DeclaringType);
+
+            var methodDefinition = typeDefinition.Methods
+                .Where(m => m.Name == method.Name)
+                .Where(m => m.Parameters.Count == method.GetParameters().Length)
+                .First();
+            return methodDefinition;
+        }
+
+        public static TypeDefinition GetTypeDefinitionFor(Type type)
+        {
+            if (type.IsNested && type.DeclaringType != null)
+            {
+                var parentTypeDefinition = GetTypeDefinitionFor(type.DeclaringType);
+
+                // ReSharper disable once ReplaceWithSingleCallToSingleOrDefault
+                var typeDefinition = parentTypeDefinition.NestedTypes.Where(td => td.Name == type.Name).SingleOrDefault()
+                    ?? throw new Exception($"Could not find nested type {type.Name} in declaring type {parentTypeDefinition.FullName}");
+
+                return typeDefinition;
+            }
+
+            var result = TypeDefinitionsByType.GetOrAdd(type,
+                t =>
+                {
+                    var moduleDefinition = ModuleDefinitionsByAssemblyLocation.GetOrAdd(t.Assembly.Location, GetModuleDefinitionByLocation);
+                    var typeDefinition = (TypeDefinition) moduleDefinition.GetType(type.FullName, true);
+                    if (typeDefinition is null)
+                    {
+                        var additionalMessage = string.Join(Environment.NewLine, moduleDefinition.Types
+                            .Select(td => $" - {td.FullName}"));
+                        throw new InvalidOperationException($"Could not find type {t.FullName} in {t.Assembly.Location}.{Environment.NewLine}Types we can see: {additionalMessage}");
+                    }
+
+                    return typeDefinition;
+                });
+
+            return result;
+        }
+
+        static ModuleDefinition GetModuleDefinitionByLocation(string location)
+        {
+            var moduleDefinition = ModuleDefinition.ReadModule(location,
+                new ReaderParameters
+                {
+                    AssemblyResolver = new ConventionalAssemblyResolver()
+                });
+
+            return moduleDefinition;
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Conventions/ConventionSpecifications/MustNotCreateNewInstancesOfConventionSpecification.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/ConventionSpecifications/MustNotCreateNewInstancesOfConventionSpecification.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+using Conventional;
+using Conventional.Conventions;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Calamari.Tests.Fixtures.Conventions.ConventionSpecifications
+{
+    public class MustNotCreateNewInstancesOfConventionSpecification : ConventionSpecification
+    {
+        readonly string[] forbiddenTypeNames;
+
+        public MustNotCreateNewInstancesOfConventionSpecification(Type[] forbiddenTypes, string failureMessage)
+        {
+            if (!forbiddenTypes.Any()) throw new ArgumentException("At least one forbidden type must be provided", nameof(forbiddenTypes));
+
+            forbiddenTypeNames = forbiddenTypes.Select(t => t.FullName).Where(t => t != null).ToArray();
+            FailureMessage = failureMessage;
+        }
+
+        protected override string FailureMessage { get; } = "Type creates instance(s) of forbidden type:";
+
+        public override ConventionResult IsSatisfiedBy(Type type)
+        {
+            var instructions = DecompilationCache.InstructionsFor(type);
+
+            var forbiddenNewObjInstructions = instructions
+                .Where(i => i.OpCode == OpCodes.Newobj)
+                .Where(i => i.Operand is MethodReference methodReference && forbiddenTypeNames.Contains(methodReference.DeclaringType.FullName))
+                .ToArray();
+
+            return !forbiddenNewObjInstructions.Any()
+                ? ConventionResult.Satisfied(type.FullName)
+                : ConventionResult.NotSatisfied(type.FullName,
+                    FailureMessage + Environment.NewLine + string.Join(Environment.NewLine, forbiddenNewObjInstructions.Select(x => $" - {x}")));
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Conventions/PackageRetentionConventions.cs
+++ b/source/Calamari.Tests/Fixtures/Conventions/PackageRetentionConventions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Linq;
+using Calamari.Deployment.PackageRetention.Repositories;
+using Calamari.Tests.Fixtures.Conventions.ConventionSpecifications;
+using Conventional;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Conventions
+{
+    [TestFixture]
+    public class PackageRetentionConventions
+    {
+        [Test]
+        public void MustNotCreateNewInstancesOfJsonJournalRepository()
+        {
+            const string reason = "JsonJournalRepository should only be provisioned by JsonJournalRepositoryFactory. We don't want unknown accesses to the repository floating around.";
+
+            var types = AppDomainScanner.CalamariTypes
+                                        .Where(t => t != typeof(JsonJournalRepositoryFactory)); // JsonJournalRepositoryFactory is allowed to create new instances of the repository
+
+            var forbiddenTypes = new [] { typeof(JsonJournalRepository) };
+
+            types
+                .MustConformTo(new MustNotCreateNewInstancesOfConventionSpecification(forbiddenTypes, reason))
+                .WithFailureAssertion(Assert.Fail);
+        }
+    }
+}


### PR DESCRIPTION
## Background
To make the package retention journal handle concurrency the journal should be obtained via `JsonJournalRepositoryFactory`. This is the initial solution for the time being, it may change as further retention functionality is added. But at the moment, since we don't want any uses of `JsonJournalRepository` without going through the factory we've added a convention test to prevent this from happening at runtime. This also gives us the foundation for future convention tests in Calamari.

## How to review
Pull and run `PackageRetentionConventions`. `AppDomainScanner` and `MustNotCreateNewInstancesOfConventionSpecification` are copied from `Octopus.Tests` with a couple of necessary changes due to lack of extension methods/newer language features.