### PR TITLE
Rename Status to ResourceStatus

### DIFF
--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusChecker.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusChecker.cs
@@ -73,12 +73,12 @@ namespace Calamari.Kubernetes.ResourceStatus
 
         private static DeploymentStatus GetDeploymentStatus(List<Resource> resources)
         {
-            if (resources.All(resource => resource.Status == Resources.ResourceStatus.Successful))
+            if (resources.All(resource => resource.ResourceStatus == Resources.ResourceStatus.Successful))
             {
                 return DeploymentStatus.Succeeded;
             }
 
-            if (resources.Any(resource => resource.Status == Resources.ResourceStatus.Failed))
+            if (resources.Any(resource => resource.ResourceStatus == Resources.ResourceStatus.Failed))
             {
                 return DeploymentStatus.Failed;
             }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
@@ -74,7 +74,7 @@ namespace Calamari.Kubernetes.ResourceStatus
                 {"kind", resource.Kind},
                 {"name", resource.Name},
                 {"namespace", resource.Namespace},
-                {"status", resource.Status.ToString()},
+                {"status", resource.ResourceStatus.ToString()},
                 {"data", JsonConvert.SerializeObject(resource)},
                 {"removed", removed.ToString()}
             };

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
@@ -11,7 +11,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public int Ready { get; }
         public int Available { get; }
         public int Unavailable { get; }
-        public override ResourceStatus Status { get; }
+        public override ResourceStatus ResourceStatus { get; }
 
         public Deployment(JObject json) : base(json)
         {
@@ -21,7 +21,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             UpToDate = FieldOrDefault("$.status.updatedReplicas", 0);
             Unavailable = FieldOrDefault("$.status.unavailableReplicas", 0);
 
-            Status = UpToDate == Replicas && Available == Replicas && Ready == Replicas 
+            ResourceStatus = UpToDate == Replicas && Available == Replicas && Ready == Replicas 
                 ? ResourceStatus.Successful 
                 : ResourceStatus.InProgress;
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
@@ -5,7 +5,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     public class Pod : Resource
     {
         public string Phase { get; }
-        public override ResourceStatus Status { get; }
+        public override ResourceStatus ResourceStatus { get; }
     
         public Pod(JObject json) : base(json)
         {
@@ -16,13 +16,13 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             {
                 case"Succeeded": 
                 case "Running":
-                    Status = ResourceStatus.Successful;
+                    ResourceStatus = ResourceStatus.Successful;
                     break;
                 case "Pending":
-                    Status = ResourceStatus.InProgress;
+                    ResourceStatus = ResourceStatus.InProgress;
                     break;
                 default:
-                    Status = ResourceStatus.Failed;
+                    ResourceStatus = ResourceStatus.Failed;
                     break;
             }
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ReplicaSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ReplicaSet.cs
@@ -10,7 +10,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public int Ready { get; }
         public int Replicas { get; }
     
-        public override ResourceStatus Status { get; }
+        public override ResourceStatus ResourceStatus { get; }
         
         public ReplicaSet(JObject json) : base(json)
         {
@@ -20,11 +20,11 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     
             if (Ready == Replicas && Available == Replicas)
             {
-                Status = ResourceStatus.Successful;
+                ResourceStatus = ResourceStatus.Successful;
             }
             else
             {
-                Status = ResourceStatus.InProgress;
+                ResourceStatus = ResourceStatus.InProgress;
             }
         }
         public override bool HasUpdate(Resource lastStatus)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
@@ -25,7 +25,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         [JsonIgnore]
         public string Namespace { get; }
         [JsonIgnore]
-        public virtual ResourceStatus Status => ResourceStatus.Successful;
+        public virtual ResourceStatus ResourceStatus => ResourceStatus.Successful;
         [JsonIgnore]
         public virtual string ChildKind => "";
     


### PR DESCRIPTION
This PR changes the `Status` property on Kubernetes resource classes to `ResourceStatus`. This is to prevent the naming clashing with the `Status` column of a `kubectl get` command to a Pod and a PVC.