### PR TITLE
Adds support for S3 feed

### DIFF
--- a/source/Calamari.Aws/Calamari.Aws.csproj
+++ b/source/Calamari.Aws/Calamari.Aws.csproj
@@ -27,10 +27,11 @@
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.106" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.106.34" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.111.37" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.105.43" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.9.14" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.8.10" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.116" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.8.8" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.128" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Calamari.Common/Features/Packages/FeedType.cs
+++ b/source/Calamari.Common/Features/Packages/FeedType.cs
@@ -10,6 +10,7 @@ namespace Calamari.Common.Features.Packages
         Maven,
         GitHub,
         Helm,
-        AwsElasticContainerRegistry
+        AwsElasticContainerRegistry,
+        S3
     }
 }

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -23,7 +23,7 @@
     <RootNamespace>Calamari</RootNamespace>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net40;net452;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.1;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -48,6 +48,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.8.8" />
     <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -23,6 +23,8 @@
     <RootNamespace>Calamari</RootNamespace>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net452;netstandard2.1;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -23,10 +23,7 @@
     <RootNamespace>Calamari</RootNamespace>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net452;netstandard2.1;net40</TargetFrameworks>
+    <TargetFrameworks>net40;net452;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/MavenPackageDownloader.cs
@@ -200,7 +200,7 @@ namespace Calamari.Integration.Packages.Download
                 }
                 catch (Exception ex)
                 {
-                    if (retry == maxDownloadAttempts)
+                    if ((retry + 1) == maxDownloadAttempts)
                         throw new MavenDownloadException("Failed to download the Maven artifact.\r\nLast Exception Message: " + ex.Message);
                     Thread.Sleep(downloadAttemptBackoff);
                 }

--- a/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
@@ -67,6 +67,9 @@ namespace Calamari.Integration.Packages.Download
                 case FeedType.AwsElasticContainerRegistry :
                     downloader = new DockerImagePackageDownloader(engine, fileSystem, commandLineRunner, variables);
                     break;
+                case FeedType.S3:
+                    downloader = new S3PackageDownloader(log, fileSystem);
+                    break;
                 default:
                     throw new NotImplementedException($"No Calamari downloader exists for feed type `{feedType}`.");
             }

--- a/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
@@ -91,10 +91,11 @@ namespace Calamari.Integration.Packages.Download
 
 #if NET40
                         var response = s3Client.GetObject(bucketName, fileName);
+                        response.WriteResponseStreamToFile(localDownloadName);
 #else
                         var response = s3Client.GetObjectAsync(bucketName, fileName).GetAwaiter().GetResult();
+                        response.WriteResponseStreamToFileAsync(localDownloadName, false, CancellationToken.None).GetAwaiter().GetResult();
 #endif
-                        response.WriteResponseStreamToFile(localDownloadName);
                         var packagePhysicalFileMetadata = PackagePhysicalFileMetadata.Build(localDownloadName);
                         return packagePhysicalFileMetadata
                                ?? throw new CommandException($"Unable to retrieve metadata for package {packageId}, version {version}");

--- a/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
@@ -59,7 +59,7 @@ namespace Calamari.Integration.Packages.Download
             var (bucketName, prefix) = GetBucketAndKey(packageId);
             if (string.IsNullOrWhiteSpace(bucketName) || string.IsNullOrWhiteSpace(prefix))
             {
-                throw new InvalidOperationException("Invalid PackageId for S3 feed. Expecting format `<bucketName>/<packageId>`");
+                throw new InvalidOperationException($"Invalid PackageId for S3 feed. Expecting format `<bucketName>/<packageId>`, but received ${bucketName}/{prefix}");
             }
 
             var cacheDirectory = PackageDownloaderUtils.GetPackageRoot(feedId);

