### PR TITLE
Don't modify the collection while enumerating

### DIFF
--- a/source/Calamari/Deployment/PackageRetention/Model/PackageJournal.cs
+++ b/source/Calamari/Deployment/PackageRetention/Model/PackageJournal.cs
@@ -115,7 +115,9 @@ namespace Calamari.Deployment.PackageRetention.Model
                     foreach (var entry in journalRepository.GetAllJournalEntries())
                     {
                         var locks = entry.GetLockDetails();
-                        var staleLocks = locks.Where(u => u.DateTime.Add(timeBeforeExpiration) <= DateTime.Now);
+                        var staleLocks = locks
+                            .Where(u => u.DateTime.Add(timeBeforeExpiration) <= DateTime.Now)
+                            .ToList();
 
                         foreach (var staleLock in staleLocks)
                         {


### PR DESCRIPTION
The `ToList` prevents the modifying the collection while enumerating it. The test changes make the tests actually work 😉 and test for the failure mode customers were experiencing.
Relates to https://github.com/OctopusDeploy/Issues/issues/7744