### PR TITLE
fix Python updateprogress()

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Python/Configuration.py
+++ b/source/Calamari.Common/Features/Scripting/Python/Configuration.py
@@ -50,7 +50,7 @@ def createartifact(path, fileName = None):
     print("##octopus[stdout-default]");
     print("##octopus[createArtifact path='{0}' name='{1}' length='{2}']".format(servicepath, serviceFileName, length))
 
-def updateprogress(progress, message=None):
+def updateprogress(progress, message=""):
     encodedProgress = encode(str(progress))
     encodedMessage = encode(message)
 

--- a/source/Calamari.Tests/Fixtures/Python/PythonFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Python/PythonFixture.cs
@@ -85,6 +85,14 @@ namespace Calamari.Tests.Fixtures.Python
         {
             var (output, _) = RunScript("updateprogress.py");
             output.AssertSuccess();
+            output.AssertOutput("##octopus[progress percentage='NTA=' message='']");
+        }
+
+        [Test, RequiresMinimumPython3Version(4)]
+        public void ShouldWriteUpdateProgressWithCustomMessage()
+        {
+            var (output, _) = RunScript("updateprogresswithmessage.py");
+            output.AssertSuccess();
             output.AssertOutput("##octopus[progress percentage='NTA=' message='SGFsZiBXYXk=']");
         }
 

--- a/source/Calamari.Tests/Fixtures/Python/Scripts/updateprogress.py
+++ b/source/Calamari.Tests/Fixtures/Python/Scripts/updateprogress.py
@@ -1,1 +1,1 @@
-updateprogress(50, "Half Way")
+updateprogress(50)

--- a/source/Calamari.Tests/Fixtures/Python/Scripts/updateprogresswithmessage.py
+++ b/source/Calamari.Tests/Fixtures/Python/Scripts/updateprogresswithmessage.py
@@ -1,0 +1,1 @@
+updateprogress(50, "Half Way")


### PR DESCRIPTION
According to the [documentation](https://octopus.com/docs/deployments/custom-scripts/logging-messages-in-scripts) the message for updateprogress in Python scripts is optional. However, when a message is not provided the script fails because the default for message is None which is then passed to the inner encode() function that does not like None. 

In this fix the default value for message is changed from None to "" (empty string). Further this PR provided necessary test fixtures to assert the correct behavior.