### PR TITLE
Adding AzureResourceGroupActionHandlerFixutre tests from Sashimi.AzureResourceGroup

### DIFF
--- a/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Calamari.Common.Features.Deployment;
+using Calamari.Common.Features.Scripts;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Testing;
+using Calamari.Testing.Helpers;
+using Calamari.Tests;
+using Calamari.Tests.Fixtures;
+using Microsoft.Azure.Management.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Calamari.AzureResourceGroup.Tests
+{
+    [TestFixture]
+    class AzureResourceGroupActionHandlerFixture
+    {
+        string clientId;
+        string clientSecret;
+        string tenantId;
+        string subscriptionId;
+        IResourceGroup resourceGroup;
+        IAzure azure;
+        
+        static string GetTestPath(params string[] paths) => Path.Combine(TestEnvironment.CurrentWorkingDirectory ?? string.Empty, Path.Combine(paths));
+
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            clientId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId);
+            clientSecret = ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword);
+            tenantId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId);
+            subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
+
+            var resourceGroupName = SdkContext.RandomResourceName(nameof(AzureResourceGroupActionHandlerFixture), 60);
+
+            var credentials = SdkContext.AzureCredentialsFactory.FromServicePrincipal(clientId,
+                                                                                      clientSecret,
+                                                                                      tenantId,
+                                                                                      AzureEnvironment.AzureGlobalCloud);
+
+            azure = Microsoft.Azure.Management.Fluent.Azure
+                             .Configure()
+                             .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
+                             .Authenticate(credentials)
+                             .WithSubscription(subscriptionId);
+
+            resourceGroup = await azure.ResourceGroups
+                                       .Define(resourceGroupName)
+                                       .WithRegion(Region.USWest)
+                                       .CreateAsync();
+        }
+
+        [OneTimeTearDown]
+        public async Task Cleanup()
+        {
+            if (resourceGroup != null)
+            {
+                await azure.ResourceGroups.DeleteByNameAsync(resourceGroup.Name);
+            }
+        }
+
+        [Test]
+        public void Deploy_with_template_in_package()
+        {
+            var packagePath = TestEnvironment.GetTestPath("Packages", "AzureResourceGroup");
+            CommandTestBuilder.CreateAsync<DeployAzureResourceGroupCommand, Program>()
+                                    .WithArrange(context =>
+                                                 {
+                                                     AddDefaults(context);
+                                                     context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupDeploymentMode, "Complete");
+                                                     context.Variables.Add("Octopus.Action.Azure.TemplateSource", "Package");
+                                                     context.Variables.Add("Octopus.Action.Azure.ResourceGroupTemplate", "azure_website_template.json");
+                                                     context.Variables.Add("Octopus.Action.Azure.ResourceGroupTemplateParameters", "azure_website_params.json");
+                                                     context.WithFilesToCopy(packagePath);
+                                                 })
+                                    .Execute();
+        }
+
+        [Test]
+        public void Deploy_with_template_inline()
+        {
+            var packagePath = TestEnvironment.GetTestPath("Packages", "AzureResourceGroup");
+            var paramsFileContent = File.ReadAllText(Path.Combine(packagePath, "azure_website_params.json"));
+            var parameters = JObject.Parse(paramsFileContent)["parameters"].ToString();
+
+            CommandTestBuilder.CreateAsync<DeployAzureResourceGroupCommand, Program>()
+                              .WithArrange(context =>
+                                           {
+                                               AddDefaults(context);
+                                               context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupDeploymentMode, "Complete");
+                                               context.Variables.Add("Octopus.Action.Azure.TemplateSource", "Inline");
+                                               context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupTemplate, File.ReadAllText(Path.Combine(packagePath, "azure_website_template.json")));
+                                               context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupTemplateParameters, parameters);
+
+                                               context.WithFilesToCopy(packagePath);
+                                           })
+                              .Execute();
+        }
+
+        [Test]
+        [WindowsTest]
+        [RequiresPowerShell5OrAbove]
+        public void Deploy_Ensure_Tools_Are_Configured()
+        {
+            var packagePath = TestEnvironment.GetTestPath("Packages", "AzureResourceGroup");
+            var paramsFileContent = File.ReadAllText(Path.Combine(packagePath, "azure_website_params.json"));
+            var parameters = JObject.Parse(paramsFileContent)["parameters"].ToString();
+            var psScript = @"
+$ErrorActionPreference = 'Continue'
+az --version
+Get-AzureEnvironment
+az group list";
+
+            CommandTestBuilder.CreateAsync<DeployAzureResourceGroupCommand, Program>()
+                              .WithArrange(context =>
+                                           {
+                                               AddDefaults(context);
+                                               context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupDeploymentMode, "Complete");
+                                               context.Variables.Add("Octopus.Action.Azure.TemplateSource", "Inline");
+                                               context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupTemplate, File.ReadAllText(Path.Combine(packagePath, "azure_website_template.json")));
+                                               context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupTemplateParameters, parameters);
+                                               context.Variables.Add(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.CustomScripts);
+                                               context.Variables.Add(KnownVariables.Action.CustomScripts.GetCustomScriptStage(DeploymentStages.Deploy, ScriptSyntax.PowerShell), psScript);
+                                               context.Variables.Add(KnownVariables.Action.CustomScripts.GetCustomScriptStage(DeploymentStages.PreDeploy, ScriptSyntax.CSharp), "Console.WriteLine(\"Hello from C#\");");
+                                               context.Variables.Add(KnownVariables.Action.CustomScripts.GetCustomScriptStage(DeploymentStages.PostDeploy, ScriptSyntax.FSharp), "printfn \"Hello from F#\"");
+
+                                               context.WithFilesToCopy(packagePath);
+                                           })
+                              .Execute();
+        }
+
+        void AddDefaults(CommandTestBuilderContext context)
+        {
+            context.Variables.Add("Octopus.Account.AccountType", "AzureServicePrincipal");
+            context.Variables.Add(AzureAccountVariables.SubscriptionId, subscriptionId);
+            context.Variables.Add(AzureAccountVariables.TenantId, tenantId);
+            context.Variables.Add(AzureAccountVariables.ClientId, clientId);
+            context.Variables.Add(AzureAccountVariables.Password, clientSecret);
+            context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupName, resourceGroup.Name);
+            context.Variables.Add("ResourceGroup", resourceGroup.Name);
+            context.Variables.Add("SKU", "Shared");
+            context.Variables.Add("WebSite", SdkContext.RandomResourceName(String.Empty, 12));
+            context.Variables.Add("Location", resourceGroup.RegionName);
+            context.Variables.Add("AccountPrefix", SdkContext.RandomResourceName(String.Empty, 6));
+        }
+    }
+}

