### PR TITLE
Collect metrics on Deployment Package sizes

### DIFF
--- a/source/Calamari.Common/Features/Packages/CombinedPackageExtractor.cs
+++ b/source/Calamari.Common/Features/Packages/CombinedPackageExtractor.cs
@@ -29,7 +29,7 @@ namespace Calamari.Common.Features.Packages
                 new ZipPackageExtractor(log),
                 new TarPackageExtractor(log),
                 new JarPackageExtractor(new JarTool(commandLineRunner, log, variables))
-            };
+            }.Select(e => e.WithExtractionLimits(log)).ToArray();
         }
 
         public string[] Extensions => extractors.SelectMany(e => e.Extensions).OrderBy(e => e).ToArray();

--- a/source/Calamari.Common/Features/Packages/ExtractionLimitsDecorator.cs
+++ b/source/Calamari.Common/Features/Packages/ExtractionLimitsDecorator.cs
@@ -1,0 +1,60 @@
+﻿using System.IO;
+using Calamari.Common.Plumbing.Extensions;
+using Calamari.Common.Plumbing.Logging;
+using SharpCompress.Archives;
+using SharpCompress.Readers;
+
+namespace Calamari.Common.Features.Packages
+{
+    public class ExtractionLimitsDecorator : IPackageExtractor
+    {
+        public IPackageExtractor ConcreteExtractor { get; }
+        readonly ILog log;
+        public string[] Extensions => ConcreteExtractor.Extensions;
+
+        public ExtractionLimitsDecorator(IPackageExtractor concreteExtractor, ILog log)
+        {
+            ConcreteExtractor = concreteExtractor;
+            this.log = log;
+        }
+        public int Extract(string packageFile, string directory)
+        {
+            using (var timer = log.BeginTimedOperation($"Extract package"))
+            {
+                LogArchiveMetrics(packageFile, timer.OperationId);
+
+                var result = ConcreteExtractor.Extract(packageFile, directory);
+                timer.Complete();
+
+                return result;
+            }
+        }
+
+        void LogArchiveMetrics(string archivePath, string operationId)
+        {
+            try
+            {
+                using (var archiveDetails = ArchiveFactory.Open(archivePath))
+                {
+                    var compressionRatio = archiveDetails.TotalUncompressSize == 0 ? 0 : (double)archiveDetails.TotalSize / archiveDetails.TotalUncompressSize;
+
+                    log.LogMetric("DeploymentPackageCompressedSize", archiveDetails.TotalSize, operationId);
+                    log.LogMetric("DeploymentPackageUncompressedSize", archiveDetails.TotalUncompressSize, operationId);
+                    log.LogMetric("DeploymentPackageCompressionRatio", compressionRatio, operationId);
+                }
+            }
+            catch
+            {
+                log.Verbose("Could not collect archive metrics");
+            }
+        }
+    }
+
+    public static class ExtractionLimitsExtensions
+    {
+        public static IPackageExtractor WithExtractionLimits(this IPackageExtractor concreteExtractor, ILog log)
+        {
+            return new ExtractionLimitsDecorator(concreteExtractor, log);
+        }
+    }
+}

--- a/source/Calamari.Common/Plumbing/Extensions/LogExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/LogExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.ServiceMessages;
+
+namespace Calamari.Common.Plumbing.Extensions
+{
+    public static class LogExtensions
+    {
+        public static Operation BeginTimedOperation(this ILog log, string operationMessage)
+        {
+            return new Operation(log, operationMessage);
+        }
+
+        public static void LogMetric(this ILog log, string metricName, object metricValue, string? operationId = null)
+        {
+            var serviceMessageParameters = new Dictionary<string, string>
+            {
+                { ServiceMessageNames.CalamariDeploymentMetric.OperationIdAttribute, operationId },
+                { ServiceMessageNames.CalamariDeploymentMetric.MetricAttribute, metricName },
+                { ServiceMessageNames.CalamariDeploymentMetric.ValueAttribute, metricValue.ToString() },
+            };
+
+            log.WriteServiceMessage(new ServiceMessage(ServiceMessageNames.CalamariDeploymentMetric.Name, serviceMessageParameters));
+        }
+    }
+}

