### PR TITLE
Add "awsUseWorkerCredentials" argument for aws worker credentials auth

### DIFF
--- a/source/Calamari.Common/Features/Discovery/KubernetesCluster.cs
+++ b/source/Calamari.Common/Features/Discovery/KubernetesCluster.cs
@@ -19,7 +19,8 @@ namespace Calamari.Common.Features.Discovery
                 accountId,
                 assumeRole,
                 workerPool,
-                tags);
+                tags,
+                accountId == null);
         }
 
         public static KubernetesCluster CreateForAks(string name,
@@ -45,7 +46,8 @@ namespace Calamari.Common.Features.Discovery
             string? accountId, 
             AwsAssumeRole? awsAssumeRole, 
             string? workerPool,
-            TargetTags tags)
+            TargetTags tags,
+            bool awsUseWorkerCredentials = false)
         {
             Name = name;
             ClusterName = clusterName;
@@ -55,6 +57,7 @@ namespace Calamari.Common.Features.Discovery
             AwsAssumeRole = awsAssumeRole;
             WorkerPool = workerPool;
             Tags = tags;
+            AwsUseWorkerCredentials = awsUseWorkerCredentials;
         }
 
         public string? WorkerPool { get; }
@@ -68,6 +71,8 @@ namespace Calamari.Common.Features.Discovery
         public string? Endpoint { get; }
         
         public string? AccountId { get; }
+        
+        public bool AwsUseWorkerCredentials { get; }
         
         public AwsAssumeRole? AwsAssumeRole { get; }
         

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -160,6 +160,7 @@ namespace Calamari.Tests.KubernetesFixtures
                     { "octopusRoles", "discovery-role" },
                     { "updateIfExisting", bool.TrueString },
                     { "isDynamic", bool.TrueString },
+                    { "awsUserWorkerCredentials", bool.FalseString },
                     { "awsAssumeRole", bool.FalseString },
                 });
         

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -160,7 +160,7 @@ namespace Calamari.Tests.KubernetesFixtures
                     { "octopusRoles", "discovery-role" },
                     { "updateIfExisting", bool.TrueString },
                     { "isDynamic", bool.TrueString },
-                    { "awsUserWorkerCredentials", bool.FalseString },
+                    { "awsUseWorkerCredentials", bool.FalseString },
                     { "awsAssumeRole", bool.FalseString },
                 });
         

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -161,6 +161,7 @@ namespace Calamari.Tests.KubernetesFixtures
                         { "octopusRoles", "discovery-role" },
                         { "updateIfExisting", bool.TrueString },
                         { "isDynamic", bool.TrueString },
+                        { "awsUserWorkerCredentials", bool.TrueString },
                         { "awsAssumeRole", bool.TrueString },
                         { "awsAssumeRoleArn", eksIamRolArn },
                     };
@@ -206,6 +207,7 @@ namespace Calamari.Tests.KubernetesFixtures
                         { "octopusRoles", "discovery-role" },
                         { "updateIfExisting", bool.TrueString },
                         { "isDynamic", bool.TrueString },
+                        { "awsUserWorkerCredentials", bool.TrueString },
                         { "awsAssumeRole", bool.FalseString }
                     };
 
@@ -250,6 +252,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "octopusRoles", "discovery-role" },
                 { "updateIfExisting", bool.TrueString },
                 { "isDynamic", bool.TrueString },
+                { "awsUserWorkerCredentials", bool.FalseString },
                 { "awsAssumeRole", bool.FalseString }
             };
             
@@ -294,6 +297,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "octopusRoles", "discovery-role" },
                 { "updateIfExisting", bool.TrueString },
                 { "isDynamic", bool.TrueString },
+                { "awsUserWorkerCredentials", bool.FalseString },
                 { "awsAssumeRole", bool.TrueString },
                 { "awsAssumeRoleArn", eksIamRolArn },
                 { "awsAssumeRoleSession", "ThisIsASessionName" },

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -161,7 +161,7 @@ namespace Calamari.Tests.KubernetesFixtures
                         { "octopusRoles", "discovery-role" },
                         { "updateIfExisting", bool.TrueString },
                         { "isDynamic", bool.TrueString },
