### PR TITLE
Migrate Azure WebApp, AppService, ResourceGroup and Service Fabric to MSAL

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -50,8 +50,8 @@ namespace Calamari.AzureAppService.Tests
             subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
             resourceGroupLocation = Environment.GetEnvironmentVariable("AZURE_NEW_RESOURCE_REGION") ?? "eastus";
 
-            authToken = await Auth.GetAuthTokenAsync(activeDirectoryEndpointBaseUri, resourceManagementEndpointBaseUri,
-                tenantId, clientId, clientSecret);
+            authToken = await Auth.GetAuthTokenAsync(tenantId, clientId, clientSecret, resourceManagementEndpointBaseUri, activeDirectoryEndpointBaseUri);
+
 
             var resourcesClient = new ResourcesManagementClient(subscriptionId,
                 new ClientSecretCredential(tenantId, clientId, clientSecret));

--- a/source/Calamari.AzureAppService.Tests/AppServiceSettingsBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceSettingsBehaviourFixture.cs
@@ -58,8 +58,7 @@ namespace Calamari.AzureAppService.Tests
 
             var resourceGroupLocation = Environment.GetEnvironmentVariable("AZURE_NEW_RESOURCE_REGION") ?? "eastus";
 
-            authToken = await Auth.GetAuthTokenAsync(activeDirectoryEndpointBaseUri,
-                resourceManagementEndpointBaseUri, tenantId, clientId, clientSecret);
+            authToken = await Auth.GetAuthTokenAsync(tenantId, clientId, clientSecret, resourceManagementEndpointBaseUri, activeDirectoryEndpointBaseUri);
 
             var resourcesClient = new ResourcesManagementClient(subscriptionId,
                 new ClientSecretCredential(tenantId, clientId, clientSecret));

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviorFixture.cs
@@ -198,22 +198,11 @@ namespace Calamari.AzureAppService.Tests
                 Environment.GetEnvironmentVariable(AccountVariables.ActiveDirectoryEndPoint) ??
                 DefaultVariables.ActiveDirectoryEndpoint;
 
-            var authContext = GetContextUri(activeDirectoryEndpointBaseUri, tenantId);
-            var context = new AuthenticationContext(authContext);
-            var result = await context.AcquireTokenAsync(resourceManagementEndpointBaseUri,
-                new ClientCredential(applicationId, password));
-
-            return result.AccessToken;
-        }
-
-        string GetContextUri(string activeDirectoryEndPoint, string tenantId)
-        {
-            if (!activeDirectoryEndPoint.EndsWith("/"))
-            {
-                return $"{activeDirectoryEndPoint}/{tenantId}";
-            }
-
-            return $"{activeDirectoryEndPoint}{tenantId}";
+            return await Auth.GetAuthTokenAsync(tenantId,
+                                                applicationId,
+                                                password,
+                                                resourceManagementEndpointBaseUri,
+                                                activeDirectoryEndpointBaseUri);
         }
     }
 }

--- a/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
@@ -57,8 +57,7 @@ namespace Calamari.AzureAppService.Tests
             subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
             var resourceGroupLocation = Environment.GetEnvironmentVariable("AZURE_NEW_RESOURCE_REGION") ?? "eastus";
 
-            authToken = await Auth.GetAuthTokenAsync(activeDirectoryEndpointBaseUri, resourceManagementEndpointBaseUri,
-                tenantId, clientId, clientSecret);
+            authToken = await Auth.GetAuthTokenAsync(tenantId, clientId, clientSecret, resourceManagementEndpointBaseUri, activeDirectoryEndpointBaseUri);
 
             var resourcesClient = new ResourcesManagementClient(subscriptionId,
                 new ClientSecretCredential(tenantId, clientId, clientSecret));

--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.48.1" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
+++ b/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.48.1" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.9.0-preview" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>

