### PR TITLE
Prevent unreachable k8 cluster from failing script execution

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -76,7 +76,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 variables.Set("Octopus.Action.Kubernetes.PodServiceAccountTokenPath", podServiceAccountToken.FilePath);
                 variables.Set("Octopus.Action.Kubernetes.CertificateAuthorityPath", certificateAuthority.FilePath);
                 var wrapper = CreateWrapper();
-                TestScript(wrapper, "Test-Script");
+                TestScriptAndVerifyCluster(wrapper, "Test-Script");
             }
         }
         
@@ -92,7 +92,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Azure.Password", ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword));
             variables.Set("Octopus.Action.Azure.ClientId", ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId));
             var wrapper = CreateWrapper();
-            TestScript(wrapper, "Test-Script");
+            TestScriptAndVerifyCluster(wrapper, "Test-Script");
         }
 
         [Test]
@@ -107,9 +107,28 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set($"{clientCert}.CertificatePem", aksClusterClientCertificate);
             variables.Set($"{clientCert}.PrivateKeyPem", aksClusterClientKey);
             var wrapper = CreateWrapper();
+            TestScriptAndVerifyCluster(wrapper, "Test-Script");
+        }
+
+        [Test]
+        public void UnreachableK8Cluster_ShouldExecuteTargetScript()
+        {
+            const string certificateAuthority = "myauthority";
+            const string unreachableClusterUrl = "https://example.kubernetes.com";
+            const string clientCert = "myclientcert";
+            
+            variables.Set(SpecialVariables.ClusterUrl, unreachableClusterUrl);
+            variables.Set("Octopus.Action.Kubernetes.CertificateAuthority", certificateAuthority);
+            variables.Set($"{certificateAuthority}.CertificatePem", aksClusterCaCertificate);
+            variables.Set("Octopus.Action.Kubernetes.ClientCertificate", clientCert);
+            variables.Set($"{clientCert}.CertificatePem", aksClusterClientCertificate);
+            variables.Set($"{clientCert}.PrivateKeyPem", aksClusterClientKey);
+
+            var wrapper = CreateWrapper();
+
             TestScript(wrapper, "Test-Script");
         }
-        
+
         [Test]
         public void DiscoverKubernetesClusterWithAzureServicePrincipalAccount()
         {

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -90,7 +90,24 @@ namespace Calamari.Tests.KubernetesFixtures
             return new Dictionary<string, string>();
         }
 
