### PR TITLE
Add extra output variables for S3 Upload step

### DIFF
--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -140,21 +140,38 @@ namespace Calamari.Aws.Deployment.Conventions
         {
             log.SetOutputVariableButDoNotAddToVariables(PackageVariables.Output.FileName, Path.GetFileName(deployment.PackageFilePath));
             log.SetOutputVariableButDoNotAddToVariables(PackageVariables.Output.FilePath, deployment.PackageFilePath);
-            foreach (var result in results)
+            var successfulResults = results.Where(z => z.IsSuccess()).ToArray();
+            if (successfulResults.Length == 1)
             {
-                if (!result.IsSuccess()) continue;
-                var packageName = Path.GetFileName(deployment.PackageFilePath);
-                log.Info($"Saving bucket key to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Key[{packageName}]\"");
-                log.SetOutputVariableButDoNotAddToVariables($"Package.Key[{packageName}]", result.BucketKey);
-                log.Info($"Saving object S3 URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.S3Uri[{packageName}]\"");
-                log.SetOutputVariableButDoNotAddToVariables($"Package.S3Uri[{packageName}]", $"s3://{result.BucketName}/{result.BucketKey}");
-                log.Info($"Saving object URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Uri[{packageName}]\"");
-                log.SetOutputVariableButDoNotAddToVariables($"Package.Uri[{packageName}]", $"https://{result.BucketName}.s3.{awsEnvironmentGeneration.AwsRegion.SystemName}.amazonaws.com/{result.BucketKey}");
+                log.Info($"Saving bucket key to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Key\"");
+                log.SetOutputVariableButDoNotAddToVariables($"Package.Key", successfulResults[0].BucketKey);
+                log.Info($"Saving object S3 URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.S3Uri\"");
+                log.SetOutputVariableButDoNotAddToVariables($"Package.S3Uri", $"s3://{successfulResults[0].BucketName}/{successfulResults[0].BucketKey}");
+                log.Info($"Saving object URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Uri\"");
+                log.SetOutputVariableButDoNotAddToVariables($"Package.Uri", $"https://{successfulResults[0].BucketName}.s3.{awsEnvironmentGeneration.AwsRegion.SystemName}.amazonaws.com/{successfulResults[0].BucketName}");
                 //  ARN format: `arn:aws:s3:::bucket-name/key` (Note: China (Beijing region (cn-north-1) uses `aws-cn` instead of `aws`)
-                log.Info($"Saving object ARN to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Arn[{packageName}]\"");
-                log.SetOutputVariableButDoNotAddToVariables($"Package.Arn[{packageName}]", $"arn:{(awsEnvironmentGeneration.AwsRegion.SystemName.Equals("cn-north-1") ? "aws-cn" : "aws")}:s3:::{result.BucketName}/{result.BucketKey}");
-                log.Info($"Saving object version id to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.ObjectVersion[{packageName}]\"");
-                log.SetOutputVariableButDoNotAddToVariables($"Package.ObjectVersion[{packageName}]", result.Version);
+                log.Info($"Saving object ARN to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Arn\"");
+                log.SetOutputVariableButDoNotAddToVariables($"Package.Arn", $"arn:{(awsEnvironmentGeneration.AwsRegion.SystemName.Equals("cn-north-1") ? "aws-cn" : "aws")}:s3:::{successfulResults[0].BucketName}/{successfulResults[0].BucketKey}");
+                log.Info($"Saving object version id to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.ObjectVersion\"");
+                log.SetOutputVariableButDoNotAddToVariables($"Package.ObjectVersion", successfulResults[0].Version);
+            }
+            else
+            {
+                foreach (var result in successfulResults)
+                {
+                    var fileName = Path.GetFileName(result.BucketKey);
+                    log.Info($"Saving bucket key to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Key[{fileName}]\"");
+                    log.SetOutputVariableButDoNotAddToVariables($"Package.Key[{fileName}]", result.BucketKey);
+                    log.Info($"Saving object S3 URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.S3Uri[{fileName}]\"");
+                    log.SetOutputVariableButDoNotAddToVariables($"Package.S3Uri[{fileName}]", $"s3://{result.BucketName}/{result.BucketKey}");
+                    log.Info($"Saving object URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Uri[{fileName}]\"");
+                    log.SetOutputVariableButDoNotAddToVariables($"Package.Uri[{fileName}]", $"https://{result.BucketName}.s3.{awsEnvironmentGeneration.AwsRegion.SystemName}.amazonaws.com/{result.BucketKey}");
+                    //  ARN format: `arn:aws:s3:::bucket-name/key` (Note: China (Beijing region (cn-north-1) uses `aws-cn` instead of `aws`)
+                    log.Info($"Saving object ARN to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Arn[{fileName}]\"");
+                    log.SetOutputVariableButDoNotAddToVariables($"Package.Arn[{fileName}]", $"arn:{(awsEnvironmentGeneration.AwsRegion.SystemName.Equals("cn-north-1") ? "aws-cn" : "aws")}:s3:::{result.BucketName}/{result.BucketKey}");
+                    log.Info($"Saving object version id to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.ObjectVersion[{fileName}]\"");
+                    log.SetOutputVariableButDoNotAddToVariables($"Package.ObjectVersion[{fileName}]", result.Version);
+                }
             }
         }
 

