### PR TITLE
Created TinyType class

### DIFF
--- a/source/Calamari.Common/Plumbing/Deployment/PackageRetention/CaseInsensitiveTinyType.cs
+++ b/source/Calamari.Common/Plumbing/Deployment/PackageRetention/CaseInsensitiveTinyType.cs
@@ -4,22 +4,40 @@ using YamlDotNet.Core.Tokens;
 
 namespace Calamari.Deployment.PackageRetention
 {
-    public abstract class CaseInsensitiveTinyType : TinyType<string>
+    public abstract class CaseInsensitiveTinyType : TinyType<string>//, IEquatable<CaseInsensitiveTinyType>
     {
         protected CaseInsensitiveTinyType(string value)
             : base(value)
         {
         }
+        /*
 
-        protected bool Equals(CaseInsensitiveTinyType other)
+        public bool Equals(CaseInsensitiveTinyType? other)
         {
-            return Value == other.Value;
+            return this == other;
+        }     */
+
+        public override bool Equals(object? obj)
+        {
+            if (obj == null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+
+            if (obj is CaseInsensitiveTinyType ciTinyT)
+                return string.Equals(ciTinyT.Value, Value, StringComparison.OrdinalIgnoreCase);;
+
+            return false;
         }
 
-        public static bool operator == (CaseInsensitiveTinyType first, CaseInsensitiveTinyType second)
+        public override int GetHashCode()
+        {
+            return GetType().GetHashCode() ^ (Value != null ? Value.ToLowerInvariant().GetHashCode() : 0);
+        }
+
+        public static bool operator ==(CaseInsensitiveTinyType first, CaseInsensitiveTinyType second)
         {
             if (first is null || second is null) return false;
-            return string.Equals(first.Value, second.Value, StringComparison.OrdinalIgnoreCase);
+            return first.Equals(second);
         }
 
         public static bool operator !=(CaseInsensitiveTinyType first, CaseInsensitiveTinyType second)

--- a/source/Calamari.Common/Plumbing/Deployment/PackageRetention/CaseInsensitiveTinyType.cs
+++ b/source/Calamari.Common/Plumbing/Deployment/PackageRetention/CaseInsensitiveTinyType.cs
@@ -4,47 +4,16 @@ using YamlDotNet.Core.Tokens;
 
 namespace Calamari.Deployment.PackageRetention
 {
-    //TODO: Replace this basic tiny types implementation with the Octopus one.
-    public abstract class CaseInsensitiveTinyType
+    public abstract class CaseInsensitiveTinyType : TinyType<string>
     {
-        public readonly string Value;
-
-        public CaseInsensitiveTinyType(string value)
+        protected CaseInsensitiveTinyType(string value)
+            : base(value)
         {
-            this.Value = value;
         }
+
         protected bool Equals(CaseInsensitiveTinyType other)
         {
             return Value == other.Value;
-        }
-
-        static object Create(Type type, string value)
-        {
-            return Activator.CreateInstance(type, value);
-        }
-
-        public static T Create<T>(string value) where T : CaseInsensitiveTinyType
-        {
-            return (T)Create(typeof(T), value);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != this.GetType())
-                return false;
-
-            var other = (CaseInsensitiveTinyType)obj;
-
-            return this == other;
-        }
-
-        public override int GetHashCode()
-        {
-            return (Value != null ? Value.GetHashCode() : 0);
         }
 
         public static bool operator == (CaseInsensitiveTinyType first, CaseInsensitiveTinyType second)
@@ -56,11 +25,6 @@ namespace Calamari.Deployment.PackageRetention
         public static bool operator !=(CaseInsensitiveTinyType first, CaseInsensitiveTinyType second)
         {
             return !(first == second);
-        }
-
-        public override string ToString()
-        {
-            return Value;
         }
     }
 }

--- a/source/Calamari.Common/Plumbing/Deployment/PackageRetention/CaseInsensitiveTinyType.cs
+++ b/source/Calamari.Common/Plumbing/Deployment/PackageRetention/CaseInsensitiveTinyType.cs
@@ -4,18 +4,12 @@ using YamlDotNet.Core.Tokens;
 
 namespace Calamari.Deployment.PackageRetention
 {
-    public abstract class CaseInsensitiveTinyType : TinyType<string>//, IEquatable<CaseInsensitiveTinyType>
+    public abstract class CaseInsensitiveTinyType : TinyType<string>
     {
         protected CaseInsensitiveTinyType(string value)
             : base(value)
         {
         }
-        /*
-
-        public bool Equals(CaseInsensitiveTinyType? other)
-        {
-            return this == other;
-        }     */
 
         public override bool Equals(object? obj)
         {
@@ -34,13 +28,13 @@ namespace Calamari.Deployment.PackageRetention
             return GetType().GetHashCode() ^ (Value != null ? Value.ToLowerInvariant().GetHashCode() : 0);
         }
 
-        public static bool operator ==(CaseInsensitiveTinyType first, CaseInsensitiveTinyType second)
+        public static bool operator ==(CaseInsensitiveTinyType? first, CaseInsensitiveTinyType? second)
         {
             if (first is null || second is null) return false;
             return first.Equals(second);
         }
 
-        public static bool operator !=(CaseInsensitiveTinyType first, CaseInsensitiveTinyType second)
+        public static bool operator !=(CaseInsensitiveTinyType? first, CaseInsensitiveTinyType? second)
         {
             return !(first == second);
         }

--- a/source/Calamari.Common/Plumbing/Deployment/PackageRetention/TinyType.cs
+++ b/source/Calamari.Common/Plumbing/Deployment/PackageRetention/TinyType.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Dynamic;
+using YamlDotNet.Core.Tokens;
+
+namespace Calamari.Deployment.PackageRetention
+{
+    //TODO: At some point, replace this basic tiny types implementation with the Octopus one.  The blocking issue is Net40 atm.
+    public abstract class TinyType<T> : IComparable, IEquatable<TinyType<T>> where T : IComparable
+    {
+        public readonly T Value;
+
+        protected TinyType(T value)
+        {
+            this.Value = value;
+        }
+
+        public bool Equals(TinyType<T> other)
+        {
+            return Value.Equals(other.Value);
+        }
+
+        static object Create(Type type, T value)
+        {
+            return Activator.CreateInstance(type, value);
+        }
+
+        public static U Create<U>(T value) where U : TinyType<T>
+        {
+            return (U)Create(typeof(U), value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+
+            var other = (TinyType<T>)obj;
+
+            return this == other;
+        }
+
+        public override int GetHashCode()
+        {
+            return (Value != null ? Value.GetHashCode() : 0);
+        }
+
+        public int CompareTo(object obj)
+        {
+            throw new NotImplementedException();
+        }
+
+        public static bool operator == (TinyType<T> first, TinyType<T> second)
+        {
+            if (first is null || second is null) return false;
+            return first.Value.Equals(second.Value);
+        }
+
+        public static bool operator !=(TinyType<T> first, TinyType<T> second)
+        {
+            return !(first == second);
+        }
+
+        public override string ToString()
+        {
+            return Value?.ToString();
+        }
+    }
+}

--- a/source/Calamari.Common/Plumbing/Deployment/PackageRetention/TinyType.cs
+++ b/source/Calamari.Common/Plumbing/Deployment/PackageRetention/TinyType.cs
@@ -5,7 +5,7 @@ using YamlDotNet.Core.Tokens;
 namespace Calamari.Deployment.PackageRetention
 {
     //TODO: At some point, replace this basic tiny types implementation with the Octopus one.  The blocking issue is Net40 atm.
-    public abstract class TinyType<T> : IComparable, IEquatable<TinyType<T>> where T : IComparable
+    public abstract class TinyType<T> where T : IComparable
     {
         public readonly T Value;
 
@@ -13,12 +13,6 @@ namespace Calamari.Deployment.PackageRetention
         {
             this.Value = value;
         }
-
-        public bool Equals(TinyType<T> other)
-        {
-            return Value.Equals(other.Value);
-        }
-
         static object Create(Type type, T value)
         {
             return Activator.CreateInstance(type, value);
@@ -29,7 +23,7 @@ namespace Calamari.Deployment.PackageRetention
             return (U)Create(typeof(U), value);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
                 return false;
@@ -45,18 +39,13 @@ namespace Calamari.Deployment.PackageRetention
 
         public override int GetHashCode()
         {
-            return (Value != null ? Value.GetHashCode() : 0);
+            return GetType().GetHashCode() ^ (Value != null ? Value.GetHashCode() : 0);
         }
 
-        public int CompareTo(object obj)
-        {
-            throw new NotImplementedException();
-        }
-
-        public static bool operator == (TinyType<T> first, TinyType<T> second)
+        public static bool operator == (TinyType<T>? first, TinyType<T>? second)
         {
             if (first is null || second is null) return false;
-            return first.Value.Equals(second.Value);
+            return first.Equals(second);
         }
 
         public static bool operator !=(TinyType<T> first, TinyType<T> second)

--- a/source/Calamari.Tests/Fixtures/PackageRetention/CaseInsensitiveTinyTypeFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageRetention/CaseInsensitiveTinyTypeFixture.cs
@@ -45,9 +45,7 @@ namespace Calamari.Tests.Fixtures.PackageRetention
             var tt2 = AnotherTinyType.Create<AnotherTinyType>("value");
             Assert.AreNotEqual(tt1.GetHashCode(), tt2.GetHashCode());
         }
-
-
-
+        
         class ATinyType : CaseInsensitiveTinyType
         {
             public ATinyType(string value) : base(value)

--- a/source/Calamari.Tests/Fixtures/PackageRetention/CaseInsensitiveTinyTypeFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageRetention/CaseInsensitiveTinyTypeFixture.cs
@@ -1,0 +1,65 @@
+﻿using Calamari.Deployment.PackageRetention;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.PackageRetention
+{
+    [TestFixture]
+    public class CaseInsensitiveTinyTypeFixture
+    {
+        [Test]
+        public void EquivalentValuesOfSameTypesAreEqual()
+        {
+            var tt1 = ATinyType.Create<ATinyType>("value");
+            var tt2 = ATinyType.Create<ATinyType>("value");
+            Assert.IsTrue(tt1.Equals(tt2));
+        }
+
+        [Test]
+        public void EquivalentValuesOfDifferentTypesAreNotEqual()
+        {
+            var tt1 = ATinyType.Create<ATinyType>("value");
+            var tt2 = AnotherTinyType.Create<AnotherTinyType>("value");
+            Assert.IsFalse(tt1.Equals(tt2));
+        }
+
+        [Test]
+        public void EquivalentValuesWithDifferentCasesIfSameTypesAreEqual()
+        {
+            var tt1 = ATinyType.Create<ATinyType>("VALUE");
+            var tt2 = ATinyType.Create<ATinyType>("value");
+            Assert.IsTrue(tt1.Equals(tt2));
+        }
+
+        [Test]
+        public void EquivalentValuesWithDifferentCasesHaveEqualHashCodes()
+        {
+            var tt1 = ATinyType.Create<ATinyType>("VALUE");
+            var tt2 = ATinyType.Create<ATinyType>("value");
+            Assert.AreEqual(tt1.GetHashCode(), tt2.GetHashCode());
+        }
+
+        [Test]
+        public void EquivalentValuesOfDifferentTypesDoNotHaveEqualHashCodes()
+        {
+            var tt1 = ATinyType.Create<ATinyType>("value");
+            var tt2 = AnotherTinyType.Create<AnotherTinyType>("value");
+            Assert.AreNotEqual(tt1.GetHashCode(), tt2.GetHashCode());
+        }
+
+
+
+        class ATinyType : CaseInsensitiveTinyType
+        {
+            public ATinyType(string value) : base(value)
+            {
+            }
+        }
+
+        class AnotherTinyType : CaseInsensitiveTinyType
+        {
+            public AnotherTinyType(string value) : base(value)
+            {
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/PackageRetention/TinyTypeFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageRetention/TinyTypeFixture.cs
@@ -1,0 +1,39 @@
+﻿using Calamari.Deployment.PackageRetention;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.PackageRetention
+{
+    [TestFixture]
+    public class TinyTypeFixture
+    {
+        [Test]
+        public void EquivalentValuesAreEqualTinyTypes()
+        {
+            var tt1 = ATinyType.Create<ATinyType>("Value");
+            var tt2 = AnotherTinyType.Create<AnotherTinyType>("Value");
+            Assert.AreEqual(tt1, tt2);
+        }
+
+        [Test]
+        public void EquivalentValuesHaveEqualHashCodes()
+        {
+            var tt1 = ATinyType.Create<ATinyType>("Value");
+            var tt2 = AnotherTinyType.Create<AnotherTinyType>("Value");
+            Assert.AreEqual(tt1.GetHashCode(), tt2.GetHashCode());
+        }
+
+        class ATinyType : TinyType<string>
+        {
+            public ATinyType(string value) : base(value)
+            {
+            }
+        }
+
+        class AnotherTinyType : TinyType<string>
+        {
+            public AnotherTinyType(string value) : base(value)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previously only had a CaseInsensitiveTinyType class, but I needed a 'plain' tiny type, so I extracted some functionality into a new TinyType class.

Hopefully we will eventually be able to just use the Octopus.TinyTypes library, but Net40 is a blocker for that at the moment.