### PR TITLE
Send mask log to stderr

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -30,7 +30,10 @@ function decode_servicemessagevalue
 # -----------------------------------------------------------------------------
 function __mask_sensitive_value
 {
+    # We want to write to both stdout and stderr due to a racecondition between stdout and stderr
+    # causing error logs to not be masked if stderr event is handled first.
     echo "##octopus[mask value='$(encode_servicemessagevalue "$1")']"
+    echo "##octopus[mask value='$(encode_servicemessagevalue "$1")']" >&2
 }
 
 __mask_sensitive_value $sensitiveVariableKey


### PR DESCRIPTION
We’ve started to see test failures on sensitive value masking after upgrading Calamari to net6.
This PR adds a small change to add the mask service message to stderr.

In our `SilentProcessRunner` we use dotnet Process and `OutputDataReceived` and `ErrorDataReceived` both run on separate threads asynchronously under the hood and we cannot guarantee the order in which are handled. Therefore, in situations where stderr events come through first (n times), sensitive values may be leaked if our masking log from stdout is not handled.

This race condition was still possible prior to upgrading, but the timings weren't as drastic which was why this wasn’t surfaced before the upgrade.

Reproductions steps can be found in the shortcut ticket. To test this change, add the respective line to the repro to see the output.

[sc-41797]

---
# Before
<img width="908" alt="Pasted Graphic 4" src="https://user-images.githubusercontent.com/97423717/228384861-d5a5dcc9-114d-4071-9d5c-837a1a6eefa3.png">


<img width="1168" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/97423717/228384855-1d7769d4-790f-4975-aedc-02fbf6aabbf2.png">




# After
<img width="905" alt="Pasted Graphic 3" src="https://user-images.githubusercontent.com/97423717/228384840-48c21bd2-470c-450a-bc77-8bf24f301c3f.png">


<img width="1165" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/97423717/228384833-5341c211-abb5-440d-809b-f60ea71a9773.png">