--- a/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
@@ -68,7 +68,7 @@ namespace Calamari.Integration.Packages.Download
             {
                 try
                 {
-                    using (var s3Client = new AmazonS3Client(new BasicAWSCredentials(feedUsername, feedPassword)))
+                    using (var s3Client = string.IsNullOrEmpty(feedUsername) ? new AmazonS3Client() : new AmazonS3Client(new BasicAWSCredentials(feedUsername, feedPassword)))
                     {
                         bool fileExists = false;
                         string fileName = "";

--- a/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Alphaleonis.Win32.Filesystem;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Packages;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Octopus.CoreUtilities.Extensions;
+using Octopus.Versioning;
+
+namespace Calamari.Integration.Packages.Download
+{
+    public class S3PackageDownloader : IPackageDownloader
+    {
+        static string[] knownFileExtensions = { ".zip", ".tar.gz", ".tar.bz2", ".tar.gz", ".tgz", ".tar.bz" };
+        
+        const char BucketFileSeparator = '/';
+        readonly ILog log;
+        readonly ICalamariFileSystem fileSystem;
+        
+        static readonly IPackageDownloaderUtils PackageDownloaderUtils = new PackageDownloaderUtils();
+
+        public S3PackageDownloader(ILog log, ICalamariFileSystem fileSystem)
+        {
+            this.log = log;
+            this.fileSystem = fileSystem;
+        }
+        
+        string BuildFileName(string prefix, string version, string extension)
+        {
+            return $"{prefix}.{version}{extension}";
+        }
+        
+        (string BucketName, string Filename) GetBucketAndKey(string searchTerm)
+        {
+            var splitString = searchTerm.Split(new [] { BucketFileSeparator }, 2);
+            if (splitString.Length == 0)
+                return ("", "");
+            if (splitString.Length == 1)
+                return (splitString[0], "");
+            
+            return (splitString[0], splitString[1]);
+        }
+
+        public PackagePhysicalFileMetadata DownloadPackage(string packageId,
+                                                           IVersion version,
+                                                           string feedId,
+                                                           Uri feedUri,
+                                                           string? feedUsername,
+                                                           string? feedPassword,
+                                                           bool forcePackageDownload,
+                                                           int maxDownloadAttempts,
+                                                           TimeSpan downloadAttemptBackoff)
+        {
+            var (bucketName, prefix) = GetBucketAndKey(packageId);
+            if (string.IsNullOrWhiteSpace(bucketName) || string.IsNullOrWhiteSpace(prefix))
+            {
+                throw new InvalidOperationException("Invalid PackageId for S3 feed. Expecting format `<bucketName>/<packageId>`");
+            }
+
+            var cacheDirectory = PackageDownloaderUtils.GetPackageRoot(feedId);
+
+            for (var retry = 0; retry < maxDownloadAttempts; ++retry)
+            {
+                try
+                {
+                    using (var s3Client = new AmazonS3Client(new BasicAWSCredentials(feedUsername, feedPassword)))
+                    {
+                        bool fileExists = false;
+                        string fileName = "";
+                        for (int i = 0; i < knownFileExtensions.Length && !fileExists; i++)
+                        {
+                            fileName = BuildFileName(prefix, version.ToString(), knownFileExtensions[i]);
+                            fileExists = FileExistsInBucket(s3Client, bucketName, fileName, CancellationToken.None).GetAwaiter().GetResult();
+                        }
+
+                        if (!fileExists)
+                            throw new Exception($"Unable to download package {packageId} {version}: file not found");
+
+                        var localDownloadName = Path.Combine(cacheDirectory, PackageName.ToCachedFileName(packageId, version, "." + Path.GetExtension(fileName)));
+
+                        var response = s3Client.GetObject(bucketName, fileName);
+                        response.WriteResponseStreamToFile(localDownloadName);
+                        var packagePhysicalFileMetadata = PackagePhysicalFileMetadata.Build(localDownloadName);
+                        return packagePhysicalFileMetadata
+                               ?? throw new CommandException($"Unable to retrieve metadata for package {packageId}, version {version}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (retry == maxDownloadAttempts)
+                        throw new CommandException($"Unable to download package {packageId} {version}: " + ex.Message);
+                    Thread.Sleep(downloadAttemptBackoff);
+                }
+            }
+            
+            throw new CommandException($"Failed to download package {packageId} {version}");
+        }
+        
+        async Task<bool> FileExistsInBucket(AmazonS3Client client, string bucketName, string prefix, CancellationToken cancellationToken)
+        {
+            var request = new ListObjectsRequest
+            {
+                BucketName = bucketName,
+                Prefix = prefix
+            };
+
+            var response = await client.ListObjectsAsync(request, cancellationToken);
+            return response.S3Objects.Any();
+        }     
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Integration.Packages.Download;
+using Calamari.Testing;
+using Calamari.Tests.AWS;
+using Calamari.Tests.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Versioning;
+using InMemoryLog = Calamari.Testing.Helpers.InMemoryLog;
+using TestEnvironment = Calamari.Testing.Helpers.TestEnvironment;
+
+namespace Calamari.Tests.Fixtures.Integration.Packages
+{
+    [TestFixture]
+    public class S3PackageDownloaderFixture : CalamariFixture
+    {
+        string rootDir;
+        static readonly string TentacleHome = TestEnvironment.GetTestPath("Fixtures", "PackageDownload");
+        readonly string region;
+        readonly string bucketName;
+
+        public S3PackageDownloaderFixture()
+        {
+            region = RegionRandomiser.GetARegion();
+            bucketName = Guid.NewGuid().ToString("N");
+        }
+
+        [OneTimeSetUp]
+        public async Task TestFixtureSetUp()
+        {
+            rootDir = GetFixtureResource(this.GetType().Name);
+            if (Directory.Exists(rootDir))
+            {
+                Directory.Delete(rootDir, true);
+            }
+            
+            Environment.SetEnvironmentVariable("TentacleHome", TentacleHome);
+            await Validate(async client => await client.PutBucketAsync(bucketName));
+            Directory.CreateDirectory(GetFixtureResource(rootDir));
+        }
+
+        [OneTimeTearDown]
+        public async Task TestFixtureTearDown()
+        {
+            if (Directory.Exists(rootDir))
+            {
+                Directory.Delete(rootDir, true);
+            }
+            
+            Environment.SetEnvironmentVariable("TentacleHome", null);
+            await Validate(async client =>
+                     {
+                         var response = await client.ListObjectsAsync(bucketName);
+                         foreach (var s3Object in response.S3Objects)
+                         {
+                             await client.DeleteObjectAsync(bucketName, s3Object.Key);
+                         }
+                         await client.DeleteBucketAsync(bucketName);
+                     });
+        }
+        
+        static S3PackageDownloader GetDownloader()
+        {
+            return new S3PackageDownloader(new InMemoryLog(), CalamariPhysicalFileSystem.GetPhysicalFileSystem());
+        }
+
+        [Test]
+        public async Task CanDownloadPackage()
+        {
+            string filename = "Acme.Core.1.0.0.0-bugfix.zip";
+            string packageId = $"{bucketName}/Acme.Core";
+            var version = VersionFactory.CreateVersion("1.0.0.0-bugfix", VersionFormat.Semver);
+            
+            File.Copy(GetFixtureResource("Samples", filename), Path.Combine(rootDir, filename));
+
+            await Validate(async client => await client.PutObjectAsync(new PutObjectRequest
+                                                                       {
+                                                                           BucketName = bucketName,
+                                                                           Key = filename,
+                                                                           InputStream = File.OpenRead(Path.Combine(rootDir, filename))
+                                                                       },
+                                                                       CancellationToken.None));
+
+            var downloader = GetDownloader();
+            var package = downloader.DownloadPackage(packageId,
+                                                     version,
+                                                     "s3-feed",
+                                                     new Uri("http://please-ignore.com"),
+                                                     ExternalVariables.Get(ExternalVariable.AwsAcessKey),
+                                                     ExternalVariables.Get(ExternalVariable.AwsSecretKey),
+                                                     true,
+                                                     3,
+                                                     TimeSpan.FromSeconds(3));
+
+            package.PackageId.Should().Be(packageId);
+            package.Size.Should().Be(new FileInfo(Path.Combine(rootDir, filename)).Length);
+        }
+
+        protected async Task Validate(Func<AmazonS3Client, Task> execute)
+        {
+            var credentials = new BasicAWSCredentials(
+                                                      ExternalVariables.Get(ExternalVariable.AwsAcessKey),
+                                                      ExternalVariables.Get(ExternalVariable.AwsSecretKey));
+
+            var config = new AmazonS3Config {AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.GetBySystemName(region)};
+            
+            using (var client = new AmazonS3Client(credentials, config))
+            {
+                await execute(client);
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
@@ -7,6 +7,7 @@ using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Integration.Packages.Download;
 using Calamari.Testing;
 using Calamari.Tests.AWS;
@@ -69,7 +70,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         
         static S3PackageDownloader GetDownloader()
         {
-            return new S3PackageDownloader(new InMemoryLog(), CalamariPhysicalFileSystem.GetPhysicalFileSystem());
+            return new S3PackageDownloader(ConsoleLog.Instance, CalamariPhysicalFileSystem.GetPhysicalFileSystem());
         }
 
         [Test]


### PR DESCRIPTION
### Background

Adds support for basic S3 feed with supplied credentials. This package feed expects packages in the format of `{bucketName}/{packageName}` and will attempt to find matching files in the bucket by going through the list of know extensions (starting with `zip`). Having access to an S3 feed will enable serverless deployment scenarios, which are typically uploaded to an S3 bucket as a single file.

Related Server PR https://github.com/OctopusDeploy/OctopusDeploy/pull/11606

### How to review

I have done smoke testing and everything appears to work correctly. The one thing that might be surprising is the packageId format, but on the other hand we use the same format for github and docker feeds, so maybe that's ok.

I've only done a happy path test, as it's not clear what exactly needs testing, as the feed mostly calls to AWS SDK and we probably don't need to test that the SDK works.