### PR TITLE
Added RetryTracker to file move - from community PR by voronoipotato

### DIFF
--- a/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
@@ -564,7 +564,7 @@ namespace Calamari.Common.Plumbing.FileSystem
 
         public void MoveFile(string sourceFile, string destinationFile)
         {
-            File.Move(sourceFile, destinationFile);
+            RetryTrackerFileAction(() => File.Move(sourceFile, destinationFile), destinationFile, "move");
         }
 
         public void EnsureDirectoryExists(string directoryPath)

--- a/source/Calamari.Shared/Commands/ApplyDeltaCommand.cs
+++ b/source/Calamari.Shared/Commands/ApplyDeltaCommand.cs
@@ -80,7 +80,7 @@ namespace Calamari.Commands
                     throw new CommandLineException("OctoDiff", result.ExitCode, result.Errors);
                 }
 
-                File.Move(tempNewFilePath, newFilePath);
+                fileSystem.MoveFile(tempNewFilePath, newFilePath);
 
                 if (!File.Exists(newFilePath))
                     throw new CommandException($"Failed to apply delta file {deltaFilePath} to {basisFilePath}");


### PR DESCRIPTION
See original [PR ](https://github.com/OctopusDeploy/Calamari/pull/921) from [@voronoipotato](https://github.com/voronoipotato)

There appear to be one or two other uses of File.Move instead of the filesystem.MoveFile, however this PR should fix https://github.com/OctopusDeploy/Issues/issues/7775 . The ApplyDeltaCommand already leverages the CalamariPhysicalFileSystem for other operations so it appears File.Move was overlooked because it previously was just a wrapper around File.Move.

Hope it helps!