--- a/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
+++ b/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
@@ -7,6 +7,8 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.38.1" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
@@ -14,5 +16,18 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari.AzureResourceGroup\Calamari.AzureResourceGroup.csproj" />
+    <ProjectReference Include="..\Calamari.Testing\Calamari.Testing.csproj" />
+    <ProjectReference Include="..\Calamari.Tests\Calamari.Tests.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Packages\AzureResourceGroup\azure_website_params.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Packages\AzureResourceGroup\azure_website_template.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Packages\AzureResourceGroup\Default.aspx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/source/Calamari.AzureResourceGroup.Tests/Packages/AzureResourceGroup/Default.aspx
+++ b/source/Calamari.AzureResourceGroup.Tests/Packages/AzureResourceGroup/Default.aspx
@@ -1,0 +1,37 @@
+﻿<%@ Page Language="C#" AutoEventWireup="true" %>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head id="Head1" runat="server">
+    <title></title>
+</head>
+<body>
+    <form id="form1" runat="server">
+    <div>
+      <h1>Hello!</h1>
+
+      <p>
+        Application settings:
+      </p>
+
+      <table>
+        <tr>
+          <td>Key</td>
+          <td>Value</td>
+        </tr>
+      <% 
+        foreach (var key in ConfigurationManager.AppSettings.Keys)
+        {
+      %>
+          <tr>
+            <td><%= key %></td>
+            <td><code><%= ConfigurationManager.AppSettings[key.ToString()] %></code></td>
+          </tr>
+      <%
+        } 
+      %>
+    </div>
+    </form>
+</body>
+</html>

--- a/source/Calamari.AzureResourceGroup.Tests/Packages/AzureResourceGroup/azure_website_params.json
+++ b/source/Calamari.AzureResourceGroup.Tests/Packages/AzureResourceGroup/azure_website_params.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+	    "siteName": {
+	      "value": "#{WebSite}"
+	    },
+        "sku": {
+          "value": "#{SKU}"
+        },
+	    "hostingPlanName": {
+	      "value": "octopus-sample"
+	    },
+	    "siteLocation": {
+	      "value": "#{Location}"
+	    },
+	    "storageAccountPrefix": {
+	      "value": "#{AccountPrefix}"
+	    },
+	    "storageAccountList": {
+          "value": [
+            {
+              "name": "appdev",
+              "location": "Central US",
+              "storageAccountType": "Standard_LRS"
+            },
+            {
+              "name": "dbdev",
+              "location": "Central US",
+              "storageAccountType": "Standard_GRS"
+            },
+            {
+              "name": "webdev",
+              "location": "Central US",
+              "storageAccountType": "Standard_ZRS"
+            },
+            {
+              "name": "archdev",
+              "location": "West US",
+              "storageAccountType": "Premium_LRS"
+            }
+          ]
+        }
+   }
+}

