### PR TITLE
Rename package retention journal if contents are invalid

### DIFF
--- a/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepository.cs
+++ b/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepository.cs
@@ -73,9 +73,8 @@ namespace Calamari.Deployment.PackageRetention.Repositories
 
                     log.Warn($"The existing package retention journal file {journalPath} could not be read. The file will be renamed to {backupJournalFileName}. A new journal will be created.");
 
-                    var backupJournalPath = Path.GetDirectoryName(journalPath) + Path.DirectorySeparatorChar + backupJournalFileName;
                     // NET Framework 4.0 doesn't have File.Move(source, dest, overwrite) so we use Copy and Delete to replicate this
-                    File.Copy(journalPath, backupJournalPath, true);
+                    File.Copy(journalPath, Path.Combine(Path.GetDirectoryName(journalPath), backupJournalFileName), true);
                     File.Delete(journalPath);
 
                     journalEntries = new Dictionary<PackageIdentity, JournalEntry>();

--- a/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepository.cs
+++ b/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepository.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Calamari.Common.Features.Processes.Semaphores;
 using Calamari.Common.Plumbing.Deployment.PackageRetention;
 using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Deployment.PackageRetention.Model;
 using Newtonsoft.Json;
 
@@ -19,13 +20,15 @@ namespace Calamari.Deployment.PackageRetention.Repositories
 
         readonly ICalamariFileSystem fileSystem;
         readonly string journalPath;
+        readonly ILog log;
 
         readonly IDisposable semaphore;
 
-        public JsonJournalRepository(ICalamariFileSystem fileSystem, ISemaphoreFactory semaphoreFactory, string journalPath)
+        public JsonJournalRepository(ICalamariFileSystem fileSystem, ISemaphoreFactory semaphoreFactory, string journalPath, ILog log)
         {
             this.fileSystem = fileSystem;
             this.journalPath = journalPath;
+            this.log = log;
 
             this.semaphore = semaphoreFactory.Acquire(SemaphoreName, "Another process is using the package retention journal");
 
@@ -58,8 +61,25 @@ namespace Calamari.Deployment.PackageRetention.Repositories
             if (File.Exists(journalPath))
             {
                 var json = File.ReadAllText(journalPath);
-                journalEntries = JsonConvert.DeserializeObject<List<JournalEntry>>(json)
-                                            .ToDictionary(entry => entry.Package, entry => entry);
+
+                if (TryParseJournal(json, out var journalContents))
+                {
+                    journalEntries = journalContents.ToDictionary(entry => entry.Package, entry => entry);
+                }
+                else
+                {
+                    var journalFileName = Path.GetFileNameWithoutExtension(journalPath);
+                    var backupJournalFileName = $"{journalFileName}_{DateTimeOffset.UtcNow:yyyyMMddTHHmmss}.json"; // eg. PackageRetentionJournal_20210101T120000.json
+
+                    log.Warn($"The existing package retention journal file {journalPath} could not be read. The file will be renamed to {backupJournalFileName}. A new journal will be created.");
+
+                    var backupJournalPath = Path.GetDirectoryName(journalPath) + Path.DirectorySeparatorChar + backupJournalFileName;
+                    // NET Framework 4.0 doesn't have File.Move(source, dest, overwrite) so we use Copy and Delete to replicate this
+                    File.Copy(journalPath, backupJournalPath, true);
+                    File.Delete(journalPath);
+
+                    journalEntries = new Dictionary<PackageIdentity, JournalEntry>();
+                }
             }
             else
             {
@@ -83,6 +103,21 @@ namespace Calamari.Deployment.PackageRetention.Repositories
         public void Dispose()
         {
             semaphore.Dispose();
+        }
+
+        static bool TryParseJournal(string json, out List<JournalEntry> result)
+        {
+            try
+            {
+                result = JsonConvert.DeserializeObject<List<JournalEntry>>(json);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Log.Verbose($"Unable to parse the package retention journal file. Error message: {e.ToString()}");
+                result = new List<JournalEntry>();
+                return false;
+            }
         }
     }
 }

