### PR TITLE
Remove NonWindows attribute

### DIFF
--- a/source/Calamari.Terraform.Tests/CommandsFixture.cs
+++ b/source/Calamari.Terraform.Tests/CommandsFixture.cs
@@ -18,7 +18,6 @@ using Calamari.Terraform.Commands;
 using Calamari.Terraform.Tests.CommonTemplates;
 using Calamari.Testing;
 using Calamari.Testing.Helpers;
-using Calamari.Testing.Requirements;
 using FluentAssertions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -29,7 +28,6 @@ namespace Calamari.Terraform.Tests
     [TestFixture("0.11.15")]
     [TestFixture("0.13.0")]
     [TestFixture("1.0.0")]
-    [NonWindowsTest]
     public class CommandsFixture
     {
         string? customTerraformExecutable;


### PR DESCRIPTION
[sc-29614]

A `[NonWindows]` attribute sneaked in when we [migrated integration tests](https://github.com/OctopusDeploy/Sashimi.Terraform/pull/51) from Sashimi to Calamari.

This caused 102 / 110 test cases not running on Windows, and no stack traces are printed. This PR removes this attribute, making the tests actually running to facilitate further investigation to fix these tests more properly on Windows.