### PR TITLE
Fix slow syncing due to nuke

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -13,12 +13,16 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <NukeExcludeDirectoryBuild>True</NukeExcludeDirectoryBuild>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="NuGet.CommandLine" Version="6.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Nuke.Common" Version="6.1.1" />
+        <PackageReference Include="Nuke.Common" Version="6.3.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Looks like Calamari suffers from the same syncing issue due to `Nuke` scanning too aggressively. Same fix applied here as copied from https://github.com/OctopusDeploy/OctopusDeploy/pull/16288

EDIT: The slowness is not consistently reproducible. Happened to me when I loaded up Calamari for the first time in a long time. But seems fine for others who work on Calamari a lot. So this fix is more for future proofing and better practice.