### PR TITLE
Consolidated package clears stale zips during build

### DIFF
--- a/build/Calamari.Consolidated.nuspec
+++ b/build/Calamari.Consolidated.nuspec
@@ -13,5 +13,6 @@
     </metadata>
     <files>
         <file src="..\artifacts\consolidated\Calamari.*.zip" target="contentFiles\any\any\" />
+        <file src="Calamari.Consolidated.targets" target="build\" />
     </files>
 </package>

--- a/build/Calamari.Consolidated.targets
+++ b/build/Calamari.Consolidated.targets
@@ -1,12 +1,18 @@
 <Project>
-  <Target Name="ClearOldConsolidatedCalamariPackages" BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectory">
+  <Target Name="ClearOldConsolidatedCalamariPackages" AfterTargets="CopyFilesToOutputDirectory">
     <ItemGroup>
-       <FilesToDelete Include="$(OutDir)\Calamari.*.zip"/>
-     </ItemGroup>
-     <Message Text="Clearing Consolidated Calamari packages from $(OutDir)"/>
-     <Delete Files="@(FilesToDelete)">
-       <Output TaskParameter="DeletedFiles" ItemName="FilesDeleted" />
-     </Delete>
-     <Message Text="Removed: @(FilesDeleted)"/>
+      <TargetCalamari
+        Include="@(None);@(Content)"
+        Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)', '^Calamari\.([a-zA-Z0-9]*)$')) AND '%(Extension)' == '.zip'" />
+      <OldCalamari Include="$(OutDir)\Calamari.*.zip" />
+      <OldCalamari Remove="@(TargetCalamari)" MatchOnMetadata="Filename" />
+    </ItemGroup>
+    <Message Text="Clearing stale Consolidated Calamari packages from $(OutDir)"/>
+    <Message Text="Current Calamari package to keep is @(TargetCalamari)"/>
+    <Message Text="Stale Calamari packages are @(OldCalamari)"/>
+    <Delete Files="@(OldCalamari)">
+      <Output TaskParameter="DeletedFiles" ItemName="OldCalamariDeleted" />
+    </Delete>
+    <Message Text="Cleared stale Calamari packages: @(OldCalamariDeleted)"/>
   </Target>
 </Project>

--- a/build/Calamari.Consolidated.targets
+++ b/build/Calamari.Consolidated.targets
@@ -1,0 +1,12 @@
+<Project>
+  <Target Name="ClearOldConsolidatedCalamariPackages" BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectory">
+    <ItemGroup>
+       <FilesToDelete Include="$(OutDir)\Calamari.*.zip"/>
+     </ItemGroup>
+     <Message Text="Clearing Consolidated Calamari packages from $(OutDir)"/>
+     <Delete Files="@(FilesToDelete)">
+       <Output TaskParameter="DeletedFiles" ItemName="FilesDeleted" />
+     </Delete>
+     <Message Text="Removed: @(FilesDeleted)"/>
+  </Target>
+</Project>


### PR DESCRIPTION
# Background
The CCPT used to proactively go and [clear any old Consolidated packages](https://github.com/OctopusDeploy/ConsolidateCalamariPackagesTask/blob/master/source/ConsolidateCalamariPackagesTask/Consolidate.cs#L42) from the consuming project's `bin` directory as part of the compilation phase. 

We've recently moved that consolidation work from Server to this Calamari repo.

## Before
In our new world, we don't yet have anything equivalent, so it's possible for multiple Consolidated packages to accrue in Server's `bin` directory, which is both a waste of space, and likely breaks the system, because Server wouldn't know which one is the correct one to pick up.

## After
This PR updates the `Calamari.Consolidated.nupkg` to include an MSBuild `targets` file. By convention, NuGet and `dotnet` know that this target should be integrated into the build process of any project referencing this package.

This `targets` file introduces a Build Target to the MSBuild pipeline called `ClearOldConsolidatedCalamariPackages`, which triggers just before any missing Content files are copied to the `bin` directory. 

This target deletes any existing Consolidated Calamari packages, which handles cases like upgrading from Server-built Calamari to our new pre-packaged Consolidated package, or upgrading between versions of the pre-packaged Consolidated package (which will have different file names, and so would have caused duplication).

## Drawback/Future Improvements
~There is a slight inefficiency here, in that any time the `_CopyOutOfDateSourceItemsToOutputDirectory` target triggers (which MSBuild will do if _any_ of the Content files for the project are out of date and need to be copied over), then we will delete matching Calamari zips from the bin directory, including our desired one.~

~This means that if an unrelated content file (eg `docs.html`) changed, this target would run, and we would have a slightly unnecessary deletion and re-copy of our Calamari package to the bin directory. It's all entirely functional, but it's not as optimised as it could be.~

~In the future, we could look into using MSBuild's Output properties to get name of our expected "proper" version of the Calamari package, and add that as an exclusion to the deletion, which would allow us to run this Target later in the build pipeline (eg after compile). But for now, this should be good enough.~

I've added a commit which changes the approach to be much more targeted, removing this drawback. The changes are:

* First go and find the current Calamari consolidated package our Project is referencing
* Then, go search the bin directory for all potential Calamari packages, but exclude the latest one

This then allows us to run the purge at a less specific time, because the timing no longer matters: the task will only delete truly stale files.

This also fixes the inefficiency where we might be needlessly deleting and re-copying the same file.