### PR TITLE
Reverts netfx upgrades for `master`

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -201,7 +201,7 @@ namespace Calamari.Build
                                 OperatingSystem.IsWindows() ? Frameworks.Net40 : Frameworks.Net60,
                                 nugetVersion);
                       DoPublish(RootProjectName,
-                                OperatingSystem.IsWindows() ? Frameworks.Net48 : Frameworks.Net60,
+                                OperatingSystem.IsWindows() ? Frameworks.Net452 : Frameworks.Net60,
                                 nugetVersion,
                                 FixedRuntimes.Cloud);
 
@@ -235,7 +235,7 @@ namespace Calamari.Build
         void PublishCalamariProjects(List<Project> projects)
         {
             // All cross-platform Target Frameworks contain dots, all NetFx Target Frameworks don't
-            // eg: net40, net48 vs netcoreapp3.1, net5.0, net6.0
+            // eg: net40, net452, net48 vs netcoreapp3.1, net5.0, net6.0
             bool IsCrossPlatform(string targetFramework) => targetFramework.Contains('.');
 
             var calamariPackages = projects
@@ -339,7 +339,7 @@ namespace Calamari.Build
                                                     OperatingSystem.IsWindows() ? Frameworks.Net40 : Frameworks.Net60,
                                                     nugetVersion),
                                     () => DoPackage(RootProjectName,
-                                                    OperatingSystem.IsWindows() ? Frameworks.Net48 : Frameworks.Net60,
+                                                    OperatingSystem.IsWindows() ? Frameworks.Net452 : Frameworks.Net60,
                                                     nugetVersion,
                                                     FixedRuntimes.Cloud),
                                 };
