### PR TITLE
Bumping from netcoreapp3.1 to net6.0

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -30,7 +30,7 @@ WarningMessage="${Yellow}\
 ║ WARNING:                                               ║
 ║ Building Calamari on a non-windows machine will result ║
 ║ in Calmari and Calamari.Cloud nuget packages being     ║
-║ built against net6.0. This means that some      ║
+║ built against net6.0. This means that some             ║
 ║ steps may not work as expected because they require a  ║
 ║ .Net Framework compatible Calamari Nuget Package.      ║
 ╬════════════════════════════════════════════════════════╬\

--- a/build-local.sh
+++ b/build-local.sh
@@ -30,7 +30,7 @@ WarningMessage="${Yellow}\
 ║ WARNING:                                               ║
 ║ Building Calamari on a non-windows machine will result ║
 ║ in Calmari and Calamari.Cloud nuget packages being     ║
-║ built against netcoreapp3.1. This means that some      ║
+║ built against net6.0. This means that some      ║
 ║ steps may not work as expected because they require a  ║
 ║ .Net Framework compatible Calamari Nuget Package.      ║
 ╬════════════════════════════════════════════════════════╬\

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -190,7 +190,7 @@ namespace Calamari.Build
                       if (!OperatingSystem.IsWindows())
                           Log.Warning("Building Calamari on a non-windows machine will result "
                                       + "in the {DefaultNugetPackageName} and {CloudNugetPackageName} "
-                                      + "nuget packages being built as .Net Core 3.1 packages "
+                                      + "nuget packages being built as .Net Core 6.0 packages "
                                       + "instead of as .Net Framework 4.0 and 4.5.2 respectively. "
                                       + "This can cause compatibility issues when running certain "
                                       + "deployment steps in Octopus Server",
@@ -198,16 +198,16 @@ namespace Calamari.Build
 
                       var nugetVersion = NugetVersion.Value;
                       DoPublish(RootProjectName,
-                                OperatingSystem.IsWindows() ? Frameworks.Net40 : Frameworks.NetCoreApp31,
+                                OperatingSystem.IsWindows() ? Frameworks.Net40 : Frameworks.Net60,
                                 nugetVersion);
                       DoPublish(RootProjectName,
-                                OperatingSystem.IsWindows() ? Frameworks.Net452 : Frameworks.NetCoreApp31,
+                                OperatingSystem.IsWindows() ? Frameworks.Net452 : Frameworks.Net60,
                                 nugetVersion,
                                 FixedRuntimes.Cloud);
 
                       // Create the self-contained Calamari packages for each runtime ID defined in Calamari.csproj
                       foreach (var rid in Solution.GetProject(RootProjectName).GetRuntimeIdentifiers()!)
-                          DoPublish(RootProjectName, Frameworks.NetCoreApp31, nugetVersion, rid);
+                          DoPublish(RootProjectName, Frameworks.Net60, nugetVersion, rid);
                   });
 
         Target PublishCalamariFlavourProjects =>
@@ -336,10 +336,10 @@ namespace Calamari.Build
                                 var packageActions = new List<Action>
                                 {
                                     () => DoPackage(RootProjectName,
-                                                    OperatingSystem.IsWindows() ? Frameworks.Net40 : Frameworks.NetCoreApp31,
+                                                    OperatingSystem.IsWindows() ? Frameworks.Net40 : Frameworks.Net60,
                                                     nugetVersion),
                                     () => DoPackage(RootProjectName,
-                                                    OperatingSystem.IsWindows() ? Frameworks.Net452 : Frameworks.NetCoreApp31,
+                                                    OperatingSystem.IsWindows() ? Frameworks.Net452 : Frameworks.Net60,
                                                     nugetVersion,
                                                     FixedRuntimes.Cloud),
                                 };
