### PR TITLE
Fix failing Calamari build

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
@@ -8,7 +8,7 @@
 [Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using EKS cluster name my-eks-cluster
 [Verbose] Attempting to authenticate with aws-cli
-[Verbose] Unable to authenticate to <server> using the aws cli. Failed with error message: Error reading JObject from JsonReader. Path '', line 0, position 0.
+[Verbose] Unable to authenticate to <server> using the aws cli. Failed with error message: Unexpected character encountered while parsing value: P. Path '', line 0, position 0.
 [Verbose] Attempting to authenticate with aws-iam-authenticator
 [Verbose] "kubectl" config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1beta1 --exec-arg=token --exec-arg=-i --exec-arg=my-eks-cluster --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -209,7 +209,7 @@ namespace Calamari.Tests.KubernetesFixtures
                         var downloadUrl = GetGcloudDownloadLink(tuple.version);
                         var fileName = GetGcloudZipFileName(tuple.version);
 
-                        await DownloadGcloud(GetGcloudZipFileName(tuple.version),
+                        await DownloadGcloud(fileName,
                             client,
                             downloadUrl,
                             destinationDirectoryName);

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -133,7 +133,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 AwsCliExecutable = await DownloadCli("aws",
                     () =>
                     {
-                        var version = "2.11.0";
+                        var version = "latest";
                         return Task.FromResult((version, GetAwsCliDownloadLink(version)));
                     },
                     async (destinationDirectoryName, tuple) =>
@@ -283,12 +283,13 @@ namespace Calamari.Tests.KubernetesFixtures
 
         static string GetAwsCliDownloadLink(string version)
         {
+            var versionString = version != "latest" ? $"-{version}" : "";
             if (CalamariEnvironment.IsRunningOnNix)
-                return $"https://awscli.amazonaws.com/awscli-exe-linux-x86_64-{version}.zip";
+                return $"https://awscli.amazonaws.com/awscli-exe-linux-x86_64{versionString}.zip";
             if (CalamariEnvironment.IsRunningOnMac)
-                return $"https://awscli.amazonaws.com/AWSCLIV2-{version}.pkg";
+                return $"https://awscli.amazonaws.com/AWSCLIV2{versionString}.pkg";
 
-            return $"https://awscli.amazonaws.com/AWSCLIV2-{version}.msi";
+            return $"https://awscli.amazonaws.com/AWSCLIV2{versionString}.msi";
         }
 
         static string GetAwsCliExecutablePath(string extractPath)

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -134,7 +134,7 @@ namespace Calamari.Tests.KubernetesFixtures
                     () =>
                     {
                         var version = "2.8.3";
-                        return Task.FromResult((version, GetAwsCliDownloadLink()));
+                        return Task.FromResult((version, GetAwsCliDownloadLink(version)));
                     },
                     async (destinationDirectoryName, tuple) =>
                     {
@@ -281,14 +281,14 @@ namespace Calamari.Tests.KubernetesFixtures
             return "AWSCLIV2.msi";
         }
 
-        static string GetAwsCliDownloadLink()
+        static string GetAwsCliDownloadLink(string version)
         {
             if (CalamariEnvironment.IsRunningOnNix)
-                return "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip";
+                return $"https://awscli.amazonaws.com/awscli-exe-linux-x86_64-{version}.zip";
             if (CalamariEnvironment.IsRunningOnMac)
-                return "https://awscli.amazonaws.com/AWSCLIV2.pkg";
+                return $"https://awscli.amazonaws.com/AWSCLIV2-{version}.pkg";
 
-            return "https://awscli.amazonaws.com/AWSCLIV2.msi";
+            return $"https://awscli.amazonaws.com/AWSCLIV2-{version}.msi";
         }
 
         static string GetAwsCliExecutablePath(string extractPath)

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -133,7 +133,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 AwsCliExecutable = await DownloadCli("aws",
                     () =>
                     {
-                        var version = "latest";
+                        var version = "2.8.3";
                         return Task.FromResult((version, GetAwsCliDownloadLink(version)));
                     },
                     async (destinationDirectoryName, tuple) =>
@@ -191,8 +191,8 @@ namespace Calamari.Tests.KubernetesFixtures
                             }
                         }
 
-                        return !string.IsNullOrWhiteSpace(destinationDirectoryName) 
-                            ? GetAwsCliExecutablePath(destinationDirectoryName) 
+                        return !string.IsNullOrWhiteSpace(destinationDirectoryName)
+                            ? GetAwsCliExecutablePath(destinationDirectoryName)
                             : string.Empty;
                     });
             }

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -302,6 +302,12 @@ namespace Calamari.Tests.KubernetesFixtures
                                     "aws.exe");
             }
 
