### PR TITLE
Use Legacy for $PSNativeCommandArgumentPassing

### DIFF
--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -1,6 +1,7 @@
 ﻿param([string]$OctopusKey="")
 {{StartOfBootstrapScriptDebugLocation}}
 $ErrorActionPreference = 'Stop'
+$PSNativeCommandArgumentPassing = 'Legacy'
 
 # All PowerShell scripts invoked by Calamari will be bootstrapped using this script. This script:
 #  1. Declares/overrides various functions for scripts to use


### PR DESCRIPTION
This is the back-port for the PowerShell 7.3 command parsing fix: https://github.com/OctopusDeploy/Calamari/pull/968