--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -115,7 +115,7 @@ namespace Calamari.Aws.Deployment.Conventions
             {
                 (await UploadAll(options, Factory, deployment)).Tee(responses =>
                 {
-                    SetOutputVariables(Factory, deployment, responses);
+                    SetOutputVariables(deployment, responses);
                 });
             }
             catch (AmazonS3Exception exception)
@@ -136,7 +136,7 @@ namespace Calamari.Aws.Deployment.Conventions
             }
         }
 
-        private void SetOutputVariables(Func<AmazonS3Client> factory, RunningDeployment deployment, IEnumerable<S3UploadResult> results)
+        private void SetOutputVariables(RunningDeployment deployment, IEnumerable<S3UploadResult> results)
         {
             log.SetOutputVariableButDoNotAddToVariables(PackageVariables.Output.FileName, Path.GetFileName(deployment.PackageFilePath));
             log.SetOutputVariableButDoNotAddToVariables(PackageVariables.Output.FilePath, deployment.PackageFilePath);

--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -143,8 +143,17 @@ namespace Calamari.Aws.Deployment.Conventions
             foreach (var result in results)
             {
                 if (!result.IsSuccess()) continue;
-                log.Info($"Saving object version id to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Files[{result.BucketKey}]\"");
-                log.SetOutputVariableButDoNotAddToVariables($"Files[{result.BucketKey}]", result.Version);
+                var packageName = Path.GetFileName(deployment.PackageFilePath);
+                log.Info($"Saving bucket key to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Key[{packageName}]\"");
+                log.SetOutputVariableButDoNotAddToVariables($"Package.Key[{packageName}]", result.BucketKey);
+                log.Info($"Saving object S3 URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.S3Uri[{packageName}]\"");
+                log.SetOutputVariableButDoNotAddToVariables($"Package.S3Uri[{packageName}]", $"s3://{result.BucketName}/{result.BucketKey}");
+                log.Info($"Saving object URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Uri[{packageName}]\"");
+                log.SetOutputVariableButDoNotAddToVariables($"Package.Uri[{packageName}]", $"https://{result.BucketName}.s3.{awsEnvironmentGeneration.AwsRegion.SystemName}.amazonaws.com/{result.BucketKey}");
+                log.Info($"Saving object ARN to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Arn[{packageName}]\"");
+                log.SetOutputVariableButDoNotAddToVariables($"Package.Arn", $"arn:{(awsEnvironmentGeneration.AwsRegion.SystemName.Equals("cn-north-1") ? "aws-cn" : "aws")}:s3:::{result.BucketName}/{result.BucketKey}");
+                log.Info($"Saving object version id to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.ObjectVersion[{packageName}]\"");
+                log.SetOutputVariableButDoNotAddToVariables($"Package.ObjectVersion[{packageName}]", result.Version);
             }
         }
 

--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -141,36 +141,41 @@ namespace Calamari.Aws.Deployment.Conventions
             log.SetOutputVariableButDoNotAddToVariables(PackageVariables.Output.FileName, Path.GetFileName(deployment.PackageFilePath));
             log.SetOutputVariableButDoNotAddToVariables(PackageVariables.Output.FilePath, deployment.PackageFilePath);
             var successfulResults = results.Where(z => z.IsSuccess()).ToArray();
