### PR TITLE
Set default regex match timeout to prevent ReDoS

### DIFF
--- a/source/Calamari.Common/AppDomainConfiguration.cs
+++ b/source/Calamari.Common/AppDomainConfiguration.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Calamari.Common
+{
+    internal static class AppDomainConfiguration
+    {
+        public static readonly TimeSpan DefaultRegexMatchTimeout = TimeSpan.FromSeconds(1);
+        
+        /// <summary>
+        /// Adds default max timout to avoid ReDoS attacks
+        /// </summary>
+        public static void SetDefaultRegexMatchTimeout() 
+            => AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", DefaultRegexMatchTimeout);
+    }
+}

--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -27,6 +27,8 @@ namespace Calamari.Common
 {
     public abstract class CalamariFlavourProgram
     {
+        internal static readonly TimeSpan DefaultRegexMatchTimeout = TimeSpan.FromSeconds(1);
+        
         protected readonly ILog Log;
 
         protected CalamariFlavourProgram(ILog log)
@@ -38,6 +40,10 @@ namespace Calamari.Common
         {
             try
             {
+                // adds default max timout to avoid ReDoS attacks
+                // https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.matchtimeout
+                AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", DefaultRegexMatchTimeout);
+                
                 SecurityProtocols.EnableAllSecurityProtocols();
                 var options = CommonOptions.Parse(args);
 

--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -27,8 +27,6 @@ namespace Calamari.Common
 {
     public abstract class CalamariFlavourProgram
     {
-        internal static readonly TimeSpan DefaultRegexMatchTimeout = TimeSpan.FromSeconds(1);
-        
         protected readonly ILog Log;
 
         protected CalamariFlavourProgram(ILog log)
@@ -40,9 +38,7 @@ namespace Calamari.Common
         {
             try
             {
-                // adds default max timout to avoid ReDoS attacks
-                // https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.matchtimeout
-                AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", DefaultRegexMatchTimeout);
+                AppDomainConfiguration.SetDefaultRegexMatchTimeout();
                 
                 SecurityProtocols.EnableAllSecurityProtocols();
                 var options = CommonOptions.Parse(args);

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -31,6 +31,8 @@ namespace Calamari.Common
 {
     public abstract class CalamariFlavourProgramAsync
     {
+        internal static readonly TimeSpan DefaultRegexMatchTimeout = TimeSpan.FromSeconds(1);
+        
         readonly ILog log;
 
         protected CalamariFlavourProgramAsync(ILog log)
@@ -99,6 +101,10 @@ namespace Calamari.Common
         {
             try
             {
+                // adds default max timout to avoid ReDoS attacks
+                // https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.matchtimeout
+                AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", DefaultRegexMatchTimeout);
+                
                 SecurityProtocols.EnableAllSecurityProtocols();
                 var options = CommonOptions.Parse(args);
 

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -31,8 +31,6 @@ namespace Calamari.Common
 {
     public abstract class CalamariFlavourProgramAsync
     {
-        internal static readonly TimeSpan DefaultRegexMatchTimeout = TimeSpan.FromSeconds(1);
-        
         readonly ILog log;
 
         protected CalamariFlavourProgramAsync(ILog log)
@@ -101,9 +99,7 @@ namespace Calamari.Common
         {
             try
             {
-                // adds default max timout to avoid ReDoS attacks
-                // https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.matchtimeout
-                AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", DefaultRegexMatchTimeout);
+                AppDomainConfiguration.SetDefaultRegexMatchTimeout();
                 
                 SecurityProtocols.EnableAllSecurityProtocols();
                 var options = CommonOptions.Parse(args);

--- a/source/Calamari.Common/Plumbing/AppDomainConfiguration.cs
+++ b/source/Calamari.Common/Plumbing/AppDomainConfiguration.cs
@@ -1,13 +1,13 @@
 using System;
 
-namespace Calamari.Common
+namespace Calamari.Common.Plumbing
 {
     internal static class AppDomainConfiguration
     {
         public static readonly TimeSpan DefaultRegexMatchTimeout = TimeSpan.FromSeconds(1);
         
         /// <summary>
-        /// Adds default max timout to avoid ReDoS attacks
+        /// Adds default max timeout to avoid ReDoS attacks
         /// </summary>
         public static void SetDefaultRegexMatchTimeout() 
             => AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", DefaultRegexMatchTimeout);

--- a/source/Calamari.Tests/Fixtures/ProgramFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ProgramFixture.cs
@@ -55,7 +55,7 @@ namespace Calamari.Tests.Fixtures
         {
             RunProgram();
             var regexTimeout = AppDomain.CurrentDomain.GetData("REGEX_DEFAULT_MATCH_TIMEOUT");
-            regexTimeout.Should().Be(CalamariFlavourProgram.DefaultRegexMatchTimeout);
+            regexTimeout.Should().Be(AppDomainConfiguration.DefaultRegexMatchTimeout);
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/ProgramFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ProgramFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Text.RegularExpressions;
 using Calamari.Common;
+using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Deployment;
 using FluentAssertions;

--- a/source/Calamari.Tests/Fixtures/ProgramFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ProgramFixture.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Net;
+using System.Text.RegularExpressions;
+using Calamari.Common;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Deployment;
 using FluentAssertions;
@@ -46,6 +48,14 @@ namespace Calamari.Tests.Fixtures
                 WebRequest.DefaultWebProxy = existingProxy;
                 EnvironmentHelper.SetEnvironmentVariable("TentacleProxyHost", null);
             }
+        }
+
+        [Test]
+        public void DefaultRegexMatchTimeoutIsSet()
+        {
+            RunProgram();
+            var regexTimeout = AppDomain.CurrentDomain.GetData("REGEX_DEFAULT_MATCH_TIMEOUT");
+            regexTimeout.Should().Be(CalamariFlavourProgram.DefaultRegexMatchTimeout);
         }
     }
 }


### PR DESCRIPTION
## Background

[sc-6247]

This PR addresses [this issue](https://github.com/OctopusDeploy/ResearchAndDevelopment/issues/479).

There are a couple of ReDoS vulnerabilities found in [OctopusDeploy](https://github.com/OctopusDeploy/OctopusDeploy). These issues were addressed by globally setting the default Regex match timeout to 1 second in [this PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/12586).

There are no known vulnerabilities found yet in this repository. However, since we also use Regex, there could be attack surfaces in the future. If they were exploited, it could result in that the worker or server running the Calamari program maxing out CPU and being unable to respond. Therefore, we are preventively adopting a similar approach to globally limit the match timeout for Regex to be 1 second for Calamari and flavours as well.

The default timeout can be overridden where needed:
```cs
new Regex( --, --, TimeSpan.FromSeconds(10));
```
