### PR TITLE
Implement Pod status

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
@@ -215,7 +215,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
     
     public class PodResponseBuilder
     {
-        private const string template = @"
+        private const string Template = @"
 {{
     ""kind"": ""Pod"",
     ""metadata"": {{
@@ -235,7 +235,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         
         public string Build()
         {
-            return string.Format(template, Phase, InitContainerStatuses, ContainerStatuses);
+            return string.Format(Template, Phase, InitContainerStatuses, ContainerStatuses);
         }
         
         public PodResponseBuilder WithPhase(string phase)

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
@@ -1,0 +1,261 @@
+using System.Linq;
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using KubernetesResources = Calamari.Kubernetes.ResourceStatus.Resources;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class PodTests
+    {
+        [Test]
+        public void WhenThePodCannotBeScheduled_TheStatusShouldBePending()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Pending")
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("Pending");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.InProgress);
+        }
+        
+        [Test]
+        public void WhenInitContainerIsBeingCreatedWithoutErrors_TheStatusShouldShowNumberOfInitContainersReady()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Pending")
+                .WithInitContainerStatuses(new State[]
+                {
+                    new State { Waiting = new Waiting { Reason = "PodInitializing" } },
+                    new State { Terminated = new Terminated { Reason = "Completed" } }
+                })
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("Init:1/2");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.InProgress);
+        }
+        
+        [Test]
+        public void WhenInitContainerCouldNotPullImages_TheStatusShouldShowInitImagePullBackOff()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Pending")
+                .WithInitContainerStatuses(new State[]
+                {
+                    new State { Waiting = new Waiting { Reason = "ImagePullBackOff" } }
+                })
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("Init:ImagePullBackOff");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Failed);
+        }
+        
+        [Test]
+        public void WhenInitContainerCouldNotExecuteSuccessfully_TheStatusShouldShowCrashLoopBackOff()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Pending")
+                .WithInitContainerStatuses(new State[]
+                {
+                    new State { Waiting = new Waiting { Reason = "CrashLoopBackOff" } }
+                })
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("Init:CrashLoopBackOff");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Failed);
+        }
+        
+        [Test]
+        public void WhenContainerIsBeingCreated_TheStatusShouldShowContainerCreating()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Pending")
+                .WithContainerStatuses(new State[]
+                {
+                    new State { Waiting = new Waiting { Reason = "ContainerCreating" } }
+                })
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("ContainerCreating");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.InProgress);
+        }
+        
+        [Test]
+        public void WhenContainerCannotPullImage_TheStatusShouldShowImagePullBackOff()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Pending")
+                .WithContainerStatuses(new State[]
+                {
+                    new State { Waiting = new Waiting { Reason = "ImagePullBackOff" } }
+                })
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("ImagePullBackOff");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Failed);
+        }
+        
+        [Test]
+        public void WhenContainerFailsExecutionAndRestarting_TheStatusShouldShowCrashLoopBackOff()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Pending")
+                .WithContainerStatuses(new State[]
+                {
+                    new State { Waiting = new Waiting { Reason = "CrashLoopBackOff" } }
+                })
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("CrashLoopBackOff");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Failed);
+        }
+        
+        [Test]
+        public void WhenContainerCannotStartExecutionAndWillNotRestart_TheStatusShouldShowContainerCannotRun()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Failed")
+                .WithContainerStatuses(new State[]
+                {
+                    new State { Terminated = new Terminated { Reason = "ContainerCannotRun" } }
+                })
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("ContainerCannotRun");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Failed);
+        }
+        
+        [Test]
+        public void WhenContainerFailsExecutionAndWillNotRestart_TheStatusShouldShowError()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Failed")
+                .WithContainerStatuses(new State[]
+                {
+                    new State { Terminated = new Terminated { Reason = "Error" } }
+                })
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("Error");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Failed);
+        }
+        
+        [Test]
+        public void WhenContainerHasCompletedSuccessfully_TheStatusShouldShowCompleted()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Succeeded")
+                .WithContainerStatuses(new State[]
+                {
+                    new State { Terminated = new Terminated { Reason = "Completed" } }
+                })
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("Completed");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Successful);
+        }
+        
+        [Test]
+        public void WhenContainerIsRunningWithoutErrors_TheStatusShouldShowRunning()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Running")
+                .WithContainerStatuses(new State[]
+                {
+                    new State { Running = new Running() }
+                })
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("Running");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Successful);
+        }
+
+        [Test]
+        public void WhenMoreThanOneContainersFailed_TheStatusShouldShowTheFirstError()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Pending")
+                .WithContainerStatuses(new State[]
+                {
+                    new State { Waiting = new Waiting { Reason = "ImagePullBackOff" } },
+                    new State { Waiting = new Waiting { Reason = "CrashLoopBackOff" } }
+                })
+                .Build();
+    
+            var pod = (Pod)ResourceFactory.FromJson(podResponse);
+
+            pod.Status.Should().Be("ImagePullBackOff");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Failed);
+        }
+    }
+    
+    public class PodResponseBuilder
+    {
+        private const string template = @"
+{{
+    ""kind"": ""Pod"",
+    ""metadata"": {{
+        ""name"": ""Test"",
+        ""uid"": ""123""
+    }},
+    ""status"": {{
+        ""phase"": ""{0}"",
+        ""initContainerStatuses"": {1},
+        ""containerStatuses"": {2}
+    }}
+}}";
+    
+        private string Phase { get; set; } = "Running";
+        private string InitContainerStatuses { get; set; } = "[]";
+        private string ContainerStatuses { get; set; } = "[]";
+        
+        public string Build()
+        {
+            return string.Format(template, Phase, InitContainerStatuses, ContainerStatuses);
+        }
+        
+        public PodResponseBuilder WithPhase(string phase)
+        {
+            Phase = phase;
+            return this;
+        }
+    
+        public PodResponseBuilder WithInitContainerStatuses(params State[] initContainerStates)
+        {
+            var statuses = initContainerStates.Select(state => new ContainerStatus { State = state });
+            InitContainerStatuses = JsonConvert.SerializeObject(statuses);
+            return this;
+        }
+    
+        public PodResponseBuilder WithContainerStatuses(params State[] containerStates)
+        {
+            var statuses = containerStates.Select(state => new ContainerStatus { State = state });
+            ContainerStatuses = JsonConvert.SerializeObject(statuses);
+            return this;
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ContainerStatus.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ContainerStatus.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    public class ContainerStatus
+    {
+        [JsonPropertyName("state")]
+        public State State { get; set; }
+    }
+
+    public class State
+    {
+        [JsonPropertyName("running")]
+        public Running Running { get; set; }
+        
+        [JsonPropertyName("waiting")]
+        public Waiting Waiting { get; set; }
+        
+        [JsonPropertyName("terminated")]
+        public Terminated Terminated { get; set; }
+    }
+    
+    public class Running {}
+    
+    public class Waiting
+    {
+        [JsonPropertyName("reason")]
+        public string Reason { get; set; }
+    }
+    
+    public class Terminated
+    {
+        [JsonPropertyName("reason")]
+        public string Reason { get; set; }
+    }
+}

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ContainerStatus.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ContainerStatus.cs
@@ -1,22 +1,22 @@
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
     public class ContainerStatus
     {
-        [JsonPropertyName("state")]
+        [JsonProperty("state")]
         public State State { get; set; }
     }
 
     public class State
     {
-        [JsonPropertyName("running")]
+        [JsonProperty("running")]
         public Running Running { get; set; }
         
-        [JsonPropertyName("waiting")]
+        [JsonProperty("waiting")]
         public Waiting Waiting { get; set; }
         
-        [JsonPropertyName("terminated")]
+        [JsonProperty("terminated")]
         public Terminated Terminated { get; set; }
     }
     
@@ -24,13 +24,13 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     
     public class Waiting
     {
-        [JsonPropertyName("reason")]
+        [JsonProperty("reason")]
         public string Reason { get; set; }
     }
     
     public class Terminated
     {
-        [JsonPropertyName("reason")]
+        [JsonProperty("reason")]
         public string Reason { get; set; }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
@@ -14,10 +14,10 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             var phase = Field("$.status.phase");
             var initContainerStatuses = data
                 .SelectToken("$.status.initContainerStatuses")
-                ?.ToObject<ContainerStatus[]>() ?? Array.Empty<ContainerStatus>();
+                ?.ToObject<ContainerStatus[]>() ?? new ContainerStatus[] { };
             var containerStatuses = data
                 .SelectToken("$.status.containerStatuses")
-                ?.ToObject<ContainerStatus[]>() ?? Array.Empty<ContainerStatus>();
+                ?.ToObject<ContainerStatus[]>() ?? new ContainerStatus[] { };
 
             (Status, ResourceStatus) = GetStatus(phase, initContainerStatuses, containerStatuses);
         }
@@ -66,11 +66,9 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         private static (string, ResourceStatus) GetStatus(ContainerStatus[] containerStatuses)
         {
             var erroredContainer = containerStatuses.FirstOrDefault(HasError);
-            if (erroredContainer != null)
-            {
-                return (GetReason(erroredContainer), ResourceStatus.Failed);
-            }
-            return (GetReason(containerStatuses.FirstOrDefault(HasReason)), ResourceStatus.InProgress);
+            return erroredContainer != null 
+                ? (GetReason(erroredContainer), ResourceStatus.Failed) 
+                : (GetReason(containerStatuses.FirstOrDefault(HasReason)), ResourceStatus.InProgress);
         }
         
         private static string GetReason(ContainerStatus status)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
@@ -28,7 +27,9 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             return last.ResourceStatus != ResourceStatus || last.Status != Status;
         }
 
