### PR TITLE
Update Octopus.Versioning to 5.1.141

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -60,7 +60,7 @@
     <ItemGroup>
         <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
         <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
-        <PackageReference Include="Octopus.Versioning" Version="5.0.5" /> <!-- TODO @team-deploy-fnm: Octopus.Versioning > 5.0.5 is not compatible with net40. This package should be updated when Calamari moves to net5.0 -->
+        <PackageReference Include="Octopus.Versioning" Version="5.1.141" />
         <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
         <PackageReference Include="Octostache" Version="2.14.0" />
         <PackageReference Include="SharpCompress" Version="0.24.0" />

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -58,14 +58,15 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
-      <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
-      <PackageReference Include="Octopus.Versioning" Version="4.3.5" />
-      <PackageReference Include="Octostache" Version="2.14.0" />
-      <PackageReference Include="SharpCompress" Version="0.24.0" />
-      <PackageReference Include="XPath2" Version="1.0.12" />
-      <PackageReference Include="YamlDotNet" Version="8.1.2" />
-      <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+        <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
+        <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
+        <PackageReference Include="Octopus.Versioning" Version="5.0.5" /> <!-- TODO @team-deploy-fnm: Octopus.Versioning > 5.0.5 is not compatible with net40. This package should be updated when Calamari moves to net5.0 -->
+        <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
+        <PackageReference Include="Octostache" Version="2.14.0" />
+        <PackageReference Include="SharpCompress" Version="0.24.0" />
+        <PackageReference Include="XPath2" Version="1.0.12" />
+        <PackageReference Include="YamlDotNet" Version="8.1.2" />
+        <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -54,7 +54,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Octodiff" Version="1.1.2" />
-    <PackageReference Include="Octopus.Versioning" Version="4.3.5" />
+    <PackageReference Include="Octopus.Versioning" Version="5.0.5" /> <!-- TODO @team-deploy-fnm: Octopus.Versioning > 5.0.5 is not compatible with net40. This package should be updated when Calamari moves to net5.0 -->
+    <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="Octostache" Version="2.14.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -54,7 +54,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Octodiff" Version="1.1.2" />
-    <PackageReference Include="Octopus.Versioning" Version="5.0.5" /> <!-- TODO @team-deploy-fnm: Octopus.Versioning > 5.0.5 is not compatible with net40. This package should be updated when Calamari moves to net5.0 -->
+    <PackageReference Include="Octopus.Versioning" Version="5.1.141" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="Octostache" Version="2.14.0" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -52,7 +52,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
-    <PackageReference Include="Octopus.Versioning" Version="4.3.5" />
+    <PackageReference Include="Octopus.Versioning" Version="5.0.5" /> <!-- TODO @team-deploy-fnm: Octopus.Versioning > 5.0.5 is not compatible with net40. This package should be updated when Calamari moves to net5.0 -->
+    <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Octodiff" Version="1.1.2" />
     <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
-    <PackageReference Include="Octopus.Versioning" Version="5.0.5" /> <!-- TODO @team-deploy-fnm: Octopus.Versioning > 5.0.5 is not compatible with net40. This package should be updated when Calamari moves to net5.0 -->
+    <PackageReference Include="Octopus.Versioning" Version="5.1.141" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />


### PR DESCRIPTION
Versioning is quite far behind and some changes have been made to fix DockerTag equality. `5.1.141` is the latest version.