### PR TITLE
Merge forward from 2021.3 release

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Autofac;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -15,12 +16,14 @@ namespace Calamari.Common.Features.StructuredVariables
     public class StructuredConfigVariablesModule : Module
     {
         protected override void Load(ContainerBuilder builder)
-        {
-            builder.RegisterType<JsonFormatVariableReplacer>().As<IFileFormatVariableReplacer>();
-            builder.RegisterType<XmlFormatVariableReplacer>().As<IFileFormatVariableReplacer>();
-            builder.RegisterType<YamlFormatVariableReplacer>().As<IFileFormatVariableReplacer>();
-            builder.RegisterType<PropertiesFormatVariableReplacer>().As<IFileFormatVariableReplacer>();
+        {            
+            builder.RegisterType<JsonFormatVariableReplacer>().As<IFileFormatVariableReplacer>().WithPriority(1);
+            builder.RegisterType<XmlFormatVariableReplacer>().As<IFileFormatVariableReplacer>().WithPriority(2);
+            builder.RegisterType<YamlFormatVariableReplacer>().As<IFileFormatVariableReplacer>().WithPriority(3);
+            builder.RegisterType<PropertiesFormatVariableReplacer>().As<IFileFormatVariableReplacer>().WithPriority(4);
 
+            builder.RegisterPrioritisedList<IFileFormatVariableReplacer>();
+            
             builder.RegisterType<StructuredConfigVariablesService>().As<IStructuredConfigVariablesService>();
         }
     }
@@ -40,7 +43,7 @@ namespace Calamari.Common.Features.StructuredVariables
         readonly ILog log;
 
         public StructuredConfigVariablesService(
-            IFileFormatVariableReplacer[] replacers,
+            PrioritisedList<IFileFormatVariableReplacer> replacers,
             IVariables variables,
             ICalamariFileSystem fileSystem,
             ILog log)
@@ -48,20 +51,7 @@ namespace Calamari.Common.Features.StructuredVariables
             this.fileSystem = fileSystem;
             this.log = log;
 
-            allReplacers = replacers;
-            
-#if NET40
-            // Temporary fix for dependency resolution happening backwards for .NET 4.0 versus 4.5.2 and dotnet
-            allReplacers = new IFileFormatVariableReplacer[]
-            {
-                replacers.OfType<JsonFormatVariableReplacer>().FirstOrDefault(),
-                replacers.OfType<XmlFormatVariableReplacer>().FirstOrDefault(),
-                replacers.OfType<YamlFormatVariableReplacer>().FirstOrDefault(),
-                replacers.OfType<PropertiesFormatVariableReplacer>().FirstOrDefault()
-            }.Where(x => x != null).ToArray();
-#endif
-                
-            
+            allReplacers = replacers.ToArray();
             this.variables = variables;
 
             jsonReplacer = replacers.FirstOrDefault(r => r.FileFormatName == StructuredConfigVariablesFileFormats.Json)
@@ -164,7 +154,7 @@ namespace Calamari.Common.Features.StructuredVariables
         {
             log.Verbose($"The file at {filePath} does not match any known filename patterns. "
                         + "The file will be tried as multiple formats and will be treated as the first format that can be successfully parsed.");
-
+            
             // Order so that the json replacer comes first
             yield return jsonReplacer;
             foreach (var replacer in allReplacers.Except(new[] { jsonReplacer }))

--- a/source/Calamari.Common/Plumbing/Extensions/ContainerBuilderExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/ContainerBuilderExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using Autofac.Builder;
+using Autofac.Features.Metadata;
+using Calamari.Common.Util;
+
+namespace Calamari.Common.Plumbing.Extensions
+{
+    public static class ContainerBuilderServicePrioritisationExtensions
+    {
+        const string RegistrationPriorityMetadataKey = "RegistrationPriority";
+        
+        public static void WithPriority<TLimit, TActivatorData, TRegistrationStyle>(this IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> target, int priority)
+        {
+            target.WithMetadata(RegistrationPriorityMetadataKey, priority);
+        }
+
+        public static void RegisterPrioritisedList<T>(this ContainerBuilder builder)
+        {
+            builder.Register(c =>
+                             {
+                                 var registeredServices = c.Resolve<IEnumerable<Meta<T>>>().ToList();
+                
+                                 // Start by getting the core list of prioritised registrations
+                                 var prioritisedServices = registeredServices
+                                                           .Where(t => t.Metadata.ContainsKey(RegistrationPriorityMetadataKey))
+                                                           .OrderBy(t => t.Metadata[RegistrationPriorityMetadataKey])
+                                                           .Select(t => t.Value);
+                                 
+                                 // Also grab any extras that had no priority metadata 
+                                 var unprioritisedServices = registeredServices
+                                                             .Where(t => t.Metadata.ContainsKey(RegistrationPriorityMetadataKey) != true)
+                                                             .Select(t => t.Value);
+                
+                                 // Return the prioritised services first, followed by the unprioritised ones in any order
+                                 return new PrioritisedList<T>(prioritisedServices.Union(unprioritisedServices));
+                             });
+        }
+    }
+    
+    /// <summary>
+    /// Helper class to enable the DI container to provide a list of services where order is important,
+    /// supported by registration of specific metadata using <see cref="ContainerBuilderServicePrioritisationExtensions"/>
+    /// </summary>
+    /// <typeparam name="T">Service requiring prioritisation</typeparam>
+    public class PrioritisedList<T> : List<T>
+    {
+        public PrioritisedList()
+        { }
+        
+        public PrioritisedList(IEnumerable<T> collection)
+            : base(collection)
+        { }
+    }
+}

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
@@ -11,6 +11,7 @@ using Calamari.Aws.Integration.CloudFormation;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.StructuredVariables;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -107,7 +108,7 @@ namespace Calamari.Tests.AWS.CloudFormation
                     variables,
                     fileSystem,
                     new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
-                    new StructuredConfigVariablesService(new IFileFormatVariableReplacer[]
+                    new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                                                          {
                                                              new JsonFormatVariableReplacer(fileSystem, log),
                                                              new XmlFormatVariableReplacer(fileSystem, log),
@@ -144,7 +145,7 @@ namespace Calamari.Tests.AWS.CloudFormation
                                                               variables,
                                                               fileSystem,
                                                               new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
-                                                              new StructuredConfigVariablesService(new IFileFormatVariableReplacer[]
+                                                              new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                                                               {
                                                                   new JsonFormatVariableReplacer(fileSystem, log),
                                                                   new XmlFormatVariableReplacer(fileSystem, log),

--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -18,6 +18,7 @@ using Calamari.Aws.Deployment;
 using Calamari.Aws.Integration.S3;
 using Calamari.Aws.Serialization;
 using Calamari.Common.Features.StructuredVariables;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Serialization;
 using Calamari.Tests.Fixtures.Deployment.Packages;
 using Calamari.Tests.Helpers;
@@ -397,7 +398,7 @@ namespace Calamari.Tests.AWS
                     fileSystem,
                     new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem), variables),
                     new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
-                    new StructuredConfigVariablesService(new IFileFormatVariableReplacer[]
+                    new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                     {
                         new JsonFormatVariableReplacer(fileSystem, log),
                         new XmlFormatVariableReplacer(fileSystem, log),

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Plumbing.Deployment;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Tests.Helpers;
@@ -46,7 +47,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
             variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, FileName);
             variables.Set(PackageVariables.CustomInstallationDirectory, CurrentPath);
 
-            var service = new StructuredConfigVariablesService(new []
+            var service = new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
             {
                 replacer
             }, variables, fileSystem, log);

--- a/source/Calamari.Tests/Fixtures/Util/PrioritisedRegistrationFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/PrioritisedRegistrationFixture.cs
@@ -1,0 +1,120 @@
+﻿using Autofac;
+using Calamari.Common.Plumbing.Extensions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Util
+{
+    [TestFixture]
+    public class PrioritisedRegistrationFixture
+    {
+        ContainerBuilder builder;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            builder = new ContainerBuilder();
+            builder.RegisterPrioritisedList<ITestService>();
+        }
+        
+        [Test]
+        public void WithNoServices_ReturnsEmptyList()
+        {
+            var services = ResolvePrioritisedList();
+            
+            services.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WithUnprioritisedServices_ReturnsListInAnyOrder()
+        {
+            builder.RegisterType<TestServiceA>().As<ITestService>();
+            builder.RegisterType<TestServiceB>().As<ITestService>();
+
+            var services = ResolvePrioritisedList();
+
+            services.Should().Contain(its => its.Identifier == "ServiceA");
+            services.Should().Contain(its => its.Identifier == "ServiceB");
+        }
+        
+        [Test]
+        public void WithPrioritisedServices_ReturnsListInPriorityOrder()
+        {
+            builder.RegisterType<TestServiceB>().As<ITestService>().WithPriority(1);
+            builder.RegisterType<TestServiceA>().As<ITestService>().WithPriority(2);
+
+            var services = ResolvePrioritisedList();
+
+            services[0].Identifier.Should().Be("ServiceB");
+            services[1].Identifier.Should().Be("ServiceA");
+        }
+        
+        [Test]
+        public void WithPrioritisedServices_ReturnsListInPriorityOrder_RegardlessOfRegistrationOrder()
+        {
+            builder.RegisterType<TestServiceA>().As<ITestService>().WithPriority(2);
+            builder.RegisterType<TestServiceB>().As<ITestService>().WithPriority(1);
+
+            var services = ResolvePrioritisedList();
+
+            services[0].Identifier.Should().Be("ServiceB");
+            services[1].Identifier.Should().Be("ServiceA");
+        }
+        
+        [Test]
+        public void WithMixedPrioritisedAndUnprioritisedServices_ReturnsPrioritisedFirst_FollowedByUnprioritised()
+        {
+            builder.RegisterType<TestServiceA>().As<ITestService>().WithPriority(2);
+            builder.RegisterType<TestServiceB>().As<ITestService>();
+            builder.RegisterType<TestServiceC>().As<ITestService>().WithPriority(1);
+
+            var services = ResolvePrioritisedList();
+
+            services[0].Identifier.Should().Be("ServiceC");
+            services[1].Identifier.Should().Be("ServiceA");
+            services[2].Identifier.Should().Be("ServiceB");
+        }
+        
+        [Test]
+        public void WithDuplicatePrioritisations_DoesntBlowUp()
+        {
+            builder.RegisterType<TestServiceA>().As<ITestService>().WithPriority(1);
+            builder.RegisterType<TestServiceB>().As<ITestService>().WithPriority(1);
+            builder.RegisterType<TestServiceC>().As<ITestService>().WithPriority(1);
+
+            var services = ResolvePrioritisedList();
+
+            services.Count.Should().Be(3);
+        }
+
+        PrioritisedList<ITestService> ResolvePrioritisedList()
+        {
+            var container = builder.Build();
+
+            using (var scope = container.BeginLifetimeScope())
+            {
+                return scope.Resolve<PrioritisedList<ITestService>>();
+            }
+        }
+
+        public class TestServiceA : ITestService
+        {
+            public string Identifier => "ServiceA";
+        }
+        
+        public class TestServiceB : ITestService
+        {
+            public string Identifier => "ServiceB";
+        }
+        
+        public class TestServiceC : ITestService
+        {
+            public string Identifier => "ServiceC";
+        }
+
+        public interface ITestService
+        {
+            string Identifier { get; }
+        }
+    }
+}

--- a/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
@@ -10,6 +10,7 @@ using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing.Commands;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Tests.Helpers;
@@ -134,7 +135,7 @@ namespace Calamari.Tests.Java.Fixtures.Deployment
                 commandLineRunner,
                 new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem), variables),
                 new ExtractPackage(new CombinedPackageExtractor(log, variables, commandLineRunner), fileSystem, variables, log),
-                new StructuredConfigVariablesService(new IFileFormatVariableReplacer[]
+                new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                 {
                     new JsonFormatVariableReplacer(fileSystem, log),
                     new XmlFormatVariableReplacer(fileSystem, log),


### PR DESCRIPTION
Merges forward https://github.com/OctopusDeploy/Calamari/pull/825, which addresses https://github.com/OctopusDeploy/Issues/issues/7371, replacing the short term fix we applied in https://github.com/OctopusDeploy/Calamari/pull/820