### PR TITLE
Add keyVaultTenantId when signing using azure signtool

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -63,6 +63,10 @@ namespace Calamari.Build
         [Secret]
         readonly string? AzureKeyVaultAppSecret;
 
+        [Parameter]
+        [Secret]
+        readonly string? AzureKeyVaultTenantId;
+
         [Parameter] 
         readonly string? AzureKeyVaultCertificateName;
 
@@ -362,7 +366,7 @@ namespace Calamari.Build
 
             if (WillSignBinaries)
                 Signing.SignAndTimestampBinaries(publishedTo, AzureKeyVaultUrl, AzureKeyVaultAppId,
-                                                 AzureKeyVaultAppSecret, AzureKeyVaultCertificateName,
+                                                 AzureKeyVaultAppSecret, AzureKeyVaultTenantId, AzureKeyVaultCertificateName,
                                                  SigningCertificatePath, SigningCertificatePassword);
 
             return publishedTo;
@@ -379,7 +383,7 @@ namespace Calamari.Build
                     Directory.GetDirectories(binDirectory, "*", new EnumerationOptions { RecurseSubdirectories = true });
                 foreach (var directory in binariesFolders)
                     Signing.SignAndTimestampBinaries(directory, AzureKeyVaultUrl, AzureKeyVaultAppId,
-                                                     AzureKeyVaultAppSecret, AzureKeyVaultCertificateName,
+                                                     AzureKeyVaultAppSecret, AzureKeyVaultTenantId, AzureKeyVaultCertificateName,
                                                      SigningCertificatePath, SigningCertificatePassword);
             }
             
@@ -402,7 +406,7 @@ namespace Calamari.Build
 
             if (WillSignBinaries)
                 Signing.SignAndTimestampBinaries(publishedTo, AzureKeyVaultUrl, AzureKeyVaultAppId,
-                                                 AzureKeyVaultAppSecret, AzureKeyVaultCertificateName,
+                                                 AzureKeyVaultAppSecret, AzureKeyVaultTenantId, AzureKeyVaultCertificateName,
                                                  SigningCertificatePath, SigningCertificatePassword);
 
             var nuspec = $"{publishedTo}/{packageId}.nuspec";

--- a/build/Signing.cs
+++ b/build/Signing.cs
@@ -23,6 +23,7 @@ namespace Calamari.Build
             string? azureKeyVaultUrl,
             string? azureKeyVaultAppId,
             string? azureKeyVaultAppSecret,
+            string? azureKeyVaultTenantId,
             string? azureKeyVaultCertificateName,
             string? signingCertificatePath,
             string? signingCertificatePassword)
@@ -50,6 +51,7 @@ namespace Calamari.Build
             if (azureKeyVaultUrl.IsNullOrEmpty() &&
                 azureKeyVaultAppId.IsNullOrEmpty() &&
                 azureKeyVaultAppSecret.IsNullOrEmpty() &&
+                azureKeyVaultTenantId.IsNullOrEmpty() &&
                 azureKeyVaultCertificateName.IsNullOrEmpty())
             {
                 if (signingCertificatePath.IsNullOrEmpty() ||
@@ -75,6 +77,7 @@ namespace Calamari.Build
                     azureKeyVaultUrl!,
                     azureKeyVaultAppId!,
                     azureKeyVaultAppSecret!,
+                    azureKeyVaultTenantId!,
                     azureKeyVaultCertificateName!);
             }
         }
@@ -102,6 +105,7 @@ namespace Calamari.Build
             string vaultUrl,
             string vaultAppId,
             string vaultAppSecret,
+            string vaultTenantId,
             string vaultCertificateName,
             string display = "",
             string displayUrl = "")
@@ -113,6 +117,7 @@ namespace Calamari.Build
                     _.SetKeyVaultUrl(vaultUrl)
                      .SetKeyVaultClientId(vaultAppId)
                      .SetKeyVaultClientSecret(vaultAppSecret)
+                     .SetKeyVaultTenantId(vaultTenantId)
                      .SetKeyVaultCertificateName(vaultCertificateName)
                      .SetFileDigest("sha256")
                      .SetDescription(display)

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -21,12 +21,12 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Nuke.Common" Version="6.0.1" />
+        <PackageReference Include="Nuke.Common" Version="6.1.1" />
 <!--        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />-->
     </ItemGroup>
 
     <ItemGroup>
-      <PackageDownload Include="AzureSignTool" Version="[2.0.17]" />
+      <PackageDownload Include="AzureSignTool" Version="[3.0.0]" />
       <PackageDownload Include="GitVersion.Tool" Version="[5.9.0]" />
     </ItemGroup>
 


### PR DESCRIPTION
This is effectively the same as #866 and #868 but slightly different - as cake has been nuked.

* Add keyVaultTenantId when signing with Azure Sign Tool
* Updates `Nuke.Common` version to latest - from `6.0.1` to  `6.1.1`