### PR TITLE
Changed all retention log levels to be info or lower, and added extra check for IsRetentionEnabled 

### DIFF
--- a/source/Calamari.Shared/Commands/ApplyDeltaCommand.cs
+++ b/source/Calamari.Shared/Commands/ApplyDeltaCommand.cs
@@ -56,7 +56,14 @@ namespace Calamari.Commands
             try
             {
                 ValidateParameters(out basisFilePath, out deltaFilePath, out newFilePath);
-                packageJournal.ApplyRetention(PackageStore.GetPackagesDirectory());
+                try
+                {
+                    packageJournal.ApplyRetention(PackageStore.GetPackagesDirectory());
+                }
+                catch (Exception ex)
+                {
+                    log.Info($"Unable to apply retention to package.  Error message: {ex.ToString()}");
+                }
 
                 var tempNewFilePath = newFilePath + ".partial";
 #if USE_OCTODIFF_EXE

--- a/source/Calamari/Deployment/PackageRetention/Model/Journal.cs
+++ b/source/Calamari/Deployment/PackageRetention/Model/Journal.cs
@@ -44,6 +44,12 @@ namespace Calamari.Deployment.PackageRetention.Model
 
         public void RegisterPackageUse(out bool packageRegistered)
         {
+            if (!IsRetentionEnabled())
+            {
+                packageRegistered = false;
+                return;
+            }
+
             try
             {
                 RegisterPackageUse(new PackageIdentity(variables), new ServerTaskId(variables), out packageRegistered);
@@ -51,7 +57,7 @@ namespace Calamari.Deployment.PackageRetention.Model
             catch (Exception ex)
             {
                 packageRegistered = false;
-                log.Error($"Unable to register package use for retention.{Environment.NewLine}{ex.ToString()}");
+                log.Info($"Unable to register package use for retention.{Environment.NewLine}{ex.ToString()}");
             }
         }
 
@@ -99,7 +105,7 @@ namespace Calamari.Deployment.PackageRetention.Model
             catch (Exception ex)
             {
                 //We need to ensure that an issue with the journal doesn't interfere with the deployment.
-                log.Error($"Unable to register package use for retention.{Environment.NewLine}{ex.ToString()}");
+                log.Info($"Unable to register package use for retention.{Environment.NewLine}{ex.ToString()}");
             }
         }
 
@@ -142,7 +148,7 @@ namespace Calamari.Deployment.PackageRetention.Model
             catch (Exception ex)
             {
                 //We need to ensure that an issue with the journal doesn't interfere with the deployment.
-                log.Error($"Unable to deregister package use for retention.{Environment.NewLine}{ex.ToString()}");
+                log.Info($"Unable to deregister package use for retention.{Environment.NewLine}{ex.ToString()}");
             }
         }
 
@@ -198,7 +204,7 @@ namespace Calamari.Deployment.PackageRetention.Model
                         {
                             if (string.IsNullOrWhiteSpace(package?.Path) || !fileSystem.FileExists(package.Path))
                             {
-                                log.Warn($"Package at {package?.Path} not found.");
+                                log.Info($"Package at {package?.Path} not found.");
                                 continue;
                             }
 
@@ -211,7 +217,7 @@ namespace Calamari.Deployment.PackageRetention.Model
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex.Message);
+                    Log.Info(ex.Message);
                 }
             }
             else
@@ -287,7 +293,7 @@ namespace Calamari.Deployment.PackageRetention.Model
             }
             catch (Exception ex)
             {
-                log.Error($"Unable to expire stale package locks.{Environment.NewLine}{ex.ToString()}");
+                log.Info($"Unable to expire stale package locks.{Environment.NewLine}{ex.ToString()}");
             }
         }
     }

--- a/source/Calamari/Deployment/PackageRetention/PackageJournalCommandDecorator.cs
+++ b/source/Calamari/Deployment/PackageRetention/PackageJournalCommandDecorator.cs
@@ -42,7 +42,7 @@ namespace Calamari.Deployment.PackageRetention
                 }
                 catch (Exception ex)
                 {
-                    log.Error($"Unable to register package use.{Environment.NewLine}{ex.ToString()}");
+                    log.Info($"Unable to register package use.{Environment.NewLine}{ex.ToString()}");
                 }
             }
 


### PR DESCRIPTION
A call to Journal.RegisterPackageUse(out bool packageRegistered) wasn't protected with a call to IsRetentionEnabled().  This PR adds that call.

I've also changed retention log levels to be info or lower - they don't need to be higher than that at the moment.

A new try/catch was added to the apply delta command, where it was maybe potentially _possible_ for an exception to be thrown by retention.