-        protected void TestScript(IScriptWrapper wrapper, string scriptName, string kubectlExe = "kubectl")
+        protected void TestScript(IScriptWrapper wrapper, string scriptName)
+        {
+            using (var dir = TemporaryDirectory.Create())
+            {
+                var folderPath = Path.Combine(dir.DirectoryPath, "Folder with spaces");
+
+                using (var temp = new TemporaryFile(Path.Combine(folderPath, $"{scriptName}.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
+                {
+                    Directory.CreateDirectory(folderPath);
+                    File.WriteAllText(temp.FilePath, $"echo running target script...");
+
+                    var output = ExecuteScript(wrapper, temp.FilePath);
+                    output.AssertSuccess();
+                }
+            }
+        }
+        
+        protected void TestScriptAndVerifyCluster(IScriptWrapper wrapper, string scriptName, string kubectlExe = "kubectl")
         {
             using (var dir = TemporaryDirectory.Create())
             {

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -95,7 +95,28 @@ namespace Calamari.Tests.KubernetesFixtures
             var kubectlExecutable = variables.Get(KubeCtlExecutableVariableName) ??
                 throw new Exception($"Unable to find required kubectl executable in variable '{KubeCtlExecutableVariableName}'");
             
-            TestScript(wrapper, "Test-Script", kubectlExecutable);
+            TestScriptAndVerifyCluster(wrapper, "Test-Script", kubectlExecutable);
+        }
+
+        [Test]
+        public void UnreachableK8Cluster_ShouldExecuteTargetScript()
+        {
+            const string account = "eks_account";
+            const string certificateAuthority = "myauthority";
+            const string unreachableClusterEndpoint = "https://example.kubernetes.com";
+            
+            variables.Set(Deployment.SpecialVariables.Account.AccountType, "AmazonWebServicesAccount");
+            variables.Set(SpecialVariables.ClusterUrl, unreachableClusterEndpoint);
+            variables.Set(SpecialVariables.EksClusterName, eksClusterName);
+            variables.Set("Octopus.Action.Aws.Region", region);
+            variables.Set("Octopus.Action.AwsAccount.Variable", account);
+            variables.Set($"{account}.AccessKey", eksClientID);
+            variables.Set($"{account}.SecretKey", eksSecretKey);
+            variables.Set("Octopus.Action.Kubernetes.CertificateAuthority", certificateAuthority);
+            variables.Set($"{certificateAuthority}.CertificatePem", eksClusterCaCertificate);
+            var wrapper = CreateWrapper();
+
+            TestScript(wrapper, "Test-Script");
         }
 
         [Test]

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
@@ -49,7 +49,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Aws.Region", region);
 
             var wrapper = CreateWrapper();
-            TestScript(wrapper, "Test-Script");
+            TestScriptAndVerifyCluster(wrapper, "Test-Script");
         }
 
         [Test]

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureGke.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureGke.cs
@@ -62,7 +62,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Kubernetes.CertificateAuthority", certificateAuthority);
             variables.Set($"{certificateAuthority}.CertificatePem", gkeClusterCaCertificate);
             var wrapper = CreateWrapper();
-            TestScript(wrapper, "Test-Script");
+            TestScriptAndVerifyCluster(wrapper, "Test-Script");
         }
 
         [Test]
@@ -77,6 +77,23 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.GoogleCloud.Project", gkeProject);
             variables.Set("Octopus.Action.GoogleCloud.Zone", gkeLocation);
             var wrapper = CreateWrapper();
+            TestScriptAndVerifyCluster(wrapper, "Test-Script");
+        }
+
+        [Test]
+        public void UnreachableK8Cluster_ShouldExecuteTargetScript()
+        {
+            const string unreachableClusterUrl = "https://example.kubernetes.com";
+            const string certificateAuthority = "myauthority";
+
+            variables.Set(SpecialVariables.ClusterUrl, unreachableClusterUrl);
+            variables.Set(Deployment.SpecialVariables.Account.AccountType, "Token");
+            variables.Set(Deployment.SpecialVariables.Account.Token, gkeToken);
+            variables.Set("Octopus.Action.Kubernetes.CertificateAuthority", certificateAuthority);
+            variables.Set($"{certificateAuthority}.CertificatePem", gkeClusterCaCertificate);
+
+            var wrapper = CreateWrapper();
+
             TestScript(wrapper, "Test-Script");
         }
     }


### PR DESCRIPTION
**Background:**
When the EKS cluster is unreachable when Calamari tries to setup a k8 authentication context, the current state of Calamari throws an exception, causing the step to fail. This PR changes the behaviour to continue executing in the above scenario.

While the current behaviour make sense for a built-in k8 step, we would want to proceed execution of a target script as this may be a valid scenario where the script may not be directly working on the target.


[Fixes https://github.com/OctopusDeploy/Issues/issues/7506](https://github.com/OctopusDeploy/Issues/issues/7603)

Results
---
Before:
<img width="1136" alt="Screen Shot 2022-06-17 at 11 54 25 AM" src="https://user-images.githubusercontent.com/97423717/174196609-c22961d1-8307-49ab-8e48-cdfba1bdcd64.png">

After (+logs):
[ServerTasks-2429.log.txt](https://github.com/OctopusDeploy/Calamari/files/8953468/ServerTasks-2429.log.txt)
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/97423717/174916612-64689657-1aac-4ad8-bdb4-a3cb9b5f1a15.png">

---