-        private (string, ResourceStatus) GetStatus(string phase, ContainerStatus[] initContainerStatuses,
+        private (string, ResourceStatus) GetStatus(
+            string phase, 
+            ContainerStatus[] initContainerStatuses,
             ContainerStatus[] containerStatuses)
         {
             switch (phase)
@@ -75,7 +76,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         {
             if (status == null)
             {
-                return null;
+                return "Pending";
             }
             
             if (status.State.Terminated != null)
@@ -88,7 +89,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                 return status.State.Waiting.Reason;
             }
 
-            return null;
+            return "Pending";
         }
 
         private static bool HasError(ContainerStatus status)
@@ -100,8 +101,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
             if (status.State.Waiting != null)
             {
-                return status.State.Waiting.Reason != "PodInitializing" &&
-                       status.State.Waiting.Reason != "ContainerCreating";
+                return status.State.Waiting.Reason != "PodInitializing" 
+                    && status.State.Waiting.Reason != "ContainerCreating";
             }
 
             return false;

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
@@ -1,36 +1,123 @@
+using System;
+using System.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
     public class Pod : Resource
     {
-        public string Phase { get; }
+        public string Status { get; }
         public override ResourceStatus ResourceStatus { get; }
     
         public Pod(JObject json) : base(json)
         {
-            Phase = Field("$.status.phase");
-            
-            // TODO implement this
-            switch (Phase)
-            {
-                case"Succeeded": 
-                case "Running":
-                    ResourceStatus = ResourceStatus.Successful;
-                    break;
-                case "Pending":
-                    ResourceStatus = ResourceStatus.InProgress;
-                    break;
-                default:
-                    ResourceStatus = ResourceStatus.Failed;
-                    break;
-            }
+            var phase = Field("$.status.phase");
+            var initContainerStatuses = data
+                .SelectToken("$.status.initContainerStatuses")
+                ?.ToObject<ContainerStatus[]>() ?? Array.Empty<ContainerStatus>();
+            var containerStatuses = data
+                .SelectToken("$.status.containerStatuses")
+                ?.ToObject<ContainerStatus[]>() ?? Array.Empty<ContainerStatus>();
+
+            (Status, ResourceStatus) = GetStatus(phase, initContainerStatuses, containerStatuses);
         }
     
         public override bool HasUpdate(Resource lastStatus)
         {
             var last = CastOrThrow<Pod>(lastStatus);
-            return last.Phase != Phase;
+            return last.ResourceStatus != ResourceStatus || last.Status != Status;
+        }
+
+        private (string, ResourceStatus) GetStatus(string phase, ContainerStatus[] initContainerStatuses,
+            ContainerStatus[] containerStatuses)
+        {
+            switch (phase)
+            {
+                case "Pending":
+                    if (!initContainerStatuses.Any() && !containerStatuses.Any())
+                    {
+                        return ("Pending", ResourceStatus.InProgress);
+                    }
+                    return initContainerStatuses.All(HasCompleted) 
+                        ? GetStatus(containerStatuses) 
+                        : GetInitializingStatus(initContainerStatuses);
+                case "Failed":
+                    return (GetReason(containerStatuses.FirstOrDefault()), ResourceStatus.Failed);
+                case "Succeeded":
+                    return (GetReason(containerStatuses.FirstOrDefault()), ResourceStatus.Successful);
+                default:
+                    return ("Running", ResourceStatus.Successful);
+            }
+        }
+
+        private (string, ResourceStatus) GetInitializingStatus(ContainerStatus[] initContainerStatuses)
+        {
+            var erroredContainer = initContainerStatuses.FirstOrDefault(HasError);
+            if (erroredContainer != null)
+            {
+                return ($"Init:{GetReason(erroredContainer)}", ResourceStatus.Failed);
+            }
+
+            var totalInit = initContainerStatuses.Length;
+            var readyInit = initContainerStatuses.Where(HasCompleted).Count();
+            return ($"Init:{readyInit}/{totalInit}", ResourceStatus.InProgress);
+        }
+
+        private (string, ResourceStatus) GetStatus(ContainerStatus[] containerStatuses)
+        {
+            var erroredContainer = containerStatuses.FirstOrDefault(HasError);
+            if (erroredContainer != null)
+            {
+                return (GetReason(erroredContainer), ResourceStatus.Failed);
+            }
+            return (GetReason(containerStatuses.FirstOrDefault(HasReason)), ResourceStatus.InProgress);
+        }
+        
+        private static string GetReason(ContainerStatus status)
+        {
+            if (status == null)
+            {
+                return null;
+            }
+            
+            if (status.State.Terminated != null)
+            {
+                return status.State.Terminated.Reason;
+            }
+
+            if (status.State.Waiting != null)
+            {
+                return status.State.Waiting.Reason;
+            }
+
+            return null;
+        }
+
+        private static bool HasError(ContainerStatus status)
+        {
+            if (status.State.Terminated != null)
+            {
+                return status.State.Terminated.Reason != "Completed";
+            }
+
+            if (status.State.Waiting != null)
+            {
+                return status.State.Waiting.Reason != "PodInitializing" &&
+                       status.State.Waiting.Reason != "ContainerCreating";
+            }
+
+            return false;
+        }
+
+        private static bool HasReason(ContainerStatus status)
+        {
+            return status.State.Terminated != null || status.State.Waiting != null;
+        }
+        
+        private static bool HasCompleted(ContainerStatus status)
+        {
+            return status.State.Terminated != null && status.State.Terminated.Reason == "Completed";
         }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
@@ -51,7 +50,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             }
         }
 
