### PR TITLE
Don't delete unextracted package files as part of lifecycle retention

### DIFF
--- a/source/Calamari.Tests/Fixtures/Deployment/CleanFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/CleanFixture.cs
@@ -70,7 +70,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             result.AssertSuccess();
 
             Assert.False(fileSystem.DirectoryExists(Path.Combine(stagingDirectory, "Acme.1.0.0")));
-            Assert.False(fileSystem.FileExists(Path.Combine(packagesDirectory, "Acme.1.0.0.nupkg")));
         }
 
         [Test]
@@ -81,7 +80,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             result.AssertSuccess();
 
             Assert.False(fileSystem.DirectoryExists(Path.Combine(stagingDirectory, "Acme.1.0.0")));
-            Assert.False(fileSystem.FileExists(Path.Combine(packagesDirectory, "Acme.1.0.0.nupkg")));
         }
 
         private void CreateDeployment(string extractedFrom, string extractedTo, DateTimeOffset date, string retentionPolicySet)

--- a/source/Calamari/Deployment/Retention/RetentionPolicy.cs
+++ b/source/Calamari/Deployment/Retention/RetentionPolicy.cs
@@ -65,25 +65,11 @@ namespace Calamari.Deployment.Retention
             {
                 DeleteExtractionDestination(deployment, preservedEntries);
 
-                foreach (var package in deployment.Packages)
-                {
-                    DeleteExtractionSource(package, preservedEntries);
-                }
+                // Deleting packages is now handled by package retention
             }
             deploymentJournal.RemoveJournalEntries(deploymentsToDelete.Select(x => x.Id));
 
             RemovedFailedPackageDownloads();
-        }
-
-        void DeleteExtractionSource(DeployedPackage deployedPackage, List<JournalEntry> preservedEntries)
-        {
-            if (string.IsNullOrWhiteSpace(deployedPackage.DeployedFrom)
-                || !fileSystem.FileExists(deployedPackage.DeployedFrom)
-                || preservedEntries.Any(entry => entry.Packages.Any(p => deployedPackage.DeployedFrom.Equals(p.DeployedFrom, StringComparison.Ordinal))))
-                return;
-
-            Log.Info($"Removing package file '{deployedPackage.DeployedFrom}'");
-            fileSystem.DeleteFile(deployedPackage.DeployedFrom, FailureOptions.IgnoreFailure);
         }
 
         void DeleteExtractionDestination(JournalEntry deployment, List<JournalEntry> preservedEntries)


### PR DESCRIPTION
## Background
Since #team-fire-and-motion are adding package retention to workers we shouldn't need this functionality when the lifecycle retention policy gets applied as it will be moved to package retention. However, we do still want to clean up the `ExtractedTo` directory where appropriate. This PR removes the functionality which removes package files stored on a tentacle/worker (ie. the package files now remain on the machine).

## How to review

1. Start Octopus server
2. Create a Tentacle using the latest `main` branch from `OctopusTentacle` (or any version really)
3. Set up an external package feed `Library -> External Feeds`. I use `https://www.nuget.org/api/v2`.
4. Add a "Deploy a package" step, for the package specify anything with multiple versions. I used `Newtonsoft.Json`.
5. Set the retention policy of the default lifecycle to keep 1 release.
6. Create a release - for this release pick an older version of the package eg. `12.0.1`. Deploy the release.
7. Create another release - for this release pick the next version up eg. `12.0.2`. Deploy the release.
8. Create another release - for this release pick the next version up eg. `12.0.3`. Deploy the release. This release should contain a log that looks like the following:
![image](https://user-images.githubusercontent.com/11970672/142797877-559fdd5e-df28-4687-9d1a-fdc4c76980b8.png)
  Note this is using an old version of Calamari. As you can see it removes both the `ExtractedTo` at `C:\Octopus\Applications\<tentaclename>\Development\Newtonsoft.Json\12.0.1` and the `DeployedFrom` at `C:\Octopus\<tentaclename>\Files\Newtonsoft.Json@S12.0.1...`.
9. Pull this branch and build Calamari
10. Run Calamari in your IDE with the following arguments and environment variables:
```
TentacleJournal=C:\Octopus\<tentaclename>\DeploymentJournal.xml
TentacleName=C:\Octopus\<tentaclename>
clean --retentionPolicySet "Environments-1/Projects-1/Step-Deploy a Package/Machines-61/<default>" --releases 1
```
You can find the `retentionPolicySet` in `DeploymentJournal.xml` at the home directory of your machine. It should look something like `Environments-1/Projects-1/Step-Deploy a Package/Machines-1/<default>`.
11. The log should only say that it removed the `ExtractedTo` contents with no mention of the `DeployedFrom`. Check the `Files` directory of your tentacle and `Newtonsoft.Json@S12.0.2` should still be there.

The tests have been changed as well to account for the fact that packages aren't being deleted anymore. I think this makes sense for `RetentionPolicyFixture` since removing packages won't be its responsibility anymore. Not as sure about `CleanFixture` though but the same logic applies - it won't be dealing with packages anymore.