### PR TITLE
Fix Helm Upgrade Command to work with Kubernetes Targets which don't have a ClusterUrl set

### DIFF
--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -64,8 +64,6 @@ namespace Calamari.Kubernetes.Commands
             if (!File.Exists(pathToPackage))
                 throw new CommandException("Could not find package file: " + pathToPackage);
 
-            ValidateRequiredVariables();
-
             var conventions = new List<IConvention>
             {
                 new DelegateInstallConvention(d => extractPackage.ExtractToStagingDirectory(pathToPackage)),
@@ -94,14 +92,6 @@ namespace Calamari.Kubernetes.Commands
             }
 
             return 0;
-        }
-
-        void ValidateRequiredVariables()
-        {
-            if (!variables.IsSet(SpecialVariables.ClusterUrl))
-            {
-                throw new CommandException($"The variable `{SpecialVariables.ClusterUrl}` is not provided.");
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
# Background

If Cluster URL is null, the Upgrade Helm step will fail, even if the Cluster URL is not required (eg: AKS (Azure) K8s Clusters).
This has been an issue when creating Kubernetes Cluster targets for Azure via service messages because the ClusterURL is set to null in that case. Rather than correct the service message change, I've opted to remove the redundant and unnecessary check from Calamari which means all Clusters which currently have this issue will now work with the Helm step.

**Note:** Add clusters via the UI will result in Cluster URL being set to an empty string which bypasses this issue.

Here is a screen cap of two clusters with URL null, one AKS (url not required) and one EKS (url required) you can see that the error message for the EKS cluster is still informative without this check.
<img width="1411" alt="image" src="https://user-images.githubusercontent.com/97430840/170917235-ed9e3850-642d-46b5-a0ae-88ca62a3c007.png">