--- a/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepository.cs
+++ b/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepository.cs
@@ -62,7 +62,7 @@ namespace Calamari.Deployment.PackageRetention.Repositories
             {
                 var json = File.ReadAllText(journalPath);
 
-                if (TryParseJournal(json, out var journalContents))
+                if (TryDeserializeJournalEntries(json, out var journalContents))
                 {
                     journalEntries = journalContents.ToDictionary(entry => entry.Package, entry => entry);
                 }
@@ -104,7 +104,7 @@ namespace Calamari.Deployment.PackageRetention.Repositories
             semaphore.Dispose();
         }
 
-        static bool TryParseJournal(string json, out List<JournalEntry> result)
+        static bool TryDeserializeJournalEntries(string json, out List<JournalEntry> result)
         {
             try
             {
@@ -113,7 +113,7 @@ namespace Calamari.Deployment.PackageRetention.Repositories
             }
             catch (Exception e)
             {
-                Log.Verbose($"Unable to parse the package retention journal file. Error message: {e.ToString()}");
+                Log.Verbose($"Unable to deserialize entries in the package retention journal file. Error message: {e.ToString()}");
                 result = new List<JournalEntry>();
                 return false;
             }

--- a/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepositoryFactory.cs
+++ b/source/Calamari/Deployment/PackageRetention/Repositories/JsonJournalRepositoryFactory.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Calamari.Common.Features.Processes.Semaphores;
 using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Deployment.PackageRetention.Repositories
@@ -13,11 +14,13 @@ namespace Calamari.Deployment.PackageRetention.Repositories
         readonly ICalamariFileSystem fileSystem;
         readonly ISemaphoreFactory semaphoreFactory;
         readonly string journalPath;
+        readonly ILog log;
 
-        public JsonJournalRepositoryFactory(ICalamariFileSystem fileSystem, ISemaphoreFactory semaphoreFactory, IVariables variables)
+        public JsonJournalRepositoryFactory(ICalamariFileSystem fileSystem, ISemaphoreFactory semaphoreFactory, IVariables variables, ILog log)
         {
             this.fileSystem = fileSystem;
             this.semaphoreFactory = semaphoreFactory;
+            this.log = log;
 
             var packageRetentionJournalPath = variables.Get(KnownVariables.Calamari.PackageRetentionJournalPath);
             if (packageRetentionJournalPath == null)
@@ -30,7 +33,7 @@ namespace Calamari.Deployment.PackageRetention.Repositories
 
         public IJournalRepository CreateJournalRepository()
         {
-            return new JsonJournalRepository(fileSystem, semaphoreFactory, journalPath);
+            return new JsonJournalRepository(fileSystem, semaphoreFactory, journalPath, log);
         }
     }
 }


### PR DESCRIPTION
Updated from https://github.com/OctopusDeploy/Calamari/pull/787 copy-pasted description:

This PR adds a check when reading from the journal file on whether the contents are valid json or not. If not, the old file is renamed to `<OLDNAME>_<DATETIME>.json` where `<DATETIME>` is the current datetime.

## How to test

1. Start Octopus server
2. Add a Tentacle
3. Add a package to the built-in feed (or use one from an external feed)
3. Add a "Transfer a package" step, select the package and specify a transfer destination
4. Set up project variables to debug Calamari (Mark's [guide here](https://trello.com/c/jS95BzZ3/10-how-do-i-debug-calamari))
4. Create a release and deploy it
5. Attach Calamari (make sure to build) to the process
6. `PackageRetentionJournal.json` should be created in the root directory of the tentacle
7. Open the file location of the tentacle and locate `PackageRetentionJournal.json`
8. Edit it to be invalid json eg. remove the closing `]`
9. Re-deploy the release w/ attaching Calamari
10. A backup `.json` file should be created and the `PackageRetentionJournal.json` will be restored to valid json. The log should look something like this:
![image](https://user-images.githubusercontent.com/11970672/141048701-4c942a72-eb0a-4a13-92ac-630b64fc27ec.png)