### PR TITLE
Warn and prevent use of Azure-CLI v2.40

### DIFF
--- a/source/Calamari.AzureScripting/Scripts/AzureContext.sh
+++ b/source/Calamari.AzureScripting/Scripts/AzureContext.sh
@@ -33,6 +33,15 @@ function setup_context {
             export AZURE_EXTENSION_DIR="$HOME/.azure/cliextensions"
         fi
 
+        # Azure CLI v2.40 has a bug in it which breaks login. Warn customers if affected and fail the step.
+        if grep -q "\"azure-cli\": \"2.40.0\"" <<< "$(az version --output json)";
+        then
+            echo "##octopus[stdout-error]"
+            echo "Azure CLI v2.40 contained a bug which prevents Octopus from performing non-interactive login. Please update your deployment target/worker to use a version of Azure CLI other than 2.40. See https://oc.to/AzureCLIv240Bug for further details."
+
+            exit 1
+        fi
+
         # authenticate with the Azure CLI
         echo "##octopus[stdout-verbose]"
 


### PR DESCRIPTION
I started working on this PR to detect and warn customers about OctopusDeploy/Issues#7782, however when I was doing local testing, after going down a number of rabbit holes, I found that no matter what I do Az CLI 2.40 completely freezes when called by Octopus. Even `az version` doesn't work. 

The Bash version of the check represents what I previously had for Powershell, but you can see the Powershell one has been expanded to try to work around this hanging problem, to no avail.

I don't know if we'll revive this one at some time later, but it's not one that I can figure out on Friday afternoon!