+            // For developers on a Mac - ensure aws cli is installed manually and on your PATH.
+            if (CalamariEnvironment.IsRunningOnMac)
+            {
+                return "aws";
+            }
+
             return Path.Combine(extractPath, "aws", "dist", "aws");
         }
 

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -133,7 +133,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 AwsCliExecutable = await DownloadCli("aws",
                     () =>
                     {
-                        var version = "2.8.3";
+                        var version = "2.11.0";
                         return Task.FromResult((version, GetAwsCliDownloadLink(version)));
                     },
                     async (destinationDirectoryName, tuple) =>

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -255,7 +255,6 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Aws.Region", "eks_region");
             variables.Set($"{account}.AccessKey", "eksAccessKey");
             variables.Set($"{account}.SecretKey", "eksSecretKey");
-            Console.WriteLine($"CLUSTER URL VALUE: {variables.Get(SpecialVariables.ClusterUrl)}");
             var wrapper = CreateWrapper();
             TestScriptInReadOnlyMode(wrapper).AssertSuccess();
         }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -238,7 +238,6 @@ namespace Calamari.Tests.KubernetesFixtures
         }
         
         [Test]
-        [WindowsTest] // This test requires the aws cli tools. Currently only configured to install on Windows
         [RequiresNonMono] // as Mac and Linux installation requires Distro specific tooling
         public void ExecutionWithEKS_AwsCLIAuthenticator()
         {

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -238,7 +238,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
         
         [Test]
-        [WindowsTest] // This test requires the aws cli tools. Currently only configured to install on Linux & Windows
+        [WindowsTest] // This test requires the aws cli tools. Currently only configured to install on Windows
         [RequiresNonMono] // as Mac and Linux installation requires Distro specific tooling
         public void ExecutionWithEKS_AwsCLIAuthenticator()
         {

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -238,6 +238,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
         
         [Test]
+        [WindowsTest] // This test requires the aws cli tools. Currently only configured to install on Linux & Windows
         [RequiresNonMono] // as Mac and Linux installation requires Distro specific tooling
         public void ExecutionWithEKS_AwsCLIAuthenticator()
         {

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -255,6 +255,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Aws.Region", "eks_region");
             variables.Set($"{account}.AccessKey", "eksAccessKey");
             variables.Set($"{account}.SecretKey", "eksSecretKey");
+            Console.WriteLine($"CLUSTER URL VALUE: {variables.Get(SpecialVariables.ClusterUrl)}");
             var wrapper = CreateWrapper();
             TestScriptInReadOnlyMode(wrapper).AssertSuccess();
         }

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/GKE/gke.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/GKE/gke.tf
@@ -1,3 +1,17 @@
+# VPC
+resource "google_compute_network" "vpc" {
+  name                    = "${random_pet.prefix.id}-vpc"
+  auto_create_subnetworks = "false"
+}
+
+# Subnet
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${random_pet.prefix.id}-subnet"
+  region        = local.region
+  network       = google_compute_network.vpc.name
+  ip_cidr_range = "10.10.0.0/24"
+}
+
 resource "google_container_cluster" "default" {
   name               = "${random_pet.prefix.id}-gke"
   project            = "octopus-api-tester"

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/GKE/gke.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/GKE/gke.tf
@@ -2,6 +2,7 @@
 resource "google_compute_network" "vpc" {
   name                    = "${random_pet.prefix.id}-vpc"
   auto_create_subnetworks = "false"
+  project                 = "octopus-api-tester"
 }
 
 # Subnet
@@ -10,6 +11,7 @@ resource "google_compute_subnetwork" "subnet" {
   region        = local.region
   network       = google_compute_network.vpc.name
   ip_cidr_range = "10.10.0.0/24"
+  project       = "octopus-api-tester"
 }
 
 resource "google_container_cluster" "default" {

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/GKE/gke.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/GKE/gke.tf
@@ -25,6 +25,9 @@ resource "google_container_cluster" "default" {
       issue_client_certificate = true
     }
   }
+
+  network    = google_compute_network.vpc.name
+  subnetwork = google_compute_subnetwork.subnet.name
 }
 
 data "google_client_config" "default" {

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/GKE/providers.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/GKE/providers.tf
@@ -12,7 +12,11 @@ terraform {
   required_version = ">= 0.15"
 }
 
+locals {
+  region = "australia-southeast1"
+}
+
 provider "google" {
-  region      = "australia-southeast1"
+  region      = local.region
   zone        = "australia-southeast1-c"
 }

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -405,7 +405,7 @@ namespace Calamari.Kubernetes
                     log.Verbose("Could not find the aws cli, falling back to the aws-iam-authenticator.");
                     return false;
                 }
-                
+
                 try {
                     var awsCliVersion = GetAwsCliVersion();
                     var minimumAwsCliVersionForAuth = new SemanticVersion("1.16.156");
@@ -418,7 +418,7 @@ namespace Calamari.Kubernetes
                             SetKubeConfigAuthenticationToAwsCli(user, clusterName, region, apiVersion);
                             return true;
                         }
-                        
+
                         log.Verbose("The EKS cluster Url specified should contain a valid aws region name");
                     }
 
