### PR TITLE
Fix AzureKubernetesDiscoverer Name to match what server sends

### DIFF
--- a/source/Calamari.Aws/Kubernetes/Discovery/AwsKubernetesDiscoverer.cs
+++ b/source/Calamari.Aws/Kubernetes/Discovery/AwsKubernetesDiscoverer.cs
@@ -16,8 +16,8 @@ namespace Calamari.Aws.Kubernetes.Discovery
         {
         }
 
-        public override string Name => "Aws";
-        
+        public override string Type => "Aws";
+
         public override IEnumerable<KubernetesCluster> DiscoverClusters(string contextJson)
         {
             if (!TryGetDiscoveryContext<AwsAuthenticationDetails>(contextJson, out var authenticationDetails, out var workerPoolId))

--- a/source/Calamari.Aws/Kubernetes/Discovery/AwsKubernetesDiscoverer.cs
+++ b/source/Calamari.Aws/Kubernetes/Discovery/AwsKubernetesDiscoverer.cs
@@ -16,30 +16,36 @@ namespace Calamari.Aws.Kubernetes.Discovery
         {
         }
 
+        /// <remarks>
+        /// This type value here must be the same as in Octopus.Server.Orchestration.ServerTasks.Deploy.TargetDiscovery.AwsAuthenticationContext
+        /// This value is hardcoded because:
+        /// a) There is currently no existing project to place code shared between server and Calamari, and
+        /// b) We expect a bunch of stuff in the Sashimi/Calamari space to be refactored back into the OctopusDeploy solution soon.
+        /// </remarks>
         public override string Type => "Aws";
 
         public override IEnumerable<KubernetesCluster> DiscoverClusters(string contextJson)
         {
             if (!TryGetDiscoveryContext<AwsAuthenticationDetails>(contextJson, out var authenticationDetails, out var workerPoolId))
                 yield break;
-            
+
             var accessKeyOrWorkerCredentials = authenticationDetails.Credentials.Type == "account"
                 ? $"Access Key: {authenticationDetails.Credentials.Account.AccessKey}"
                 : $"Using Worker Credentials on Worker Pool: {workerPoolId}";
 
             Log.Verbose("Looking for Kubernetes clusters in AWS using:");
             Log.Verbose($"  Regions: [{string.Join(",",authenticationDetails.Regions)}]");
-            
+
             Log.Verbose("  Account:");
             Log.Verbose($"    {accessKeyOrWorkerCredentials}");
-            
+
             if (authenticationDetails.Role.Type == "assumeRole")
             {
                 Log.Verbose("  Role:");
                 Log.Verbose($"    ARN: {authenticationDetails.Role.Arn}");
                 if (!authenticationDetails.Role.SessionName.IsNullOrEmpty())
                     Log.Verbose($"    Session Name: {authenticationDetails.Role.SessionName}");
-                if (authenticationDetails.Role.SessionDuration != null) 
+                if (authenticationDetails.Role.SessionDuration != null)
                     Log.Verbose($"    Session Duration: {authenticationDetails.Role.SessionDuration}");
                 if (!authenticationDetails.Role.ExternalId.IsNullOrEmpty())
                     Log.Verbose($"    External Id: {authenticationDetails.Role.ExternalId}");
@@ -51,7 +57,7 @@ namespace Calamari.Aws.Kubernetes.Discovery
 
             if (!authenticationDetails.TryGetCredentials(Log, out var credentials))
                 yield break;
-            
+
             foreach (var region in authenticationDetails.Regions)
             {
                 var client = new AmazonEKSClient(credentials,
@@ -69,7 +75,7 @@ namespace Calamari.Aws.Kubernetes.Discovery
                             credentialsRole.SessionDuration,
                             credentialsRole.ExternalId)
                         : null;
-                    
+
                     yield return KubernetesCluster.CreateForEks(cluster.Arn,
                         cluster.Name,
                         cluster.Endpoint,

--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -14,7 +14,7 @@ namespace Calamari.Azure.Kubernetes.Discovery
         {
         }
 
-        public override string Name => KubernetesAuthenticationContextTypes.AzureServicePrincipal;
+        public override string Name => "Azure";
 
         public override IEnumerable<KubernetesCluster> DiscoverClusters(string contextJson)
         {

--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -14,7 +14,7 @@ namespace Calamari.Azure.Kubernetes.Discovery
         {
         }
 
-        public override string Name => "Azure";
+        public override string Type => "Azure";
 
         public override IEnumerable<KubernetesCluster> DiscoverClusters(string contextJson)
         {

--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -7,27 +7,33 @@ using Calamari.Common.Plumbing.Logging;
 namespace Calamari.Azure.Kubernetes.Discovery
 {
     using AzureTargetDiscoveryContext = TargetDiscoveryContext<AccountAuthenticationDetails<ServicePrincipalAccount>>;
-    
+
     public class AzureKubernetesDiscoverer : KubernetesDiscovererBase
     {
         public AzureKubernetesDiscoverer(ILog log) : base(log)
         {
         }
 
+        /// <remarks>
+        /// This type value here must be the same as in Octopus.Server.Orchestration.ServerTasks.Deploy.TargetDiscovery.TargetDiscoveryAuthenticationDetailsFactory.AzureAuthenticationDetailsFactory
+        /// This value is hardcoded because:
+        /// a) There is currently no existing project to place code shared between server and Calamari, and
+        /// b) We expect a bunch of stuff in the Sashimi/Calamari space to be refactored back into the OctopusDeploy solution soon.
+        /// </remarks>
         public override string Type => "Azure";
 
         public override IEnumerable<KubernetesCluster> DiscoverClusters(string contextJson)
         {
             if (!TryGetDiscoveryContext<AccountAuthenticationDetails<ServicePrincipalAccount>>(contextJson, out var authenticationDetails, out _))
                 return Enumerable.Empty<KubernetesCluster>();
-            
+
             var account = authenticationDetails.AccountDetails;
             Log.Verbose("Looking for Kubernetes clusters in Azure using:");
             Log.Verbose($"  Subscription ID: {account.SubscriptionNumber}");
             Log.Verbose($"  Tenant ID: {account.TenantId}");
             Log.Verbose($"  Client ID: {account.ClientId}");
             var azureClient = account.CreateAzureClient();
-            
+
             return azureClient.KubernetesClusters.List()
                               .Select(c => KubernetesCluster.CreateForAks(
                                   $"aks/{account.SubscriptionNumber}/{c.ResourceGroupName}/{c.Name}",

--- a/source/Calamari.Common/Features/Discovery/IKubernetesDiscoverer.cs
+++ b/source/Calamari.Common/Features/Discovery/IKubernetesDiscoverer.cs
@@ -6,8 +6,8 @@ namespace Calamari.Common.Features.Discovery
 {
     public interface IKubernetesDiscoverer
     {
-        string Name { get; }
-        
+        string Type { get; }
+
         IEnumerable<KubernetesCluster> DiscoverClusters(string contextJson);
     }
 }

--- a/source/Calamari.Common/Features/Discovery/KubernetesDiscovererBase.cs
+++ b/source/Calamari.Common/Features/Discovery/KubernetesDiscovererBase.cs
@@ -62,7 +62,7 @@ namespace Calamari.Common.Features.Discovery
                 $"{(exception == null ? "." : $":{exception}")}.");
         }
 
-        public abstract string Name { get; }
+        public abstract string Type { get; }
         public abstract IEnumerable<KubernetesCluster> DiscoverClusters(string contextJson);
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -153,7 +153,7 @@ namespace Calamari.Tests.KubernetesFixtures
         
             var authenticationDetails =
                 new AccountAuthenticationDetails<ServicePrincipalAccount>(
-                    KubernetesAuthenticationContextTypes.AzureServicePrincipal,
+                    "Azure",
                     "Accounts-1",
                     account);
         

--- a/source/Calamari/Kubernetes/Commands/Discovery/KubernetesDiscovererFactory.cs
+++ b/source/Calamari/Kubernetes/Commands/Discovery/KubernetesDiscovererFactory.cs
@@ -13,7 +13,7 @@ namespace Calamari.Kubernetes.Commands.Discovery
 
         public KubernetesDiscovererFactory(IEnumerable<IKubernetesDiscoverer> discoverers)
         {
-            this.discoverers = discoverers.ToDictionary(x => x.Name, x => x);
+            this.discoverers = discoverers.ToDictionary(x => x.Type, x => x);
         }
         
         public bool TryGetKubernetesDiscoverer(string type, out IKubernetesDiscoverer discoverer)


### PR DESCRIPTION
# Background

After looking at @IsaacCalligeros95's [PR](https://github.com/OctopusDeploy/Calamari/pull/898) I realised I had introduced a bug in K8s target discovery when I [added Target Discovery Telemetry](https://github.com/OctopusDeploy/OctopusDeploy/pull/12707). It broke because I forgot that K8s target discovery uses the Type property on the Authentication Context payload to figure out which type of discoverer to use (AWS or Azure). Previously the `Type` value for the Azure payload would be `"AzureServicePrinciple"` but now it is `"Azure"` as the authentication method eg: `"ServicePrinciple"` is stored on a separate property (which isn't including in Calamari, as it's only used in Telemetry on Server). 

# Results
I've updated the value of the `Name` property on `AzureKubernetesDiscoverer` to `"Azure"` to match what the server sends but I've also updated the `Name` property to be called `Type` to match the property name on the Authentication Context.

Story: [sc-9442]