--- a/source/Calamari.AzureResourceGroup.Tests/Packages/AzureResourceGroup/azure_website_template.json
+++ b/source/Calamari.AzureResourceGroup.Tests/Packages/AzureResourceGroup/azure_website_template.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "siteName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the web app that you wish to create."
+      }
+    },
+    "hostingPlanName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the App Service plan to use for hosting the web app."
+      }
+    },
+    "siteLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "The location to use for creating the web app and hosting plan. It must be one of the Azure locations that support web apps."
+      }
+    },
+    "sku": {
+      "type": "string",
+      "allowedValues": [
+        "Free",
+        "Shared",
+        "Basic",
+        "Standard"
+      ],
+      "defaultValue": "Free",
+      "metadata": {
+        "description": "The pricing tier for the hosting plan."
+      }
+    },
+    "workerSize": {
+      "type": "string",
+      "allowedValues": [
+        "0",
+        "1",
+        "2"
+      ],
+      "defaultValue": "0",
+      "metadata": {
+        "description": "The instance size of the hosting plan (small, medium, or large)."
+      }
+    },
+    "storageAccountPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Prefix to add to the name of the storage account"
+      }
+    },
+    "storageAccountList": {
+      "type": "array",
+      "metadata": {
+          "description": "List of storage accounts that need to be created"
+      }
+    }
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-04-01",
+      "name": "[parameters('hostingPlanName')]",
+      "type": "Microsoft.Web/serverfarms",
+      "location": "[parameters('siteLocation')]",
+      "properties": {
+        "name": "[parameters('hostingPlanName')]",
+        "sku": "[parameters('sku')]",
+        "workerSize": "[parameters('workerSize')]",
+        "numberOfWorkers": 1
+      }
+    },
+    {
+      "apiVersion": "2015-04-01",
+      "name": "[parameters('siteName')]",
+      "type": "Microsoft.Web/sites",
+      "location": "[parameters('siteLocation')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]"
+      ],
+      "properties": {
+        "serverFarmId": "[parameters('hostingPlanName')]"
+      }
+    },
+    {
+      "name": "[concat(parameters('storageAccountPrefix'), parameters('storageAccountList')[copyIndex()].name)]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[parameters('storageAccountList')[copyIndex()].location]",
+      "copy": {
+          "name": "storageAccountLoop",
+          "count": "[length(parameters('storageAccountList'))]"
+      },
+      "properties": {
+          "accountType": "[parameters('storageAccountList')[copyIndex()].storageAccountType]"
+      }
+    }    
+  ],
+  "outputs": {
+    "siteUri": {
+      "type": "string",
+      "value": "[concat('http://',reference(resourceId('Microsoft.Web/sites', parameters('siteName'))).hostNames[0])]"
+    },
+    "stgobject1": {
+      "type": "object",
+      "value": "[reference(concat('Microsoft.Storage/storageAccounts/', concat(parameters('storageAccountPrefix'), parameters('storageAccountList')[0].name)),providers('Microsoft.Storage', 'storageAccounts').apiVersions[0])]"
+    },
+    "stgobject2": {
+      "type": "object",
+      "value": "[reference(concat('Microsoft.Storage/storageAccounts/', concat(parameters('storageAccountPrefix'), parameters('storageAccountList')[1].name)),providers('Microsoft.Storage', 'storageAccounts').apiVersions[0])]"
+    },
+    "stgobject3": {
+      "type": "object",
+      "value": "[reference(concat('Microsoft.Storage/storageAccounts/', concat(parameters('storageAccountPrefix'), parameters('storageAccountList')[2].name)),providers('Microsoft.Storage', 'storageAccounts').apiVersions[0])]"
+    }
+  }
+}

--- a/source/Calamari.Tests/RequiresWindowsAttribute.cs
+++ b/source/Calamari.Tests/RequiresWindowsAttribute.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using OSPlatform = System.Runtime.InteropServices.OSPlatform;
+
+namespace Calamari.Tests
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class WindowsTestAttribute : NUnitAttribute, IApplyToTest
+    {
+        readonly string message;
+
+        public WindowsTestAttribute() : this("This test only runs on Windows")
+        {
+        }
+
+        public WindowsTestAttribute(string message)
+        {
+            this.message = message;
+        }
+        
+        static bool IsRunningOnWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public void ApplyToTest(Test test)
+        {
+            if (test.RunState == RunState.NotRunnable || test.RunState == RunState.Ignored)
+                return;
+
+            if (!IsRunningOnWindows)
+            {
+                test.RunState = RunState.Skipped;
+                test.Properties.Add(PropertyNames.SkipReason, message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Background

As a part of dependency management work, we're migrating the Calamari half of Sashimi.Flavour projects to this Calamari repository. These tests lived inside the Sashimi half of AzureResourceGroup but were integration tests, running against the Sashimi handlers. This PR brings the tests into the Calamari repository to avoid running these tests in Server.

# How to review this PR
* Changes relate to calling the CommandTestHandler as opposed to the Sashimi Actionhandler
* Some existing packages and filters have been pulled into Calamari to accommodate these tests
* Compare to https://github.com/OctopusDeploy/Sashimi.AzureResourceGroup/blob/main/source/Sashimi.Tests/AzureResourceGroupActionHandlerFixture.cs for reference