@@ -380,7 +380,7 @@ namespace Calamari.Build
                   .Executes(async () =>
                   {
                       var nugetVersion = NugetVersion.Value;
-                      var defaultTarget = OperatingSystem.IsWindows() ? Frameworks.Net48 : Frameworks.Net60;
+                      var defaultTarget = OperatingSystem.IsWindows() ? Frameworks.Net461 : Frameworks.Net60;
                       AbsolutePath binFolder = SourceDirectory / "Calamari.Tests" / "bin" / Configuration / defaultTarget;
                       Directory.Exists(binFolder);
                       var actions = new List<Action>

--- a/build/Frameworks.cs
+++ b/build/Frameworks.cs
@@ -5,7 +5,8 @@ namespace Calamari.Build
     public static class Frameworks
     {
         public const string Net40 = "net40";
-        public const string Net48 = "net48";
+        public const string Net452 = "net452";
+        public const string Net461 = "net461";
         public const string Net60 = "net6.0";
     }
 }

--- a/source/Calamari.Aws/Calamari.Aws.csproj
+++ b/source/Calamari.Aws/Calamari.Aws.csproj
@@ -21,7 +21,7 @@
     <StartupObject />
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net48;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/source/Calamari.Azure/Calamari.Azure.csproj
+++ b/source/Calamari.Azure/Calamari.Azure.csproj
@@ -7,7 +7,7 @@
         <Copyright>Octopus Deploy Pty Ltd</Copyright>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net48;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net452;netstandard2.1</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>netstandard2.1</TargetFramework>

--- a/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
+++ b/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
@@ -8,7 +8,7 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -11,7 +11,7 @@
     <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.AzureCloudService.Tests/Calamari.AzureCloudService.Tests.csproj
+++ b/source/Calamari.AzureCloudService.Tests/Calamari.AzureCloudService.Tests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <RootNamespace>Calamari.AzureCloudService.Tests</RootNamespace>
         <AssemblyName>Calamari.AzureCloudService.Tests</AssemblyName>
-        <TargetFramework>net48</TargetFramework>
+        <TargetFramework>net461</TargetFramework>
         <IsPackable>false</IsPackable>
         <LangVersion>8</LangVersion>
     </PropertyGroup>

--- a/source/Calamari.AzureCloudService/Calamari.AzureCloudService.csproj
+++ b/source/Calamari.AzureCloudService/Calamari.AzureCloudService.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>Calamari.AzureCloudService</AssemblyName>
     <RootNamespace>Calamari.AzureCloudService</RootNamespace>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>

--- a/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
+++ b/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
@@ -6,7 +6,7 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
+++ b/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
@@ -10,7 +10,7 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net452;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.AzureScripting.Tests/Calamari.AzureScripting.Tests.csproj
+++ b/source/Calamari.AzureScripting.Tests/Calamari.AzureScripting.Tests.csproj
@@ -9,7 +9,7 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net48;net6.0</TargetFrameworks>
+        <TargetFrameworks>net461;net6.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.AzureScripting/Calamari.AzureScripting.csproj
+++ b/source/Calamari.AzureScripting/Calamari.AzureScripting.csproj
@@ -11,7 +11,7 @@
         <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net48;net6.0</TargetFrameworks>
+        <TargetFrameworks>net452;net6.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.AzureScripting/CalamariCertificateStore.cs
+++ b/source/Calamari.AzureScripting/CalamariCertificateStore.cs
@@ -128,7 +128,7 @@ namespace Calamari.AzureScripting
         {
             try
             {
-#if NET48
+#if NET452
                 return certificate2.HasPrivateKey && certificate2.PrivateKey != null;
 #else
                 return certificate2.HasPrivateKey && (

--- a/source/Calamari.AzureServiceFabric.Tests/Calamari.AzureServiceFabric.Tests.csproj
+++ b/source/Calamari.AzureServiceFabric.Tests/Calamari.AzureServiceFabric.Tests.csproj
@@ -4,7 +4,7 @@
         <RootNamespace>Calamari.AzureServiceFabric.Tests</RootNamespace>
         <AssemblyName>Calamari.AzureServiceFabric.Tests</AssemblyName>
         <IsPackable>false</IsPackable>
-        <TargetFramework>net48</TargetFramework>
+        <TargetFramework>net452</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />

--- a/source/Calamari.AzureServiceFabric/Calamari.AzureServiceFabric.csproj
+++ b/source/Calamari.AzureServiceFabric/Calamari.AzureServiceFabric.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Calamari.AzureWebApp.Tests/Calamari.AzureWebApp.Tests.csproj
+++ b/source/Calamari.AzureWebApp.Tests/Calamari.AzureWebApp.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Calamari.AzureWebApp.Tests</RootNamespace>
     <AssemblyName>Calamari.AzureWebApp.Tests</AssemblyName>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
+++ b/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
@@ -364,7 +364,8 @@ $ErrorActionPreference = 'Continue'
 az --version
 az group list";
             File.WriteAllText(Path.Combine(tempPath.DirectoryPath, "PreDeploy.ps1"), psScript);
-
+            
+            // This should be references from Sashimi.Server.Contracts, since Calamari.AzureWebApp is a net461 project this cannot be included.
             var AccountType = "Octopus.Account.AccountType";
 
             await CommandTestBuilder.CreateAsync<DeployAzureWebCommand, Program>()

--- a/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
+++ b/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
+++ b/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
@@ -4,13 +4,13 @@
         <RootNamespace>Calamari.CloudAccounts</RootNamespace>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net48;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net452;netstandard2.1</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
         <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
         <Reference Include="Microsoft.CSharp" />
     </ItemGroup>

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net48;netstandard2.1;net40</TargetFrameworks>
+        <TargetFrameworks>net452;netstandard2.1;net40</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>netstandard2.1</TargetFramework>
@@ -11,7 +11,7 @@
         <DefineConstants>$(DefineConstants);USE_ALPHAFS_FOR_LONG_FILE_PATH_SUPPORT;HAS_SSL3</DefineConstants>
         <PlatformTarget>anycpu</PlatformTarget>
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
         <DefineConstants>$(DefineConstants);USE_ALPHAFS_FOR_LONG_FILE_PATH_SUPPORT;HAS_SSL3</DefineConstants>
         <PlatformTarget>anycpu</PlatformTarget>
     </PropertyGroup>
@@ -22,7 +22,7 @@
       <LangVersion>8</LangVersion>
       <Nullable>enable</Nullable>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net48' ">
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
         <NoWarn>CS8600;CS8601;CS8602;CS8603;CS8604</NoWarn>
     </PropertyGroup>
 
@@ -42,13 +42,13 @@
         <Reference Include="System.Web" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
         <PackageReference Include="Autofac" Version="4.8.0" />
         <PackageReference Include="Polly" Version="5.4.0" />
         <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net48' ">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
         <Reference Include="System.Security" />
         <Reference Include="System.Net" />
         <PackageReference Include="NuGet.CommandLine" Version="2.8.6" />

--- a/source/Calamari.Common/Plumbing/Pipeline/IBehaviourExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Pipeline/IBehaviourExtensions.cs
@@ -9,7 +9,7 @@
         {
 #if NETSTANDARD
             return Task.CompletedTask;
-#elif NET48
+#elif NET452
             return Task.FromResult(0);
 #else
             return Net40CompletedTask;

--- a/source/Calamari.GoogleCloudScripting.Tests/Calamari.GoogleCloudScripting.Tests.csproj
+++ b/source/Calamari.GoogleCloudScripting.Tests/Calamari.GoogleCloudScripting.Tests.csproj
@@ -8,7 +8,7 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net48;net6.0</TargetFrameworks>
+        <TargetFrameworks>net461;net6.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.GoogleCloudScripting/Calamari.GoogleCloudScripting.csproj
+++ b/source/Calamari.GoogleCloudScripting/Calamari.GoogleCloudScripting.csproj
@@ -9,7 +9,7 @@
         <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net48;net6.0</TargetFrameworks>
+        <TargetFrameworks>net452;net6.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -10,7 +10,7 @@
         <LangVersion>9</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net48;net6.0</TargetFrameworks>
+        <TargetFrameworks>net452;net6.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>net6.0</TargetFramework>
@@ -25,8 +25,8 @@
         <PackageReference Include="scriptcs" Version="0.17.1" />
     </ItemGroup>
 
-    <!-- The following is to stop incorrect nullable reference type warnings for net48 build -->
-    <PropertyGroup Condition="'$(TargetFramework)' == 'net48' ">
+    <!-- The following is to stop incorrect nullable reference type warnings for net452 build -->
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net452' ">
         <NoWarn>CS8600;CS8601;CS8602;CS8603;CS8604</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -25,7 +25,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net48;netstandard2.1;net40</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.1;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -34,14 +34,14 @@
     <DefineConstants>$(DefineConstants);USE_NUGET_V2_LIBS;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT</DefineConstants>
     <PlatformTarget>anycpu</PlatformTarget>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);USE_NUGET_V2_LIBS;SUPPORTS_POLLY;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT</DefineConstants>
     <PlatformTarget>anycpu</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <DefineConstants>$(DefineConstants);USE_NUGET_V3_LIBS;SUPPORTS_POLLY</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net48' ">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
     <NoWarn>CS8600;CS8601;CS8602;CS8603;CS8604;DE0003;DE0004</NoWarn>
   </PropertyGroup>
 
@@ -76,7 +76,7 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
     <PackageReference Include="Polly" Version="5.4.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net48' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="BouncyCastle" Version="1.8.1-octopus" />
     <PackageReference Include="MarkdownSharp" Version="1.13.0.0" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
@@ -103,7 +103,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
     <PackageReference Include="Polly" Version="5.4.0" />
   </ItemGroup>

--- a/source/Calamari.Terraform.Tests/Calamari.Terraform.Tests.csproj
+++ b/source/Calamari.Terraform.Tests/Calamari.Terraform.Tests.csproj
@@ -8,7 +8,7 @@
         <LangVersion>9</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net48;net6.0</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.Terraform/Calamari.Terraform.csproj
+++ b/source/Calamari.Terraform/Calamari.Terraform.csproj
@@ -11,7 +11,7 @@
   <!-- Cake build looks for xpath Project/PropertyGroup/TargetFrameworks with a fallback of Project/PropertyGroup/TargetFramework
         in PublishCalamariProjects task. If making changes, be sure to look there to make sure it's all alright still -->
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net452;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>net6.0</TargetFramework>

--- a/source/Calamari.Testing/Calamari.Testing.csproj
+++ b/source/Calamari.Testing/Calamari.Testing.csproj
@@ -7,7 +7,7 @@
         <LangVersion>default</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net48;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net452;netstandard2.1</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>netstandard2.1</TargetFramework>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -12,7 +12,7 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>net6.0</TargetFramework>
@@ -20,7 +20,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <DefineConstants>$(DefineConstants);NETCORE;AWS;AZURE_CORE;JAVA_SUPPORT</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <DefineConstants>$(DefineConstants);NETFX;AWS;IIS_SUPPORT;USE_NUGET_V2_LIBS;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT;WINDOWS_USER_ACCOUNT_SUPPORT;WINDOWS_REGISTRY_SUPPORT</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
@@ -41,7 +41,7 @@
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.3.0" />
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net48'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />
     <Reference Include="System.Core" />
@@ -253,7 +253,7 @@
     <CreateItem Include="@(PackageDefinitions)" Condition="'%(Name)' == 'ScriptCS'">
       <Output TaskParameter="Include" ItemName="ScriptCSRef" />
     </CreateItem>
-    <CreateItem Include="@(PackageDefinitions)" Condition=" '$(TargetFramework)' == 'net48' And '%(Name)' == 'NuGet.CommandLine'">
+    <CreateItem Include="@(PackageDefinitions)" Condition=" '$(TargetFramework)' == 'net461' And '%(Name)' == 'NuGet.CommandLine'">
       <Output TaskParameter="Include" ItemName="NuGetCommandLineRef" />
     </CreateItem>
     <PropertyGroup>
@@ -268,11 +268,11 @@
       <FSharpFilesExe Condition="'$(TargetFramework)' == 'net6.0'" Include="$(FSharpCompilerToolsExe)" />
       <ScriptCSFiles Include="$(ScriptCS)" />
       <ScriptCSFilesExe Condition="'$(TargetFramework)' == 'net6.0'" Include="$(ScriptCSExe)" />
-      <NuGetFiles Include="$(NuGetCommandLine)" Condition=" '$(TargetFramework)' == 'net48'" />
+      <NuGetFiles Include="$(NuGetCommandLine)" Condition=" '$(TargetFramework)' == 'net461'" />
     </ItemGroup>
     <Copy SourceFiles="@(FSharpFiles)" DestinationFolder="$(OutDir)/FSharp/" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(ScriptCSFiles)" DestinationFolder="$(OutDir)/ScriptCS/" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(NuGetFiles)" DestinationFolder="$(OutDir)/NuGet/" SkipUnchangedFiles="true" Condition="'$(TargetFramework)' == 'net48'" />
+    <Copy SourceFiles="@(NuGetFiles)" DestinationFolder="$(OutDir)/NuGet/" SkipUnchangedFiles="true" Condition="'$(TargetFramework)' == 'net461'" />
     <Exec Command="chmod +x %(FSharpFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'net6.0'" />
     <Exec Command="chmod +x %(ScriptCSFilesExe.Identity)" IgnoreExitCode="true" Condition="'$(TargetFramework)' == 'net6.0'" />
     <Copy SourceFiles="@(FSharpFiles)" DestinationFolder="$(PublishDir)/FSharp/" Condition="'$(PublishDir)' != ''" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -20,12 +20,12 @@
     <ApplicationManifest>Calamari.exe.manifest</ApplicationManifest>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net40;net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net40;net452;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net48' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);IIS_SUPPORT;WINDOWS_CERTIFICATE_STORE_SUPPORT</DefineConstants>
     <PlatformTarget>anycpu</PlatformTarget>
   </PropertyGroup>
@@ -33,10 +33,10 @@
     <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
   </PropertyGroup>
   <!--
-	The net48 build is the one that pulls in the AWS and Azure extensions. We treat
+	The net452 build is the one that pulls in the AWS and Azure extensions. We treat
 	this build as the "Cloud" build.
   -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />
     <ProjectReference Include="..\Calamari.Azure\Calamari.Azure.csproj" />
   </ItemGroup>
@@ -51,7 +51,7 @@
     </PackageReference>
     <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
     <ProjectReference Include="..\Calamari.Shared\Calamari.Shared.csproj" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net452" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -80,7 +80,7 @@
     <Reference Include="System" />
     <Reference Include="System.Security" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net48' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Autofac" Version="4.8.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Our recent `netfx` upgrades from 4.5.2/4.6.1 to 4.8 caused some issues with certain steps running in the Worker Tools execution containers.

We rolled back the version of Calamari in use in Server, but in doing so also nuked some other changes we want to keep.

This PR merges forward the reverts to the netfx upgrade commits so we can re-release the changes we want to keep; the netfx changes can be re-integrated later.