### PR TITLE
Adding functionality to use tools in a Calamari Command Test Builder

### DIFF
--- a/source/Calamari.Testing/Calamari.Testing.csproj
+++ b/source/Calamari.Testing/Calamari.Testing.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
+        <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Calamari.Testing/CommandTestBuilderContext.cs
+++ b/source/Calamari.Testing/CommandTestBuilderContext.cs
@@ -9,6 +9,9 @@ namespace Calamari.Testing
     public class CommandTestBuilderContext
     {
         public List<(string? filename, Stream contents)> Files = new List<(string?, Stream)>();
+        
+        public IList<IDeploymentTool> Tools { get; } = (IList<IDeploymentTool>) new List<IDeploymentTool>();
+
         internal bool withStagedPackageArgument;
 
         public VariableDictionary Variables { get; } = new VariableDictionary();
@@ -46,6 +49,12 @@ namespace Calamari.Testing
         public CommandTestBuilderContext WithDataFile(Stream fileContents, string? fileName = null, Action<int>? progress = null)
         {
             Files.Add((fileName, fileContents));
+            return this;
+        }
+        
+        public CommandTestBuilderContext WithTool(IDeploymentTool tool)
+        {
+            Tools.Add(tool);
             return this;
         }
     }

--- a/source/Calamari.Testing/CommandTestBuilderContext.cs
+++ b/source/Calamari.Testing/CommandTestBuilderContext.cs
@@ -11,7 +11,7 @@ namespace Calamari.Testing
     {
         public List<(string? filename, Stream contents)> Files = new List<(string?, Stream)>();
         
-        public IList<IDeploymentTool> Tools { get; } = (IList<IDeploymentTool>) new List<IDeploymentTool>();
+        public List<IDeploymentTool> Tools { get; } = new();
 
         internal bool withStagedPackageArgument;
 

--- a/source/Calamari.Testing/CommandTestBuilderContext.cs
+++ b/source/Calamari.Testing/CommandTestBuilderContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using Calamari.Common.Plumbing.Extensions;
+using Calamari.Testing.Tools;
 using Octostache;
 
 namespace Calamari.Testing

--- a/source/Calamari.Testing/IDeploymentTool.cs
+++ b/source/Calamari.Testing/IDeploymentTool.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using Octopus.CoreUtilities;
+
+namespace Calamari.Testing
+{
+    //TODO: This is pulled in from Sashimi.Server.Contracts as an attempt to run Calamari Commands with Tools. Ideally this wouldn't be duplicated.
+    public interface IDeploymentTool
+    {
+        string Id { get; }
+        Maybe<string> SubFolder { get; }
+        bool AddToPath { get; }
+        Maybe<string> ToolPathVariableToSet { get; }
+        string[] SupportedPlatforms { get; }
+        Maybe<DeploymentToolPackage> GetCompatiblePackage(string platform);
+    }
+
+    public class DeploymentToolPackage
+    {
+        public DeploymentToolPackage(IDeploymentTool tool, string id)
+        {
+            Tool = tool;
+            Id = id;
+            BootstrapperModulePaths = new string[0];
+        }
+
+        public DeploymentToolPackage(IDeploymentTool tool, string id, IReadOnlyList<string> modulePaths)
+        {
+            Tool = tool;
+            Id = id;
+            BootstrapperModulePaths = modulePaths;
+        }
+
+        public IDeploymentTool Tool { get; }
+        public string Id { get; }
+        public IReadOnlyList<string> BootstrapperModulePaths { get; set; }
+    }
+}

--- a/source/Calamari.Testing/Tools/BootstrapperModuleDeploymentTool.cs
+++ b/source/Calamari.Testing/Tools/BootstrapperModuleDeploymentTool.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Octopus.CoreUtilities;
+
+namespace Calamari.Testing.Tools;
+
+public class BoostrapperModuleDeploymentTool : IDeploymentTool
+{
+    private readonly IReadOnlyList<string> modulePaths;
+
+    public BoostrapperModuleDeploymentTool(
+        string id,
+        IReadOnlyList<string> modulePaths,
+        params string[] supportedPlatforms)
+    {
+        this.modulePaths = modulePaths;
+        this.Id = id;
+        this.SupportedPlatforms = supportedPlatforms ?? new string[0];
+    }
+
+    public string Id { get; }
+
+    public Maybe<string> SubFolder => Maybe<string>.None;
+
+    public bool AddToPath => false;
+
+    public Maybe<string> ToolPathVariableToSet => Maybe<string>.None;
+
+    public string[] SupportedPlatforms { get; }
+
+    public Maybe<DeploymentToolPackage> GetCompatiblePackage(
+        string platform)
+    {
+        return platform != "win-x64" && platform != "netfx" ? Maybe<DeploymentToolPackage>.None : new DeploymentToolPackage((IDeploymentTool) this, this.Id, this.modulePaths).AsSome<DeploymentToolPackage>();
+    }
+}

--- a/source/Calamari.Testing/Tools/IDeploymentTool.cs
+++ b/source/Calamari.Testing/Tools/IDeploymentTool.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using Octopus.CoreUtilities;
 
-namespace Calamari.Testing
+namespace Calamari.Testing.Tools
 {
     //TODO: This is pulled in from Sashimi.Server.Contracts as an attempt to run Calamari Commands with Tools. Ideally this wouldn't be duplicated.
     public interface IDeploymentTool

--- a/source/Calamari.Testing/Tools/InPathDeploymentTool.cs
+++ b/source/Calamari.Testing/Tools/InPathDeploymentTool.cs
@@ -1,0 +1,35 @@
+using System;
+using Octopus.CoreUtilities;
+
+namespace Calamari.Testing.Tools;
+
+public class InPathDeploymentTool : IDeploymentTool
+{
+    public InPathDeploymentTool(
+        string id,
+        string? subFolder = null,
+        string? toolPathVariableToSet = null,
+        string[]? supportedPlatforms = null)
+    {
+        this.Id = id;
+        this.SubFolder = subFolder == null ? Maybe<string>.None : Maybe<string>.Some(subFolder);
+        this.ToolPathVariableToSet = toolPathVariableToSet == null ? Maybe<string>.None : Maybe<string>.Some(toolPathVariableToSet);
+        this.SupportedPlatforms = supportedPlatforms ?? new string[0];
+    }
+
+    public string Id { get; }
+
+    public Maybe<string> SubFolder { get; }
+
+    public bool AddToPath => true;
+
+    public Maybe<string> ToolPathVariableToSet { get; }
+
+    public string[] SupportedPlatforms { get; }
+
+    public virtual Maybe<DeploymentToolPackage> GetCompatiblePackage(
+        string platform)
+    {
+        return new DeploymentToolPackage((IDeploymentTool) this, this.Id).AsSome<DeploymentToolPackage>();
+    }
+}


### PR DESCRIPTION
This is a draft spike to allow adding tools i.e. Azure CLI etc to the CalamariTestBuilder. Sashimi works this way allowing ActionHandlers tests to execute with specific tools available. This is a spike for getting a nuget package to test whether this works in AzureScripting.