+            var actionName = deployment.Variables["Octopus.Action.Name"];
             if (successfulResults.Length == 1)
             {
-                log.Info($"Saving bucket key to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Key\"");
+                log.Info($"Saving bucket key to variable \"Octopus.Action[{actionName}].Output.Package.Key\"");
                 log.SetOutputVariableButDoNotAddToVariables($"Package.Key", successfulResults[0].BucketKey);
-                log.Info($"Saving object S3 URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.S3Uri\"");
+                log.Info($"Saving object S3 URI to variable \"Octopus.Action[{actionName}].Output.Package.S3Uri\"");
                 log.SetOutputVariableButDoNotAddToVariables($"Package.S3Uri", $"s3://{successfulResults[0].BucketName}/{successfulResults[0].BucketKey}");
-                log.Info($"Saving object URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Uri\"");
+                log.Info($"Saving object URI to variable \"Octopus.Action[{actionName}].Output.Package.Uri\"");
                 log.SetOutputVariableButDoNotAddToVariables($"Package.Uri", $"https://{successfulResults[0].BucketName}.s3.{awsEnvironmentGeneration.AwsRegion.SystemName}.amazonaws.com/{successfulResults[0].BucketName}");
                 //  ARN format: `arn:aws:s3:::bucket-name/key` (Note: China (Beijing region (cn-north-1) uses `aws-cn` instead of `aws`)
-                log.Info($"Saving object ARN to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Arn\"");
+                log.Info($"Saving object ARN to variable \"Octopus.Action[{actionName}].Output.Package.Arn\"");
                 log.SetOutputVariableButDoNotAddToVariables($"Package.Arn", $"arn:{(awsEnvironmentGeneration.AwsRegion.SystemName.Equals("cn-north-1") ? "aws-cn" : "aws")}:s3:::{successfulResults[0].BucketName}/{successfulResults[0].BucketKey}");
-                log.Info($"Saving object version id to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.ObjectVersion\"");
+                log.Info($"Saving object version id to variable \"Octopus.Action[{actionName}].Output.Package.ObjectVersion\"");
                 log.SetOutputVariableButDoNotAddToVariables($"Package.ObjectVersion", successfulResults[0].Version);
+                log.Info($"Saving object version id to variable \"Octopus.Action[{actionName}].Output.Files[{successfulResults[0].BucketKey}]\"");
+                log.SetOutputVariableButDoNotAddToVariables($"Files[{successfulResults[0].BucketKey}]", successfulResults[0].Version);
             }
             else
             {
                 foreach (var result in successfulResults)
                 {
                     var fileName = Path.GetFileName(result.BucketKey);
-                    log.Info($"Saving bucket key to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Key[{fileName}]\"");
+                    log.Info($"Saving bucket key to variable \"Octopus.Action[{actionName}].Output.Package.Key[{fileName}]\"");
                     log.SetOutputVariableButDoNotAddToVariables($"Package.Key[{fileName}]", result.BucketKey);
-                    log.Info($"Saving object S3 URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.S3Uri[{fileName}]\"");
+                    log.Info($"Saving object S3 URI to variable \"Octopus.Action[{actionName}].Output.Package.S3Uri[{fileName}]\"");
                     log.SetOutputVariableButDoNotAddToVariables($"Package.S3Uri[{fileName}]", $"s3://{result.BucketName}/{result.BucketKey}");
-                    log.Info($"Saving object URI to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Uri[{fileName}]\"");
+                    log.Info($"Saving object URI to variable \"Octopus.Action[{actionName}].Output.Package.Uri[{fileName}]\"");
                     log.SetOutputVariableButDoNotAddToVariables($"Package.Uri[{fileName}]", $"https://{result.BucketName}.s3.{awsEnvironmentGeneration.AwsRegion.SystemName}.amazonaws.com/{result.BucketKey}");
                     //  ARN format: `arn:aws:s3:::bucket-name/key` (Note: China (Beijing region (cn-north-1) uses `aws-cn` instead of `aws`)
-                    log.Info($"Saving object ARN to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.Arn[{fileName}]\"");
+                    log.Info($"Saving object ARN to variable \"Octopus.Action[{actionName}].Output.Package.Arn[{fileName}]\"");
                     log.SetOutputVariableButDoNotAddToVariables($"Package.Arn[{fileName}]", $"arn:{(awsEnvironmentGeneration.AwsRegion.SystemName.Equals("cn-north-1") ? "aws-cn" : "aws")}:s3:::{result.BucketName}/{result.BucketKey}");
-                    log.Info($"Saving object version id to variable \"Octopus.Action[{deployment.Variables["Octopus.Action.Name"]}].Output.Package.ObjectVersion[{fileName}]\"");
+                    log.Info($"Saving object version id to variable \"Octopus.Action[{actionName}].Output.Package.ObjectVersion[{fileName}]\"");
                     log.SetOutputVariableButDoNotAddToVariables($"Package.ObjectVersion[{fileName}]", result.Version);
+                    log.Info($"Saving object version id to variable \"Octopus.Action[{actionName}].Output.Files[{result.BucketKey}]\"");
+                    log.SetOutputVariableButDoNotAddToVariables($"Files[{result.BucketKey}]", result.Version);
                 }
             }
         }

