### PR TITLE
Allow all types of worker credentials for EKS discovery

### DIFF
--- a/source/Calamari.Aws/Kubernetes/Discovery/AwsAuthenticationDetails.cs
+++ b/source/Calamari.Aws/Kubernetes/Discovery/AwsAuthenticationDetails.cs
@@ -9,102 +9,64 @@ namespace Calamari.Aws.Kubernetes.Discovery
     public class AwsAuthenticationDetails : ITargetDiscoveryAuthenticationDetails
     {
         const string DefaultSessionName = "OctopusKubernetesClusterDiscovery";
-        
+
         /// <exception cref="AggregateException">
         /// If both InstanceProfile and EnvironmentVariable Credentials fail.
         /// Contains AmazonClientExceptions for both InstanceProfile and EnvironmentVariable failures</exception>
         /// <exception cref="AmazonClientException">If Basic (Account) Credentials fail</exception>
-        public bool TryGetCredentials(ILog log, out AWSCredentials credentials)
+        public AWSCredentials GetCredentials()
         {
-            credentials = null;
-            if (Credentials.Type == "account")
-            {
-                try
-                {
-                    credentials = new BasicAWSCredentials(Credentials.Account.AccessKey, Credentials.Account.SecretKey);
-                }
-                // Catching a generic Exception because AWS SDK throws undocumented exceptions.
-                catch (Exception e)
-                {
-                    log.Warn("Unable to authorise credentials, see verbose log for details.");
-                    log.Verbose($"Unable to authorise credentials for Account: {e}");
-                    return false;
-                }
-            }
-            else
-            {
-                try
-                {
-                    // If not currently running on an EC2 instance,
-                    // this will throw an exception.
-                    credentials = new InstanceProfileAWSCredentials();
-                }
-                // Catching a generic Exception because AWS SDK throws undocumented exceptions.
-                catch (Exception instanceProfileException)
-                {
-                    try
-                    {
-                        // The last attempt is trying to use Environment Variables.
-                        credentials = new EnvironmentVariablesAWSCredentials();
-                    }
-                    // Catching a generic Exception because AWS SDK throws undocumented exceptions.
-                    catch (Exception environmentVariablesException)
-                    {
-                        log.Warn("Unable to authorise credentials, see verbose log for details.");
-                        log.Verbose($"Unable to authorise credentials for Instance Profile: {instanceProfileException}");
-                        log.Verbose($"Unable to authorise credentials for Environment Variables: {environmentVariablesException}");
-                        return false;
-                    }
-                }
-            }
+            var credentials = Credentials.Type == "account"
+                ? new BasicAWSCredentials(Credentials.Account.AccessKey, Credentials.Account.SecretKey)
+                : FallbackCredentialsFactory.GetCredentials();
 
             if (Role.Type == "assumeRole")
             {
-                credentials = new AssumeRoleAWSCredentials(credentials,
+                return new AssumeRoleAWSCredentials(credentials,
                     Role.Arn,
                     Role.SessionName ?? DefaultSessionName,
                     new AssumeRoleAWSCredentialsOptions
                         { ExternalId = Role.ExternalId, DurationSeconds = Role.SessionDuration });
             }
-            
-            return true;
+
+            return credentials;
         }
-        
+
         public string Type { get; set; }
 
         public AwsCredentials Credentials { get; set; }
-        
+
         public AwsAssumedRole Role { get; set; }
 
         public IEnumerable<string> Regions { get; set; }
     }
-    
+
     public class AwsAssumedRole
     {
         public string Type { get; set; }
-            
+
         public string Arn { get; set; }
-        
+
         public string SessionName { get; set; }
-        
+
         public int? SessionDuration { get; set; }
-        
+
         public string ExternalId { get; set; }
     }
-    
+
     public class AwsCredentials
     {
         public string Type { get; set; }
-            
+
         public string AccountId { get; set; }
-            
+
         public AwsAccount Account { get; set; }
     }
 
     public class AwsAccount
     {
         public string AccessKey { get; set; }
-        
+
         public string SecretKey { get; set; }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/EKS/eks.kubernetes.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/EKS/eks.kubernetes.tf
@@ -13,8 +13,8 @@ provider "kubernetes" {
   token                  = data.aws_eks_cluster_auth.default.token
 }
 
-resource "local_file" "kubeconfig" {
-  sensitive_content = templatefile("${path.module}/kubeconfig.tpl", {
+resource "local_sensitive_file" "kubeconfig" {
+  content = templatefile("${path.module}/kubeconfig.tpl", {
     cluster_name = aws_eks_cluster.default.name,
     cluster_ca    = data.aws_eks_cluster.default.certificate_authority[0].data,
     endpoint     = data.aws_eks_cluster.default.endpoint,


### PR DESCRIPTION
# Background

Originally worker credentials were discovery for EKS discovery by initially trying to retrieve EC2 credentials and then attempt to use Environment variable based account credentials. This means that other valid credentials that could be used (such as a k8s pod IAM role available to all containers in that pod).

# Result

I've updated the code so that it now uses a "FallbackFactory" which will go through all the different ways AWS can authenticate and this should (pending tests) cover the case above.

Note: that AWS has a specific order in which it attempts to retrieve credentials with EC2 instance being the last one. This is an AWS factory so I think that order should be sufficient for most users and it should match other AWS SDKs (like the one used for step-package-ecs target discovery)

[sc-25801]