### PR TITLE
Bump version of dotnet sdk from 3.1 to 6.0 in test script

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/EC2/test.sh
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/EC2/test.sh
@@ -3,7 +3,7 @@ sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get update
 sudo apt-get install -y apt-transport-https unzip
 sudo apt-get update
-sudo apt-get install -y dotnet-sdk-3.1
+sudo apt-get install -y dotnet-sdk-6.0
 
 export AWS_CLUSTER_URL=${endpoint}
 export AWS_CLUSTER_NAME=${cluster_name}


### PR DESCRIPTION
[sc-11764] (internal link)

This PR updates dotnet sdk from 3.1 to 6.0 in a test set up script. 