### PR TITLE
Removing ADAL from 2022.4 AzureAppService for MSAL

### DIFF
--- a/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
+++ b/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Azure.ResourceManager.Resources" Version="1.0.0-preview.2" />
     <PackageReference Include="Microsoft.Azure.Management.Storage" Version="24.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.38.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/source/Calamari.AzureAppService/Auth.cs
+++ b/source/Calamari.AzureAppService/Auth.cs
@@ -3,8 +3,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Calamari.AzureAppService.Azure;
 using Microsoft.Identity.Client;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
-using ClientCredential = Microsoft.IdentityModel.Clients.ActiveDirectory.ClientCredential;
 
 namespace Calamari.AzureAppService
 {
@@ -22,12 +20,7 @@ namespace Calamari.AzureAppService
 
         public static async Task<string> GetAuthTokenAsync(ServicePrincipalAccount principalAccount)
         {
-            string authContext =
-                GetContextUri(principalAccount.ActiveDirectoryEndpointBaseUri, principalAccount.TenantId);
-            var context = new AuthenticationContext(authContext);
-            var result = await context.AcquireTokenAsync(principalAccount.ResourceManagementEndpointBaseUri,
-                new ClientCredential(principalAccount.ClientId, principalAccount.Password));
-            return result.AccessToken;
+            return await GetAuthTokenAsync(principalAccount.TenantId, principalAccount.ClientId, principalAccount.Password, principalAccount.ResourceManagementEndpointBaseUri, principalAccount.ActiveDirectoryEndpointBaseUri);
         }
 
         public static async Task<string> GetAuthTokenAsync(string tenantId, string applicationId, string password, string managementEndPoint, string activeDirectoryEndPoint)


### PR DESCRIPTION
Tidy's up a reference to ADAL and replaces with MSAL - [see original change for details](https://github.com/OctopusDeploy/Calamari/pull/963)

ADAL deprecation https://learn.microsoft.com/en-us/azure/active-directory/develop/msal-migration