### PR TITLE
Use S3 region value instead of S3Region class

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
@@ -151,8 +151,18 @@ namespace Calamari.Integration.Packages.Download
                  var region = s3Client.GetBucketLocationAsync(bucketName, CancellationToken.None).GetAwaiter().GetResult();
 #endif
 
+                string regionString = region.Location.Value;
                 // If the bucket is in the us-east-1 region, then the region name is not included in the response.
-                return string.IsNullOrEmpty(region.Location.Value) ? "us-east-1" : region.Location.Value;
+                if (string.IsNullOrEmpty(regionString))
+                {
+                    regionString = "us-east-1";
+                }
+                else if (regionString.Equals("EU", StringComparison.OrdinalIgnoreCase))
+                {
+                    regionString = "eu-west-1";
+                }
+                
+                return regionString;
             }
         }
 

--- a/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
@@ -151,7 +151,7 @@ namespace Calamari.Integration.Packages.Download
                  var region = s3Client.GetBucketLocationAsync(bucketName, CancellationToken.None).GetAwaiter().GetResult();
 #endif
 
-                return region.Location;
+                return region.Location.Value ?? "us-east-1";
             }
         }
 

--- a/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
@@ -151,7 +151,8 @@ namespace Calamari.Integration.Packages.Download
                  var region = s3Client.GetBucketLocationAsync(bucketName, CancellationToken.None).GetAwaiter().GetResult();
 #endif
 
-                return region.Location.Value ?? "us-east-1";
+                // If the bucket is in the us-east-1 region, then the region name is not included in the response.
+                return string.IsNullOrEmpty(region.Location.Value) ? "us-east-1" : region.Location.Value;
             }
         }
 

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
@@ -27,7 +27,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         static readonly string TentacleHome = TestEnvironment.GetTestPath("Fixtures", "PackageDownload");
         readonly string region;
         readonly string bucketName;
-
+        
         public S3PackageDownloaderFixture()
         {
             region = RegionRandomiser.GetARegion();


### PR DESCRIPTION
This is a quick fix to an issue caused by an edge case in region lookup code in `S3PackageDownloader`. AWS SDK does not return the region name for the default region, so we need to supply it manually.