### PR TITLE
Adding release notes for calamari

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -479,7 +479,14 @@ namespace Calamari.Build
             _ => _.DependsOn(PackageConsolidatedCalamariZip)
                   .Executes(() =>
                             {
-                                NuGetPack(s => s.SetTargetPath(BuildDirectory / "Calamari.Consolidated.nuspec")
+                                var releaseNotes = IsLocalBuild ? "Local" : File.ReadAllText(ArtifactsDirectory / "ReleaseNotes.md");
+                                
+                                var nuspec = BuildDirectory / "Calamari.Consolidated.nuspec";
+                                var text = File.ReadAllText(nuspec);
+                                text = text.Replace("$releaseNotes$", releaseNotes);
+                                File.WriteAllText(nuspec, text);
+                                
+                                NuGetPack(s => s.SetTargetPath(nuspec)
                                                 .SetVersion(NugetVersion.Value)
                                                 .SetOutputDirectory(ArtifactsDirectory));
                             });

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -479,7 +479,7 @@ namespace Calamari.Build
             _ => _.DependsOn(PackageConsolidatedCalamariZip)
                   .Executes(() =>
                             {
-                                var releaseNotes = IsLocalBuild ? "Local" : File.ReadAllText(RootDirectory / "ReleaseNotes.md");
+                                var releaseNotes = IsLocalBuild ? "Local" : File.ReadAllText(RootDirectory / "releasenotes" / "ReleaseNotes.md");
                                 
                                 var nuspec = BuildDirectory / "Calamari.Consolidated.nuspec";
                                 var text = File.ReadAllText(nuspec);

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -481,14 +481,8 @@ namespace Calamari.Build
                             {
                                 var releaseNotes = IsLocalBuild ? "Local" : File.ReadAllText(RootDirectory / "releasenotes" / "ReleaseNotes.md");
                                 
-                                var nuspec = BuildDirectory / "Calamari.Consolidated.nuspec";
-                                var text = File.ReadAllText(nuspec);
-                                text = text.Replace("$releaseNotes$", releaseNotes);
-                                
-                                var nuspecForPublish = BuildAssemblyDirectory / "Calamari.Consolidated.nuspec";
-                                File.WriteAllText(nuspecForPublish, text);
-                                
-                                NuGetPack(s => s.SetTargetPath(nuspecForPublish)
+                                NuGetPack(s => s.SetTargetPath(BuildDirectory / "Calamari.Consolidated.nuspec")
+                                            .SetProperty("releaseNotes", releaseNotes)
                                             .SetBasePath(BuildDirectory)
                                             .SetVersion(NugetVersion.Value)
                                             .SetOutputDirectory(ArtifactsDirectory));

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -479,7 +479,7 @@ namespace Calamari.Build
             _ => _.DependsOn(PackageConsolidatedCalamariZip)
                   .Executes(() =>
                             {
-                                var releaseNotes = IsLocalBuild ? "Local" : File.ReadAllText(ArtifactsDirectory / "ReleaseNotes.md");
+                                var releaseNotes = IsLocalBuild ? "Local" : File.ReadAllText(RootDirectory / "ReleaseNotes.md");
                                 
                                 var nuspec = BuildDirectory / "Calamari.Consolidated.nuspec";
                                 var text = File.ReadAllText(nuspec);
@@ -489,8 +489,9 @@ namespace Calamari.Build
                                 File.WriteAllText(nuspecForPublish, text);
                                 
                                 NuGetPack(s => s.SetTargetPath(nuspecForPublish)
-                                                .SetVersion(NugetVersion.Value)
-                                                .SetOutputDirectory(ArtifactsDirectory));
+                                            .SetBasePath(BuildDirectory)
+                                            .SetVersion(NugetVersion.Value)
+                                            .SetOutputDirectory(ArtifactsDirectory));
                             });
         
         Target UpdateCalamariVersionOnOctopusServer =>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -484,9 +484,11 @@ namespace Calamari.Build
                                 var nuspec = BuildDirectory / "Calamari.Consolidated.nuspec";
                                 var text = File.ReadAllText(nuspec);
                                 text = text.Replace("$releaseNotes$", releaseNotes);
-                                File.WriteAllText(nuspec, text);
                                 
-                                NuGetPack(s => s.SetTargetPath(nuspec)
+                                var nuspecForPublish = BuildAssemblyDirectory / "Calamari.Consolidated.nuspec";
+                                File.WriteAllText(nuspecForPublish, text);
+                                
+                                NuGetPack(s => s.SetTargetPath(nuspecForPublish)
                                                 .SetVersion(NugetVersion.Value)
                                                 .SetOutputDirectory(ArtifactsDirectory));
                             });

--- a/build/Calamari.Consolidated.nuspec
+++ b/build/Calamari.Consolidated.nuspec
@@ -10,6 +10,7 @@
         <contentFiles>
             <files include="any/any/Calamari.*.zip" buildAction="None" copyToOutput="true" />
         </contentFiles>
+        <releaseNotes>$releaseNotes$</releaseNotes>
     </metadata>
     <files>
         <file src="..\artifacts\consolidated\Calamari.*.zip" target="contentFiles\any\any\" />

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -30,10 +30,4 @@
       <ProjectReference Include="..\source\Calamari.ConsolidateCalamariPackages\Calamari.ConsolidateCalamariPackages.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <None Update="Calamari.Consolidated.nuspec">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
-
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -30,4 +30,10 @@
       <ProjectReference Include="..\source\Calamari.ConsolidateCalamariPackages\Calamari.ConsolidateCalamariPackages.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <None Update="Calamari.Consolidated.nuspec">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Adding the release notes from the Calamari pipeline to the Calamari.Consolidated.nuspec definition for the package. This change isn't much of a value add, and the Calamari package isn't publicly consumable, so doesn't technically come under Sensible Defaults. Feedback pushing against whether this is worthwhile adding is welcome.