### PR TITLE
Updating InstallTools class to install a fixed version of KubeCtl (v1.23.6)

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -58,9 +58,11 @@ namespace Calamari.Tests.KubernetesFixtures
                 KubectlExecutable = await DownloadCli("Kubectl",
                                                       async () =>
                                                       {
-                                                          var message = await client.GetAsync("https://storage.googleapis.com/kubernetes-release/release/stable.txt");
-                                                          message.EnsureSuccessStatusCode();
-                                                          return (await message.Content.ReadAsStringAsync(), null);
+                                                          // TODO: Figure out if we want to continue using stable version even if bugs may be introduced.
+                                                          // var message = await client.GetAsync("https://storage.googleapis.com/kubernetes-release/release/stable.txt");
+                                                          // message.EnsureSuccessStatusCode();
+                                                          // return (await message.Content.ReadAsStringAsync(), null);
+                                                          return await Task.FromResult(("v1.23.6", ""));
                                                       },
                                                       async (destinationDirectoryName, tuple) =>
                                                       {

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -62,7 +62,8 @@ namespace Calamari.Tests.KubernetesFixtures
                                                           // var message = await client.GetAsync("https://storage.googleapis.com/kubernetes-release/release/stable.txt");
                                                           // message.EnsureSuccessStatusCode();
                                                           // return (await message.Content.ReadAsStringAsync(), null);
-                                                          return await Task.FromResult(("v1.23.6", ""));
+                                                          const string requiredVersion = "v1.23.6";
+                                                          return await Task.FromResult((requiredVersion, ""));
                                                       },
                                                       async (destinationDirectoryName, tuple) =>
                                                       {

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
@@ -269,7 +269,7 @@ namespace Calamari.Tests.KubernetesFixtures
             TestScript(wrapper, "Test-Script");
         }
 
-        [Test]
+        [Test, Ignore("Test currently doesn't assert anything so it's not useful, to be investigated and updated.")]
         public void UsingEc2Instance()
         {
             var terraformWorkingFolder = InitialiseTerraformWorkingFolder("terraform_working_ec2", "KubernetesFixtures/Terraform/EC2");


### PR DESCRIPTION
There is currently a bug in the new version of Kubectl (v1.24.0) which makes some tests fail.