### PR TITLE
Fix pod status

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
@@ -113,7 +113,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         public void WhenContainerFailsExecutionAndRestarting_TheStatusShouldShowCrashLoopBackOff()
         {
             var podResponse = new PodResponseBuilder()
-                .WithPhase("Pending")
+                .WithPhase("Running")
                 .WithContainerStatuses(new State[]
                 {
                     new State { Waiting = new Waiting { Reason = "CrashLoopBackOff" } }
@@ -195,7 +195,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         }
 
         [Test]
-        public void WhenMoreThanOneContainersFailed_TheStatusShouldShowTheFirstError()
+        public void WhenMoreThanOneContainersHaveErrors_TheStatusShouldShowTheFirstError()
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Pending")

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
@@ -195,7 +195,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         }
 
         [Test]
-        public void WhenMoreThanOneContainersHaveErrors_TheStatusShouldShowTheFirstError()
+        public void WhenMoreThanOneContainerHasErrors_TheStatusShouldShowTheFirstError()
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Pending")

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
@@ -27,7 +27,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             return last.ResourceStatus != ResourceStatus || last.Status != Status;
         }
 
-        private (string, ResourceStatus) GetStatus(
+        private static (string, ResourceStatus) GetStatus(
             string phase, 
             ContainerStatus[] initContainerStatuses,
             ContainerStatus[] containerStatuses)
@@ -47,7 +47,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                 case "Succeeded":
                     return (GetReason(containerStatuses.FirstOrDefault()), ResourceStatus.Successful);
                 default:
-                    return ("Running", ResourceStatus.Successful);
+                    return GetStatus(containerStatuses);
             }
         }
 
@@ -67,16 +67,26 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         private static (string, ResourceStatus) GetStatus(ContainerStatus[] containerStatuses)
         {
             var erroredContainer = containerStatuses.FirstOrDefault(HasError);
-            return erroredContainer != null 
-                ? (GetReason(erroredContainer), ResourceStatus.Failed) 
-                : (GetReason(containerStatuses.FirstOrDefault(HasReason)), ResourceStatus.InProgress);
+            if (erroredContainer != null)
+            {
+                return (GetReason(erroredContainer), ResourceStatus.Failed);
+            }
+
+            var containerWithReason = containerStatuses.FirstOrDefault(HasReason);
+            if (containerWithReason != null)
+            {
+                return (GetReason(containerWithReason), ResourceStatus.InProgress);
+            }
+
+            return ("Running", ResourceStatus.Successful);
         }
         
         private static string GetReason(ContainerStatus status)
         {
+            // In real scenario this shouldn't happen, but we give it a default value just in case
             if (status == null)
             {
-                return "Pending";
+                return "-";
             }
             
             if (status.State.Terminated != null)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
@@ -86,7 +86,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             // In real scenario this shouldn't happen, but we give it a default value just in case
             if (status == null)
             {
-                return "-";
+                return string.Empty;
             }
             
             if (status.State.Terminated != null)


### PR DESCRIPTION
[sc-44236]

There was a bug in the [previous implementation](https://github.com/OctopusDeploy/Calamari/pull/1005) of Pod status which I discovered while manually testing other stuff.

When the container of the Pod is in a `CrashLoopBackOff` state, the `phase` of the Pod is actually `Running` instead of `Pending`. I incorrectly thought it was `Pending`, so the implementation wasn't correct as well. 

I've modified the relevant test case and fixed the implementation. I also updated the [doc](https://docs.google.com/spreadsheets/d/13zaYtw6V0OVT_8M57bq2W6vCLbk33lCqZQkT6TXgd7g/edit#gid=0) (internal).

<img width="1020" alt="Screenshot 2023-03-28 at 3 10 30 PM" src="https://user-images.githubusercontent.com/97418140/228109088-dcfffad7-cb3b-447e-ae96-f1131d87b74e.png">
