### PR TITLE
Applying target discovery changes

### DIFF
--- a/source/Calamari.Tests/Fixtures/Manifest/InstructionBuilder.cs
+++ b/source/Calamari.Tests/Fixtures/Manifest/InstructionBuilder.cs
@@ -25,7 +25,7 @@ namespace Calamari.Tests.Fixtures.Manifest
             instructions.Add(
                              new Instruction
                              {
-                                 Launcher = LaunchTools.LaunchTools.Calamari,
+                                 Launcher = Calamari.LaunchTools.LaunchTools.Calamari,
                                  LauncherInstructions = JsonConvert.SerializeObject(new CalamariInstructions
                                                                                     {
                                                                                         Command = commandName,
@@ -41,7 +41,7 @@ namespace Calamari.Tests.Fixtures.Manifest
         {
             instructions.Add(new Instruction
             {
-                Launcher = LaunchTools.LaunchTools.Node,
+                Launcher = Calamari.LaunchTools.LaunchTools.Node,
                 LauncherInstructions = JsonConvert.SerializeObject(new NodeInstructions
                                                                    {
                                                                        BootstrapperPathVariable = nameof(NodeInstructions.BootstrapperPathVariable),

--- a/source/Calamari.Tests/Fixtures/Manifest/InstructionBuilder.cs
+++ b/source/Calamari.Tests/Fixtures/Manifest/InstructionBuilder.cs
@@ -48,7 +48,8 @@ namespace Calamari.Tests.Fixtures.Manifest
                                                                        NodePathVariable = nameof(NodeInstructions.NodePathVariable),
                                                                        TargetPathVariable = nameof(NodeInstructions.TargetPathVariable),
                                                                        InputsVariable = nameof(NodeInstructions.InputsVariable),
-                                                                       DeploymentTargetInputsVariable = nameof(NodeInstructions.DeploymentTargetInputsVariable)
+                                                                       DeploymentTargetInputsVariable = nameof(NodeInstructions.DeploymentTargetInputsVariable),
+                                                                       BootstrapperInvocationCommand = "Execute"
                                                                    },
                                                                    JsonSerialization.GetDefaultSerializerSettings())
             });

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -47,7 +47,7 @@ namespace Calamari.Tests.KubernetesFixtures
                                                         },
                                                         async (destinationDirectoryName, tuple) =>
                                                         {
-                                                            var fileName = GetTerraformFileName(tuple.latestVersion);
+                                                            var fileName = GetTerraformFileName(tuple.version);
 
                                                             await DownloadTerraform(fileName, client, tuple.data, destinationDirectoryName);
 
@@ -64,7 +64,7 @@ namespace Calamari.Tests.KubernetesFixtures
                                                       },
                                                       async (destinationDirectoryName, tuple) =>
                                                       {
-                                                          var downloadUrl = GetKubectlDownloadLink(tuple.latestVersion);
+                                                          var downloadUrl = GetKubectlDownloadLink(tuple.version);
 
                                                           await Download(Path.Combine(destinationDirectoryName, GetKubectlFileName()), client, downloadUrl);
 
@@ -75,12 +75,13 @@ namespace Calamari.Tests.KubernetesFixtures
                 AwsAuthenticatorExecutable = await DownloadCli("aws-iam-authenticator",
                                                                async () =>
                                                                {
+                                                                   const string requiredVersion = "v0.5.3";
                                                                    client.DefaultRequestHeaders.Add("User-Agent", "Octopus");
-                                                                   var json = await client.GetAsync("https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/latest");
+                                                                   var json = await client.GetAsync($"https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/tags/{requiredVersion}");
                                                                    json.EnsureSuccessStatusCode();
                                                                    var jObject = JObject.Parse(await json.Content.ReadAsStringAsync());
                                                                    var downloadUrl = jObject["assets"].Children().FirstOrDefault(token => token["name"].Value<string>().EndsWith(GetAWSAuthenticatorFileNameEndsWith()))?["browser_download_url"].Value<string>();
-                                                                   return (jObject["tag_name"].Value<string>(), downloadUrl);
+                                                                   return (requiredVersion, downloadUrl);
                                                                },
                                                                async (destinationDirectoryName, tuple) =>
                                                                {
@@ -94,10 +95,10 @@ namespace Calamari.Tests.KubernetesFixtures
                                                                () => Task.FromResult<(string, string)>(("346.0.0", string.Empty)),
                                                                async (destinationDirectoryName, tuple) =>
                                                                {
-                                                                   var downloadUrl = GetGcloudDownloadLink(tuple.latestVersion);
-                                                                   var fileName = GetGcloudZipFileName(tuple.latestVersion);
+                                                                   var downloadUrl = GetGcloudDownloadLink(tuple.version);
+                                                                   var fileName = GetGcloudZipFileName(tuple.version);
 
-                                                                   await DownloadGcloud(GetGcloudZipFileName(tuple.latestVersion), client, downloadUrl, destinationDirectoryName);
+                                                                   await DownloadGcloud(GetGcloudZipFileName(tuple.version), client, downloadUrl, destinationDirectoryName);
 
                                                                    return GetGcloudExecutablePath(destinationDirectoryName);
                                                                });
@@ -247,10 +248,10 @@ namespace Calamari.Tests.KubernetesFixtures
             TestContext.Progress.WriteLine("Cannot create symbolic link: {0}, Calamari does not currently support the extraction of symbolic links", sourcepath);
         }
 
-        async Task<string> DownloadCli(string toolName, Func<Task<(string latestVersion, string data)>> versionFetcher, Func<string, (string latestVersion, string data), Task<string>> downloader)
+        async Task<string> DownloadCli(string toolName, Func<Task<(string version, string data)>> versionFetcher, Func<string, (string version, string data), Task<string>> downloader)
         {
             var data = await versionFetcher();
-            var destinationDirectoryName = TestEnvironment.GetTestPath("Tools", toolName, data.latestVersion);
+            var destinationDirectoryName = TestEnvironment.GetTestPath("Tools", toolName, data.version);
 
             string ShouldDownload()
             {

--- a/source/Calamari.Tests/LaunchTools/NodeExecutorFixture.cs
+++ b/source/Calamari.Tests/LaunchTools/NodeExecutorFixture.cs
@@ -1,0 +1,106 @@
+﻿using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.Commands;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.LaunchTools;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.LaunchTools
+{
+    [TestFixture]
+    public class NodeExecutorFixture
+    {
+        [Test]
+        public void Execute_UsesCorrectCommandLineInvocation_ForExecution()
+        {
+            // Arrange
+            var instructions = BuildInstructions("Execute");
+            var variables = BuildVariables();
+            var options = BuildOptions();
+            var commandLineRunner = Substitute.For<ICommandLineRunner>();
+            var sut = new NodeExecutor(options, variables, commandLineRunner, new InMemoryLog());
+            CommandLineInvocation capturedInvocation = null;
+            var fakeResult = new CommandResult("fakeCommand", 0);
+            commandLineRunner.Execute(Arg.Do<CommandLineInvocation>(arg => capturedInvocation = arg)).Returns(fakeResult);
+
+            // Act
+            sut.Execute(instructions);
+
+            // Assert
+            var arguments = capturedInvocation.Arguments.Split(' ');
+            arguments.Should().HaveCount(8)
+                .And.HaveElementAt(0, "\"expectedBootstrapperPath\\bootstrapper.js\"")
+                .And.HaveElementAt(1, "\"Execute\"")
+                .And.HaveElementAt(2, "\"expectedTargetPath\"")
+                .And.HaveElementAt(4, "\"encryptionPassword\"")
+                .And.HaveElementAt(5, "\"Octopuss\"")
+                .And.HaveElementAt(6, "\"inputsKey\"")
+                .And.HaveElementAt(7, "\"targetInputsKey\"");
+        }
+
+        [Test]
+        public void Execute_UsesCorrectCommandLineInvocation_ForTargetDiscovery()
+        {
+            // Arrange
+            var instructions = BuildInstructions("Discovery");
+            var variables = BuildVariables();
+            var options = BuildOptions();
+            var commandLineRunner = Substitute.For<ICommandLineRunner>();
+            var sut = new NodeExecutor(options, variables, commandLineRunner, new InMemoryLog());
+            CommandLineInvocation capturedInvocation = null;
+            var fakeResult = new CommandResult("fakeCommand", 0);
+            commandLineRunner.Execute(Arg.Do<CommandLineInvocation>(arg => capturedInvocation = arg)).Returns(fakeResult);
+
+            // Act
+            sut.Execute(instructions);
+
+            // Assert
+            var arguments = capturedInvocation.Arguments.Split(' ');
+            arguments.Should().HaveCount(7)
+                .And.HaveElementAt(0, "\"expectedBootstrapperPath\\bootstrapper.js\"")
+                .And.HaveElementAt(1, "\"Discovery\"")
+                .And.HaveElementAt(2, "\"expectedTargetPath\"")
+                .And.HaveElementAt(4, "\"encryptionPassword\"")
+                .And.HaveElementAt(5, "\"Octopuss\"")
+                .And.HaveElementAt(6, "\"discoveryContextKey\"");
+        }
+
+        private string BuildInstructions(string command) => $@"{{
+    ""nodePathVariable"": ""nodePathKey"",
+    ""targetPathVariable"": ""targetPathKey"",
+    ""bootstrapperPathVariable"": ""bootstrapperVarKey"",
+    ""bootstrapperInvocationCommand"": ""{command}"",
+    ""inputsVariable"": ""inputsKey"",
+    ""deploymentTargetInputsVariable"": ""targetInputsKey"",
+    ""targetDiscoveryContextVariable"": ""discoveryContextKey""
+}}";
+
+        private CommonOptions BuildOptions() => CommonOptions.Parse(new[]
+            {
+                "Test",
+                "--variables",
+                "firstInsensitiveVariablesFileName",
+                "--sensitiveVariables",
+                "firstSensitiveVariablesFileName",
+                "--sensitiveVariables",
+                "secondSensitiveVariablesFileName",
+                "--sensitiveVariablesPassword",
+                "encryptionPassword"
+            });
+
+        private CalamariVariables BuildVariables()
+        {
+            var variables = new CalamariVariables();
+            variables.Set("nodePathKey", "expectedNodePath");
+            variables.Set("targetPathKey", "expectedTargetPath");
+            variables.Set("bootstrapperVarKey", "expectedBootstrapperPath");
+            variables.Set("inputsKey", @"{ input: ""foo"" }");
+            variables.Set("targetInputsKey", @"{ targetInput: ""bar"" }");
+            variables.Set("foo", "AwsAccount");
+            variables.Set("discoveryContextKey", @"{ ""blah"": ""baz"" }");
+            return variables;
+        }
+    }
+}

--- a/source/Calamari.Tests/LaunchTools/NodeExecutorFixture.cs
+++ b/source/Calamari.Tests/LaunchTools/NodeExecutorFixture.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 using System;
+using System.IO;
 
 namespace Calamari.Tests.LaunchTools
 {
@@ -36,7 +37,7 @@ namespace Calamari.Tests.LaunchTools
             // Assert
             var arguments = capturedInvocation.Arguments.Split(' ');
             arguments.Should().HaveCount(8)
-                .And.HaveElementAt(0, "\"expectedBootstrapperPath\\bootstrapper.js\"")
+                .And.HaveElementAt(0, $"\"{Path.Combine("expectedBootstrapperPath","bootstrapper.js")}\"")
                 .And.HaveElementAt(1, $"\"{executionCommand}\"")
                 .And.HaveElementAt(2, "\"expectedTargetPath\"")
                 .And.HaveElementAt(4, "\"encryptionPassword\"")
@@ -66,7 +67,7 @@ namespace Calamari.Tests.LaunchTools
             // Assert
             var arguments = capturedInvocation.Arguments.Split(' ');
             arguments.Should().HaveCount(7)
-                .And.HaveElementAt(0, "\"expectedBootstrapperPath\\bootstrapper.js\"")
+                .And.HaveElementAt(0, $"\"{Path.Combine("expectedBootstrapperPath","bootstrapper.js")}\"")
                 .And.HaveElementAt(1, $"\"{discoveryCommand}\"")
                 .And.HaveElementAt(2, "\"expectedTargetPath\"")
                 .And.HaveElementAt(4, "\"encryptionPassword\"")

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -77,14 +77,18 @@ namespace Calamari.LaunchTools
             parameters.Add(sensitiveVariablesFilePath);
             parameters.Add(options.InputVariables.SensitiveVariablesPassword);
             parameters.Add(AesEncryption.SaltRaw);
-            if (instructions.BootstrapperInvocationCommand == "Execute")
+            if (string.Equals(instructions.BootstrapperInvocationCommand, "Execute", StringComparison.OrdinalIgnoreCase))
             {
                 parameters.Add(instructions.InputsVariable);
                 parameters.Add(instructions.DeploymentTargetInputsVariable);
             }
-            else
+            else if (string.Equals(instructions.BootstrapperInvocationCommand, "Discover", StringComparison.OrdinalIgnoreCase))
             {
                 parameters.Add(instructions.TargetDiscoveryContextVariable);
+            }
+            else
+            {
+                throw new CommandException($"Unknown bootstrapper invocation command: '{instructions.BootstrapperInvocationCommand}'");
             }
 
             return string.Join(" ", parameters.Select(p => $"\"{p}\""));


### PR DESCRIPTION
Adds functionality so that Calamari can execute step package discovery scripts.

Using patch created via diff between:
2708dcfcb732b7aa01f7fe2eb9f554e5227ba54d (master)
f5fa34f545f9488525e0793d20e618761d102ea0 (geoffb/step-package-target-discovery)