--- a/source/Calamari.Aws/Integration/S3/S3UploadResult.cs
+++ b/source/Calamari.Aws/Integration/S3/S3UploadResult.cs
@@ -19,6 +19,7 @@ namespace Calamari.Aws.Integration.S3
             return !Response.None();
         }
 
+        public string BucketName => Request.BucketName;
         public string BucketKey => Request.Key;
 
         /// <summary>


### PR DESCRIPTION
# Background

When uploading an entire package file you can choose to use the filename of the package as the key for the file (and optionally add prefix). The resulting filename is not available as an output variable.

# Solution

When uploading an entire package file the resulting key should be available in an output variable. The following output variables should be added to support this scenario:

- `Package.Key` should return the key to the uploaded file, including any prefix which may have been specified
- `Package.S3Uri` should return the S3 Uri to the uploaded file, of the form `s3://bucket-name/key`
- `Package.Uri` should return the virtual-hosted-style Uri to the uploaded file, of the form `https://bucket-name.s3.region.amazonaws.com/key`
- `Package.Arn` should return the [ARN](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-arn-format.html) for the uploaded file, of the form `arn:aws:s3:::bucket-name/key` (Note: China (Beijing) region uses `aws-cn` instead of `aws`)
- `Package.ObjectVersion` should return the version of the object, if applicable.

This should cover key scenarios allowing the package to be referenced in subsequent steps.

# Result

When uploading a single file to S3 Bucket, these output variables will be created:
- Octopus.Action[`step-name`].Output.Package.Key: The key to the uploaded file, including any prefix which may have been specified.
- Octopus.Action[`step-name`].Output.Package.S3Uri: The S3 Uri to the uploaded file, of the form `s3://bucket-name/key`                                              
- Octopus.Action[`step-name`].Output.Package.Uri: The virtual-hosted-style Uri to the uploaded file, of the form `https://bucket-name.s3.region.amazonaws.com/key` 
- Octopus.Action[`step-name`].Output.Package.Arn: The ARN for the uploaded file, of the form `arn:aws:s3:::bucket-name/key` 
- Octopus.Action[`step-name`].Output.Package.ObjectVersion: The version of the object, if applicable. (`Not versioned` is returned if the object doesn't have a version)

![image](https://user-images.githubusercontent.com/79076870/155259466-3bf7ae0b-b051-4398-beab-2ce45da171f9.png)

When uploading multiple files to S3 Bucker, these output variables will be created:
- Octopus.Action[`step-name`].Output.Package.Key[`file-name`]: The key to the uploaded file, including any prefix which may have been specified.
- Octopus.Action[`step-name`].Output.Package.S3Uri[`file-name`]: The S3 Uri to the uploaded file, of the form `s3://bucket-name/key`                                              
- Octopus.Action[`step-name`].Output.Package.Uri[`file-name`]: The virtual-hosted-style Uri to the uploaded file, of the form `https://bucket-name.s3.region.amazonaws.com/key` 
- Octopus.Action[`step-name`].Output.Package.Arn[`file-name`]: The ARN for the uploaded file, of the form `arn:aws:s3:::bucket-name/key` 
- Octopus.Action[`step-name`].Output.Package.ObjectVersion[`file-name`]: The version of the object, if applicable. (`Not versioned` is returned if the object doesn't have a version)

![screencapture-localhost-5000-octopus-html-2022-02-23-15_03_32](https://user-images.githubusercontent.com/79076870/155260001-186f91b9-70c5-4eae-8a8a-20cffc1e002e.png)

# Testing
- Smoke testing using a script step to print out the output variables after the "Upload to AWS S3 Bucket" step shows that the variables are created correctly (see screenshots above).
- ⚠️  Unit testing: I've have attempted to have unit test coverage. Unfortunately, with the current implementation of the Calamari command, there is no way to access the values of the output variables in unit tests. To enable this, we will need to refactor the command class. Given the time constraint of this cycle, I think we should leave this for now.
