### PR TITLE
Fix installation script for GCP on Windows

### DIFF
--- a/source/Calamari.GoogleCloudScripting.Tests/Calamari.GoogleCloudScripting.Tests.csproj
+++ b/source/Calamari.GoogleCloudScripting.Tests/Calamari.GoogleCloudScripting.Tests.csproj
@@ -7,7 +7,7 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net461;net6.0</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.GoogleCloudScripting.Tests/Calamari.GoogleCloudScripting.Tests.csproj
+++ b/source/Calamari.GoogleCloudScripting.Tests/Calamari.GoogleCloudScripting.Tests.csproj
@@ -5,9 +5,10 @@
         <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <LangVersion>8</LangVersion>
         <IsPackable>false</IsPackable>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net462;net6.0</TargetFrameworks>
+        <TargetFrameworks>net461;net6.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
+++ b/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
@@ -30,6 +30,8 @@ namespace Calamari.GoogleCloudScripting.Tests
 
         class DownloadCLI: IEnumerable
         {
+            private string postfix = "";
+            
             Object RetrieveFileFromGoogleCloudStorage(StorageClient client)
             {
                 var results = client.ListObjects("cloud-sdk-release", "google-cloud-sdk-");
@@ -42,8 +44,6 @@ namespace Calamari.GoogleCloudScripting.Tests
                         listOfFilesSortedByCreatedDate.Add(result.TimeCreated.Value, result);
                     }
                 }
-
-                string postfix = "";
 
                 if (OperatingSystem.IsLinux())
                 {
@@ -95,7 +95,7 @@ namespace Calamari.GoogleCloudScripting.Tests
                     client.DownloadObject(fileToDownload, fileStream);
                 }
         
-                var destinationDirectory = Path.Combine(rootPath, Path.GetFileNameWithoutExtension(fileToDownload.Name));
+                var destinationDirectory = Path.Combine(rootPath, Path.GetFileName(fileToDownload.Name).Replace(postfix, ""));
                 var gcloudExe = Path.Combine(destinationDirectory, "google-cloud-sdk", "bin", $"gcloud{(OperatingSystem.IsWindows() ? ".cmd" : String.Empty)}");
         
                 if (!File.Exists(gcloudExe))

--- a/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
+++ b/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
@@ -17,34 +17,23 @@ using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 using NUnit.Framework.Internal;
 using NUnit.Framework;
