### PR TITLE
Backporting change to install a fixed version of Kubectl (d51f6b2d6965)

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -58,9 +58,11 @@ namespace Calamari.Tests.KubernetesFixtures
                 KubectlExecutable = await DownloadCli("Kubectl",
                                                       async () =>
                                                       {
-                                                          var message = await client.GetAsync("https://storage.googleapis.com/kubernetes-release/release/stable.txt");
-                                                          message.EnsureSuccessStatusCode();
-                                                          return (await message.Content.ReadAsStringAsync(), null);
+                                                          // TODO: Figure out if we want to continue using stable version even if bugs may be introduced.
+                                                          // var message = await client.GetAsync("https://storage.googleapis.com/kubernetes-release/release/stable.txt");
+                                                          // message.EnsureSuccessStatusCode();
+                                                          // return (await message.Content.ReadAsStringAsync(), null);
+                                                          return await Task.FromResult(("v1.23.6", ""));
                                                       },
                                                       async (destinationDirectoryName, tuple) =>
                                                       {


### PR DESCRIPTION
**Background**
Adding the changes for #848 to LTS branches. Without this, tests will try to download the latest kubectl version which causes the tests to fail with `invalid apiVersion "client.authentication.k8s.io/v1alpha1"`