--- a/source/Calamari.Common/Plumbing/Logging/Operation.cs
+++ b/source/Calamari.Common/Plumbing/Logging/Operation.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Calamari.Common.Plumbing.ServiceMessages;
+
+namespace Calamari.Common.Plumbing.Logging
+{
+    public class Operation : IDisposable
+    {
+        public bool IsAbandoned { get; private set; }
+        public string OperationId { get; }
+
+        readonly ILog logger;
+        readonly Stopwatch stopwatch;
+        readonly string operationName;
+
+        bool isCompleted;
+        bool isDisposed;
+
+        public Operation(ILog logger, string operationName)
+        {
+            OperationId = Guid.NewGuid().ToString("n");
+            this.logger = logger;
+            this.operationName = operationName;
+            stopwatch = Stopwatch.StartNew();
+            isDisposed = false;
+
+            logger.VerboseFormat($"Timed operation '{operationName}' started.");
+        }
+
+        public void Complete()
+        {
+            if (isCompleted || IsAbandoned) throw new InvalidOperationException("This logging operation has already been completed or abandoned.");
+            
+            logger.VerboseFormat($"Timed operation '{operationName}' completed in {stopwatch.ElapsedMilliseconds}ms.");
+            LogTimedOperationServiceMessage(stopwatch.ElapsedMilliseconds, Outcome.Completed);
+
+            isCompleted = true;
+            Dispose();
+        }
+
+        void LogTimedOperationServiceMessage(long stopwatchElapsedMilliseconds, Outcome operationOutcome)
+        {
+            // Determine operation duration
+            // Construct service message ##octopus[serviceMessage='calamari-timed-operation' name='Deployment package extraction' operationId='679d7cfadc614909a87e2005000c84c1' durationMilliseconds='1642' outcome='Completed']
+            var serviceMessageParameters = new Dictionary<string, string>
+            {
+                { ServiceMessageNames.CalamariTimedOperation.OperationIdAttribute, OperationId },
+                { ServiceMessageNames.CalamariTimedOperation.NameAttribute, operationName },
+                { ServiceMessageNames.CalamariTimedOperation.DurationMillisecondsAttribute, stopwatchElapsedMilliseconds.ToString() },
+                { ServiceMessageNames.CalamariTimedOperation.OutcomeAttribute, operationOutcome.ToString() },
+            };
+
+            logger.WriteServiceMessage(new ServiceMessage(ServiceMessageNames.CalamariTimedOperation.Name, serviceMessageParameters));
+        }
+
+        public void Abandon(Exception? ex = null)
+        {
+            if (isCompleted || IsAbandoned) throw new InvalidOperationException("This logging operation has already been completed or abandoned.");
+
+            LogTimedOperationServiceMessage(stopwatch.ElapsedMilliseconds, Outcome.Abandoned);
+            
+            IsAbandoned = true;
+            Dispose();
+        }
+
+        public void Dispose()
+        {
+            if (isDisposed)
+            {
+                return;
+            }
+
+            if (!isCompleted && !IsAbandoned)
+            {
+                Abandon();
+            }
+
+            isDisposed = true;
+        }
+
+        enum Outcome
+        {
+            Completed,
+            Abandoned
+        }
+    }
+}

--- a/source/Calamari.Common/Plumbing/ServiceMessages/ServiceMessageNames.cs
+++ b/source/Calamari.Common/Plumbing/ServiceMessages/ServiceMessageNames.cs
@@ -35,5 +35,22 @@ namespace Calamari.Common.Plumbing.ServiceMessages
             public const string SizeAttribute = "size";
             public const string Error = "error";
         }
+
+        public static class CalamariTimedOperation
+        {
+            public const string Name = "calamari-timed-operation";
+            public const string NameAttribute = "name";
+            public const string OperationIdAttribute = "operationId";
+            public const string DurationMillisecondsAttribute = "durationMilliseconds";
+            public const string OutcomeAttribute = "outcome";
+        }
+
+        public static class CalamariDeploymentMetric
+        {
+            public const string Name = "calamari-deployment-metric";
+            public const string OperationIdAttribute = "operationId";
+            public const string MetricAttribute = "metric";
+            public const string ValueAttribute = "value";
+        }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Deployment/Conventions/ExtractPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Conventions/ExtractPackageFixture.cs
@@ -6,7 +6,6 @@ using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Fixtures.Util;
-using Calamari.Tests.Helpers;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -83,7 +82,6 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
             Assert.That(variables.Get("OctopusOriginalPackageDirectoryPath"), Does.EndWith(Path.Combine("Acme.Web", "1.0.0")));
         }
 
