### PR TITLE
Fix kubectl test bug by ensuring executable from known version is used in generated script

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
@@ -28,6 +28,8 @@ namespace Calamari.Tests.KubernetesFixtures
     [Category(TestCategory.RunOnceOnWindowsAndLinux)]
     public class KubernetesContextScriptWrapperLiveFixture: KubernetesContextScriptWrapperLiveFixtureBase
     {
+        const string KubeCtlExecutableVariableName = "Octopus.Action.Kubernetes.CustomKubectlExecutable";
+        
         InstallTools installTools;
 
         string eksClientID;
@@ -75,7 +77,7 @@ namespace Calamari.Tests.KubernetesFixtures
         [SetUp]
         public void SetExtraVariables()
         {
-            variables.Set("Octopus.Action.Kubernetes.CustomKubectlExecutable", installTools.KubectlExecutable);
+            variables.Set(KubeCtlExecutableVariableName, installTools.KubectlExecutable);
         }
 
         protected override Dictionary<string, string> GetEnvironments()
@@ -271,7 +273,14 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Kubernetes.CertificateAuthority", certificateAuthority);
             variables.Set($"{certificateAuthority}.CertificatePem", eksClusterCaCertificate);
             var wrapper = CreateWrapper();
-            TestScript(wrapper, "Test-Script", variables.Get("Octopus.Action.Kubernetes.CustomKubectlExecutable"));
+            
+            // When authorising via AWS, We need to make sure we are using the correct version of
+            // kubectl for the test script as newer versions may cause kubectl to fail with an error like:
+            // 'error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"'
+            var kubectlExecutable = variables.Get(KubeCtlExecutableVariableName) ??
+                throw new Exception($"Unable to find required kubectl executable in variable '{KubeCtlExecutableVariableName}'");
+            
+            TestScript(wrapper, "Test-Script", kubectlExecutable);
         }
 
         [Test, Ignore("Test currently doesn't assert anything so it's not useful, to be investigated and updated.")]

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
@@ -271,7 +271,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Kubernetes.CertificateAuthority", certificateAuthority);
             variables.Set($"{certificateAuthority}.CertificatePem", eksClusterCaCertificate);
             var wrapper = CreateWrapper();
-            TestScript(wrapper, "Test-Script");
+            TestScript(wrapper, "Test-Script", variables.Get("Octopus.Action.Kubernetes.CustomKubectlExecutable"));
         }
 
         [Test, Ignore("Test currently doesn't assert anything so it's not useful, to be investigated and updated.")]

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -93,7 +93,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 using (var temp = new TemporaryFile(Path.Combine(folderPath, $"{scriptName}.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
                 {
                     Directory.CreateDirectory(folderPath);
-                    File.WriteAllText(temp.FilePath, $"{kubectlExe} version{Environment.NewLine}{kubectlExe} cluster-info");
+                    File.WriteAllText(temp.FilePath, $"{kubectlExe} cluster-info");
 
                     var output = ExecuteScript(wrapper, temp.FilePath);
                     output.AssertSuccess();

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -93,7 +93,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 using (var temp = new TemporaryFile(Path.Combine(folderPath, $"{scriptName}.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
                 {
                     Directory.CreateDirectory(folderPath);
-                    File.WriteAllText(temp.FilePath, $"{kubectlExe} --version{Environment.NewLine}{kubectlExe} cluster-info");
+                    File.WriteAllText(temp.FilePath, $"{kubectlExe} version{Environment.NewLine}{kubectlExe} cluster-info");
 
                     var output = ExecuteScript(wrapper, temp.FilePath);
                     output.AssertSuccess();

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -84,7 +84,7 @@ namespace Calamari.Tests.KubernetesFixtures
             return new Dictionary<string, string>();
         }
 
-        protected void TestScript(IScriptWrapper wrapper, string scriptName)
+        protected void TestScript(IScriptWrapper wrapper, string scriptName, string kubectlExe = "kubectl")
         {
             using (var dir = TemporaryDirectory.Create())
             {
@@ -93,7 +93,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 using (var temp = new TemporaryFile(Path.Combine(folderPath, $"{scriptName}.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
                 {
                     Directory.CreateDirectory(folderPath);
-                    File.WriteAllText(temp.FilePath, $"kubectl --version{Environment.NewLine}kubectl cluster-info");
+                    File.WriteAllText(temp.FilePath, $"{kubectlExe} --version{Environment.NewLine}{kubectlExe} cluster-info");
 
                     var output = ExecuteScript(wrapper, temp.FilePath);
                     output.AssertSuccess();

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -93,7 +93,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 using (var temp = new TemporaryFile(Path.Combine(folderPath, $"{scriptName}.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
                 {
                     Directory.CreateDirectory(folderPath);
-                    File.WriteAllText(temp.FilePath, "kubectl cluster-info");
+                    File.WriteAllText(temp.FilePath, $"kubectl --version{Environment.NewLine}kubectl cluster-info");
 
                     var output = ExecuteScript(wrapper, temp.FilePath);
                     output.AssertSuccess();


### PR DESCRIPTION
The first attempt to fix this issue was done in [this PR](https://github.com/OctopusDeploy/Calamari/pull/848) but that didn't completely fix the issue due to the fact that the generated scripts in the tests were using which ever version of `kubectl` was on the path for the agent.

In this PR I've updated the script generation to point specifically to the version of `kubectl` which was downloaded by the test setup code so that this issue doesn't occur.