### PR TITLE
Look at size on disk when calculating compression ratio

### DIFF
--- a/source/Calamari.Common/Features/Packages/Decorators/ArchiveLimits/EnforceCompressionRatioDecorator.cs
+++ b/source/Calamari.Common/Features/Packages/Decorators/ArchiveLimits/EnforceCompressionRatioDecorator.cs
@@ -36,7 +36,7 @@ namespace Calamari.Common.Features.Packages.Decorators.ArchiveLimits
                     {
                         var compressedSize = archiveInfo.Length;
                         var uncompressedSize = archive.TotalUncompressSize;
-                        var compressionRatio = uncompressedSize == 0 ? 0 : (double)uncompressedSize / compressedSize;
+                        var compressionRatio = compressedSize == 0 ? 0 : (double)uncompressedSize / compressedSize;
 
                         if (compressionRatio > maximumCompressionRatio)
                         {

--- a/source/Calamari.Common/Features/Packages/Decorators/ArchiveLimits/EnforceCompressionRatioDecorator.cs
+++ b/source/Calamari.Common/Features/Packages/Decorators/ArchiveLimits/EnforceCompressionRatioDecorator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using SharpCompress.Archives;
 
 namespace Calamari.Common.Features.Packages.Decorators.ArchiveLimits
@@ -30,11 +31,12 @@ namespace Calamari.Common.Features.Packages.Decorators.ArchiveLimits
             {
                 if (maximumCompressionRatio >= 1)
                 {
+                    var archiveInfo = new FileInfo(packageFile);
                     using (var archive = ArchiveFactory.Open(packageFile))
                     {
+                        var compressedSize = archiveInfo.Length;
                         var uncompressedSize = archive.TotalUncompressSize;
-                        var compressedSize = archive.TotalSize;
-                        var compressionRatio = uncompressedSize == 0 ? 0 : uncompressedSize / compressedSize;
+                        var compressionRatio = uncompressedSize == 0 ? 0 : (double)uncompressedSize / compressedSize;
 
                         if (compressionRatio > maximumCompressionRatio)
                         {


### PR DESCRIPTION
The previous iteration of the Compression Ratio calculation used the compressed size reported by the archive, which wasn't giving an accurate picture and was skewing the ratio.

This PR uses the file size on disk as the compressed size, which gives a correct representation of the Ratio.