### PR TITLE
Spike to test adding tools to a Calamari Command Builder

### DIFF
--- a/source/Calamari.Testing/Calamari.Testing.csproj
+++ b/source/Calamari.Testing/Calamari.Testing.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
+        <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Calamari.Testing/CommandTestBuilderContext.cs
+++ b/source/Calamari.Testing/CommandTestBuilderContext.cs
@@ -9,6 +9,9 @@ namespace Calamari.Testing
     public class CommandTestBuilderContext
     {
         public List<(string? filename, Stream contents)> Files = new List<(string?, Stream)>();
+        
+        public IList<IDeploymentTool> Tools { get; } = (IList<IDeploymentTool>) new List<IDeploymentTool>();
+
         internal bool withStagedPackageArgument;
 
         public VariableDictionary Variables { get; } = new VariableDictionary();
@@ -46,6 +49,12 @@ namespace Calamari.Testing
         public CommandTestBuilderContext WithDataFile(Stream fileContents, string? fileName = null, Action<int>? progress = null)
         {
             Files.Add((fileName, fileContents));
+            return this;
+        }
+        
+        public CommandTestBuilderContext WithTool(IDeploymentTool tool)
+        {
+            Tools.Add(tool);
             return this;
         }
     }

--- a/source/Calamari.Testing/IDeploymentTool.cs
+++ b/source/Calamari.Testing/IDeploymentTool.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using Octopus.CoreUtilities;
+
+namespace Calamari.Testing
+{
+    //TODO: This is pulled in from Sashimi.Server.Contracts as an attempt to run Calamari Commands with Tools. Ideally this wouldn't be duplicated.
+    public interface IDeploymentTool
+    {
+        string Id { get; }
+        Maybe<string> SubFolder { get; }
+        bool AddToPath { get; }
+        Maybe<string> ToolPathVariableToSet { get; }
+        string[] SupportedPlatforms { get; }
+        Maybe<DeploymentToolPackage> GetCompatiblePackage(string platform);
+    }
+
+    public class DeploymentToolPackage
+    {
+        public DeploymentToolPackage(IDeploymentTool tool, string id)
+        {
+            Tool = tool;
+            Id = id;
+            BootstrapperModulePaths = new string[0];
+        }
+
+        public DeploymentToolPackage(IDeploymentTool tool, string id, IReadOnlyList<string> modulePaths)
+        {
+            Tool = tool;
+            Id = id;
+            BootstrapperModulePaths = modulePaths;
+        }
+
+        public IDeploymentTool Tool { get; }
+        public string Id { get; }
+        public IReadOnlyList<string> BootstrapperModulePaths { get; set; }
+    }
+}

--- a/source/Calamari/Deployment/PackageRetention/Model/PackageJournal.cs
+++ b/source/Calamari/Deployment/PackageRetention/Model/PackageJournal.cs
@@ -115,7 +115,9 @@ namespace Calamari.Deployment.PackageRetention.Model
                     foreach (var entry in journalRepository.GetAllJournalEntries())
                     {
                         var locks = entry.GetLockDetails();
-                        var staleLocks = locks.Where(u => u.DateTime.Add(timeBeforeExpiration) <= DateTime.Now);
+                        var staleLocks = locks
+                            .Where(u => u.DateTime.Add(timeBeforeExpiration) <= DateTime.Now)
+                            .ToList();
 
                         foreach (var staleLock in staleLocks)
                         {


### PR DESCRIPTION
This is a draft spike to allow adding tools i.e. Azure CLI etc to the CalamariTestBuilder. Sashimi works this way allowing ActionHandlers tests to execute with specific tools available. This is a spike for getting a nuget package to test whether this works in AzureScripting.