-                        { "awsUserWorkerCredentials", bool.TrueString },
+                        { "awsUseWorkerCredentials", bool.TrueString },
                         { "awsAssumeRole", bool.TrueString },
                         { "awsAssumeRoleArn", eksIamRolArn },
                     };
@@ -207,7 +207,7 @@ namespace Calamari.Tests.KubernetesFixtures
                         { "octopusRoles", "discovery-role" },
                         { "updateIfExisting", bool.TrueString },
                         { "isDynamic", bool.TrueString },
-                        { "awsUserWorkerCredentials", bool.TrueString },
+                        { "awsUseWorkerCredentials", bool.TrueString },
                         { "awsAssumeRole", bool.FalseString }
                     };
 
@@ -252,7 +252,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "octopusRoles", "discovery-role" },
                 { "updateIfExisting", bool.TrueString },
                 { "isDynamic", bool.TrueString },
-                { "awsUserWorkerCredentials", bool.FalseString },
+                { "awsUseWorkerCredentials", bool.FalseString },
                 { "awsAssumeRole", bool.FalseString }
             };
             
@@ -297,7 +297,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "octopusRoles", "discovery-role" },
                 { "updateIfExisting", bool.TrueString },
                 { "isDynamic", bool.TrueString },
-                { "awsUserWorkerCredentials", bool.FalseString },
+                { "awsUseWorkerCredentials", bool.FalseString },
                 { "awsAssumeRole", bool.TrueString },
                 { "awsAssumeRoleArn", eksIamRolArn },
                 { "awsAssumeRoleSession", "ThisIsASessionName" },

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
@@ -77,6 +77,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "octopusRoles", "discovery-role" },
                 { "updateIfExisting", bool.TrueString },
                 { "isDynamic", bool.TrueString },
+                { "awsUseWorkerCredentials", bool.TrueString },
                 { "awsAssumeRole", bool.TrueString },
                 { "awsAssumeRoleArn", eksIamRolArn },
             };
@@ -106,6 +107,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "octopusRoles", "discovery-role" },
                 { "updateIfExisting", bool.TrueString },
                 { "isDynamic", bool.TrueString },
+                { "awsUseWorkerCredentials", bool.TrueString },
                 { "awsAssumeRole", bool.FalseString }
             };
 

--- a/source/Calamari/Kubernetes/Commands/KubernetesDiscoveryCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesDiscoveryCommand.cs
@@ -121,6 +121,7 @@ namespace Calamari.Kubernetes.Commands
                 { "clusterImpersonateServiceAccount", null },
                 { "clusterServiceAccountEmails", null },
                 { "clusterUseVmServiceAccount", null },
+                { "awsUserWorkerCredentials", (cluster.AccountId == null).ToString() },
                 { "awsAssumeRole", (cluster.AwsAssumeRole != null).ToString() },
                 { "awsAssumeRoleArn", cluster.AwsAssumeRole?.Arn },
                 { "awsAssumeRoleSession", cluster.AwsAssumeRole?.Session },

--- a/source/Calamari/Kubernetes/Commands/KubernetesDiscoveryCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesDiscoveryCommand.cs
@@ -121,7 +121,7 @@ namespace Calamari.Kubernetes.Commands
                 { "clusterImpersonateServiceAccount", null },
                 { "clusterServiceAccountEmails", null },
                 { "clusterUseVmServiceAccount", null },
-                { "awsUserWorkerCredentials", (cluster.AccountId == null).ToString() },
+                { "awsUseWorkerCredentials", cluster.AwsUseWorkerCredentials.ToString() },
                 { "awsAssumeRole", (cluster.AwsAssumeRole != null).ToString() },
                 { "awsAssumeRoleArn", cluster.AwsAssumeRole?.Arn },
                 { "awsAssumeRoleSession", cluster.AwsAssumeRole?.Session },


### PR DESCRIPTION
This makes it more explicit when creating EKS targets with worker credentials instead of it being the default when no authentication is provided.

This work is in addition to [the original PR](https://github.com/OctopusDeploy/Calamari/pull/853) adding EKS Target Discovery to Calamari and will work in conjunction with [this PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/12177) which adds EKS Target Discovery functionality to Server (including updates to the Kubernetes Service Message handler).