### PR TITLE
Adding ACR and GCR feed types

### DIFF
--- a/source/Calamari.Common/Features/Packages/FeedType.cs
+++ b/source/Calamari.Common/Features/Packages/FeedType.cs
@@ -11,6 +11,8 @@ namespace Calamari.Common.Features.Packages
         GitHub,
         Helm,
         AwsElasticContainerRegistry,
-        S3
+        S3,
+        AzureContainerRegistry,
+        GoogleContainerRegistry,
     }
 }

--- a/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
@@ -64,7 +64,9 @@ namespace Calamari.Integration.Packages.Download
                     downloader = new HelmChartPackageDownloader(fileSystem);
                     break;
                 case FeedType.Docker:
-                case FeedType.AwsElasticContainerRegistry :
+                case FeedType.AwsElasticContainerRegistry:
+                case FeedType.AzureContainerRegistry:
+                case FeedType.GoogleContainerRegistry:
                     downloader = new DockerImagePackageDownloader(engine, fileSystem, commandLineRunner, variables, log);
                     break;
                 case FeedType.S3:


### PR DESCRIPTION
This is part of a Spike PR to add ACR and GCR to the list of external feeds. This is to reduce customer confusion when selecting a Docker Feed & with the server implementation will allow for the implementation of specific behavior per feed type.