-
         [Test]
         public void ShouldAppendToVersionedFolderIfAlreadyExisting()
         {
@@ -97,7 +95,6 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
             extractPackage.ExtractToApplicationDirectory(PathToPackage);
 
             Assert.That(variables.Get("OctopusOriginalPackageDirectoryPath"), Does.EndWith(Path.Combine("Acme.Web", "1.0.0_3")));
-            
         }
         
 
@@ -135,7 +132,5 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
 
             Assert.That(variables.Get("OctopusOriginalPackageDirectoryPath"), Does.EndWith(Path.Combine("Production Tokyo","Acme.Web","1.0.0")));
         }
-
-       
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/CombinedPackageExtractorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/CombinedPackageExtractorFixture.cs
@@ -1,14 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using Amazon.IdentityManagement.Model;
-using Calamari.Commands.Support;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Packages.NuGet;
 using Calamari.Common.Plumbing.Variables;
-using Calamari.Integration.Packages;
-using Calamari.Integration.Packages.NuGet;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Fixtures.Util;
 using Calamari.Tests.Helpers;
@@ -26,6 +21,8 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         {
             var combinedExtractor = CreateCombinedPackageExtractor();
             var specificExtractor = combinedExtractor.GetExtractor(filename);
+            if (specificExtractor is ExtractionLimitsDecorator decorator)
+                specificExtractor = decorator.ConcreteExtractor;
 
             Assert.AreEqual(expectedType, specificExtractor.GetType());
         }
@@ -72,7 +69,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         {
             CreateCombinedPackageExtractor().GetExtractor("blah.1.0.0.7z");
         }
-        
+
         static CombinedPackageExtractor CreateCombinedPackageExtractor()
         {
             var log = new InMemoryLog();

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/ExtractionLimitsDecoratorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/ExtractionLimitsDecoratorFixture.cs
@@ -1,0 +1,44 @@
+﻿using System.Linq;
+using Calamari.Common.Features.Packages;
+using Calamari.Testing.Helpers;
+using Calamari.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Integration.Packages
+{
+    [TestFixture]
+    public class ExtractionLimitsDecoratorFixture : CalamariFixture
+    {
+        ExtractionLimitsDecorator decorator;
+        string[] testZipPath = new[] { "Fixtures", "Integration", "Packages", "Samples", "Acme.Core.1.0.0.0-bugfix.zip" };
+
+        [SetUp]
+        public void SetUp()
+        {
+            decorator = new ExtractionLimitsDecorator(new NullExtractor(), Log);
+        }
+
+        [Test]
+        public void ShouldLogTimedOperation()
+        {
+            decorator.Extract(TestEnvironment.GetTestPath(testZipPath), TestEnvironment.GetTestPath("extracted"));
+            Assert.That(Log.Messages.Any(m => m.FormattedMessage.StartsWith("##octopus[calamari-timed-operation")), "Extract operation should be timed.");
+        }
+
+        [Test]
+        public void ShouldLogArchiveMetricsIfPossible()
+        {
+            decorator.Extract(TestEnvironment.GetTestPath(testZipPath), TestEnvironment.GetTestPath("extracted"));
+            Assert.That(Log.Messages.Count(m => m.FormattedMessage.StartsWith("##octopus[calamari-deployment-metric")) == 3, "Three deployment metrics should be captured.");
+        }
+
+        class NullExtractor : IPackageExtractor
+        {
+            public string[] Extensions => new[] { ".zip" };
+            public int Extract(string packageFile, string directory)
+            {
+                return 1;
+            }
+        }
+    }
+}

--- a/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
+++ b/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
@@ -77,7 +77,7 @@ namespace Calamari.Commands.Java
             var semaphore = SemaphoreFactory.Get();
             var journal = new DeploymentJournal(fileSystem, semaphore, variables);
             var jarTools = new JarTool(commandLineRunner, log, variables);
-            var packageExtractor = new JarPackageExtractor(jarTools);
+            var packageExtractor = new JarPackageExtractor(jarTools).WithExtractionLimits(log);
             var embeddedResources = new AssemblyEmbeddedResources();
             var javaRunner = new JavaRunner(commandLineRunner, variables);
 


### PR DESCRIPTION
This PR enables Calamari to observe metrics about:
* Deployment package extraction duration
* Deployment package size (compressed)
* Deployment package sized (extracted)
* Compression ratio

These non-identifiable metrics are collected by Octopus Server via Service Messages, so that we can gain an aggregated picture of the average and maximum sizes of archive that our customers are deploying. This will help inform future changes around deployment package management.

[sc-34750]