--- a/source/Calamari.AzureResourceGroup/ServicePrincipal.cs
+++ b/source/Calamari.AzureResourceGroup/ServicePrincipal.cs
@@ -1,18 +1,26 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Logging;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Identity.Client;
 
 namespace Calamari.AzureResourceGroup
 {
     static class ServicePrincipal
     {
         public static async Task<string> GetAuthorizationToken(string tenantId, string applicationId, string password, string managementEndPoint, string activeDirectoryEndPoint)
-        {
+        { 
             var authContext = GetContextUri(activeDirectoryEndPoint, tenantId);
             Log.Verbose($"Authentication Context: {authContext}");
-            var context = new AuthenticationContext(authContext);
-            var result = await context.AcquireTokenAsync(managementEndPoint, new ClientCredential(applicationId, password));
+
+            var app = ConfidentialClientApplicationBuilder.Create(applicationId)
+                .WithClientSecret(password)
+                .WithAuthority(authContext)
+                .Build();
+
+            var result = await app.AcquireTokenForClient(
+                    new [] { $"{managementEndPoint}/.default" })
+                .WithTenantId(tenantId)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
             return result.AccessToken;
         }
 

--- a/source/Calamari.AzureResourceGroup/ServicePrincipal.cs
+++ b/source/Calamari.AzureResourceGroup/ServicePrincipal.cs
@@ -7,7 +7,7 @@ namespace Calamari.AzureResourceGroup
     static class ServicePrincipal
     {
         public static async Task<string> GetAuthorizationToken(string tenantId, string applicationId, string password, string managementEndPoint, string activeDirectoryEndPoint)
-        { 
+        {
             var authContext = GetContextUri(activeDirectoryEndPoint, tenantId);
             Log.Verbose($"Authentication Context: {authContext}");
 

--- a/source/Calamari.AzureServiceFabric/Calamari.AzureServiceFabric.csproj
+++ b/source/Calamari.AzureServiceFabric/Calamari.AzureServiceFabric.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="2.28.3" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.48.1" />
     <PackageReference Include="Microsoft.ServiceFabric" Version="5.4.145" />
   </ItemGroup>
 

--- a/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
+++ b/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.1" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
     <PackageReference Include="Microsoft.Web.Deployment" Version="4.0.5" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.48.1" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Calamari.AzureWebApp/ServicePrincipal.cs
+++ b/source/Calamari.AzureWebApp/ServicePrincipal.cs
@@ -1,17 +1,27 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
-﻿using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Logging;
+using Microsoft.Identity.Client;
 
 namespace Calamari.AzureWebApp
 {
     static class ServicePrincipal
     {
         public static async Task<string> GetAuthorizationToken(string tenantId, string applicationId, string password, string managementEndPoint, string activeDirectoryEndPoint)
-        {
+        { 
             var authContext = GetContextUri(activeDirectoryEndPoint, tenantId);
             Log.Verbose($"Authentication Context: {authContext}");
-            var context = new AuthenticationContext(authContext);
-            var result = await context.AcquireTokenAsync(managementEndPoint, new ClientCredential(applicationId, password));
+
+            var app = ConfidentialClientApplicationBuilder.Create(applicationId)
+                                                          .WithClientSecret(password)
+                                                          .WithAuthority(authContext)
+                                                          .Build();
+
+            var result = await app.AcquireTokenForClient(
+                                                         new [] { $"{managementEndPoint}/.default" })
+                                  .WithTenantId(tenantId)
+                                  .ExecuteAsync()
+                                  .ConfigureAwait(false);
+
             return result.AccessToken;
         }
 


### PR DESCRIPTION
This PR is to migrate the soon-to-be deprecating ADAL library over to MSAL.

The impacted Calamari flavours are:
* AzureWebApp
* AzureAppService
* AzureResourceGroup
* AzureServiceFabric

[Microsoft documentation 1](https://learn.microsoft.com/en-us/azure/active-directory/develop/msal-net-migration-public-client?tabs=interactive) [documentation 2](https://learn.microsoft.com/en-us/azure/active-directory/develop/msal-net-migration-public-client?tabs=interactive)

[sc-11763]