### PR TITLE
Add link in the image-not-cached message

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
@@ -63,9 +63,16 @@ namespace Calamari.Integration.Packages.Download
             
             PerformLogin(username, password, feedHost);
 
+            const string cachedWorkerToolsShortLink = "http://g.octopushq.com/CachedWorkerToolsImages";
+            var imageNotCachedMessage =
+                $"The docker image '{fullImageName}' may not be cached." +
+                " Please note images that have not been cached may take longer to be acquired than expected." +
+                " Your deployment will begin as soon as all images have been pulled." +
+                $" Please see {cachedWorkerToolsShortLink} for more information on cached worker-tools image versions.";
+            
             if (!IsImageCached(fullImageName))
             {
-                log.Info($"The docker image '{fullImageName}' may not be cached. Please note images that have not been cached may take longer to be acquired than expected. Your deployment will begin as soon as all images have been pulled.");
+                log.Info(imageNotCachedMessage);
             }
             
             PerformPull(fullImageName);


### PR DESCRIPTION
This PR closes [this story](https://app.shortcut.com/octopusdeploy/story/893/update-cache-miss-log-message-to-include-documentation-links). A link to the documentation on cached versions of worker-tools images is shown when a non-cached image is pulled on worker.

<img width="893" alt="Screen Shot 2022-04-28 at 4 52 15 PM" src="https://user-images.githubusercontent.com/97418140/165680952-fcad4cf0-dddc-47c5-a5a1-73a8180be8da.png">

