### PR TITLE
Enable partial build and package for local testing

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -81,6 +81,12 @@
           "type": "boolean",
           "description": "Run packing step in parallel"
         },
+        "PartialBuildFlavours": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "Partition": {
           "type": "string",
           "description": "Partition to use on CI"
@@ -126,7 +132,6 @@
               "CheckForbiddenWords",
               "Clean",
               "Compile",
-              "CopySashimiPackagesForConsolidation",
               "CopyToLocalPackages",
               "Pack",
               "PackageConsolidatedCalamariZip",
@@ -153,7 +158,6 @@
               "CheckForbiddenWords",
               "Clean",
               "Compile",
-              "CopySashimiPackagesForConsolidation",
               "CopyToLocalPackages",
               "Pack",
               "PackageConsolidatedCalamariZip",

--- a/build-local.ps1
+++ b/build-local.ps1
@@ -1,3 +1,9 @@
+[CmdletBinding()]
+Param(
+    [Parameter()]
+    [string[]]$PartialBuildFlavours
+)
+
 Write-Host "
 ##################################################################################################
 #                                                                                                #
@@ -18,7 +24,15 @@ Write-Host "
 ##################################################################################################
 " -ForegroundColor Cyan
 
-./build.ps1 -BuildVerbosity Minimal -Verbosity Normal -PackInParallel -AppendTimestamp -SetOctopusServerVersion 
+if ($PartialBuildFlavours) {
+    ./build.ps1 -BuildVerbosity Minimal -Verbosity Normal -PackInParallel -AppendTimestamp -SetOctopusServerVersion -PartialBuildFlavours $PartialBuildFlavours
+} else {
+    ./build.ps1 -BuildVerbosity Minimal -Verbosity Normal -PackInParallel -AppendTimestamp -SetOctopusServerVersion
+}
+
+if ($PartialBuildFlavours) {
+    Write-Warning "You've only built a partial Calamari package. Some steps may not work."
+}
 
 Write-Host "
 ########################################################################################


### PR DESCRIPTION
# Background
The `.\build-local.ps1` script currently has a few minor time-saving optimisations, but still can take 10-15 minutes to prepare a whole Calamari package. That's way too long for an effective development loop.

# Changes
This PR adds a parameter to the build script which allows you to specify an array of Calamari Flavours to build, with everything else excluded. The core Calamari is always included, because this is needed for package acquisition, so it's very unlikely that you'll be able to get a functioning Deployment without it.

## Results
Full local build, ready for testing in Server (with a single Flavour) takes around 2.5 minutes. Build time would increase linearly for each extra flavour included.

# Usage
Execute the `build-local` script with a `-PartialBuildFlavours` parameter.

To build only AzureScripting (aka "Run an Azure Script"):
```pwsh
.\build-local.ps1 -PartialBuildFlavours Calmari.AzureScripting
```
To build AzureScripting and Terraform:
```pwsh
.\build-local.ps1 -PartialBuildFlavours Calmari.AzureScripting, Calamari.Terraform
```