### PR TITLE
Ensures structured config replacers are always in correct order

### DIFF
--- a/source/Calamari.Common/Plumbing/Extensions/ContainerBuilderExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/ContainerBuilderExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using Autofac.Builder;
+using Autofac.Features.Metadata;
+using Calamari.Common.Util;
+
+namespace Calamari.Common.Plumbing.Extensions
+{
+    public static class ContainerBuilderServicePrioritisationExtensions
+    {
+        const string RegistrationPriorityMetadataKey = "RegistrationPriority";
+        
+        public static void WithPriority<TLimit, TActivatorData, TRegistrationStyle>(this IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> target, int priority)
+        {
+            target.WithMetadata(PriorityMetadata, priority);
+        }
+
+        public static void RegisterPrioritisedList<T>(this ContainerBuilder builder)
+        {
+            builder.Register(c =>
+                             {
+                                 var registeredServices = c.Resolve<IEnumerable<Meta<T>>>().ToList();
+                
+                                 // Start by getting the core list of prioritised registrations
+                                 var prioritisedServices = registeredServices
+                                                           .Where(t => t.Metadata.ContainsKey(RegistrationPriorityMetadataKey))
+                                                           .OrderBy(t => t.Metadata[RegistrationPriorityMetadataKey])
+                                                           .Select(t => t.Value);
+                                 
+                                 // Also grab any extras that had no priority metadata 
+                                 var unprioritisedServices = registeredServices
+                                                             .Where(t => t.Metadata.ContainsKey(RegistrationPriorityMetadataKey) != true)
+                                                             .Select(t => t.Value);
+                
+                                 // Return the prioritised services first, followed by the unprioritised ones in any order
+                                 return new PrioritisedList<T>(prioritisedServices.Union(unprioritisedServices));
+                             });
+        }
+    }
+    
+    /// <summary>
+    /// Helper class to enable the DI container to provide a list of services where order is important,
+    /// supported by registration of specific metadata using <see cref="ContainerBuilderServicePrioritisationExtensions"/>
+    /// </summary>
+    /// <typeparam name="T">Service requiring prioritisation</typeparam>
+    public class PrioritisedList<T> : List<T>
+    {
+        public PrioritisedList()
+        { }
+        
+        public PrioritisedList(IEnumerable<T> collection)
+            : base(collection)
+        { }
+    }
+}

--- a/source/Calamari.Common/Plumbing/Extensions/ContainerBuilderExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/ContainerBuilderExtensions.cs
@@ -13,7 +13,7 @@ namespace Calamari.Common.Plumbing.Extensions
         
         public static void WithPriority<TLimit, TActivatorData, TRegistrationStyle>(this IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> target, int priority)
         {
-            target.WithMetadata(PriorityMetadata, priority);
+            target.WithMetadata(RegistrationPriorityMetadataKey, priority);
         }
 
         public static void RegisterPrioritisedList<T>(this ContainerBuilder builder)

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Plumbing.Deployment;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Tests.Helpers;
@@ -40,7 +41,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             replacer.IsBestReplacerForFileName(Arg.Any<string>()).Returns(true);
 
             var log = new InMemoryLog();
-            var service = new StructuredConfigVariablesService(new []
+            var service = new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
             {
                 replacer
             }, fileSystem, log);

