### PR TITLE
Suggested rework to `PublishCalamariFlavourProjects` build target

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -134,6 +134,7 @@ namespace Calamari.Build
                 SourceDirectory.GlobDirectories("**/bin", "**/obj", "**/TestResults").ForEach(DeleteDirectory);
                 EnsureCleanDirectory(ArtifactsDirectory);
                 EnsureCleanDirectory(PublishDirectory);
+                EnsureCleanDirectory(SashimiPackagesDirectory);
             });
 
         Target Restore =>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -201,8 +201,10 @@ namespace Calamari.Build
                     // eg: net40, net452, net48 vs netcoreapp3.1, net5.0, net6.0
                     bool IsCrossPlatform(string targetFramework) => targetFramework.Contains(".");
 
+                    var migratedCalamariFlavoursTests = MigratedCalamariFlavours.Flavours.Select(f => $"{f}.Tests");
                     var calamariFlavours = Solution.Projects
-                        .Where(project => MigratedCalamariFlavours.Flavours.Contains(project.Name));
+                                                   .Where(project => MigratedCalamariFlavours.Flavours.Contains(project.Name)
+                                                                     || migratedCalamariFlavoursTests.Contains(project.Name));
 
                     var packagesToBuild = calamariFlavours
                         .SelectMany(project => project.GetTargetFrameworks(), (p, f) => new
@@ -218,7 +220,7 @@ namespace Calamari.Build
                             Architecture = packageToBuild.CrossPlatform ? runtimeIdentifier : null,
                             packageToBuild.CrossPlatform
                         })
-                        .Distinct(t => new { t.Architecture, t.Framework });
+                        .Distinct(t => new { t.Project.Name, t.Architecture, t.Framework });
 
                     foreach (var packageToBuild in packagesToBuild)
                     {


### PR DESCRIPTION
This PR suggests a clearer and cleaner way to prepare the Calamari Flavour Projects for consolidation. It:

* Uses the structured `Solution` object to inspect projects rather than XML-searching the `csproj` files
* Removes the nested looping and conditionals, in favour of doing that work in LINQ before iterating
* Gives clearer names to most of the things involved
* Cleans up the whole `netfx` vs `netcore` thing with some more deliberate handling
* Has consistent whitespace and indentation