-using Object = Google.Apis.Storage.v1.Data.Object;
+using GoogleStorageObject = Google.Apis.Storage.v1.Data.Object;
 using ZipFile = System.IO.Compression.ZipFile;
 
 namespace Calamari.GoogleCloudScripting.Tests
 {
     [TestFixture]
-    [TestFixtureSource(typeof(DownloadCLI))]
+    [TestFixtureSource(typeof(DownloadCli))]
     class GoogleCloudActionHandlerFixture
     {
         private readonly string cliPath;
 
-        class DownloadCLI: IEnumerable
+        private class DownloadCli: IEnumerable
         {
-            private string postfix = "";
-            
-            Object RetrieveFileFromGoogleCloudStorage(StorageClient client)
+            private readonly string postfix = "";
+
+            public DownloadCli()
             {
-                var results = client.ListObjects("cloud-sdk-release", "google-cloud-sdk-");
-                var listOfFilesSortedByCreatedDate = new SortedList<DateTime, Object>(Comparer<DateTime>.Create((a, b) => b.CompareTo(a)));
-
-                foreach (var result in results)
-                {
-                    if (result.TimeCreated.HasValue)
-                    {
-                        listOfFilesSortedByCreatedDate.Add(result.TimeCreated.Value, result);
-                    }
-                }
-
                 if (OperatingSystem.IsLinux())
                 {
                     postfix = "-linux-x86_64.tar.gz";
@@ -53,9 +42,23 @@ namespace Calamari.GoogleCloudScripting.Tests
                 {
                     postfix = "-windows-x86_64-bundled-python.zip";
                 }
-                else if (OperatingSystem.IsMacOS())
+                else if (OperatingSystem.IsMacOs())
                 {
                     postfix = "-darwin-x86_64-bundled-python.tar.gz";
+                }
+            }
+            
+            private GoogleStorageObject RetrieveFileFromGoogleCloudStorage(StorageClient client)
+            {
+                var results = client.ListObjects("cloud-sdk-release", "google-cloud-sdk-");
+                var listOfFilesSortedByCreatedDate = new SortedList<DateTime, GoogleStorageObject>(Comparer<DateTime>.Create((a, b) => b.CompareTo(a)));
+
+                foreach (var result in results)
+                {
+                    if (result.TimeCreated.HasValue)
+                    {
+                        listOfFilesSortedByCreatedDate.Add(result.TimeCreated.Value, result);
+                    }
                 }
 
                 foreach (var file in listOfFilesSortedByCreatedDate.Where(file => file.Value.Name.EndsWith(postfix)))
@@ -67,7 +70,7 @@ namespace Calamari.GoogleCloudScripting.Tests
                     $"Could not find a suitable executable to download from Google cloud storage for the postfix {postfix}");
             }
 
-            string DownloadFile()
+            private string DownloadFile()
             {
                 GoogleCredential? credential;
                 try
@@ -79,24 +82,26 @@ namespace Calamari.GoogleCloudScripting.Tests
                     throw new Exception("Error reading json key file, please ensure file is correct.");
                 }
             
-                using StorageClient client = StorageClient.Create(credential);
+                using var client = StorageClient.Create(credential);
             
                 var fileToDownload = RetrieveFileFromGoogleCloudStorage(client);
             
-                var rootPath = TestEnvironment.GetTestPath("gcloudCLIPath");
+                var rootPath = TestEnvironment.GetTestPath("gcloud");
                 Directory.CreateDirectory(rootPath);
             
                 var zipFile = Path.Combine(rootPath, fileToDownload.Name);
         
                 if (!File.Exists(zipFile))
                 {
-                    using var fileStream =
-                        new FileStream(zipFile, FileMode.Create, FileAccess.Write, FileShare.None);
+                    using var fileStream = new FileStream(zipFile, FileMode.Create, FileAccess.Write, FileShare.None);
                     client.DownloadObject(fileToDownload, fileStream);
                 }
-        
-                var destinationDirectory = Path.Combine(rootPath, Path.GetFileName(fileToDownload.Name).Replace(postfix, ""));
-                var gcloudExe = Path.Combine(destinationDirectory, "google-cloud-sdk", "bin", $"gcloud{(OperatingSystem.IsWindows() ? ".cmd" : String.Empty)}");
+
+                // postfix is stripped from the path to prevent file paths exceeding length limit on Windows 2012
+                var shortenedName = Path.GetFileName(fileToDownload.Name).Replace(postfix, "");
+                
+                var destinationDirectory = Path.Combine(rootPath, shortenedName);
+                var gcloudExe = Path.Combine(destinationDirectory, "google-cloud-sdk", "bin", $"gcloud{(OperatingSystem.IsWindows() ? ".cmd" : string.Empty)}");
         
                 if (!File.Exists(gcloudExe))
                 {
@@ -110,8 +115,7 @@ namespace Calamari.GoogleCloudScripting.Tests
                     }
                     else
                     {
-                        throw new Exception(
-                            $"{zipFile} cannot be extracted. Supported compressions are .zip and .tar.gz.");
+                        throw new Exception($"{zipFile} cannot be extracted. Supported compressions are .zip and .tar.gz.");
                     }
                 }
 
@@ -119,37 +123,38 @@ namespace Calamari.GoogleCloudScripting.Tests
                 return gcloudExe;
             }
 
-            bool IsZip(string fileName) =>
+            private static bool IsZip(string fileName) =>
                 string.Equals(Path.GetExtension(fileName), ".zip", StringComparison.OrdinalIgnoreCase);
 
-            bool IsGZip(string fileName) =>
+            private static bool IsGZip(string fileName) =>
                 string.Equals(Path.GetExtension(fileName), ".gz", StringComparison.OrdinalIgnoreCase);
 
-            void ExtractGZip(string gzArchiveName, string destinationFolder)
+            private static void ExtractGZip(string gzArchiveName, string destinationFolder)
             {
-                Stream inStream = File.OpenRead(gzArchiveName);
-                Stream gzipStream = new GZipInputStream(inStream);
-
-                TarArchive tarArchive = TarArchive.CreateInputTarArchive(gzipStream, Encoding.UTF8);
+                using var inStream = File.OpenRead(gzArchiveName);
+                using var gzipStream = new GZipInputStream(inStream);
+                using var tarArchive = TarArchive.CreateInputTarArchive(gzipStream, Encoding.UTF8);
                 tarArchive.ExtractContents(destinationFolder);
-                tarArchive.Close();
-
-                gzipStream.Close();
-                inStream.Close();
             }
 
+            private static string PostfixWithoutExtension(string postfix) =>
+                IsZip(postfix) ? postfix.Replace(".zip", "") : postfix.Replace(".tar.gz", "");
+            
             public IEnumerator GetEnumerator()
             {
                 var result = DownloadFile();
                 var startIndex = result.IndexOf("google-cloud-sdk-", StringComparison.Ordinal);
                 var length = result.IndexOf(Path.DirectorySeparatorChar, startIndex + 1) - startIndex;
-                yield return new TestFixtureParameters(new TestFixtureData(result) { TestName = result.Substring(startIndex, length)});
+                yield return new TestFixtureParameters(new TestFixtureData(result)
+                    {
+                        TestName = $"{result.Substring(startIndex, length)}{PostfixWithoutExtension(postfix)}"
+                    });
             }
         }
 
