### PR TITLE
Fixes problems with terraform and AKS during integration test setup

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
@@ -116,7 +116,7 @@ namespace Calamari.Tests.KubernetesFixtures
 
         string RunTerraformInternal(string terraformWorkingFolder, Dictionary<string, string> env, bool printOut, params string[] args)
         {
-            var sb = new StringBuilder();
+            var stdOut = new StringBuilder();
             var environmentVars = GetEnvironmentVars();
             environmentVars["TF_IN_AUTOMATION"] = bool.TrueString;
             environmentVars.AddRange(env);
@@ -127,7 +127,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 environmentVars,
                 s =>
                 {
-                    sb.AppendLine(s);
+                    stdOut.AppendLine(s);
                     if (printOut)
                     {
                         TestContext.Progress.WriteLine(s);
@@ -138,9 +138,9 @@ namespace Calamari.Tests.KubernetesFixtures
                     TestContext.Error.WriteLine(e);
                 });
         
-            result.ExitCode.Should().Be(0);
+            result.ExitCode.Should().Be(0, because: $"`terraform {args[0]}` should run without error and exit cleanly during infrastructure setup");
         
-            return sb.ToString().Trim(Environment.NewLine.ToCharArray());
+            return stdOut.ToString().Trim(Environment.NewLine.ToCharArray());
         }
 
         protected string InitialiseTerraformWorkingFolder(string folderName, string filesSource)

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.kubernetes.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.kubernetes.tf
@@ -21,6 +21,19 @@ resource "kubernetes_service_account" "default" {
   }
 }
 
+resource "kubernetes_secret" "default" {
+  provider = kubernetes.aks
+  metadata {
+    name        = "${kubernetes_service_account.default.metadata.0.name}-secret"
+    namespace   = kubernetes_namespace.default.metadata.0.name
+    annotations = {
+      "kubernetes.io/service-account.name" = kubernetes_service_account.default.metadata.0.name
+    }
+  }
+
+  type = "kubernetes.io/service-account-token"
+}
+
 resource "kubernetes_cluster_role" "default" {
   provider = kubernetes.aks
   metadata {
@@ -48,14 +61,6 @@ resource "kubernetes_cluster_role_binding" "default" {
     api_group = ""
     kind = "ServiceAccount"
     name = kubernetes_service_account.default.metadata.0.name
-    namespace = kubernetes_namespace.default.metadata.0.name
-  }
-}
-
-data "kubernetes_secret" "default" {
-  provider = kubernetes.aks
-  metadata {
-    name = kubernetes_service_account.default.default_secret_name
     namespace = kubernetes_namespace.default.metadata.0.name
   }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.tf
@@ -21,9 +21,7 @@ resource "azurerm_kubernetes_cluster" "default" {
     os_disk_size_gb = 30
   }
 
-  role_based_access_control {
-    enabled = true
-  }
+  role_based_access_control_enabled = true
 
   service_principal {
     client_id     = var.aks_client_id

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/outputs.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/outputs.tf
@@ -1,11 +1,13 @@
 output "aks_cluster_host" {
   description = "Endpoint for AKS control plane."
   value       = azurerm_kubernetes_cluster.default.kube_config.0.host
+  sensitive   = true
 }
 
 
 output "aks_cluster_username" {
-  value = azurerm_kubernetes_cluster.default.kube_config.0.username
+  value     = azurerm_kubernetes_cluster.default.kube_config.0.username
+  sensitive = true
 }
 
 output "aks_cluster_password" {
@@ -39,6 +41,6 @@ output "aks_rg_name" {
 }
 
 output "aks_service_account_token" {
-  value     = data.kubernetes_secret.default.data.token
+  value     = kubernetes_secret.default.data.token
   sensitive = true
 }

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/providers.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "= 2.78.0" #Due to a bug with 2.79.x we are pinning to this version for now. https://github.com/Azure/AKS/issues/2584 
+      version = ">= 2.78.0" 
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
This PR fixes the setup for tests which are failing in the pipeline due to changes in Azure and the way it uses terraform.

* Terraform/Kubernetes no longer generates a default secret for service accounts, so `default_secret_name` is now empty. This PR updates the `tf` so that we explicitly create a token for the service account
* The syntax for RBAC in the azurerm provider has changed from an object to just a property
* Marginally improved the error message we'll see in the logs so that instead of "Expected 0, but got 1", we'll see "Expected 0 because `terraform apply` should run without error and exit cleanly during infrastructure setup, but got 1"