### PR TITLE
Fixed AwsS3TestScript

### DIFF
--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -322,7 +322,7 @@ namespace Calamari.Aws.Deployment.Conventions
         {
             Guard.NotNull(deployment.StagingDirectory, "deployment.StagingDirectory must not be null");
 
-            if (!options.VariableSubstitutionPatterns.Any() && !options.StructuredVariableSubstitutionPatterns.Any())
+            if (options.VariableSubstitutionPatterns.IsNullOrEmpty() && options.StructuredVariableSubstitutionPatterns.IsNullOrEmpty())
                 return deployment.PackageFilePath;
 
             var stagingDirectory = deployment.StagingDirectory;


### PR DESCRIPTION
While migrating from our main AWS account to our E2E AWS account I noticed that this [AwsS3TestScript](https://build.octopushq.com/test/-3640991104469203491?currentProjectId=OctopusDeploy_OctopusServer_TestOrchestration&expandTestHistoryInvestigationsSection=true&expandTestHistoryMutesSection=true&expandTestHistoryChartSection=true&branch=%3Cdefault%3E&pager.currentPage=1) was broken. This PR fixes the ArgumentNullException.