### PR TITLE
Fixes Structured Variable Replacer order for net40 target

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
@@ -49,6 +49,19 @@ namespace Calamari.Common.Features.StructuredVariables
             this.log = log;
 
             allReplacers = replacers;
+            
+#if NET40
+            // Temporary fix for dependency resolution happening backwards for .NET 4.0 versus 4.5.2 and dotnet
+            allReplacers = new IFileFormatVariableReplacer[]
+            {
+                replacers.OfType<JsonFormatVariableReplacer>().FirstOrDefault(),
+                replacers.OfType<XmlFormatVariableReplacer>().FirstOrDefault(),
+                replacers.OfType<YamlFormatVariableReplacer>().FirstOrDefault(),
+                replacers.OfType<PropertiesFormatVariableReplacer>().FirstOrDefault()
+            }.Where(x => x != null).ToArray();
+#endif
+                
+            
             this.variables = variables;
 
             jsonReplacer = replacers.FirstOrDefault(r => r.FileFormatName == StructuredConfigVariablesFileFormats.Json)


### PR DESCRIPTION
# Background
Fixes for Structured Variable Replacement recently went out as part of resolution to issues OctopusDeploy/Issues#7117 and OctopusDeploy/Issues#6794. 

As part of this, we changed the way we register and resolve our `IFileFormatVariableReplacer`s, which are the core of the Structured Configuration Variables feature. To maintain backward compatibility for Json, and appropriately implement a "fall-through" technique when the target file name is non-canonical to the file format, the order that the replacers are tried in is very important.

When running on the `net4.0` CLR, the dependency container is resolving the dependencies in the reverse order to which they were registered, causing Structured Config Variables to fail for situations that rely on that order being correct.

This problem was reported in OctopusDeploy/Issues#7371

The correct order for the replacers is:

1. Json
2. Xml
3. Yaml
4. Properties

# Result
This PR implements a quick fix for the .NET 4.0 problem by explicitly controlling the order in which the `IFileFormatVariableReplacer`s are passed through to the variable replacement service for `net4.0`. 

## Before
Replacement on an XML file named `.config` incorrectly succeeds using the Properties replacer, because the replacer registration order is incorrect
v<img width="1019" alt="image" src="https://user-images.githubusercontent.com/730704/153782280-de4ec4b3-291e-48b1-ab9c-f4afad2bc507.png">

## After
Replacer order is correct, and replacement on the `.config. file succeeds with the XML Replacer
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/730704/153782366-eee19cd5-e53a-4a07-8523-cc311d714793.png">