-        const string JsonEnvironmentVariableKey = "GOOGLECLOUD_OCTOPUSAPITESTER_JSONKEY";
+        private const string JsonEnvironmentVariableKey = "GOOGLECLOUD_OCTOPUSAPITESTER_JSONKEY";
 
-        static readonly string? EnvironmentJsonKey = Environment.GetEnvironmentVariable(JsonEnvironmentVariableKey);
+        private static readonly string? EnvironmentJsonKey = Environment.GetEnvironmentVariable(JsonEnvironmentVariableKey);
 
         public GoogleCloudActionHandlerFixture(string cliPath)
         {
@@ -198,7 +203,7 @@ namespace Calamari.GoogleCloudScripting.Tests
                 .Execute(false);
         }
 
-        void AddDefaults(CommandTestBuilderContext context, string? keyFile = null)
+        private void AddDefaults(CommandTestBuilderContext context, string? keyFile = null)
         {
             context.Variables.Add("Octopus.Action.GoogleCloudAccount.Variable", "MyVariable");
             context.Variables.Add("MyVariable.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(keyFile ?? EnvironmentJsonKey!)));

--- a/source/Calamari.GoogleCloudScripting.Tests/OperatingSystem.cs
+++ b/source/Calamari.GoogleCloudScripting.Tests/OperatingSystem.cs
@@ -1,5 +1,3 @@
-
-
 using System.Runtime.InteropServices;
 
 namespace Calamari.GoogleCloudScripting.Tests
@@ -9,7 +7,7 @@ namespace Calamari.GoogleCloudScripting.Tests
         public static bool IsWindows() =>
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-        public static bool IsMacOS() =>
+        public static bool IsMacOs() =>
             RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
         public static bool IsLinux() =>


### PR DESCRIPTION
[sc-29615]

This PR fixes tests for GCP when running on Window 2012 agents.

Previously there is a `PathTooLongException` thrown when running test set up on Windows 2012. The test setup downloads the `gcloud` CLI tool and extracts it. Due to the length of the extraction path, and the limitation that the file name could not exceed 260 characters on Windows 2012, the extraction fails. The tests are running fine on Linux and NetCore on Windows. It only failed when targeting .net framework and running directly on Window 2012 hosts.

Though the `PathTooLongException` could be avoided by upgrading target framework from net461 to net462, the path length limitation is on the host's file system, so long paths will still be unaddressable on Windows 2012 (resulting in "part of the path could not be found" error).

Therefore, this PR resolves this issue by shortening the installation path name. If the content of the `gcloud` installation package changes in the future and the file names get even longer, it is possible that this test will fail again. But currently I can't find a more systematic approach to address this. In the future, we should re-evaluate whether it is necessary to keep the test suite running on Windows 2012; we could just run it from a more recent version of Windows.

This PR also applies Rider's recommendations on code style where possible.