--- a/source/Calamari.Tests/Fixtures/Util/PrioritisedRegistrationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/PrioritisedRegistrationFixture.cs
@@ -1,0 +1,120 @@
+﻿using Autofac;
+using Calamari.Common.Plumbing.Extensions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Util
+{
+    [TestFixture]
+    public class PrioritisedRegistrationFixture
+    {
+        ContainerBuilder builder;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            builder = new ContainerBuilder();
+            builder.RegisterPrioritisedList<ITestService>();
+        }
+        
+        [Test]
+        public void WithNoServices_ReturnsEmptyList()
+        {
+            var services = ResolvePrioritisedList();
+            
+            services.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WithUnprioritisedServices_ReturnsListInAnyOrder()
+        {
+            builder.RegisterType<TestServiceA>().As<ITestService>();
+            builder.RegisterType<TestServiceB>().As<ITestService>();
+
+            var services = ResolvePrioritisedList();
+
+            services.Should().Contain(its => its.Identifier == "ServiceA");
+            services.Should().Contain(its => its.Identifier == "ServiceB");
+        }
+        
+        [Test]
+        public void WithPrioritisedServices_ReturnsListInPriorityOrder()
+        {
+            builder.RegisterType<TestServiceB>().As<ITestService>().WithPriority(1);
+            builder.RegisterType<TestServiceA>().As<ITestService>().WithPriority(2);
+
+            var services = ResolvePrioritisedList();
+
+            services[0].Identifier.Should().Be("ServiceB");
+            services[1].Identifier.Should().Be("ServiceA");
+        }
+        
+        [Test]
+        public void WithPrioritisedServices_ReturnsListInPriorityOrder_RegardlessOfRegistrationOrder()
+        {
+            builder.RegisterType<TestServiceA>().As<ITestService>().WithPriority(2);
+            builder.RegisterType<TestServiceB>().As<ITestService>().WithPriority(1);
+
+            var services = ResolvePrioritisedList();
+
+            services[0].Identifier.Should().Be("ServiceB");
+            services[1].Identifier.Should().Be("ServiceA");
+        }
+        
+        [Test]
+        public void WithMixedPrioritisedAndUnprioritisedServices_ReturnsPrioritisedFirst_FollowedByUnprioritised()
+        {
+            builder.RegisterType<TestServiceA>().As<ITestService>().WithPriority(2);
+            builder.RegisterType<TestServiceB>().As<ITestService>();
+            builder.RegisterType<TestServiceC>().As<ITestService>().WithPriority(1);
+
+            var services = ResolvePrioritisedList();
+
+            services[0].Identifier.Should().Be("ServiceC");
+            services[1].Identifier.Should().Be("ServiceA");
+            services[2].Identifier.Should().Be("ServiceB");
+        }
+        
+        [Test]
+        public void WithDuplicatePrioritisations_DoesntBlowUp()
+        {
+            builder.RegisterType<TestServiceA>().As<ITestService>().WithPriority(1);
+            builder.RegisterType<TestServiceB>().As<ITestService>().WithPriority(1);
+            builder.RegisterType<TestServiceC>().As<ITestService>().WithPriority(1);
+
+            var services = ResolvePrioritisedList();
+
+            services.Count.Should().Be(3);
+        }
+
+        PrioritisedList<ITestService> ResolvePrioritisedList()
+        {
+            var container = builder.Build();
+
+            using (var scope = container.BeginLifetimeScope())
+            {
+                return scope.Resolve<PrioritisedList<ITestService>>();
+            }
+        }
+
+        public class TestServiceA : ITestService
+        {
+            public string Identifier => "ServiceA";
+        }
+        
+        public class TestServiceB : ITestService
+        {
+            public string Identifier => "ServiceB";
+        }
+        
+        public class TestServiceC : ITestService
+        {
+            public string Identifier => "ServiceC";
+        }
+
+        public interface ITestService
+        {
+            string Identifier { get; }
+        }
+    }
+}

--- a/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
@@ -10,6 +10,7 @@ using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing.Commands;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Tests.Helpers;
@@ -134,7 +135,7 @@ namespace Calamari.Tests.Java.Fixtures.Deployment
                 commandLineRunner,
                 new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem), variables),
                 new ExtractPackage(new CombinedPackageExtractor(log, variables, commandLineRunner), fileSystem, variables, log),
-                new StructuredConfigVariablesService(new IFileFormatVariableReplacer[]
+                new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                 {
                     new JsonFormatVariableReplacer(fileSystem, log),
                     new XmlFormatVariableReplacer(fileSystem, log),


### PR DESCRIPTION
Back-ports and cleans up the fix for OctopusDeploy/Issues#7371

* Adds an explicit prioritisation mechanism for our registered services that works for Autofac3+
* Adds a test to validate the behaviour