### PR TITLE
Handle disabled timeouts

### DIFF
--- a/source/Calamari/Kubernetes/ResourceStatus/CountdownTimer.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/CountdownTimer.cs
@@ -33,4 +33,16 @@ namespace Calamari.Kubernetes.ResourceStatus
         public bool HasStarted() => stopwatch.IsRunning;
         public bool HasCompleted() => stopwatch.Elapsed >= duration;
     }
+
+    /// <summary>
+    /// Represents a CountdownTimer that never completes
+    /// </summary>
+    public class InfiniteCountdownTimer : ICountdownTimer
+    {
+        private bool hasStarted;
+        public void Start() => hasStarted = true;
+        public void Reset() => hasStarted = false;
+        public bool HasStarted() => hasStarted;
+        public bool HasCompleted() => false;
+    }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -94,11 +94,11 @@ namespace Calamari.Kubernetes.ResourceStatus
                 return new CommandResult(string.Empty, 1);
             }
 
-            ICountdownTimer deploymentTimer = deploymentTimeoutEnabled
-                ? new InfiniteCountdownTimer()
-                : new CountdownTimer(TimeSpan.FromSeconds(deploymentTimeoutSeconds));
+            var deploymentTimer = deploymentTimeoutEnabled
+                ? new InfiniteCountdownTimer() as ICountdownTimer
+                : new CountdownTimer(TimeSpan.FromSeconds(deploymentTimeoutSeconds)) as ICountdownTimer;
 
-            ICountdownTimer stabilizationTimer = new CountdownTimer(
+            var stabilizationTimer = new CountdownTimer(
                 stabilizationTimeoutEnabled 
                     ? TimeSpan.FromSeconds(stabilizationTimeoutSeconds) 
                     : TimeSpan.Zero);

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -61,8 +61,6 @@ namespace Calamari.Kubernetes.ResourceStatus
             var customKubectlExecutable = variables.Get(SpecialVariables.CustomKubectlExecutable);
             var deploymentTimeoutSeconds = variables.GetInt32(SpecialVariables.DeploymentTimeout) ?? 0;
             var stabilizationTimeoutSeconds = variables.GetInt32(SpecialVariables.StabilizationTimeout) ?? 0;
-            var deploymentTimeoutEnabled = variables.GetFlag(SpecialVariables.DeploymentTimeoutEnabled);
-            var stabilizationTimeoutEnabled = variables.GetFlag(SpecialVariables.StabilizationTimeoutEnabled);
             var workingDirectory = Path.GetDirectoryName(script.File);
             
             var result = NextWrapper.ExecuteScript(script, scriptSyntax, commandLineRunner, environmentVars);
@@ -94,14 +92,11 @@ namespace Calamari.Kubernetes.ResourceStatus
                 return new CommandResult(string.Empty, 1);
             }
 
-            var deploymentTimer = deploymentTimeoutEnabled
+            var deploymentTimer = deploymentTimeoutSeconds == 0
                 ? new InfiniteCountdownTimer() as ICountdownTimer
                 : new CountdownTimer(TimeSpan.FromSeconds(deploymentTimeoutSeconds)) as ICountdownTimer;
 
-            var stabilizationTimer = new CountdownTimer(
-                stabilizationTimeoutEnabled 
-                    ? TimeSpan.FromSeconds(stabilizationTimeoutSeconds) 
-                    : TimeSpan.Zero);
+            var stabilizationTimer = new CountdownTimer(TimeSpan.FromSeconds(stabilizationTimeoutSeconds));
 
             var stabilizingTimer = new StabilizingTimer(deploymentTimer, stabilizationTimer);
             

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -16,6 +16,8 @@
         public const string DeploymentWait = "Octopus.Action.KubernetesContainers.DeploymentWait";
         public const string DeploymentTimeout = "Octopus.Action.Kubernetes.DeploymentTimeout";
         public const string StabilizationTimeout = "Octopus.Action.Kubernetes.StabilizationTimeout";
+        public const string DeploymentTimeoutEnabled = "Octopus.Action.Kubernetes.DeploymentTimeoutEnabled";
+        public const string StabilizationTimeoutEnabled = "Octopus.Action.Kubernetes.StabilizationTimeoutEnabled";
 
         public const string KubernetesResourceStatusServiceMessageName = "k8s-status";
         

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -16,8 +16,6 @@
         public const string DeploymentWait = "Octopus.Action.KubernetesContainers.DeploymentWait";
         public const string DeploymentTimeout = "Octopus.Action.Kubernetes.DeploymentTimeout";
         public const string StabilizationTimeout = "Octopus.Action.Kubernetes.StabilizationTimeout";
-        public const string DeploymentTimeoutEnabled = "Octopus.Action.Kubernetes.DeploymentTimeoutEnabled";
-        public const string StabilizationTimeoutEnabled = "Octopus.Action.Kubernetes.StabilizationTimeoutEnabled";
 
         public const string KubernetesResourceStatusServiceMessageName = "k8s-status";
         


### PR DESCRIPTION
This PR handles the scenario where the timeouts are disabled.

When the total deployment timeout is disabled, it is treated as infinite timeout that never completes.
When the stabilisation timeout is disabled, it is treated as zero timeout which does not stabilise.

These timeouts are treated as disabled if unset.

<img width="996" alt="Screenshot 2023-03-20 at 12 38 53 PM" src="https://user-images.githubusercontent.com/97418140/226218778-4ef295f2-4326-4cd2-a435-3242fa307b22.png">

