### PR TITLE
Clearing Windows temp Nuget cache on package acquisition

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3LibDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3LibDownloader.cs
@@ -28,7 +28,8 @@ namespace Calamari.Integration.Packages.NuGet
                 sourceRepository.PackageSource.Credentials = new PackageSourceCredential("octopus", cred.UserName, cred.Password, true);
             }
 
-            var providers = new SourceRepositoryDependencyProvider(sourceRepository, logger, new SourceCacheContext(){NoCache = true});
+            var sourceCacheContext = new SourceCacheContext() { NoCache = true, };
+            var providers = new SourceRepositoryDependencyProvider(sourceRepository, logger, sourceCacheContext);
             var libraryIdentity = new LibraryIdentity(packageId, version.ToNuGetVersion(), LibraryType.Package);
 
             var targetPath = Directory.GetParent(targetFilePath).FullName;
@@ -46,6 +47,7 @@ namespace Calamari.Integration.Packages.NuGet
             }
 
             File.Move(targetTempNupkg, targetFilePath);
+            sourceCacheContext.Dispose();
         }
 
         public class NugetLogger : ILogger


### PR DESCRIPTION
Older implementations of NuGet cache packages on windows in a temp directory i.e. `C:\Windows\Temp\NuGet\TempCache` see https://github.com/NuGet/Home/issues/802. This change addresses cleaning this directory for each package pull.

Existing packages listed in the folder are intentionally being ignored as a part of this change, this can be implemented in the Retention policies, and a spike of the change works, but it's hard to know whether we're just impacting Octopus packages or others local machine caches. Cleaning this directory is still being left to customers. Due to our implementation `SourceRepositoryDependencyProvider` with `NoCache = true` this change will not impact performance, NoCache means we're pulling the package each and every time if retention policies have cleaned the tentacle package cache. 

This change doesn't address the nuget locals all -clear behavior listed in the ticket, customers could set their temp NuGet path to `C:\Windows\Temp\NuGet\TempCache` to clear this as expected but simply deleting the folder works and isn't an issue moving forward.

Fixes https://github.com/OctopusDeploy/Issues/issues/7328