### PR TITLE
Consolidate ServiceMessageCollectorLog and InMemoryLog

### DIFF
--- a/source/Calamari.Testing/Helpers/InMemoryLog.cs
+++ b/source/Calamari.Testing/Helpers/InMemoryLog.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.ServiceMessages;
 
 namespace Calamari.Testing.Helpers
 {
@@ -10,6 +11,7 @@ namespace Calamari.Testing.Helpers
         public List<Message> Messages { get; } = new List<Message>();
         public List<string> StandardOut { get; } = new List<string>();
         public List<string> StandardError  { get; }= new List<string>();
+        public List<ServiceMessage> ServiceMessages { get; } = new List<ServiceMessage>();
 
         public IEnumerable<string> MessagesVerboseFormatted => Messages.Where(m => m.Level == Level.Verbose).Select(m => m.FormattedMessage);
         public IEnumerable<string> MessagesInfoFormatted => Messages.Where(m => m.Level == Level.Info).Select(m => m.FormattedMessage);
@@ -76,6 +78,12 @@ namespace Calamari.Testing.Helpers
             base.ErrorFormat(messageFormat, args);
         }
 
+        public override void WriteServiceMessage(ServiceMessage serviceMessage)
+        {
+            ServiceMessages.Add(serviceMessage);
+            base.WriteServiceMessage(serviceMessage);
+        }
+        
         public class Message
         {
             public Level Level { get; }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -134,9 +134,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [TestCase(true)]
         public void DiscoverKubernetesClusterWithAzureServicePrincipalAccount(bool setHealthCheckContainer)
         {
-            var serviceMessageCollectorLog = new ServiceMessageCollectorLog();
-            Log = serviceMessageCollectorLog;
-
             var scope = new TargetDiscoveryScope("TestSpace",
                 "Staging",
                 "testProject",
@@ -197,10 +194,10 @@ namespace Calamari.Tests.KubernetesFixtures
                 KubernetesDiscoveryCommand.CreateKubernetesTargetServiceMessageName,
                 serviceMessageProperties);
 
-            serviceMessageCollectorLog.ServiceMessages.Should()
-                                      .ContainSingle(s => s.Properties["name"] == targetName)
-                                      .Which.Should()
-                                      .BeEquivalentTo(expectedServiceMessage);
+            Log.ServiceMessages.Should()
+                .ContainSingle(s => s.Properties["name"] == targetName)
+                .Which.Should()
+                .BeEquivalentTo(expectedServiceMessage);
         }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -150,19 +150,16 @@ namespace Calamari.Tests.KubernetesFixtures
             AwsAuthenticationDetails authenticationDetails,
             Dictionary<string,string> properties)
         {
-            var serviceMessageCollectorLog = new ServiceMessageCollectorLog();
-            Log = serviceMessageCollectorLog;
-
             DoDiscovery(authenticationDetails);
 
             var expectedServiceMessage = new ServiceMessage(
                 KubernetesDiscoveryCommand.CreateKubernetesTargetServiceMessageName,
                 properties);
 
-            serviceMessageCollectorLog.ServiceMessages.Should()
-                                      .ContainSingle(s => s.Properties["name"] == properties["name"])
-                                      .Which.Should()
-                                      .BeEquivalentTo(expectedServiceMessage);
+            Log.ServiceMessages.Should()
+                .ContainSingle(s => s.Properties["name"] == properties["name"])
+                .Which.Should()
+                .BeEquivalentTo(expectedServiceMessage);
         }
 
         protected CalamariResult ExecuteDiscoveryCommand<TAuthenticationDetails>(
@@ -183,17 +180,6 @@ namespace Calamari.Tests.KubernetesFixtures
                                        .Action(KubernetesDiscoveryCommand.Name)
                                        .Argument("variables", variablesFile.FilePath)
                                        .Argument("extensions", string.Join(',', extensions)));
-            }
-        }
-
-        protected class ServiceMessageCollectorLog : InMemoryLog
-        {
-            public List<ServiceMessage> ServiceMessages { get; } = new List<ServiceMessage>();
-            public override void WriteServiceMessage(ServiceMessage serviceMessage)
-            {
-                ServiceMessages.Add(serviceMessage);
-
-                base.WriteServiceMessage(serviceMessage);
             }
         }
     }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -351,22 +351,19 @@ namespace Calamari.Tests.KubernetesFixtures
                     Regions = new []{region}
                 };
                 
-                var serviceMessageCollectorLog = new ServiceMessageCollectorLog();
-                Log = serviceMessageCollectorLog;
-                
                 DoDiscovery(authenticationDetails);
 
-                serviceMessageCollectorLog.ServiceMessages.Should().BeEmpty();
+                Log.ServiceMessages.Should().BeEmpty();
 
-                serviceMessageCollectorLog.Messages.Should().NotContain(m => m.Level == InMemoryLog.Level.Error);
+                Log.Messages.Should().NotContain(m => m.Level == InMemoryLog.Level.Error);
 
-                serviceMessageCollectorLog.StandardError.Should().BeEmpty();
+                Log.StandardError.Should().BeEmpty();
 
-                serviceMessageCollectorLog.Messages.Should()
-                                          .ContainSingle(m =>
-                                              m.Level == InMemoryLog.Level.Warn &&
-                                              m.FormattedMessage ==
-                                              "Unable to authorise credentials, see verbose log for details.");
+                Log.Messages.Should()
+                    .ContainSingle(m =>
+                        m.Level == InMemoryLog.Level.Warn &&
+                        m.FormattedMessage ==
+                        "Unable to authorise credentials, see verbose log for details.");
             }
             finally
             {
@@ -394,23 +391,20 @@ namespace Calamari.Tests.KubernetesFixtures
                 Role = new AwsAssumedRole { Type = "noAssumedRole" },
                 Regions = new []{region}
             };
-            
-            var serviceMessageCollectorLog = new ServiceMessageCollectorLog();
-            Log = serviceMessageCollectorLog;
-            
+
             DoDiscovery(authenticationDetails);
 
-            serviceMessageCollectorLog.ServiceMessages.Should().BeEmpty();
+            Log.ServiceMessages.Should().BeEmpty();
 
-            serviceMessageCollectorLog.Messages.Should().NotContain(m => m.Level == InMemoryLog.Level.Error);
+            Log.Messages.Should().NotContain(m => m.Level == InMemoryLog.Level.Error);
 
-            serviceMessageCollectorLog.StandardError.Should().BeEmpty();
+            Log.StandardError.Should().BeEmpty();
 
-            serviceMessageCollectorLog.Messages.Should()
-                                      .ContainSingle(m =>
-                                          m.Level == InMemoryLog.Level.Warn &&
-                                          m.FormattedMessage ==
-                                          "Unable to authorise credentials, see verbose log for details."); 
+            Log.Messages.Should()
+                .ContainSingle(m =>
+                    m.Level == InMemoryLog.Level.Warn &&
+                    m.FormattedMessage ==
+                    "Unable to authorise credentials, see verbose log for details."); 
         }
     }
 }


### PR DESCRIPTION
In some Kubernetes fixtures we need to assert on the service message sent to the server. Since `InMemoryLog` does not provide methods to record the service messages, a `ServiceMessageCollectorLog` class was extended from it to provide this capability. This was needed because before all Calamari flavours were incorporated, the Kubernetes fixtures and `InMemoryLog` lived in separate repositories.

Now all flavours are consolidated in this single repository, the service message collection methods should be moved into the `InMemoryLog` itself.