### PR TITLE
Support other resources including secrets and configMaps defined in the "Deploy Container" step

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/KubernetesYamlTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/KubernetesYamlTests.cs
@@ -65,5 +65,26 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
 
             got.Should().BeEquivalentTo(expected);
         }
+
+        [Test]
+        public void ShouldHandleMultipleYamlFiles()
+        {
+            var manifest = TestFileLoader.Load("single-deployment.yaml");
+            var multipleFileInput = new string[] {manifest, manifest};
+            var got = KubernetesYaml.GetDefinedResources(multipleFileInput, string.Empty);
+            var expected = new ResourceIdentifier[]
+            {
+                new ResourceIdentifier(
+                    "Deployment",
+                    "nginx",
+                    "test"),
+                new ResourceIdentifier(
+                    "Deployment",
+                    "nginx",
+                    "test"),
+            };
+
+            got.Should().BeEquivalentTo(expected);
+        }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/KubernetesYamlTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/KubernetesYamlTests.cs
@@ -12,7 +12,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         public void ShouldGenerateCorrectIdentifiers()
         {
             var input = TestFileLoader.Load("single-deployment.yaml");
-            var got = KubernetesYaml.GetDefinedResources(input, string.Empty);
+            var got = KubernetesYaml.GetDefinedResources(new string[] { input }, string.Empty);
             var expected = new ResourceIdentifier[]
             {
                 new ResourceIdentifier(
@@ -29,7 +29,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         public void ShouldOmitDefinitionIfTheMetadataSectionIsNotSet()
         {
             var input = TestFileLoader.Load("invalid.yaml");
-            var got = KubernetesYaml.GetDefinedResources(input, string.Empty);
+            var got = KubernetesYaml.GetDefinedResources(new string[] { input }, string.Empty);
             got.Should().BeEmpty();
         }
         
@@ -37,7 +37,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         public void ShouldHandleMultipleResourcesDefinedInTheSameFile()
         {
             var input = TestFileLoader.Load("multiple-resources.yaml");
-            var got = KubernetesYaml.GetDefinedResources(input, string.Empty);
+            var got = KubernetesYaml.GetDefinedResources(new string[] { input }, string.Empty);
             var expected = new ResourceIdentifier[]
             {
                 new ResourceIdentifier("Deployment", "nginx", "default"),
@@ -53,7 +53,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         {
             const string defaultNamespace = "DefaultNamespace";
             var input = TestFileLoader.Load("no-namespace.yaml");
-            var got = KubernetesYaml.GetDefinedResources(input, defaultNamespace);
+            var got = KubernetesYaml.GetDefinedResources(new string[] { input }, defaultNamespace);
             var expected = new ResourceIdentifier[]
             {
                 new ResourceIdentifier(

--- a/source/Calamari/Kubernetes/ResourceStatus/KubernetesYaml.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/KubernetesYaml.cs
@@ -15,19 +15,22 @@ namespace Calamari.Kubernetes.ResourceStatus
         /// Gets resource identifiers which are defined in a YAML file.
         /// A YAML file can define multiple resources, separated by '---'.
         /// </summary>
-        public static IEnumerable<ResourceIdentifier> GetDefinedResources(string manifests, string defaultNamespace)
+        public static IEnumerable<ResourceIdentifier> GetDefinedResources(IEnumerable<string> manifests, string defaultNamespace)
         {
-            var input = new StringReader(manifests);
-
-            var parser = new Parser(input);
-            parser.Consume<StreamStart>();
-            
-            while (!parser.Accept<StreamEnd>(out _))
+            foreach (var manifest in manifests)
             {
-                var definedResource = GetDefinedResource(parser, defaultNamespace);
-                if (definedResource != null)
+                var input = new StringReader(manifest);
+    
+                var parser = new Parser(input);
+                parser.Consume<StreamStart>();
+                
+                while (!parser.Accept<StreamEnd>(out _))
                 {
-                    yield return definedResource;
+                    var definedResource = GetDefinedResource(parser, defaultNamespace);
+                    if (definedResource != null)
+                    {
+                        yield return definedResource;
+                    }
                 }
             }
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -79,13 +79,13 @@ namespace Calamari.Kubernetes.ResourceStatus
             
             var definedResources = KubernetesYaml.GetDefinedResources(manifests, defaultNamespace).ToList();
             
-            var secret = GetSecret();
+            var secret = GetSecret(defaultNamespace);
             if (secret != null)
             {
                 definedResources.Add(secret);
             }
             
-            var configMap = GetConfigMap();
+            var configMap = GetConfigMap(defaultNamespace);
             if (configMap != null)
             {
                 definedResources.Add(configMap);
@@ -144,15 +144,25 @@ namespace Calamari.Kubernetes.ResourceStatus
                 yield return fileSystem.ReadFile(file);
             }
         }
-
-        private ResourceIdentifier GetSecret()
+        
+        private ResourceIdentifier GetConfigMap(string defaultNamespace)
         {
-            return null;
+            if (!variables.GetFlag("Octopus.Action.KubernetesContainers.KubernetesConfigMapEnabled"))
+            {
+                return null;
+            }
+            var configMapName = variables.Get("Octopus.Action.KubernetesContainers.ComputedConfigMapName");
+            return string.IsNullOrEmpty(configMapName) ? null : new ResourceIdentifier("ConfigMap", configMapName, defaultNamespace);
         }
-
-        private ResourceIdentifier GetConfigMap()
+        
+        private ResourceIdentifier GetSecret(string defaultNamespace)
         {
-            return null;
+            if (!variables.GetFlag("Octopus.Action.KubernetesContainers.KubernetesSecretEnabled"))
+            {
+                return null;
+            }
+            var secretName = variables.Get("Octopus.Action.KubernetesContainers.ComputedSecretName");
+            return string.IsNullOrEmpty(secretName) ? null : new ResourceIdentifier("Secret", secretName, defaultNamespace);
         }
     }
 }


### PR DESCRIPTION
[sc-44227]

The "Deploy Kubernetes Container" step allows users to add other resources including Secrets, ConfigMaps, Services and Ingresses. Like in the screenshot below:

<img width="1392" alt="Screenshot 2023-03-28 at 3 51 57 PM" src="https://user-images.githubusercontent.com/97418140/228115183-c5687613-2ced-4f14-be33-3cb64b7f0e72.png">

The current implementation does not show these extra resources in the status check. This PR adds the support for these resources.

In a "Deploy Kubernetes Container" step with a Secret, a ConfigMap and a Service defined, we now can show the resource status for all of those (we haven't implemented Ingresses yet, but once it is implemented this should work as well).

<img width="1521" alt="Screenshot 2023-03-28 at 3 44 59 PM" src="https://user-images.githubusercontent.com/97418140/228115618-6622bb74-f88d-4fec-b45d-ff1fcd8d92b0.png">

*Note these logs are added ad hoc just to indicate the status checks are performed. They don't exist in the actual PR*