### PR TITLE
Fix Azure Scripting Issue with TLS version on Windows 2016

### DIFF
--- a/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
+++ b/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
@@ -94,6 +94,7 @@ function Initialize-AzureRmContext {
 
     # Force any output generated to be verbose in Octopus logs.
     Write-Host "##octopus[stdout-verbose]"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
     Write-Host "##octopus[stdout-default]"
 }


### PR DESCRIPTION
[sc-29612]

This PR fixes the TLS version mismatch issue for AzureScripting tests when running with PowerShell Desktop on Windows 2016.