### PR TITLE
Parse package version when we have all the pieces

### DIFF
--- a/source/Calamari.Tests/Fixtures/Commands/RegisterPackageUseCommandTest.cs
+++ b/source/Calamari.Tests/Fixtures/Commands/RegisterPackageUseCommandTest.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Calamari.Commands;
+using Calamari.Common.Plumbing.Deployment.PackageRetention;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Commands
+{
+    [TestFixture]
+    public class RegisterPackageUseCommandTest
+    {
+        [Test]
+        public void SupportsMavenVersionFormats()
+        {
+            var registerPackageCmd = new RegisterPackageUseCommand(Substitute.For<ILog>(), Substitute.For<IManagePackageCache>(), Substitute.For<ICalamariFileSystem>());
+            registerPackageCmd.Execute(new[] { "-packageId=Blah", "-packageVersion=3.7.4.20220919T144341Z", "-packageVersionFormat=Maven", "-packagePath=C:\\Octopus" }).Should().Be(0);
+        }
+    }
+}

--- a/source/Calamari/Commands/RegisterPackageUseCommand.cs
+++ b/source/Calamari/Commands/RegisterPackageUseCommand.cs
@@ -13,6 +13,7 @@ namespace Calamari.Commands
     {
         PackageId packageId;
         VersionFormat versionFormat;
+        string rawVersionString;
         IVersion packageVersion;
         PackagePath packagePath;
         ServerTaskId taskId;
@@ -35,7 +36,7 @@ namespace Calamari.Commands
                             }
                             versionFormat = format;
                         });
-            Options.Add("packageVersion=", "Package version of the used package", v => packageVersion = VersionFactory.TryCreateVersion(v, versionFormat));
+            Options.Add("packageVersion=", "Package version of the used package", v => rawVersionString = v);
             Options.Add("packagePath=", "Path to the package", v => packagePath = new PackagePath(v));
             Options.Add("taskId=", "Id of the task that is using the package", v => taskId = new ServerTaskId(v));
         }
@@ -45,6 +46,7 @@ namespace Calamari.Commands
             try
             {
                 Options.Parse(commandLineArguments);
+                packageVersion = VersionFactory.TryCreateVersion(rawVersionString, versionFormat);
                 RegisterPackageUse();
             }
             catch (Exception ex)


### PR DESCRIPTION
Calculate the package version after Options have been parsed to ensure that both the version string and version format have been parsed.

Relates to https://github.com/OctopusDeploy/Issues/issues/7604