### PR TITLE
Ensure tests actually run

### DIFF
--- a/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
@@ -65,10 +65,10 @@ namespace Calamari.AzureResourceGroup.Tests
         }
 
         [Test]
-        public void Deploy_with_template_in_package()
+        public async Task Deploy_with_template_in_package()
         {
             var packagePath = TestEnvironment.GetTestPath("Packages", "AzureResourceGroup");
-            CommandTestBuilder.CreateAsync<DeployAzureResourceGroupCommand, Program>()
+            await CommandTestBuilder.CreateAsync<DeployAzureResourceGroupCommand, Program>()
                                     .WithArrange(context =>
                                                  {
                                                      AddDefaults(context);
@@ -82,13 +82,13 @@ namespace Calamari.AzureResourceGroup.Tests
         }
 
         [Test]
-        public void Deploy_with_template_inline()
+        public async Task Deploy_with_template_inline()
         {
             var packagePath = TestEnvironment.GetTestPath("Packages", "AzureResourceGroup");
             var paramsFileContent = File.ReadAllText(Path.Combine(packagePath, "azure_website_params.json"));
             var parameters = JObject.Parse(paramsFileContent)["parameters"].ToString();
 
-            CommandTestBuilder.CreateAsync<DeployAzureResourceGroupCommand, Program>()
+            await CommandTestBuilder.CreateAsync<DeployAzureResourceGroupCommand, Program>()
                               .WithArrange(context =>
                                            {
                                                AddDefaults(context);
@@ -105,7 +105,7 @@ namespace Calamari.AzureResourceGroup.Tests
         [Test]
         [WindowsTest]
         [RequiresPowerShell5OrAbove]
-        public void Deploy_Ensure_Tools_Are_Configured()
+        public async Task Deploy_Ensure_Tools_Are_Configured()
         {
             var packagePath = TestEnvironment.GetTestPath("Packages", "AzureResourceGroup");
             var paramsFileContent = File.ReadAllText(Path.Combine(packagePath, "azure_website_params.json"));
@@ -116,7 +116,7 @@ az --version
 Get-AzureEnvironment
 az group list";
 
-            CommandTestBuilder.CreateAsync<DeployAzureResourceGroupCommand, Program>()
+            await CommandTestBuilder.CreateAsync<DeployAzureResourceGroupCommand, Program>()
                               .WithArrange(context =>
                                            {
                                                AddDefaults(context);

--- a/source/Calamari.AzureScripting.Tests/AzurePowershellCommandFixture.cs
+++ b/source/Calamari.AzureScripting.Tests/AzurePowershellCommandFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Scripting;
@@ -38,7 +39,7 @@ namespace Calamari.AzureScripting.Tests
         [Test]
         [WindowsTest]
         [RequiresPowerShell5OrAbove]
-        public void ExecuteAnInlineWindowsPowerShellScript()
+        public async Task ExecuteAnInlineWindowsPowerShellScript()
         {
             var psScript = @"
 $ErrorActionPreference = 'Continue'
@@ -46,19 +47,20 @@ az --version
 Get-AzureEnvironment
 az group list";
 
-            var calamariCommand = CommandTestBuilder.CreateAsync<RunScriptCommand, Program>()
+            await CommandTestBuilder.CreateAsync<RunScriptCommand, Program>()
                               .WithArrange(context =>
                                            {
                                                AddDefaults(context);
                                                context.Variables.Add(ScriptVariables.ScriptSource, ScriptVariables.ScriptSourceOptions.Inline);
                                                context.Variables.Add(ScriptVariables.Syntax, ScriptSyntax.PowerShell.ToString());
                                                context.Variables.Add(ScriptVariables.ScriptBody, psScript);
-                                           }).Execute();
+                                           })
+                              .Execute();
         }
 
         [Test]
         [RequiresPowerShell5OrAbove]
-        public void ExecuteAnInlinePowerShellCoreScript()
+        public async Task ExecuteAnInlinePowerShellCoreScript()
         {
             var psScript = @"
 $ErrorActionPreference = 'Continue'
@@ -66,7 +68,7 @@ az --version
 Get-AzureEnvironment
 az group list";
 
-            CommandTestBuilder.CreateAsync<RunScriptCommand, Program>()
+            await CommandTestBuilder.CreateAsync<RunScriptCommand, Program>()
                                     .WithArrange(context =>
                                                  {
                                                      AddDefaults(context);
@@ -80,7 +82,7 @@ az group list";
 
         [Test]
         [RequiresPowerShell5OrAbove]
-        public void ExecuteAnInlinePowerShellCoreScriptAgainstAnInvalidAzureEnvironment()
+        public async Task ExecuteAnInlinePowerShellCoreScriptAgainstAnInvalidAzureEnvironment()
         {
             var psScript = @"
 $ErrorActionPreference = 'Continue'
@@ -88,7 +90,7 @@ az --version
 Get-AzureEnvironment
 az group list";
 
-            CommandTestBuilder.CreateAsync<RunScriptCommand, Program>()
+            await CommandTestBuilder.CreateAsync<RunScriptCommand, Program>()
                               .WithArrange(context =>
                                            {
                                                AddDefaults(context);

--- a/source/Calamari.AzureScripting.Tests/Calamari.AzureScripting.Tests.csproj
+++ b/source/Calamari.AzureScripting.Tests/Calamari.AzureScripting.Tests.csproj
@@ -22,6 +22,8 @@
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
         <PackageReference Include="NSubstitute" Version="4.2.1" />
         <PackageReference Include="Shouldly" Version="2.8.2" />
+        <PackageReference Include="Octopus.Dependencies.AzureCLI" Version="2.0.50"/>
+        <PackageReference Include="Octopus.Dependencies.AzureCmdlets" Version="6.13.1" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Calamari.AzureScripting\Calamari.AzureScripting.csproj" />


### PR DESCRIPTION
[sc-7405]

In our previous migration, some migrated tests have a `[Test] public void MyTest()` signature, which does not actually run to the completion of asynchronous code if any. This caused some tests to pass without actually executing.

When having the return type `void`, the test method is treated as synchronous, and returns successfully immediately:

<img width="473" alt="Screen Shot 2022-10-21 at 6 21 42 PM" src="https://user-images.githubusercontent.com/97418140/197119943-6a65970f-e1d5-4a2e-b3f0-d3a6aa531442.png">

Ideally they should have the signature `[Test] public async Task MyTest()` to execute correctly and make things clear. So this PR changes the wrong method signatures to this. 

That said, if the return type is `Task` but the `async` keyword is missing, NUnit still waits until the returned `Task` is resolved, therefore the tests are executed correctly:

<img width="598" alt="Screen Shot 2022-10-21 at 6 22 40 PM" src="https://user-images.githubusercontent.com/97418140/197120241-33dcb775-9489-4fed-a215-de8ed7602d62.png">

For this reason, the test methods which has the signatures like `[Test] public Task MyTest()` (lacking `async`) still works - no need to modify them.