@@ -431,7 +431,7 @@ namespace Calamari.Kubernetes
 
                 return false;
             }
-            
+
             string GetEksClusterRegion(string clusterUrl) => clusterUrl.Replace(".eks.amazonaws.com", "").Split('.').Last();
 
             SemanticVersion GetAwsCliVersion()
@@ -445,12 +445,20 @@ namespace Calamari.Kubernetes
 
             string GetEksClusterApiVersion(string clusterName, string region)
             {
-                var awsEksTokenCommand = string.Join("\n", ExecuteCommandAndReturnOutput(aws,
+                var logLines = ExecuteCommandAndReturnOutput(aws,
                     "eks",
                     "get-token",
                     $"--cluster-name={clusterName}",
-                    $"--region={region}"));
+                    $"--region={region}");
+                log.Warn("All log lines:");
+                foreach (var logLine in logLines)
+                {
+                    log.Warn($"'{logLine}'");
+                }
+                var awsEksTokenCommand = string.Join("\n", logLines);
 
+                log.Warn("Token command:");
+                log.Warn(awsEksTokenCommand);
                 return JObject.Parse(awsEksTokenCommand).SelectToken("apiVersion").ToString();
             }
 
@@ -568,7 +576,7 @@ namespace Calamari.Kubernetes
 
                 var commandString = invocation.ToString();
                 log.Verbose(commandString);