-        private (string, ResourceStatus) GetInitializingStatus(ContainerStatus[] initContainerStatuses)
+        private static (string, ResourceStatus) GetInitializingStatus(ContainerStatus[] initContainerStatuses)
         {
             var erroredContainer = initContainerStatuses.FirstOrDefault(HasError);
             if (erroredContainer != null)
@@ -64,7 +63,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             return ($"Init:{readyInit}/{totalInit}", ResourceStatus.InProgress);
         }
 
-        private (string, ResourceStatus) GetStatus(ContainerStatus[] containerStatuses)
+        private static (string, ResourceStatus) GetStatus(ContainerStatus[] containerStatuses)
         {
             var erroredContainer = containerStatuses.FirstOrDefault(HasError);
             if (erroredContainer != null)


### PR DESCRIPTION
[sc-44236]

This PR adds more comprehensive handling of Pod statuses. 

We attempt to create as close description as users could get from the `STATUS` column `kubectl get` command. The implemented scenarios are covered in [this spreadsheet](https://docs.google.com/spreadsheets/d/13zaYtw6V0OVT_8M57bq2W6vCLbk33lCqZQkT6TXgd7g/edit#gid=0) (internal). Please also see the unit tests to see the behaviour in difference scenarios.

The original `Phase` property which was a placeholder to be used in the walking skeleton is now removed.