### PR TITLE
Prevent unreachable k8 cluster from failing script

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -84,7 +84,24 @@ namespace Calamari.Tests.KubernetesFixtures
             return new Dictionary<string, string>();
         }
 
-        protected void TestScript(IScriptWrapper wrapper, string scriptName, string kubectlExe = "kubectl")
+        protected void TestScript(IScriptWrapper wrapper, string scriptName)
+        {
+            using (var dir = TemporaryDirectory.Create())
+            {
+                var folderPath = Path.Combine(dir.DirectoryPath, "Folder with spaces");
+        
+                using (var temp = new TemporaryFile(Path.Combine(folderPath, $"{scriptName}.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
+                {
+                    Directory.CreateDirectory(folderPath);
+                    File.WriteAllText(temp.FilePath, $"echo running target script...");
+        
+                    var output = ExecuteScript(wrapper, temp.FilePath);
+                    output.AssertSuccess();
+                }
+            }
+        }
+        
+        protected void TestScriptAndVerifyCluster(IScriptWrapper wrapper, string scriptName, string kubectlExe = "kubectl")
         {
             using (var dir = TemporaryDirectory.Create())
             {

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForAmazon.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForAmazon.cs
@@ -27,7 +27,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Aws.Region", Environment.GetEnvironmentVariable("AWS_REGION"));
 
             var wrapper = CreateWrapper();
-            TestScript(wrapper, "Test-Script");
+            TestScriptAndVerifyCluster(wrapper, "Test-Script");
         }
     }
 }

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -580,7 +580,7 @@ namespace Calamari.Kubernetes
                                              "namespace",
                                              @namespace))
                 {
-                    ExecuteKubectlCommand("create", "namespace", @namespace);
+                    TryExecuteKubectlCommand("create", "namespace", @namespace);
                 }
             }
 

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using Calamari.Common.Features.EmbeddedResources;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
@@ -159,7 +160,10 @@ namespace Calamari.Kubernetes
                     return errorResult;
                 }
 
-                CreateNamespace(@namespace);
+                if (!CreateNamespace(@namespace))
+                {
+                    log.Verbose("Could not create namespace. Continuing on, as it may not be working directly with the target.");
+                };
 
                 var outputKubeConfig = variables.GetFlag(SpecialVariables.OutputKubeConfig);
                 if (outputKubeConfig)
@@ -574,14 +578,12 @@ namespace Calamari.Kubernetes
                 return true;
             }
 
-            void CreateNamespace(string @namespace)
+            bool CreateNamespace(string @namespace)
             {
-                if (!TryExecuteKubectlCommand("get",
-                                             "namespace",
-                                             @namespace))
-                {
-                    TryExecuteKubectlCommand("create", "namespace", @namespace);
-                }
+                if (TryExecuteCommandWithVerboseLoggingOnly("get", "namespace", @namespace))
+                    return true;
+
+                return TryExecuteCommandWithVerboseLoggingOnly("create", "namespace", @namespace);
             }
 
             string GetAzEnvironment()
@@ -762,6 +764,11 @@ namespace Calamari.Kubernetes
                 return ExecuteCommand(new CommandLineInvocation(kubectl, arguments.Concat(new[] { "--request-timeout=1m" }).ToArray())).ExitCode == 0;
             }
 
+            bool TryExecuteCommandWithVerboseLoggingOnly(params string[] arguments)
+            {
+                return ExecuteCommandWithVerboseLoggingOnly(new CommandLineInvocation(kubectl, arguments.Concat(new[] { "--request-timeout=1m" }).ToArray())).ExitCode == 0;
+            }
+
             CommandResult ExecuteCommand(CommandLineInvocation invocation)
             {
                 invocation.EnvironmentVars = environmentVars;
@@ -800,6 +807,34 @@ namespace Calamari.Kubernetes
                 return result;
             }
 
+            /// <summary>
+            /// This is a special case for when the invocation results in an error
+            /// 1) but is to be expected as a valid scenario; and
+            /// 2) we don't want to inform this at an error level when this happens.
+            /// </summary>
+            /// <param name="invocation"></param>
+            /// <returns></returns>
+            CommandResult ExecuteCommandWithVerboseLoggingOnly(CommandLineInvocation invocation)
+            {
+                invocation.EnvironmentVars = environmentVars;
+                invocation.WorkingDirectory = workingDirectory;
+                invocation.OutputAsVerbose = true;
+                invocation.OutputToLog = false;
+
+                var captureCommandOutput = new CaptureCommandOutput();
+                invocation.AdditionalInvocationOutputSink = captureCommandOutput;
+
+                var commandString = invocation.ToString();
+                commandString = redactMap.Aggregate(commandString, (current, pair) => current.Replace(pair.Key, pair.Value));
+                log.Verbose(commandString);
+
+                var result = commandLineRunner.Execute(invocation);
+
+                captureCommandOutput.Messages.ForEach(message => log.Verbose(message.Text));
+
+                return result;
+            }
+
             IEnumerable<string> ExecuteCommandAndReturnOutput(string exe, params string[] arguments)
             {
                 var captureCommandOutput = new CaptureCommandOutput();
@@ -821,10 +856,7 @@ namespace Calamari.Kubernetes
 
             class CaptureCommandOutput : ICommandInvocationOutputSink
             {
-                private List<Message> messages = new List<Message>();
-
-                public List<Message> Messages => messages;
-
+                public List<Message> Messages { get; } = new List<Message>();
                 public void WriteInfo(string line)
                 {
                     Messages.Add(new Message(Level.Info, line));


### PR DESCRIPTION
**Background:**
When the EKS cluster is unreachable when Calamari tries to setup a k8 authentication context, the current state of Calamari throws an exception, causing the step to fail. This PR changes the behaviour to continue executing in the above scenario.

While the current behaviour make sense for a built-in k8 step, we would want to proceed execution of a target script as this may be a valid scenario where the script may not be directly working on the target.


[Fixes https://github.com/OctopusDeploy/Issues/issues/7506](https://github.com/OctopusDeploy/Issues/issues/7603)

Results
---
Before:
<img width="1136" alt="Screen Shot 2022-06-17 at 11 54 25 AM" src="https://user-images.githubusercontent.com/97423717/174196609-c22961d1-8307-49ab-8e48-cdfba1bdcd64.png">

After (+logs):
[ServerTasks-2429.log.txt](https://github.com/OctopusDeploy/Calamari/files/8953468/ServerTasks-2429.log.txt)
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/97423717/174916612-64689657-1aac-4ad8-bdb4-a3cb9b5f1a15.png">

---
