### PR TITLE
Allow variable substitution when uploading full package to AWS S3

### DIFF
--- a/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
+++ b/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
@@ -70,7 +70,7 @@ namespace Calamari.Aws.Commands
 
             var conventions = new List<IConvention>
             {
-                new DelegateInstallConvention(d => extractPackage.ExtractToStagingDirectory(pathToPackage)).When(_ => targetType == S3TargetMode.FileSelections),
+                new DelegateInstallConvention(d => extractPackage.ExtractToStagingDirectory(pathToPackage)),
                 new LogAwsUserInfoConvention(environment),
                 new CreateS3BucketConvention(environment, _ => bucket),
                 new UploadAwsS3Convention(

--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -369,7 +369,7 @@ namespace Calamari.Aws.Deployment.Conventions
 
         static string GetPackageExtension(RunningDeployment deployment)
         {
-            return Path.GetExtension(deployment.Variables.Get(PackageVariables.IndexedOriginalPath(null)));
+            return Path.GetExtension(deployment.PackageFilePath);
         }
 
         /// <summary>

--- a/source/Calamari.Aws/Integration/S3/S3PackageOptions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3PackageOptions.cs
@@ -6,7 +6,7 @@
         public string BucketKeyPrefix { get; set; }
         public BucketKeyBehaviourType BucketKeyBehaviour { get; set; }
 
-        public string VariableSubstitutionPatterns { get; set; }
-        public string StructuredVariableSubstitutionPatterns { get; set; }
+        public string VariableSubstitutionPatterns { get; set; } = "";
+        public string StructuredVariableSubstitutionPatterns { get; set; } = "";
     }
 }

--- a/source/Calamari.Aws/Integration/S3/S3PackageOptions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3PackageOptions.cs
@@ -5,5 +5,8 @@
         public string BucketKey { get; set; }
         public string BucketKeyPrefix { get; set; }
         public BucketKeyBehaviourType BucketKeyBehaviour { get; set; }
+
+        public string VariableSubstitutionPatterns { get; set; }
+        public string StructuredVariableSubstitutionPatterns { get; set; }
     }
 }


### PR DESCRIPTION
# Background

Users can currently perform Structured Variable Replacement and/or Variable Substitution to be run against the files from their package if they are only uploading specific files from the package. This feature should be available when uploading the entire package.

# Results

The package will now be extracted to allow for variable substitution and repackaged (if required) before being uploaded.

<img width="725" alt="Release_with_extraction_and_variable_replacement" src="https://user-images.githubusercontent.com/83486/156102293-2de57db7-e2f9-49db-bc83-0c987f675173.png">