@@ -348,7 +348,7 @@ namespace Calamari.Build
                                 // ReSharper disable once LoopCanBeConvertedToQuery
                                 foreach (var rid in Solution.GetProject(RootProjectName).GetRuntimeIdentifiers()!)
                                     packageActions.Add(() => DoPackage(RootProjectName,
-                                                                       Frameworks.NetCoreApp31,
+                                                                       Frameworks.Net60,
                                                                        nugetVersion,
                                                                        rid));
 
@@ -380,7 +380,7 @@ namespace Calamari.Build
                   .Executes(async () =>
                   {
                       var nugetVersion = NugetVersion.Value;
-                      var defaultTarget = OperatingSystem.IsWindows() ? Frameworks.Net461 : Frameworks.NetCoreApp31;
+                      var defaultTarget = OperatingSystem.IsWindows() ? Frameworks.Net461 : Frameworks.Net60;
                       AbsolutePath binFolder = SourceDirectory / "Calamari.Tests" / "bin" / Configuration / defaultTarget;
                       Directory.Exists(binFolder);
                       var actions = new List<Action>
@@ -397,7 +397,7 @@ namespace Calamari.Build
                           actions.Add(() =>
                           {
                               var publishedLocation =
-                                  DoPublish("Calamari.Tests", Frameworks.NetCoreApp31, nugetVersion, rid);
+                                  DoPublish("Calamari.Tests", Frameworks.Net60, nugetVersion, rid);
                               var zipName = $"Calamari.Tests.netcoreapp.{rid}.{nugetVersion}.zip";
                               CompressionTasks.Compress(publishedLocation, ArtifactsDirectory / zipName);
                           });

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -398,7 +398,7 @@ namespace Calamari.Build
                           {
                               var publishedLocation =
                                   DoPublish("Calamari.Tests", Frameworks.Net60, nugetVersion, rid);
-                              var zipName = $"Calamari.Tests.netcoreapp.{rid}.{nugetVersion}.zip";
+                              var zipName = $"Calamari.Tests.{rid}.{nugetVersion}.zip";
                               CompressionTasks.Compress(publishedLocation, ArtifactsDirectory / zipName);
                           });
 

--- a/build/Frameworks.cs
+++ b/build/Frameworks.cs
@@ -4,9 +4,9 @@ namespace Calamari.Build
 {
     public static class Frameworks
     {
-        public const string NetCoreApp31 = "netcoreapp3.1";
         public const string Net40 = "net40";
         public const string Net452 = "net452";
         public const string Net461 = "net461";
+        public const string Net60 = "net6.0";
     }
 }

--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -10,10 +10,10 @@
         <LangVersion>9</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net452;net6.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -29,7 +29,7 @@
     <PropertyGroup Condition="'$(TargetFramework)' == 'net452' ">
         <NoWarn>CS8600;CS8601;CS8602;CS8603;CS8604</NoWarn>
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
         <DefineConstants>$(DefineConstants);HAS_NULLABLE_REF_TYPES</DefineConstants>
     </PropertyGroup>
 

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -12,12 +12,12 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <DefineConstants>$(DefineConstants);NETCORE;AWS;AZURE_CORE;JAVA_SUPPORT</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -258,23 +258,23 @@
     </CreateItem>
     <PropertyGroup>
       <FSharpCompilerTools>@(FSharpCompilerToolsRef->'%(ResolvedPath)')/tools/*.*</FSharpCompilerTools>
-      <FSharpCompilerToolsExe Condition="'$(TargetFramework)' == 'netcoreapp3.1'">@(FSharpCompilerToolsRef->'%(ResolvedPath)')/tools/*.exe</FSharpCompilerToolsExe>
+      <FSharpCompilerToolsExe Condition="'$(TargetFramework)' == 'net6.0'">@(FSharpCompilerToolsRef->'%(ResolvedPath)')/tools/*.exe</FSharpCompilerToolsExe>
       <ScriptCS>@(ScriptCSRef->'%(ResolvedPath)')/tools/*.*</ScriptCS>
-      <ScriptCSExe Condition="'$(TargetFramework)' == 'netcoreapp3.1'">@(ScriptCSRef->'%(ResolvedPath)')/tools/*.exe</ScriptCSExe>
+      <ScriptCSExe Condition="'$(TargetFramework)' == 'net6.0'">@(ScriptCSRef->'%(ResolvedPath)')/tools/*.exe</ScriptCSExe>
       <NuGetCommandLine>@(NuGetCommandLineRef->'%(ResolvedPath)')/tools/*.*</NuGetCommandLine>
     </PropertyGroup>
     <ItemGroup>
       <FSharpFiles Include="$(FSharpCompilerTools)" />
-      <FSharpFilesExe Condition="'$(TargetFramework)' == 'netcoreapp3.1'" Include="$(FSharpCompilerToolsExe)" />
+      <FSharpFilesExe Condition="'$(TargetFramework)' == 'net6.0'" Include="$(FSharpCompilerToolsExe)" />
       <ScriptCSFiles Include="$(ScriptCS)" />
-      <ScriptCSFilesExe Condition="'$(TargetFramework)' == 'netcoreapp3.1'" Include="$(ScriptCSExe)" />
+      <ScriptCSFilesExe Condition="'$(TargetFramework)' == 'net6.0'" Include="$(ScriptCSExe)" />
       <NuGetFiles Include="$(NuGetCommandLine)" Condition=" '$(TargetFramework)' == 'net461'" />
     </ItemGroup>
     <Copy SourceFiles="@(FSharpFiles)" DestinationFolder="$(OutDir)/FSharp/" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(ScriptCSFiles)" DestinationFolder="$(OutDir)/ScriptCS/" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(NuGetFiles)" DestinationFolder="$(OutDir)/NuGet/" SkipUnchangedFiles="true" Condition="'$(TargetFramework)' == 'net461'" />
-    <Exec Command="chmod +x %(FSharpFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <Exec Command="chmod +x %(ScriptCSFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <Exec Command="chmod +x %(FSharpFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <Exec Command="chmod +x %(ScriptCSFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'net6.0'" />
     <Copy SourceFiles="@(FSharpFiles)" DestinationFolder="$(PublishDir)/FSharp/" Condition="'$(PublishDir)' != ''" />
     <Copy SourceFiles="@(ScriptCSFiles)" DestinationFolder="$(PublishDir)/ScriptCS/" Condition="'$(PublishDir)' != ''" />
   </Target>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -36,12 +36,12 @@
     <PackageReference Include="Polly" Version="5.4.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Markdown" Version="2.1.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.3.0" />
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />
     <Reference Include="System.Core" />

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
@@ -232,7 +232,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         
         void AssertUnauthenticatedSystemProxyUsed(IEnumerable<EnvironmentVariable> output)
         {
-#if !NETCOREAPP3_1
+#if !NETCOREAPP
             AssertUnauthenticatedProxyUsed(output);
 #else
             AssertNoProxyChanges(output);
@@ -241,7 +241,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         
         void AssertAuthenticatedSystemProxyUsed(IEnumerable<EnvironmentVariable> output)
         {
-#if !NETCOREAPP3_1
+#if !NETCOREAPP
             AssertAuthenticatedProxyUsed(output);
 #else
             AssertNoProxyChanges(output);

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
@@ -232,7 +232,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         
         void AssertUnauthenticatedSystemProxyUsed(IEnumerable<EnvironmentVariable> output)
         {
-#if !NETCOREAPP
+#if !NETCORE
             AssertUnauthenticatedProxyUsed(output);
 #else
             AssertNoProxyChanges(output);
@@ -241,7 +241,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         
         void AssertAuthenticatedSystemProxyUsed(IEnumerable<EnvironmentVariable> output)
         {
-#if !NETCOREAPP
+#if !NETCORE
             AssertAuthenticatedProxyUsed(output);
 #else
             AssertNoProxyChanges(output);

--- a/source/Calamari.Tests/Fixtures/Util/TestUserPrincipal.cs
+++ b/source/Calamari.Tests/Fixtures/Util/TestUserPrincipal.cs
@@ -144,9 +144,10 @@ namespace Calamari.Tests.Fixtures.Util
         }
         
         public SecurityIdentifier Sid { get; private set; }
-#pragma warning disable PC001 // API not supported on all platforms
+
+#pragma warning disable CA1416 // API not supported on all platforms
         public string NTAccountName => Sid.Translate(typeof(NTAccount)).ToString();
-#pragma warning restore PC001 // API not supported on all platforms
+#pragma warning restore CA1416 // API not supported on all platforms
         public string DomainName => NTAccountName.Split(new[] {'\\'}, 2)[0];
         public string UserName => NTAccountName.Split(new[] {'\\'}, 2)[1];
         public string SamAccountName { get; private set; }

--- a/source/Calamari.Tests/Helpers/CodeGenerator.cs
+++ b/source/Calamari.Tests/Helpers/CodeGenerator.cs
@@ -23,12 +23,12 @@ namespace Calamari.Tests.Helpers
             }
 
             var clr = new CommandLineRunner(ConsoleLog.Instance, new CalamariVariables());
-            var result = clr.Execute(CreateCommandLineInvocation("dotnet", "new console -f netcoreapp3.1"));
+            var result = clr.Execute(CreateCommandLineInvocation("dotnet", "new console -f net6.0"));
             result.VerifySuccess();
             File.WriteAllText(Path.Combine(projectPath.FullName, "global.json"),
                               @"{
     ""sdk"": {
-            ""version"": ""3.1.402"",
+            ""version"": ""6.0.10"",
             ""rollForward"": ""latestFeature""
         }
     }");

--- a/source/Calamari.Tests/KubernetesFixtures/Helm2UpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm2UpgradeFixture.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
 using Calamari.Tests.Helpers;
@@ -49,9 +50,9 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNon32BitWindows]
         [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
-        public void CustomHelmExeInPackage_RelativePath()
+        public async Task CustomHelmExeInPackage_RelativePath()
         {
-            TestCustomHelmExeInPackage_RelativePath("2.9.0");
+            await TestCustomHelmExeInPackage_RelativePath("2.9.0");
         }
 
         protected override string ExplicitExeVersion => "2.9.1";

--- a/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
@@ -1,4 +1,5 @@
-﻿using Calamari.Testing.Helpers;
+﻿using System.Threading.Tasks;
+using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
 using Calamari.Tests.Fixtures;
 using Calamari.Tests.Helpers;
@@ -32,9 +33,9 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNon32BitWindows]
         [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
-        public void CustomHelmExeInPackage_RelativePath()
+        public async Task CustomHelmExeInPackage_RelativePath()
         {
-            TestCustomHelmExeInPackage_RelativePath("3.0.1");
+            await TestCustomHelmExeInPackage_RelativePath("3.0.1");
         }
 
         protected override string ExplicitExeVersion => "3.0.2";

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -20,10 +20,10 @@
     <ApplicationManifest>Calamari.exe.manifest</ApplicationManifest>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net40;net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net40;net452;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);IIS_SUPPORT;WINDOWS_CERTIFICATE_STORE_SUPPORT</DefineConstants>
@@ -40,7 +40,7 @@
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />
     <ProjectReference Include="..\Calamari.Azure\Calamari.Azure.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />
     <ProjectReference Include="..\Calamari.Azure\Calamari.Azure.csproj" />
   </ItemGroup>
@@ -80,7 +80,7 @@
     <Reference Include="System" />
     <Reference Include="System.Security" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Autofac" Version="4.8.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Core 3.1 is coming to EOL on the [13th of December 2022](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). Internally we will be removing it from build agents. This PR is meant to remove all dependencies on core3.1 from Calamari.
[sc-9747]