-                
+
                 var result = commandLineRunner.Execute(invocation);
 
                 foreach (var message in captureCommandOutput.Messages)

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -445,12 +445,11 @@ namespace Calamari.Kubernetes
 
             string GetEksClusterApiVersion(string clusterName, string region)
             {
-                var awsEksTokenCommand = ExecuteCommandAndReturnOutput(aws,
-                                                                       "eks",
-                                                                       "get-token",
-                                                                       $"--cluster-name={clusterName}",
-                                                                       $"--region={region}")
-                    .FirstOrDefault();
+                var awsEksTokenCommand = string.Join("\n", ExecuteCommandAndReturnOutput(aws,
+                    "eks",
+                    "get-token",
+                    $"--cluster-name={clusterName}",
+                    $"--region={region}"));
 
                 return JObject.Parse(awsEksTokenCommand).SelectToken("apiVersion").ToString();
             }

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -181,7 +181,6 @@ namespace Calamari.Kubernetes
             bool TrySetupContext(string kubeConfig, string @namespace, string accountType)
             {
                 var clusterUrl = variables.Get(SpecialVariables.ClusterUrl);
-                Console.WriteLine($"TrySetupContext(): Cluster Url retrieved: {clusterUrl}");
                 var clientCert = variables.Get("Octopus.Action.Kubernetes.ClientCertificate");
                 var eksUseInstanceRole = variables.GetFlag("Octopus.Action.AwsAccount.UseInstanceRole");
                 var podServiceAccountTokenPath = variables.Get("Octopus.Action.Kubernetes.PodServiceAccountTokenPath");
@@ -388,7 +387,6 @@ namespace Calamari.Kubernetes
             {
                 var clusterName = variables.Get(SpecialVariables.EksClusterName);
                 log.Info($"Creating kubectl context to {clusterUrl} (namespace {@namespace}) using EKS cluster name {clusterName}");
-                Console.WriteLine($"Creating kubectl context to {clusterUrl} (namespace {@namespace}) using EKS cluster name {clusterName}");
 
                 if (TrySetKubeConfigAuthenticationToAwsCli(clusterName, clusterUrl, user))
                 {
@@ -414,8 +412,6 @@ namespace Calamari.Kubernetes
                     if (awsCliVersion.CompareTo(minimumAwsCliVersionForAuth) > 0)
                     {
                         var region = GetEksClusterRegion(clusterUrl);
-                        Console.WriteLine(
-                            $"TrySetKubeConfigAuthenticationToAwsCli(): clusterUrl: {clusterUrl} region: {region}");
                         if (!string.IsNullOrWhiteSpace(region))
                         {
                             var apiVersion = GetEksClusterApiVersion(clusterName, region);
@@ -454,17 +450,7 @@ namespace Calamari.Kubernetes
                     "get-token",
                     $"--cluster-name={clusterName}",
                     $"--region={region}");
-                Console.WriteLine($"ClusterName: {clusterName}");
-                Console.WriteLine($"Region: {region}");
-                Console.WriteLine("All log lines:");
-                foreach (var logLine in logLines)
-                {
-                    Console.WriteLine($"'{logLine}'");
-                }
                 var awsEksTokenCommand = string.Join("\n", logLines);
-
-                Console.WriteLine("Token command:");
-                Console.WriteLine(awsEksTokenCommand);
                 return JObject.Parse(awsEksTokenCommand).SelectToken("apiVersion").ToString();
             }
 

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -181,6 +181,7 @@ namespace Calamari.Kubernetes
             bool TrySetupContext(string kubeConfig, string @namespace, string accountType)
             {
                 var clusterUrl = variables.Get(SpecialVariables.ClusterUrl);
+                Console.WriteLine($"TrySetupContext(): Cluster Url retrieved: {clusterUrl}");
                 var clientCert = variables.Get("Octopus.Action.Kubernetes.ClientCertificate");
                 var eksUseInstanceRole = variables.GetFlag("Octopus.Action.AwsAccount.UseInstanceRole");
                 var podServiceAccountTokenPath = variables.Get("Octopus.Action.Kubernetes.PodServiceAccountTokenPath");
@@ -387,6 +388,7 @@ namespace Calamari.Kubernetes
             {
                 var clusterName = variables.Get(SpecialVariables.EksClusterName);
                 log.Info($"Creating kubectl context to {clusterUrl} (namespace {@namespace}) using EKS cluster name {clusterName}");
+                Console.WriteLine($"Creating kubectl context to {clusterUrl} (namespace {@namespace}) using EKS cluster name {clusterName}");
 
                 if (TrySetKubeConfigAuthenticationToAwsCli(clusterName, clusterUrl, user))
                 {

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -412,6 +412,8 @@ namespace Calamari.Kubernetes
                     if (awsCliVersion.CompareTo(minimumAwsCliVersionForAuth) > 0)
                     {
                         var region = GetEksClusterRegion(clusterUrl);
+                        Console.WriteLine(
+                            $"TrySetKubeConfigAuthenticationToAwsCli(): clusterUrl: {clusterUrl} region: {region}");
                         if (!string.IsNullOrWhiteSpace(region))
                         {
                             var apiVersion = GetEksClusterApiVersion(clusterName, region);
@@ -450,6 +452,8 @@ namespace Calamari.Kubernetes
                     "get-token",
                     $"--cluster-name={clusterName}",
                     $"--region={region}");
+                Console.WriteLine($"ClusterName: {clusterName}");
+                Console.WriteLine($"Region: {region}");
                 Console.WriteLine("All log lines:");
                 foreach (var logLine in logLines)
                 {

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -450,15 +450,15 @@ namespace Calamari.Kubernetes
                     "get-token",
                     $"--cluster-name={clusterName}",
                     $"--region={region}");
-                log.Warn("All log lines:");
+                Console.WriteLine("All log lines:");
                 foreach (var logLine in logLines)
                 {
-                    log.Warn($"'{logLine}'");
+                    Console.WriteLine($"'{logLine}'");
                 }
                 var awsEksTokenCommand = string.Join("\n", logLines);
 
-                log.Warn("Token command:");
-                log.Warn(awsEksTokenCommand);
+                Console.WriteLine("Token command:");
+                Console.WriteLine(awsEksTokenCommand);
                 return JObject.Parse(awsEksTokenCommand).SelectToken("apiVersion").ToString();
             }
 


### PR DESCRIPTION
The build is failing because one call seems to return json as separate log lines instead of a single log line containing the json blob. Unsure why it has randomly started doing this as I can't see a reason.. but it could be the AWS CLI? Unsure if we updated a version of something that would affect this.

[sc-42546]