### PR TITLE
Remove min nuget version

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -103,6 +103,7 @@ namespace Calamari.Build
         static AbsolutePath LocalPackagesDirectory => RootDirectory / "../LocalPackages";
 
         static AbsolutePath SashimiPackagesDirectory => SourceDirectory / "Calamari.UnmigratedCalamariFlavours" / "artifacts";
+        static AbsolutePath ConsolidatedPackageDirectory => ArtifactsDirectory / "consolidated";
 
         Lazy<string> NugetVersion { get; }
 
@@ -401,7 +402,8 @@ namespace Calamari.Build
                                     });
                                 }
 
-                                var (result, packageFilename) = new Consolidate(Log.Logger).Execute(ArtifactsDirectory / "consolidated", packageReferences);
+                                Directory.CreateDirectory(ConsolidatedPackageDirectory);
+                                var (result, packageFilename) = new Consolidate(Log.Logger).Execute(ConsolidatedPackageDirectory, packageReferences);
 
                                 if (!result)
                                     throw new Exception("Failed to consolidate calamari Packages");

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -401,7 +401,7 @@ namespace Calamari.Build
                                     });
                                 }
 
-                                var (result, packageFilename) = new Consolidate(Log.Logger).Execute(ArtifactsDirectory, packageReferences);
+                                var (result, packageFilename) = new Consolidate(Log.Logger).Execute(ArtifactsDirectory / "consolidated", packageReferences);
 
                                 if (!result)
                                     throw new Exception("Failed to consolidate calamari Packages");

--- a/build/Calamari.Consolidated.nuspec
+++ b/build/Calamari.Consolidated.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-    <metadata minClientVersion="100.0.0.1">
+    <metadata>
         <id>Calamari.Consolidated</id>
         <version>$version$</version>
         <title />

--- a/build/Calamari.Consolidated.nuspec
+++ b/build/Calamari.Consolidated.nuspec
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-    
     <metadata>
         <id>Calamari.Consolidated</id>
         <version>$version$</version>
@@ -9,10 +8,10 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Contains consolidated zip file of all Calamari flavours</description>
         <contentFiles>
-            <files include="any/any/Calamari.*.zip" buildAction="None" copyToOutput="true"/>
+            <files include="any/any/Calamari.*.zip" buildAction="None" copyToOutput="true" />
         </contentFiles>
     </metadata>
     <files>
-        <file src="..\artifacts\consolidated\Calamari.*.zip" target="contentFiles\any\any\"/>
+        <file src="..\artifacts\consolidated\Calamari.*.zip" target="contentFiles\any\any\" />
     </files>
 </package>

--- a/build/Calamari.Consolidated.nuspec
+++ b/build/Calamari.Consolidated.nuspec
@@ -8,9 +8,6 @@
         <authors>Octopus Deploy</authors>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Contains consolidated zip file of all Calamari flavours</description>
-        <dependencies>
-            <group targetFramework="net6.0" />
-        </dependencies>
         <contentFiles>
             <files include="any/any/Calamari.*.zip" buildAction="None" copyToOutput="true"/>
         </contentFiles>

--- a/build/Calamari.Consolidated.nuspec
+++ b/build/Calamari.Consolidated.nuspec
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    
     <metadata>
         <id>Calamari.Consolidated</id>
         <version>$version$</version>
@@ -7,8 +8,14 @@
         <authors>Octopus Deploy</authors>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Contains consolidated zip file of all Calamari flavours</description>
+        <dependencies>
+            <group targetFramework="net6.0" />
+        </dependencies>
+        <contentFiles>
+            <files include="any/any/Calamari.*.zip" buildAction="Content" copyToOutput="true"/>
+        </contentFiles>
     </metadata>
     <files>
-        <file src="..\artifacts\Calamari.*.zip" target="contentFiles\any\any\" />
+        <file src="..\artifacts\consolidated\Calamari.*.zip" target="contentFiles\any\any\"/>
     </files>
 </package>

--- a/build/Calamari.Consolidated.nuspec
+++ b/build/Calamari.Consolidated.nuspec
@@ -12,7 +12,7 @@
             <group targetFramework="net6.0" />
         </dependencies>
         <contentFiles>
-            <files include="any/any/Calamari.*.zip" buildAction="Content" copyToOutput="true"/>
+            <files include="any/any/Calamari.*.zip" buildAction="None" copyToOutput="true"/>
         </contentFiles>
     </metadata>
     <files>


### PR DESCRIPTION
There was a previous error in `Calamari.Consolidated.nuspec` that prevents server from consuming the generated package. This is fixed in this PR.