### PR TITLE
Warn customers if their GKE auth tooling is incorrect

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
@@ -1,6 +1,7 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
@@ -1,5 +1,6 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
@@ -1,5 +1,6 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
@@ -1,5 +1,6 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=my-special-namespace --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
@@ -1,5 +1,6 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-cluster octocluster --certificate-authority=<certificateAuthorityPath> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
@@ -1,5 +1,6 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
@@ -1,6 +1,7 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "az" cloud set --name AzureCloud
 [Verbose] Azure CLI: Authenticating with Service Principal
 [Verbose] "az" login --service-principal --username="azClientId" --password="azPassword" --tenant="azTenantId"

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
@@ -1,5 +1,6 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "az" cloud set --name AzureCloud
 [Verbose] Azure CLI: Authenticating with Service Principal
 [Verbose] "az" login --service-principal --username="azClientId" --password="azPassword" --tenant="azTenantId"

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
@@ -1,6 +1,7 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileExists.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileExists.approved.txt
@@ -1,5 +1,6 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "<customkubectl>" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "<customkubectl>" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "<customkubectl>" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "<customkubectl>" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
@@ -1,6 +1,7 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=https://someHash.gr7.ap-southeast-2.eks.amazonaws.com --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
@@ -1,6 +1,7 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenBothZoneAndRegionAreProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenBothZoneAndRegionAreProvided.approved.txt
@@ -1,5 +1,6 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] Authenticating to gcloud with key file
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"
 [Verbose] Successfully authenticated with gcloud

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenRegionIsProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenRegionIsProvided.approved.txt
@@ -1,5 +1,6 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] Authenticating to gcloud with key file
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"
 [Verbose] Successfully authenticated with gcloud

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenZoneIsProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenZoneIsProvided.approved.txt
@@ -1,5 +1,6 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] Authenticating to gcloud with key file
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"
 [Verbose] Successfully authenticated with gcloud

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithUsernamePassword.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithUsernamePassword.approved.txt
@@ -1,6 +1,7 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes.Integration;
+
+namespace Calamari.Kubernetes.Authentication
+{
+    public class AzureKubernetesServicesAuth
+    {
+        readonly AzureCli azureCli;
+        readonly Kubectl kubectlCli;
+        readonly IVariables deploymentVariables;
+
+        /// <summary>
+        /// This class is responsible for configuring the kubectl auth against an AKS cluster for an Octopus Deployment
+        /// </summary>
+        /// <param name="azureCli"></param>
+        /// <param name="kubectlCli"></param>
+        /// <param name="deploymentVariables"></param>
+        public AzureKubernetesServicesAuth(AzureCli azureCli, Kubectl kubectlCli, IVariables deploymentVariables)
+        {
+            this.azureCli = azureCli;
+            this.kubectlCli = kubectlCli;
+            this.deploymentVariables = deploymentVariables;
+        }
+
+        public bool TryConfigure(string @namespace, string kubeConfig)
+        {
+            if (!azureCli.TrySetAz())
+                return false;
+
+            var disableAzureCli = deploymentVariables.GetFlag("OctopusDisableAzureCLI");
+            if (!disableAzureCli)
+            {
+                var azEnvironment = deploymentVariables.Get("Octopus.Action.Azure.Environment") ?? "AzureCloud";
+                var subscriptionId = deploymentVariables.Get("Octopus.Action.Azure.SubscriptionId");
+                var tenantId = deploymentVariables.Get("Octopus.Action.Azure.TenantId");
+                var clientId = deploymentVariables.Get("Octopus.Action.Azure.ClientId");
+                var password = deploymentVariables.Get("Octopus.Action.Azure.Password");
+                azureCli.ConfigureAzAccount(subscriptionId, tenantId, clientId, password, azEnvironment);
+
+                var azureResourceGroup = deploymentVariables.Get("Octopus.Action.Kubernetes.AksClusterResourceGroup");
+                var azureCluster = deploymentVariables.Get(SpecialVariables.AksClusterName);
+                var azureAdmin = deploymentVariables.GetFlag("Octopus.Action.Kubernetes.AksAdminLogin");
+                azureCli.ConfigureAksKubeCtlAuthentication(kubectlCli, azureResourceGroup, azureCluster, @namespace, kubeConfig, azureAdmin);
+            }
+
+            return true;
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Authentication/GoogleKubernetesEngineAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/GoogleKubernetesEngineAuth.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes.Integration;
+
+namespace Calamari.Kubernetes.Authentication
+{
+    public class GoogleKubernetesEngineAuth
+    {
+        readonly GCloud gcloudCli;
+        readonly Kubectl kubectlCli;
+        readonly IVariables deploymentVariables;
+
+        /// <summary>
+        /// This class is responsible for configuring the kubectl auth against a GKE cluster for an Octopus Deployment
+        /// </summary>
+        /// <param name="gcloudCli"></param>
+        /// <param name="kubectlCli"></param>
+        /// <param name="deploymentVariables"></param>
+        public GoogleKubernetesEngineAuth(GCloud gcloudCli, Kubectl kubectlCli, IVariables deploymentVariables)
+        {
+            this.gcloudCli = gcloudCli;
+            this.kubectlCli = kubectlCli;
+            this.deploymentVariables = deploymentVariables;
+        }
+
+        public bool TryConfigure(bool useVmServiceAccount, string @namespace)
+        {
+            if (!gcloudCli.TrySetGcloud())
+                return false;
+
+            var accountVariable = deploymentVariables.Get("Octopus.Action.GoogleCloudAccount.Variable");
+            var jsonKey = deploymentVariables.Get($"{accountVariable}.JsonKey");
+            if (string.IsNullOrEmpty(accountVariable) || string.IsNullOrEmpty(jsonKey))
+            {
+                jsonKey = deploymentVariables.Get("Octopus.Action.GoogleCloudAccount.JsonKey");
+            }
+
+            string impersonationEmails = null;
+            if (deploymentVariables.GetFlag("Octopus.Action.GoogleCloud.ImpersonateServiceAccount"))
+            {
+                impersonationEmails = deploymentVariables.Get("Octopus.Action.GoogleCloud.ServiceAccountEmails");
+            }
+
+            var project = deploymentVariables.Get("Octopus.Action.GoogleCloud.Project") ?? string.Empty;
+            var region = deploymentVariables.Get("Octopus.Action.GoogleCloud.Region") ?? string.Empty;
+            var zone = deploymentVariables.Get("Octopus.Action.GoogleCloud.Zone") ?? string.Empty;
+            gcloudCli.ConfigureGcloudAccount(project, region, zone, jsonKey, useVmServiceAccount, impersonationEmails);
+
+            var gkeClusterName = deploymentVariables.Get(SpecialVariables.GkeClusterName);
+            gcloudCli.ConfigureGkeKubeCtlAuthentication(kubectlCli, gkeClusterName, region, zone, @namespace);
+
+            return true;
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Authentication/GoogleKubernetesEngineAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/GoogleKubernetesEngineAuth.cs
@@ -1,26 +1,34 @@
 ﻿using System;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.Integration;
+using Octopus.CoreUtilities;
+using Octopus.Versioning.Semver;
 
 namespace Calamari.Kubernetes.Authentication
 {
     public class GoogleKubernetesEngineAuth
     {
         readonly GCloud gcloudCli;
+        readonly GkeGcloudAuthPlugin authPluginCli;
         readonly Kubectl kubectlCli;
         readonly IVariables deploymentVariables;
+        readonly ILog log;
 
         /// <summary>
         /// This class is responsible for configuring the kubectl auth against a GKE cluster for an Octopus Deployment
         /// </summary>
         /// <param name="gcloudCli"></param>
+        /// <param name="authPluginCli"></param>
         /// <param name="kubectlCli"></param>
         /// <param name="deploymentVariables"></param>
-        public GoogleKubernetesEngineAuth(GCloud gcloudCli, Kubectl kubectlCli, IVariables deploymentVariables)
+        public GoogleKubernetesEngineAuth(GCloud gcloudCli,GkeGcloudAuthPlugin authPluginCli, Kubectl kubectlCli, IVariables deploymentVariables, ILog log)
         {
             this.gcloudCli = gcloudCli;
+            this.authPluginCli = authPluginCli;
             this.kubectlCli = kubectlCli;
             this.deploymentVariables = deploymentVariables;
+            this.log = log;
         }
 
         public bool TryConfigure(bool useVmServiceAccount, string @namespace)
@@ -46,10 +54,28 @@ namespace Calamari.Kubernetes.Authentication
             var zone = deploymentVariables.Get("Octopus.Action.GoogleCloud.Zone") ?? string.Empty;
             gcloudCli.ConfigureGcloudAccount(project, region, zone, jsonKey, useVmServiceAccount, impersonationEmails);
 
+            WarnCustomersAboutAuthToolingRequirements();
             var gkeClusterName = deploymentVariables.Get(SpecialVariables.GkeClusterName);
             gcloudCli.ConfigureGkeKubeCtlAuthentication(kubectlCli, gkeClusterName, region, zone, @namespace);
 
             return true;
+        }
+
+        /// <summary>
+        /// Provide a clear warning in the deployment logs if the customer's environment has a known incompatible combination of tooling
+        /// </summary>
+        /// <remarks>
+        /// From Kubectl 1.26 onward, the `gke-gcloud-auth-plugin` is required to be available on the path.
+        /// Without it, generating the `kubeconfig` will succeed, but authentication will fail.
+        /// </remarks>
+        void WarnCustomersAboutAuthToolingRequirements()
+        {
+            var kubeCtlVersion = kubectlCli.GetVersion();
+            if (kubeCtlVersion.None() || kubeCtlVersion.Value < new SemanticVersion("1.26.0"))
+                return;
+
+            if (!authPluginCli.ExistsOnPath())
+                log.Warn("From kubectl v1.26 onward, the gke-gcloud-auth-plugin needs to be available on the PATH to authenticate against GKE clusters. See https://oc.to/KubectlAuthChangesGke for more information.");
         }
     }
 }

--- a/source/Calamari/Kubernetes/Integration/AzureCli.cs
+++ b/source/Calamari/Kubernetes/Integration/AzureCli.cs
@@ -1,0 +1,95 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing;
+using Calamari.Common.Plumbing.Logging;
+
+namespace Calamari.Kubernetes.Integration
+{
+    public class AzureCli : CommandLineTool
+    {
+        public AzureCli(ILog log, ICommandLineRunner commandLineRunner, string workingDirectory, Dictionary<string, string> environmentVars)
+            : base(log, commandLineRunner, workingDirectory, environmentVars)
+        {
+        }
+
+        public bool TrySetAz()
+        {
+            var foundExecutable = CalamariEnvironment.IsRunningOnWindows
+                ? ExecuteCommandAndReturnOutput("where", "az.cmd").FirstOrDefault()
+                : ExecuteCommandAndReturnOutput("which", "az").FirstOrDefault();
+
+            if (string.IsNullOrEmpty(foundExecutable))
+            {
+                log.Error("Could not find az. Make sure az is on the PATH.");
+                return false;
+            }
+
+            ExecutableLocation = foundExecutable.Trim();
+            return true;
+        }
+
+        public void ConfigureAzAccount(string subscriptionId,
+                                       string tenantId,
+                                       string clientId,
+                                       string password,
+                                       string azEnvironment)
+        {
+            environmentVars.Add("AZURE_CONFIG_DIR", Path.Combine(workingDirectory, "azure-cli"));
+
+            TryExecuteCommandAndLogOutput(ExecutableLocation,
+                                          "cloud",
+                                          "set",
+                                          "--name",
+                                          azEnvironment);
+
+            log.Verbose("Azure CLI: Authenticating with Service Principal");
+
+            // Use the full argument with an '=' because of https://github.com/Azure/azure-cli/issues/12105
+            ExecuteCommandAndLogOutput(new CommandLineInvocation(ExecutableLocation,
+                                                                 "login",
+                                                                 "--service-principal",
+                                                                 $"--username=\"{clientId}\"",
+                                                                 $"--password=\"{password}\"",
+                                                                 $"--tenant=\"{tenantId}\""));
+
+            log.Verbose($"Azure CLI: Setting active subscription to {subscriptionId}");
+            ExecuteCommandAndLogOutput(new CommandLineInvocation(ExecutableLocation,
+                                                                 "account",
+                                                                 "set",
+                                                                 "--subscription",
+                                                                 subscriptionId));
+
+            log.Info("Successfully authenticated with the Azure CLI");
+        }
+
+        public void ConfigureAksKubeCtlAuthentication(Kubectl kubectlCli, string clusterResourceGroup, string clusterName, string clusterNamespace, string kubeConfigPath, bool adminLogin)
+        {
+            log.Info($"Creating kubectl context to AKS Cluster in resource group {clusterResourceGroup} called {clusterName} (namespace {clusterNamespace}) using a AzureServicePrincipal");
+
+            var arguments = new List<string>(new[]
+            {
+                "aks",
+                "get-credentials",
+                "--resource-group",
+                clusterResourceGroup,
+                "--name",
+                clusterName,
+                "--file",
+                $"\"{kubeConfigPath}\"",
+                "--overwrite-existing"
+            });
+            if (adminLogin)
+            {
+                arguments.Add("--admin");
+                clusterName += "-admin";
+            }
+
+            var result = ExecuteCommandAndLogOutput(new CommandLineInvocation(ExecutableLocation, arguments.ToArray()));
+            result.VerifySuccess();
+
+            kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-context", clusterName, $"--namespace={@clusterNamespace}");
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Integration/CaptureCommandOutput.cs
+++ b/source/Calamari/Kubernetes/Integration/CaptureCommandOutput.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using Calamari.Common.Plumbing.Commands;
+
+namespace Calamari.Kubernetes.Integration
+{
+    public class CaptureCommandOutput : ICommandInvocationOutputSink
+    {
+        public List<Message> Messages { get; } = new List<Message>();
+        public void WriteInfo(string line)
+        {
+            Messages.Add(new Message(Level.Info, line));
+        }
+
+        public void WriteError(string line)
+        {
+            Messages.Add(new Message(Level.Error, line));
+        }
+    }
+
+    public class Message
+    {
+        public Level Level { get; }
+        public string Text { get; }
+        public Message(Level level, string text)
+        {
+            Level = level;
+            Text = text;
+        }
+    }
+
+    public enum Level
+    {
+        Info,
+        Error
+    }
+}

--- a/source/Calamari/Kubernetes/Integration/CommandLineTool.cs
+++ b/source/Calamari/Kubernetes/Integration/CommandLineTool.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.Logging;
+
+namespace Calamari.Kubernetes.Integration
+{
+    public class CommandLineTool
+    {
+        protected readonly ILog log;
+        protected readonly string workingDirectory;
+        protected readonly Dictionary<string, string> environmentVars;
+
+        readonly ICommandLineRunner commandLineRunner;
+
+        protected CommandLineTool(ILog log, ICommandLineRunner commandLineRunner, string workingDirectory, Dictionary<string, string> environmentVars)
+        {
+            this.log = log;
+            this.commandLineRunner = commandLineRunner;
+            this.workingDirectory = workingDirectory;
+            this.environmentVars = environmentVars;
+        }
+
+        public string ExecutableLocation { get; protected set; }
+
+        protected bool TryExecuteCommandAndLogOutput(string exe, params string[] arguments)
+        {
+            var result = ExecuteCommandAndLogOutput(new CommandLineInvocation(exe, arguments));
+            return result.ExitCode == 0;
+        }
+
+        protected CommandResult ExecuteCommandAndLogOutput(CommandLineInvocation invocation)
+        {
+            invocation.EnvironmentVars = environmentVars;
+            invocation.WorkingDirectory = workingDirectory;
+            invocation.OutputAsVerbose = false;
+            invocation.OutputToLog = false;
+
+            var captureCommandOutput = new CaptureCommandOutput();
+            invocation.AdditionalInvocationOutputSink = captureCommandOutput;
+
+            LogCommandText(invocation);
+
+            var result = commandLineRunner.Execute(invocation);
+
+            LogCapturedOutput(result, captureCommandOutput);
+
+            return result;
+        }
+
+        void LogCommandText(CommandLineInvocation invocation)
+        {
+            log.Verbose(invocation.ToString());
+        }
+
+        void LogCapturedOutput(CommandResult result, CaptureCommandOutput captureCommandOutput)
+        {
+            foreach (var message in captureCommandOutput.Messages)
+            {
+                if (result.ExitCode == 0)
+                {
+                    log.Verbose(message.Text);
+                    continue;
+                }
+
+                switch (message.Level)
+                {
+                    case Level.Info:
+                        log.Verbose(message.Text);
+                        break;
+                    case Level.Error:
+                        log.Error(message.Text);
+                        break;
+                }
+            }
+        }
+
+        protected IEnumerable<string> ExecuteCommandAndReturnOutput(string exe, params string[] arguments)
+        {
+            var captureCommandOutput = new CaptureCommandOutput();
+            var invocation = new CommandLineInvocation(exe, arguments)
+            {
+                EnvironmentVars = environmentVars,
+                WorkingDirectory = workingDirectory,
+                OutputAsVerbose = false,
+                OutputToLog = false,
+                AdditionalInvocationOutputSink = captureCommandOutput
+            };
+
+            var result = commandLineRunner.Execute(invocation);
+
+            return result.ExitCode == 0
+                ? captureCommandOutput.Messages.Where(m => m.Level == Level.Info).Select(m => m.Text).ToArray()
+                : Enumerable.Empty<string>();
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Integration/GCloud.cs
+++ b/source/Calamari/Kubernetes/Integration/GCloud.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+
+namespace Calamari.Kubernetes.Integration
+{
+    public class GCloud : CommandLineTool
+    {
+        public GCloud(ILog log, ICommandLineRunner commandLineRunner, string workingDirectory, Dictionary<string, string> environmentVars) 
+            : base(log, commandLineRunner, workingDirectory, environmentVars)
+        {
+        }
+
+        public bool TrySetGcloud()
+        {
+            var foundExecutable = CalamariEnvironment.IsRunningOnWindows
+                ? ExecuteCommandAndReturnOutput("where", "gcloud.cmd").FirstOrDefault()
+                : ExecuteCommandAndReturnOutput("which", "gcloud").FirstOrDefault();
+
+            if (string.IsNullOrEmpty(foundExecutable))
+                return false;
+
+            ExecutableLocation = foundExecutable?.Trim();
+            return true;
+        }
+
+        public void ConfigureGcloudAccount(string project, string region, string zone, string jsonKey, bool useVmServiceAccount, string impersonationEmails)
+        {
+            if (!string.IsNullOrEmpty(project))
+            {
+                environmentVars.Add("CLOUDSDK_CORE_PROJECT", project);
+            }
+
+            if (!string.IsNullOrEmpty(region))
+            {
+                environmentVars.Add("CLOUDSDK_COMPUTE_REGION", region);
+            }
+
+            if (!string.IsNullOrEmpty(zone))
+            {
+                environmentVars.Add("CLOUDSDK_COMPUTE_ZONE", zone);
+            }
+
+            if (!useVmServiceAccount)
+            {
+                if (jsonKey == null)
+                {
+                    log.Error("Failed to authenticate with gcloud. Key file is empty.");
+                    return;
+                }
+
+                log.Verbose("Authenticating to gcloud with key file");
+                var bytes = Convert.FromBase64String(jsonKey);
+                using (var keyFile = new TemporaryFile(Path.Combine(workingDirectory, "gcpJsonKey.json")))
+                {
+                    File.WriteAllBytes(keyFile.FilePath, bytes);
+                    var result = ExecuteCommandAndLogOutput(new CommandLineInvocation(ExecutableLocation, "auth", "activate-service-account", $"--key-file=\"{keyFile.FilePath}\""));
+                    result.VerifySuccess();
+                }
+
+                log.Verbose("Successfully authenticated with gcloud");
+            }
+            else
+            {
+                log.Verbose("Bypassing authentication with gcloud");
+            }
+
+            if (!string.IsNullOrEmpty(impersonationEmails))
+                environmentVars.Add("CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT", impersonationEmails);
+        }
+
+        public void ConfigureGkeKubeCtlAuthentication(Kubectl kubectlCli, string gkeClusterName, string region, string zone, string @namespace)
+        {
+            log.Info($"Creating kubectl context to GKE Cluster called {gkeClusterName} (namespace {@namespace}) using a Google Cloud Account");
+
+            var arguments = new List<string>(new[]
+            {
+                "container",
+                "clusters",
+                "get-credentials",
+                gkeClusterName
+            });
+
+            if (!string.IsNullOrWhiteSpace(zone))
+            {
+                arguments.Add($"--zone={zone}");
+            }
+            else if (!string.IsNullOrWhiteSpace(region))
+            {
+                arguments.Add($"--region={region}");
+            }
+            else
+            {
+                throw new ArgumentException("Either zone or region must be defined.");
+            }
+
+            var result = ExecuteCommandAndLogOutput(new CommandLineInvocation(ExecutableLocation, arguments.ToArray()));
+            result.VerifySuccess();
+            kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-context", "--current", $"--namespace={@namespace}");
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Integration/GCloud.cs
+++ b/source/Calamari/Kubernetes/Integration/GCloud.cs
@@ -23,7 +23,10 @@ namespace Calamari.Kubernetes.Integration
                 : ExecuteCommandAndReturnOutput("which", "gcloud").FirstOrDefault();
 
             if (string.IsNullOrEmpty(foundExecutable))
+            {
+                log.Error("Could not find gcloud. Make sure gcloud is on the PATH.");
                 return false;
+            }
 
             ExecutableLocation = foundExecutable?.Trim();
             return true;

--- a/source/Calamari/Kubernetes/Integration/GkeGcloudAuthPlugin.cs
+++ b/source/Calamari/Kubernetes/Integration/GkeGcloudAuthPlugin.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing;
+using Calamari.Common.Plumbing.Logging;
+
+namespace Calamari.Kubernetes.Integration
+{
+    public class GkeGcloudAuthPlugin : CommandLineTool
+    {
+        public GkeGcloudAuthPlugin(ILog log, ICommandLineRunner commandLineRunner, string workingDirectory, Dictionary<string, string> environmentVars)
+            : base(log, commandLineRunner, workingDirectory, environmentVars)
+        {
+        }
+
+        public bool ExistsOnPath()
+        {
+            var foundExecutable = CalamariEnvironment.IsRunningOnWindows
+                ? ExecuteCommandAndReturnOutput("where", "gke-gcloud-auth-plugin.exe").FirstOrDefault()
+                : ExecuteCommandAndReturnOutput("which", "gke-gcloud-auth-plugin").FirstOrDefault();
+
+            return !string.IsNullOrEmpty(foundExecutable);
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Integration/Kubectl.cs
+++ b/source/Calamari/Kubernetes/Integration/Kubectl.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Newtonsoft.Json;
+using Octopus.CoreUtilities;
+using Octopus.Versioning.Semver;
+
+namespace Calamari.Kubernetes.Integration
+{
+    public class Kubectl : CommandLineTool
+    {
+        readonly string customKubectlExecutable;
+
+        public Kubectl(string customKubectlExecutable, ILog log, ICommandLineRunner commandLineRunner, string workingDirectory, Dictionary<string, string> environmentVars)
+            : base(log, commandLineRunner, workingDirectory, environmentVars)
+        {
+            this.customKubectlExecutable = customKubectlExecutable;
+        }
+
+        public bool TrySetKubectl()
+        {
+            if (string.IsNullOrEmpty(customKubectlExecutable))
+            {
+                var foundExecutable = CalamariEnvironment.IsRunningOnWindows
+                    ? ExecuteCommandAndReturnOutput("where", "kubectl.exe").FirstOrDefault()
+                    : ExecuteCommandAndReturnOutput("which", "kubectl").FirstOrDefault();
+
+                if (string.IsNullOrEmpty(foundExecutable))
+                {
+                    log.Error("Could not find kubectl. Make sure kubectl is on the PATH. See https://g.octopushq.com/KubernetesTarget for more information.");
+                    return false;
+                }
+
+                ExecutableLocation = foundExecutable?.Trim();
+            }
+            else
+            {
+                if (!File.Exists(customKubectlExecutable))
+                {
+                    log.Error($"The custom kubectl location of {customKubectlExecutable} does not exist. See https://g.octopushq.com/KubernetesTarget for more information.");
+                    return false;
+                }
+
+                ExecutableLocation = customKubectlExecutable;
+            }
+
+            if (TryExecuteKubectlCommand("version", "--client", "--short"))
+            {
+                log.Verbose($"Found kubectl and successfully verified it can be executed.");
+                return true;
+            }
+
+            log.Error($"Found kubectl at {ExecutableLocation}, but unable to successfully execute it. See https://g.octopushq.com/KubernetesTarget for more information.");
+            return false;
+        }
+
+        bool TryExecuteKubectlCommand(params string[] arguments)
+        {
+            return ExecuteCommandAndLogOutput(new CommandLineInvocation(ExecutableLocation, arguments.Concat(new[] { "--request-timeout=1m" }).ToArray())).ExitCode == 0;
+        }
+
+        public CommandResult ExecuteCommand(params string[] arguments)
+        {
+            var kubectlArguments = arguments.Concat(new[] { "--request-timeout=1m" }).ToArray();
+            var commandInvocation = new CommandLineInvocation(ExecutableLocation, kubectlArguments);
+            return ExecuteCommandAndLogOutput(commandInvocation);
+        }
+        
+        public void ExecuteCommandAndAssertSuccess(params string[] arguments)
+        {
+            var result = ExecuteCommand(arguments);
+            result.VerifySuccess();
+        }
+
+        public Maybe<SemanticVersion> GetVersion()
+        {
+            var kubectlVersionOutput = ExecuteCommandAndReturnOutput(ExecutableLocation, "version", "--client", "--output=json");
+            var kubeCtlVersionJson = string.Join(" ", kubectlVersionOutput);
+            try
+            {
+                var clientVersion = JsonConvert.DeserializeAnonymousType(kubeCtlVersionJson, new { clientVersion = new { gitVersion = "1.0.0" } });
+                var kubectlVersionString = clientVersion?.clientVersion?.gitVersion?.TrimStart('v');
+                if (kubectlVersionString != null)
+                {
+                    return Maybe<SemanticVersion>.Some(new SemanticVersion(kubectlVersionString));
+                }
+            }
+            catch (Exception e)
+            {
+                log.Verbose($"Unable to determine kubectl version. Failed with error message: {e.Message}");
+            }
+
+            return Maybe<SemanticVersion>.None;
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -4,19 +4,16 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
 using Calamari.Common.Features.EmbeddedResources;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing;
-using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Proxies;
 using Calamari.Common.Plumbing.Variables;
-using Newtonsoft.Json;
+using Calamari.Kubernetes.Integration;
 using Newtonsoft.Json.Linq;
 using Octopus.CoreUtilities;
 using Octopus.Versioning.Semver;
@@ -112,16 +109,16 @@ namespace Calamari.Kubernetes
         class SetupKubectlAuthentication
         {
             readonly IVariables variables;
-            readonly ILog log;
+            readonly RedactedValuesLogger log;
             readonly ScriptSyntax scriptSyntax;
             readonly ICommandLineRunner commandLineRunner;
             readonly Dictionary<string, string> environmentVars;
             readonly string workingDirectory;
-            string kubectl;
             string az;
             string aws;
             string gcloud;
-            Dictionary<string, string> redactMap = new Dictionary<string, string>();
+
+            Kubectl kubectlCli;
 
             public SetupKubectlAuthentication(IVariables variables,
                                               ILog log,
@@ -131,7 +128,7 @@ namespace Calamari.Kubernetes
                                               string workingDirectory)
             {
                 this.variables = variables;
-                this.log = log;
+                this.log = new RedactedValuesLogger(log);
                 this.scriptSyntax = scriptSyntax;
                 this.commandLineRunner = commandLineRunner;
                 this.environmentVars = environmentVars;
@@ -147,9 +144,11 @@ namespace Calamari.Kubernetes
                     environmentVars[proxyVariable.Key] = proxyVariable.Value;
                 }
 
-                var kubeConfig = ConfigureCliExecution();
+                var kubeConfig = CreateKubectlConfig();
 
-                if (!TrySetKubectl())
+                var customKubectlExecutable = variables.Get("Octopus.Action.Kubernetes.CustomKubectlExecutable");
+                kubectlCli = new Kubectl(customKubectlExecutable, log, commandLineRunner, workingDirectory, environmentVars);
+                if (!kubectlCli.TrySetKubectl())
                 {
                     return errorResult;
                 }
@@ -174,7 +173,7 @@ namespace Calamari.Kubernetes
                 var outputKubeConfig = variables.GetFlag(SpecialVariables.OutputKubeConfig);
                 if (outputKubeConfig)
                 {
-                    ExecuteKubectlCommand("config", "view");
+                    kubectlCli.ExecuteCommandAndAssertSuccess("config", "view");
                 }
 
                 return new CommandResult(string.Empty, 0);
@@ -246,26 +245,56 @@ namespace Calamari.Kubernetes
 
                 if (isUsingAzureServicePrincipalAuth)
                 {
-                    if (!TrySetAz())
-                    {
-                        log.Error("Could not find az. Make sure az is on the PATH.");
+                    var azureCli = new AzureCli(log, commandLineRunner, workingDirectory, environmentVars);
+                    if (!azureCli.TrySetAz())
                         return false;
+                    az = azureCli.ExecutableLocation;
+
+                    var disableAzureCli = variables.GetFlag("OctopusDisableAzureCLI");
+                    if (!disableAzureCli)
+                    {
+                        var azEnvironment = variables.Get("Octopus.Action.Azure.Environment") ?? "AzureCloud";
+                        var subscriptionId = variables.Get("Octopus.Action.Azure.SubscriptionId");
+                        var tenantId = variables.Get("Octopus.Action.Azure.TenantId");
+                        var clientId = variables.Get("Octopus.Action.Azure.ClientId");
+                        var password = variables.Get("Octopus.Action.Azure.Password");
+                        azureCli.ConfigureAzAccount(subscriptionId, tenantId, clientId, password, azEnvironment);
+
+                        var azureResourceGroup = variables.Get("Octopus.Action.Kubernetes.AksClusterResourceGroup");
+                        var azureCluster = variables.Get(SpecialVariables.AksClusterName);
+                        var azureAdmin = variables.GetFlag("Octopus.Action.Kubernetes.AksAdminLogin");
+                        azureCli.ConfigureAksKubeCtlAuthentication(kubectlCli, azureResourceGroup, azureCluster, @namespace, kubeConfig, azureAdmin);
                     }
-
-                    ConfigureAzAccount();
-
-                    SetupContextForAzureServicePrincipal(kubeConfig, @namespace);
                 }
                 else if (isUsingGoogleCloudAuth)
                 {
-                    if (!TrySetGcloud())
+                    var gcloudCli = new GCloud(log, commandLineRunner, workingDirectory, environmentVars);
+                    if (!gcloudCli.TrySetGcloud())
                     {
                         log.Error("Could not find gcloud. Make sure gcloud is on the PATH.");
                         return false;
                     }
 
-                    ConfigureGcloudAccount(useVmServiceAccount);
-                    SetupContextForGoogleCloudAccount(@namespace);
+                    gcloud = gcloudCli.ExecutableLocation;
+
+                    var project = variables.Get("Octopus.Action.GoogleCloud.Project") ?? string.Empty;
+                    var region = variables.Get("Octopus.Action.GoogleCloud.Region") ?? string.Empty;
+                    var zone = variables.Get("Octopus.Action.GoogleCloud.Zone") ?? string.Empty;
+                    var accountVariable = variables.Get("Octopus.Action.GoogleCloudAccount.Variable");
+                    var jsonKey = variables.Get($"{accountVariable}.JsonKey");
+                    if (string.IsNullOrEmpty(accountVariable) || string.IsNullOrEmpty(jsonKey))
+                    {
+                        jsonKey = variables.Get("Octopus.Action.GoogleCloudAccount.JsonKey");
+                    }
+                    string impersonationEmails = null;
+                    if (variables.GetFlag("Octopus.Action.GoogleCloud.ImpersonateServiceAccount"))
+                    {
+                        impersonationEmails = variables.Get("Octopus.Action.GoogleCloud.ServiceAccountEmails");
+                    }
+                    gcloudCli.ConfigureGcloudAccount(project, region, zone, jsonKey, useVmServiceAccount, impersonationEmails);
+                    
+                    var gkeClusterName = variables.Get(SpecialVariables.GkeClusterName);
+                    gcloudCli.ConfigureGkeKubeCtlAuthentication(kubectlCli, gkeClusterName, region, zone, @namespace);
                 }
                 else
                 {
@@ -283,21 +312,9 @@ namespace Calamari.Kubernetes
                     }
                     else
                     {
-                        ExecuteKubectlCommand("config",
-                                              "set-cluster",
-                                              cluster,
-                                              $"--server={clusterUrl}");
-
-                        ExecuteKubectlCommand("config",
-                                              "set-context",
-                                              context,
-                                              $"--user={user}",
-                                              $"--cluster={cluster}",
-                                              $"--namespace={@namespace}");
-
-                        ExecuteKubectlCommand("config",
-                                              "use-context",
-                                              context);
+                        kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--server={clusterUrl}");
+                        kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-context", context, $"--user={user}", $"--cluster={cluster}", $"--namespace={@namespace}");
+                        kubectlCli.ExecuteCommandAndAssertSuccess("config", "use-context", context);
 
                         var clientCertPem = variables.Get($"{clientCert}.CertificatePem");
                         var clientCertKey = variables.Get($"{clientCert}.PrivateKeyPem");
@@ -325,16 +342,10 @@ namespace Calamari.Kubernetes
 
                             // Don't leak the private key in the logs
                             log.SetOutputVariable($"{clientCert}.PrivateKeyPemBase64", clientCertKeyEncoded, variables, true);
-                            redactMap[clientCertKeyEncoded] = "<data>";
-                            redactMap[clientCertPemEncoded] = "<data>";
-                            ExecuteKubectlCommand("config",
-                                                  "set",
-                                                  $"users.{user}.client-certificate-data",
-                                                  clientCertPemEncoded);
-                            ExecuteKubectlCommand("config",
-                                                  "set",
-                                                  $"users.{user}.client-key-data",
-                                                  clientCertKeyEncoded);
+                            log.AddValueToRedact(clientCertKeyEncoded, "<data>");
+                            log.AddValueToRedact(clientCertPemEncoded, "<data>");
+                            kubectlCli.ExecuteCommandAndAssertSuccess("config", "set", $"users.{user}.client-certificate-data", clientCertPemEncoded);
+                            kubectlCli.ExecuteCommandAndAssertSuccess("config", "set", $"users.{user}.client-key-data", clientCertKeyEncoded);
                         }
 
                         if (!string.IsNullOrEmpty(certificateAuthority))
@@ -346,18 +357,12 @@ namespace Calamari.Kubernetes
                             }
 
                             var authorityData = Convert.ToBase64String(Encoding.ASCII.GetBytes(serverCertPem));
-                            redactMap[authorityData] = "<data>";
-                            ExecuteKubectlCommand("config",
-                                                  "set",
-                                                  $"clusters.{cluster}.certificate-authority-data",
-                                                  authorityData);
+                            log.AddValueToRedact(authorityData, "<data>");
+                            kubectlCli.ExecuteCommandAndAssertSuccess("config", "set", $"clusters.{cluster}.certificate-authority-data", authorityData);
                         }
                         else
                         {
-                            ExecuteKubectlCommand("config",
-                                                  "set-cluster",
-                                                  cluster,
-                                                  $"--insecure-skip-tls-verify={skipTlsVerification}");
+                            kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--insecure-skip-tls-verify={skipTlsVerification}");
                         }
 
                         switch (accountType)
@@ -402,24 +407,17 @@ namespace Calamari.Kubernetes
 
             void SetupContextForToken(string @namespace, string token, string clusterUrl, string user)
             {
-                redactMap[token] = "<token>";
+                log.AddValueToRedact(token, "<token>");
                 log.Info($"Creating kubectl context to {clusterUrl} (namespace {@namespace}) using a Token");
-                ExecuteKubectlCommand("config",
-                                      "set-credentials",
-                                      user,
-                                      $"--token={token}");
+                kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-credentials", user, $"--token={token}");
             }
 
             void SetupContextForUsernamePassword(string user)
             {
                 var username = variables.Get("Octopus.Account.Username");
                 var password = variables.Get("Octopus.Account.Password");
-                redactMap[password] = "<password>";
-                ExecuteKubectlCommand("config",
-                                      "set-credentials",
-                                      user,
-                                      $"--username={username}",
-                                      $"--password={password}");
+                log.AddValueToRedact(password, "<password>");
+                kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-credentials", user, $"--username={username}", $"--password={password}");
             }
 
             void SetupContextForAmazonServiceAccount(string @namespace, string clusterUrl, string user)
@@ -496,32 +494,17 @@ namespace Calamari.Kubernetes
 
             void SetKubeConfigAuthenticationToAwsCli(string user, string clusterName, string region, string apiVersion)
             {
-                ExecuteKubectlCommand("config",
-                                      "set-credentials",
-                                      user,
-                                      "--exec-command=aws",
-                                      "--exec-arg=eks",
-                                      "--exec-arg=get-token",
-                                      $"--exec-arg=--cluster-name={clusterName}",
-                                      $"--exec-arg=--region={region}",
-                                      $"--exec-api-version={apiVersion}");
+                kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-credentials", user, "--exec-command=aws", "--exec-arg=eks", "--exec-arg=get-token", $"--exec-arg=--cluster-name={clusterName}", $"--exec-arg=--region={region}", $"--exec-api-version={apiVersion}");
             }
 
             void SetKubeConfigAuthenticationToAwsIAm(string user, string clusterName)
             {
-                var kubectlVersion = TrySetKubectlVersion();
+                var kubectlVersion = kubectlCli.GetVersion();
                 var apiVersion = kubectlVersion.Some() && kubectlVersion.Value > new SemanticVersion("1.23.6")
                     ? "client.authentication.k8s.io/v1beta1"
                     : "client.authentication.k8s.io/v1alpha1";
 
-                ExecuteKubectlCommand("config",
-                                      "set-credentials",
-                                      user,
-                                      "--exec-command=aws-iam-authenticator",
-                                      $"--exec-api-version={apiVersion}",
-                                      "--exec-arg=token",
-                                      "--exec-arg=-i",
-                                      $"--exec-arg={clusterName}");
+                kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-credentials", user, "--exec-command=aws-iam-authenticator", $"--exec-api-version={apiVersion}", "--exec-arg=token", "--exec-arg=-i", $"--exec-arg={clusterName}");
             }
 
             void SetupContextUsingPodServiceAccount(string @namespace,
@@ -534,128 +517,25 @@ namespace Calamari.Kubernetes
                                                     string user,
                                                     string podServiceAccountToken)
             {
-                ExecuteKubectlCommand("config",
-                                      "set-cluster",
-                                      cluster,
-                                      $"--server={clusterUrl}");
+                kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--server={clusterUrl}");
 
                 if (string.IsNullOrEmpty(serverCert))
                 {
-                    ExecuteKubectlCommand("config",
-                                          "set-cluster",
-                                          cluster,
-                                          $"--insecure-skip-tls-verify={skipTlsVerification}");
+                    kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--insecure-skip-tls-verify={skipTlsVerification}");
                 }
                 else
                 {
-                    ExecuteKubectlCommand("config",
-                                          "set-cluster",
-                                          cluster,
-                                          $"--certificate-authority={serverCertPath}");
+                    kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--certificate-authority={serverCertPath}");
                 }
 
-                ExecuteKubectlCommand("config",
-                                      "set-context",
-                                      context,
-                                      $"--user={user}",
-                                      $"--cluster={cluster}",
-                                      $"--namespace={@namespace}");
-                ExecuteKubectlCommand("config",
-                                      "use-context",
-                                      context);
+                kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-context", context, $"--user={user}", $"--cluster={cluster}", $"--namespace={@namespace}");
+                kubectlCli.ExecuteCommandAndAssertSuccess("config", "use-context", context);
 
                 log.Info($"Creating kubectl context to {clusterUrl} (namespace {@namespace}) using a Pod Service Account Token");
-                redactMap[podServiceAccountToken] = "<token>";
-                ExecuteKubectlCommand("config",
-                                      "set-credentials",
-                                      user,
-                                      $"--token={podServiceAccountToken}");
+                log.AddValueToRedact(podServiceAccountToken, "<token>");
+                kubectlCli.ExecuteCommandAndAssertSuccess("config", "set-credentials", user, $"--token={podServiceAccountToken}");
             }
 
-            void SetupContextForAzureServicePrincipal(string kubeConfig, string @namespace)
-            {
-                var azureResourceGroup = variables.Get("Octopus.Action.Kubernetes.AksClusterResourceGroup");
-                var azureCluster = variables.Get(SpecialVariables.AksClusterName);
-                var azureAdmin = variables.GetFlag("Octopus.Action.Kubernetes.AksAdminLogin");
-                log.Info($"Creating kubectl context to AKS Cluster in resource group {azureResourceGroup} called {azureCluster} (namespace {@namespace}) using a AzureServicePrincipal");
-
-                var arguments = new List<string>(new[]
-                {
-                    "aks",
-                    "get-credentials",
-                    "--resource-group",
-                    azureResourceGroup,
-                    "--name",
-                    azureCluster,
-                    "--file",
-                    $"\"{kubeConfig}\"",
-                    "--overwrite-existing"
-                });
-                if (azureAdmin)
-                {
-                    arguments.Add("--admin");
-                    azureCluster += "-admin";
-                }
-
-                ExecuteCommand(az, arguments.ToArray());
-
-                ExecuteKubectlCommand("config",
-                                      "set-context",
-                                      azureCluster,
-                                      $"--namespace={@namespace}");
-            }
-
-            void SetupContextForGoogleCloudAccount(string @namespace)
-            {
-                var gkeClusterName = variables.Get(SpecialVariables.GkeClusterName);
-                log.Info($"Creating kubectl context to GKE Cluster called {gkeClusterName} (namespace {@namespace}) using a Google Cloud Account");
-
-                var arguments = new List<string>(new[]
-                {
-                    "container",
-                    "clusters",
-                    "get-credentials",
-                    gkeClusterName
-                });
-
-                var region = variables.Get("Octopus.Action.GoogleCloud.Region");
-                var zone = variables.Get("Octopus.Action.GoogleCloud.Zone");
-                if (!string.IsNullOrWhiteSpace(zone))
-                {
-                    arguments.Add($"--zone={zone}");
-                } 
-                else if (!string.IsNullOrWhiteSpace(region))
-                {
-                    arguments.Add($"--region={region}");
-                }
-                else
-                {
-                    throw new ArgumentException("Either zone or region must be defined.");
-                }
-
-                ExecuteCommand(gcloud, arguments.ToArray());
-                ExecuteKubectlCommand("config",
-                                      "set-context",
-                                      "--current",
-                                      $"--namespace={@namespace}");
-            }
-
-            bool TrySetAz()
-            {
-                az = CalamariEnvironment.IsRunningOnWindows
-                    ? ExecuteCommandAndReturnOutput("where", "az.cmd").FirstOrDefault()
-                    : ExecuteCommandAndReturnOutput("which", "az").FirstOrDefault();
-
-                if (string.IsNullOrEmpty(az))
-                {
-                    return false;
-                }
-
-                az = az.Trim();
-
-                return true;
-            }
-            
             bool TrySetAws()
             {
                 aws = CalamariEnvironment.IsRunningOnWindows
@@ -672,21 +552,6 @@ namespace Calamari.Kubernetes
                 return true;
             }
 
-            bool TrySetGcloud()
-            {
-                gcloud = CalamariEnvironment.IsRunningOnWindows
-                    ? ExecuteCommandAndReturnOutput("where", "gcloud.cmd").FirstOrDefault()
-                    : ExecuteCommandAndReturnOutput("which", "gcloud").FirstOrDefault();
-
-                if (string.IsNullOrEmpty(gcloud))
-                {
-                    return false;
-                }
-
-                gcloud = gcloud.Trim();
-                return true;
-            }
-
             bool CreateNamespace(string @namespace)
             {
                 if (TryExecuteCommandWithVerboseLoggingOnly("get", "namespace", @namespace))
@@ -695,114 +560,7 @@ namespace Calamari.Kubernetes
                 return TryExecuteCommandWithVerboseLoggingOnly("create", "namespace", @namespace);
             }
 
-            string GetAzEnvironment()
-            {
-                return variables.Get("Octopus.Action.Azure.Environment") ?? "AzureCloud";
-            }
-
-            void ConfigureAzAccount()
-            {
-                var disableAzureCli = variables.GetFlag("OctopusDisableAzureCLI");
-
-                if (disableAzureCli)
-                {
-                    return;
-                }
-
-                environmentVars.Add("AZURE_CONFIG_DIR", Path.Combine(workingDirectory, "azure-cli"));
-                TryExecuteCommand(az,
-                               "cloud",
-                               "set",
-                               "--name",
-                               GetAzEnvironment());
-
-                log.Verbose("Azure CLI: Authenticating with Service Principal");
-
-                var subscriptionId = variables.Get("Octopus.Action.Azure.SubscriptionId");
-                var tenantId = variables.Get("Octopus.Action.Azure.TenantId");
-                var clientId = variables.Get("Octopus.Action.Azure.ClientId");
-                var password = variables.Get("Octopus.Action.Azure.Password");
-
-                ExecuteCommand(az,
-                               "login",
-                               "--service-principal",
-                               // Use the full argument with an '=' because of https://github.com/Azure/azure-cli/issues/12105
-                               $"--username=\"{clientId}\"",
-                               $"--password=\"{password}\"",
-                               $"--tenant=\"{tenantId}\"");
-
-                log.Verbose($"Azure CLI: Setting active subscription to {subscriptionId}");
-                ExecuteCommand(az,
-                               "account",
-                               "set",
-                               "--subscription",
-                               subscriptionId);
-
-                log.Info("Successfully authenticated with the Azure CLI");
-            }
-
-            void ConfigureGcloudAccount(bool useVmServiceAccount)
-            {
-                var project = variables.Get("Octopus.Action.GoogleCloud.Project") ?? string.Empty;
-                var region = variables.Get("Octopus.Action.GoogleCloud.Region") ?? string.Empty;
-                var zone = variables.Get("Octopus.Action.GoogleCloud.Zone") ?? string.Empty;
-                if (!string.IsNullOrEmpty(project))
-                {
-                    environmentVars.Add("CLOUDSDK_CORE_PROJECT", project);
-                }
-                if (!string.IsNullOrEmpty(region))
-                {
-                    environmentVars.Add("CLOUDSDK_COMPUTE_REGION", region);
-                }
-                if (!string.IsNullOrEmpty(zone))
-                {
-                    environmentVars.Add("CLOUDSDK_COMPUTE_ZONE", zone);
-                }
-
-                if (!useVmServiceAccount)
-                {
-                    var accountVariable = variables.Get("Octopus.Action.GoogleCloudAccount.Variable");
-                    var jsonKey = variables.Get($"{accountVariable}.JsonKey");
-                    if (string.IsNullOrEmpty(accountVariable) || string.IsNullOrEmpty(jsonKey))
-                    {
-                        jsonKey = variables.Get("Octopus.Action.GoogleCloudAccount.JsonKey");
-                    }
-
-                    if (jsonKey == null)
-                    {
-                        log.Error("Failed to authenticate with gcloud. Key file is empty.");
-                        return;
-                    }
-
-                    log.Verbose("Authenticating to gcloud with key file");
-                    var bytes = Convert.FromBase64String(jsonKey);
-                    using (var keyFile = new TemporaryFile(Path.Combine(workingDirectory, "gcpJsonKey.json")))
-                    {
-                        File.WriteAllBytes(keyFile.FilePath, bytes);
-                        ExecuteCommand(gcloud,
-                                       "auth",
-                                       "activate-service-account",
-                                       $"--key-file=\"{keyFile.FilePath}\"");
-
-                    }
-
-                    log.Verbose("Successfully authenticated with gcloud");
-                }
-                else
-                {
-                    log.Verbose("Bypassing authentication with gcloud");
-                }
-
-                if (variables.GetFlag("Octopus.Action.GoogleCloud.ImpersonateServiceAccount"))
-                {
-                    var impersonationEmails = variables.Get("Octopus.Action.GoogleCloud.ServiceAccountEmails");
-                    if (!string.IsNullOrEmpty(impersonationEmails))
-                        environmentVars.Add("CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT", impersonationEmails);
-                }
-
-            }
-
-            string ConfigureCliExecution()
+            string CreateKubectlConfig()
             {
                 var kubeConfig = Path.Combine(workingDirectory, "kubectl-octo.yml");
 
@@ -821,59 +579,6 @@ namespace Calamari.Kubernetes
                 return kubeConfig;
             }
 
-            bool TrySetKubectl()
-            {
-                kubectl = variables.Get("Octopus.Action.Kubernetes.CustomKubectlExecutable");
-                if (string.IsNullOrEmpty(kubectl))
-                {
-                    kubectl = CalamariEnvironment.IsRunningOnWindows
-                        ? ExecuteCommandAndReturnOutput("where", "kubectl.exe").FirstOrDefault()
-                        : ExecuteCommandAndReturnOutput("which", "kubectl").FirstOrDefault();
-
-                    if (string.IsNullOrEmpty(kubectl))
-                    {
-                        log.Error("Could not find kubectl. Make sure kubectl is on the PATH. See https://g.octopushq.com/KubernetesTarget for more information.");
-                        return false;
-                    }
-
-                    kubectl = kubectl.Trim();
-                }
-                else if (!File.Exists(kubectl))
-                {
-                    log.Error($"The custom kubectl location of {kubectl} does not exist. See https://g.octopushq.com/KubernetesTarget for more information.");
-                    return false;
-                }
-
-                if (TryExecuteKubectlCommand("version", "--client", "--short"))
-                {
-                    return true;
-                }
-
-                log.Error($"Could not find kubectl. Make sure {kubectl} is on the PATH. See https://g.octopushq.com/KubernetesTarget for more information.");
-                return false;
-            }
-
-            Maybe<SemanticVersion> TrySetKubectlVersion()
-            {
-                var kubectlVersionOutput = ExecuteCommandAndReturnOutput(kubectl, "version", "--client", "--output=json");
-                var kubeCtlVersionJson = string.Join(" ", kubectlVersionOutput);
-                try
-                {
-                    var clientVersion = JsonConvert.DeserializeAnonymousType(kubeCtlVersionJson, new { clientVersion = new { gitVersion = "1.0.0" } });
-                    var kubectlVersionString = clientVersion?.clientVersion?.gitVersion?.TrimStart('v');
-                    if (kubectlVersionString != null)
-                    {
-                        return Maybe<SemanticVersion>.Some(new SemanticVersion(kubectlVersionString));
-                    }
-                }
-                catch (Exception e)
-                {
-                    log.Verbose($"Unable to determine kubectl version. Failed with error message: {e.Message}");
-                }
-
-                return Maybe<SemanticVersion>.None;
-            }
-
             void ExecuteCommand(string executable, params string[] arguments)
             {
                 ExecuteCommand(new CommandLineInvocation(executable, arguments)).VerifySuccess();
@@ -884,19 +589,9 @@ namespace Calamari.Kubernetes
                 return ExecuteCommand(new CommandLineInvocation(executable, arguments)).ExitCode == 0;
             }
 
-            void ExecuteKubectlCommand(params string[] arguments)
-            {
-                ExecuteCommand(new CommandLineInvocation(kubectl, arguments.Concat(new[] { "--request-timeout=1m" }).ToArray())).VerifySuccess();
-            }
-
-            bool TryExecuteKubectlCommand(params string[] arguments)
-            {
-                return ExecuteCommand(new CommandLineInvocation(kubectl, arguments.Concat(new[] { "--request-timeout=1m" }).ToArray())).ExitCode == 0;
-            }
-
             bool TryExecuteCommandWithVerboseLoggingOnly(params string[] arguments)
             {
-                return ExecuteCommandWithVerboseLoggingOnly(new CommandLineInvocation(kubectl, arguments.Concat(new[] { "--request-timeout=1m" }).ToArray())).ExitCode == 0;
+                return ExecuteCommandWithVerboseLoggingOnly(new CommandLineInvocation(kubectlCli.ExecutableLocation, arguments.Concat(new[] { "--request-timeout=1m" }).ToArray())).ExitCode == 0;
             }
 
             CommandResult ExecuteCommand(CommandLineInvocation invocation)
@@ -910,7 +605,6 @@ namespace Calamari.Kubernetes
                 invocation.AdditionalInvocationOutputSink = captureCommandOutput;
 
                 var commandString = invocation.ToString();
-                commandString = redactMap.Aggregate(commandString, (current, pair) => current.Replace(pair.Key, pair.Value));
                 log.Verbose(commandString);
                 
                 var result = commandLineRunner.Execute(invocation);
@@ -955,7 +649,6 @@ namespace Calamari.Kubernetes
                 invocation.AdditionalInvocationOutputSink = captureCommandOutput;
 
                 var commandString = invocation.ToString();
-                commandString = redactMap.Aggregate(commandString, (current, pair) => current.Replace(pair.Key, pair.Value));
                 log.Verbose(commandString);
 
                 var result = commandLineRunner.Execute(invocation);
@@ -982,37 +675,6 @@ namespace Calamari.Kubernetes
                 return result.ExitCode == 0
                     ? captureCommandOutput.Messages.Where(m => m.Level == Level.Info).Select(m => m.Text).ToArray()
                     : Enumerable.Empty<string>();
-            }
-
-            class CaptureCommandOutput : ICommandInvocationOutputSink
-            {
-                public List<Message> Messages { get; } = new List<Message>();
-                public void WriteInfo(string line)
-                {
-                    Messages.Add(new Message(Level.Info, line));
-                }
-
-                public void WriteError(string line)
-                {
-                    Messages.Add(new Message(Level.Error, line));
-                }
-            }
-
-            class Message
-            {
-                public Level Level { get; }
-                public string Text { get; }
-                public Message(Level level, string text)
-                {
-                    Level = level;
-                    Text = text;
-                }
-            }
-
-            enum Level
-            {
-                Info,
-                Error
             }
         }
     }

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -253,7 +253,8 @@ namespace Calamari.Kubernetes
                 else if (isUsingGoogleCloudAuth)
                 {
                     var gcloudCli = new GCloud(log, commandLineRunner, workingDirectory, environmentVars);
-                    var gcloudAuth = new GoogleKubernetesEngineAuth(gcloudCli, kubectlCli, variables);
+                    var gkeGcloudAuthPlugin = new GkeGcloudAuthPlugin(log, commandLineRunner, workingDirectory, environmentVars);
+                    var gcloudAuth = new GoogleKubernetesEngineAuth(gcloudCli, gkeGcloudAuthPlugin, kubectlCli, variables, log);
 
                     if (!gcloudAuth.TryConfigure(useVmServiceAccount, @namespace))
                         return false;

--- a/source/Calamari/Kubernetes/RedactedValuesLogger.cs
+++ b/source/Calamari/Kubernetes/RedactedValuesLogger.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.ServiceMessages;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Kubernetes
+{
+    public class RedactedValuesLogger : ILog
+    {
+        readonly ILog log;
+        readonly Dictionary<string, string> redactionMap = new Dictionary<string, string>();
+
+        public RedactedValuesLogger(ILog innerLogger)
+        {
+            log = innerLogger;
+        }
+
+        public void AddValueToRedact(string value, string replacement)
+        {
+            redactionMap[value] = replacement;
+        }
+
+        string ProcessRedactions(string rawMessage)
+        {
+            return redactionMap.Aggregate(rawMessage, (current, pair) => current.Replace(pair.Key, pair.Value));
+        }
+
+        public void Verbose(string message)
+        {
+            log.Verbose(ProcessRedactions(message));
+        }
+
+        public void VerboseFormat(string messageFormat, params object[] args)
+        {
+            log.VerboseFormat(ProcessRedactions(messageFormat), args);
+        }
+
+        public void Info(string message)
+        {
+            log.Info(ProcessRedactions(message));
+        }
+
+        public void InfoFormat(string messageFormat, params object[] args)
+        {
+            log.InfoFormat(ProcessRedactions(messageFormat), args);
+        }
+
+        public void Warn(string message)
+        {
+            log.Warn(ProcessRedactions(message));
+        }
+
+        public void WarnFormat(string messageFormat, params object[] args)
+        {
+            log.WarnFormat(ProcessRedactions(messageFormat), args);
+        }
+
+        public void Error(string message)
+        {
+            log.Error(ProcessRedactions(message));
+        }
+
+        public void ErrorFormat(string messageFormat, params object[] args)
+        {
+            log.ErrorFormat(ProcessRedactions(messageFormat), args);
+        }
+
+        public void SetOutputVariableButDoNotAddToVariables(string name, string value, bool isSensitive = false)
+        {
+            log.SetOutputVariableButDoNotAddToVariables(name, value, isSensitive);
+        }
+
+        public void SetOutputVariable(string name, string value, IVariables variables, bool isSensitive = false)
+        {
+            log.SetOutputVariable(name, value, variables, isSensitive);
+        }
+
+        public void NewOctopusArtifact(string fullPath, string name, long fileLength)
+        {
+            log.NewOctopusArtifact(fullPath, name, fileLength);
+        }
+
+        public void Progress(int percentage, string message)
+        {
+            log.Progress(percentage, message);
+        }
+
+        public void DeltaVerification(string remotePath, string hash, long size)
+        {
+            log.DeltaVerification(remotePath, hash, size);
+        }
+
+        public void DeltaVerificationError(string error)
+        {
+            log.DeltaVerificationError(ProcessRedactions(error));
+        }
+
+        public string FormatLink(string uri, string description = null)
+        {
+            return log.FormatLink(uri, description);
+        }
+
+        public void WriteServiceMessage(ServiceMessage serviceMessage)
+        {
+            log.WriteServiceMessage(serviceMessage);
+        }
+    }
+}


### PR DESCRIPTION
# Background
From `kubctl` 1.26 onward, some auth code which used to be integrated in the tool (for doing Azure- and GCloud-specific OAuth flows) has been removed, making it the vendor's responsibility to publish authentication plugins that implement their required auth logic. 

This PR is designed to help customers choose the correct tooling for their situation, and guide them to the right information if they're not in a compatible state.

## Before
If customers run into an incompatible scenario (eg they use `kubectl` >= 1.26, but don't have the `gke-gcloud-auth-plugin` installed), their auth to the cluster and therefore any step that tries to deploy to the cluster will fail. 

The warnings provided by the `kubectl` tooling may or may not be clear enough for the customer to understand what's gone wrong or what they need to do to fix it - they're out of our control. 

## After
If customers are in a situation where their GKE auth would fail, we write a warning message to the logs, and direct them to a link that can help them remediate the scenario.

Fixes OctopusDeploy/Issues#7621.
Addresses [sc-6271] (internal).

## Notes/implementation details
This PR also bundles a series of refactorings that were done to make the code easier to reason about before implementing the main change. 

The Azure equivalent is fine as-is, because the way we authenticate to Azure never invoked the Azure-specific auth from `kubectl`; instead it generates generic certificate-based auth credentials directly into the `kubeconfig`. 

The warning message for the problematic GKE configuration uses an `oc.to` link which is configured via short.io. It currently points just to [the GCloud blog about this change](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke), but we could/should probably create our own first-party blog content to put the changes in clearer context for Octopus users. This can be done at any time without a code change, we just update where the `oc.to` link points to.