### PR TITLE
Fix Nuke build on Mac

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Confused? https://help.github.com/articles/dealing-with-line-endings/
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
 *.doc diff=astextplain
 *.DOC diff=astextplain
 *.docx diff=astextplain

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -87,7 +87,7 @@ namespace Calamari.Build
         [GitVersion]
         readonly GitVersion? GitVersionInfo;
         
-        static List<string> CalamariProjectsToSkipConsolidation = new List<string> { "Calamari.CloudAccounts", "Calamari.Common", "Calamari.ConsolidateCalamariPackages" };
+        static List<string> CalamariProjectsToSkipConsolidation = new() { "Calamari.CloudAccounts", "Calamari.Common", "Calamari.ConsolidateCalamariPackages" };
 
         public Build()
         {
@@ -172,6 +172,7 @@ namespace Calamari.Build
 
         Target CalamariConsolidationTests =>
             _ => _.DependsOn(Compile)
+                  .OnlyWhenStatic(() => !IsLocalBuild)
                   .Executes(() =>
                             {
                                 DotNetTest(_ => _

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -430,12 +430,15 @@ namespace Calamari.Build
 
                                 foreach (var flavour in MigratedCalamariFlavours.Flavours)
                                 {
-                                    packageReferences.Add(new BuildPackageReference
+                                    if (Solution?.GetProject(flavour) != null)
                                     {
-                                        Name = flavour,
-                                        Version = NugetVersion.Value,
-                                        PackagePath = ArtifactsDirectory / $"{flavour}.zip"
-                                    });
+                                        packageReferences.Add(new BuildPackageReference
+                                        {
+                                            Name = flavour,
+                                            Version = NugetVersion.Value,
+                                            PackagePath = ArtifactsDirectory / $"{flavour}.zip"
+                                        });
+                                    }
                                 }
 
                                 Directory.CreateDirectory(ConsolidatedPackageDirectory);


### PR DESCRIPTION
## Background

Previously we had a [PR](https://github.com/OctopusDeploy/Calamari/pull/905) to make Nuke runnable on Mac since now this repo contains some Windows-only flavours. Despite this, there are still some remaining issues that need to be addressed before Nuke is fully working:

1. The `ConsolidationPackageTests` step fails on Mac, since the outputs are in different order and has different path separators from the contents in approved file.
2. The `PackageConsolidatedCalamariZip` step fails because it can't find the outputs for Windows-only flavours. This problem was previously neglected because of the presence of 1.
3. `.gitattributes` file does not contain explicit line-ending setting which may cause issues resulted from line-endings being auto-converted to CRLF on Mac.

## Results

This PR addressed these 3 problems listed above.

1. `ConsolidationPackageTests` is configured to only run in CI where the output is more stable. For context, this test doesn't actually test against the generated consolidated package for the current build. It only inspects the contents of a fixed version of consolidated packages that were included in the test project. So skipping it when running locally shouldn't be a problem. 
2. We now skip the Windows-only flavours on Mac for consolidation
3. We added the config for line-endings which is the same as the config in [Server](https://github.com/OctopusDeploy/OctopusDeploy/blob/master/.gitattributes#L1-L3)

Now Nuke build should run fine on both Mac and Windows:
<img width="1089" alt="Screen Shot 2022-09-15 at 11 58 47 AM" src="https://user-images.githubusercontent.com/97418140/190285198-a138a404-f2f9-4c62-b7f0-688a746929f4.png">