### PR TITLE
Create AKS Target with name to include subscription id and resource group

### DIFF
--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -27,8 +27,7 @@ namespace Calamari.Azure.Kubernetes.Discovery
             Log.Verbose($"  Tenant ID: {account.TenantId}");
             Log.Verbose($"  Client ID: {account.ClientId}");
             var azureClient = account.CreateAzureClient();
-
-            // The Fqdn stands for Fully Qualified Domain Name
+            
             return azureClient.KubernetesClusters.List()
                               .Select(c => KubernetesCluster.CreateForAks(
                                   $"aks/{account.SubscriptionNumber}/{c.ResourceGroupName}/{c.Name}",

--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -30,7 +30,8 @@ namespace Calamari.Azure.Kubernetes.Discovery
 
             // The Fqdn stands for Fully Qualified Domain Name
             return azureClient.KubernetesClusters.List()
-                              .Select(c => KubernetesCluster.CreateForAks(c.Fqdn,
+                              .Select(c => KubernetesCluster.CreateForAks(
+                                  $"aks/{account.SubscriptionNumber}/{c.ResourceGroupName}/{c.Name}",
                                   c.Name,
                                   c.ResourceGroupName,
                                   authenticationDetails.AccountId,

--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Calamari.Common.Features.Discovery;
 using Calamari.Common.Plumbing.Logging;
-using Calamari.Common.Plumbing.Variables;
-using Newtonsoft.Json;
 
 namespace Calamari.Azure.Kubernetes.Discovery
 {
@@ -30,8 +28,10 @@ namespace Calamari.Azure.Kubernetes.Discovery
             Log.Verbose($"  Client ID: {account.ClientId}");
             var azureClient = account.CreateAzureClient();
 
+            // The Fqdn stands for Fully Qualified Domain Name
             return azureClient.KubernetesClusters.List()
-                              .Select(c => KubernetesCluster.CreateForAks(c.Name,
+                              .Select(c => KubernetesCluster.CreateForAks(c.Fqdn,
+                                  c.Name,
                                   c.ResourceGroupName,
                                   authenticationDetails.AccountId,
                                   c.Tags.ToTargetTags()));

--- a/source/Calamari.Common/Features/Discovery/KubernetesCluster.cs
+++ b/source/Calamari.Common/Features/Discovery/KubernetesCluster.cs
@@ -24,12 +24,13 @@ namespace Calamari.Common.Features.Discovery
         }
 
         public static KubernetesCluster CreateForAks(string name,
+            string clusterName,
             string resourceGroupName,
             string accountId,
             TargetTags tags)
         {
             return new KubernetesCluster(name,
-                name,
+                clusterName,
                 resourceGroupName,
                 null,
                 accountId,

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -167,7 +167,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 });
         
             serviceMessageCollectorLog.ServiceMessages.Should()
-                                      .ContainSingle(s => s.Properties["name"] == aksClusterName)
+                                      .ContainSingle(s => s.Properties["name"] == aksClusterFqdn)
                                       .Which.Should()
                                       .BeEquivalentTo(expectedServiceMessage);
         }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -27,6 +27,7 @@ namespace Calamari.Tests.KubernetesFixtures
         string aksClusterName;
         string azurermResourceGroup;
         string aksPodServiceAccountToken;
+        string aksClusterFqdn;
 
         protected override string KubernetesCloudProvider => "AKS";
 
@@ -42,6 +43,7 @@ namespace Calamari.Tests.KubernetesFixtures
             aksClusterClientKey = jsonOutput["aks_cluster_client_key"]["value"].Value<string>();
             aksClusterCaCertificate = jsonOutput["aks_cluster_ca_certificate"]["value"].Value<string>();
             aksClusterName = jsonOutput["aks_cluster_name"]["value"].Value<string>();
+            aksClusterFqdn = jsonOutput["aks_cluster_fqdn"]["value"].Value<string>();
             aksPodServiceAccountToken = jsonOutput["aks_service_account_token"]["value"].Value<string>();
             azurermResourceGroup = jsonOutput["aks_rg_name"]["value"].Value<string>();
         }
@@ -151,7 +153,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 KubernetesDiscoveryCommand.CreateKubernetesTargetServiceMessageName,
                 new Dictionary<string, string>
                 {
-                    { "name", aksClusterName },
+                    { "name", aksClusterFqdn },
                     { "clusterName", aksClusterName },
                     { "clusterResourceGroup", azurermResourceGroup },
                     { "skipTlsVerification", bool.TrueString },

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/outputs.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/outputs.tf
@@ -33,11 +33,6 @@ output "aks_cluster_name" {
   value       = azurerm_kubernetes_cluster.default.name
 }
 
-output "aks_cluster_fqdn" {
-  description = "AKS Fully Qualified Domain Name"
-  value = azurerm_kubernetes_cluster.default.fqdn
-}
-
 output "aks_rg_name" {
   description = "RG name."
   value       = azurerm_resource_group.default.name

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/outputs.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/outputs.tf
@@ -33,6 +33,11 @@ output "aks_cluster_name" {
   value       = azurerm_kubernetes_cluster.default.name
 }
 
+output "aks_cluster_fqdn" {
+  description = "AKS Fully Qualified Domain Name"
+  value = azurerm_kubernetes_cluster.default.fqdn
+}
+
 output "aks_rg_name" {
   description = "RG name."
   value       = azurerm_resource_group.default.name


### PR DESCRIPTION
This is guaranteed to be unique even across different subscriptions etc.

Previously we were just using the cluster name which is obviously not unique across different subscriptions of resource groups.

This PR has pivoted to use the format `aks/{subscriptionid}/{resourcegroup}/{clustername}`
eg:
<img width="513" alt="image" src="https://user-images.githubusercontent.com/97430840/173477175-a29de070-6c78-40e8-b359-f3c219cf3cd1.png">
