### PR TITLE
Add all supported resources and their fields

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ConfigMapTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ConfigMapTests.cs
@@ -1,0 +1,38 @@
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class ConfigMapTests
+    {
+        [Test]
+        public void ShouldCollectCorrectProperties()
+        {
+            const string input = @"{
+    ""kind"": ""ConfigMap"",
+    ""metadata"": {
+        ""name"": ""my-cm"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    },
+    ""data"": {
+        ""x"": ""y"",
+        ""a"": ""b""
+    }
+}";
+            var deployment = ResourceFactory.FromJson(input);
+            
+            deployment.Should().BeEquivalentTo(new
+            {
+                Kind = "ConfigMap",
+                Name = "my-cm",
+                Namespace = "default",
+                Data = 2,
+                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful
+            });
+        }
+    }
+}
+

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ConfigMapTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ConfigMapTests.cs
@@ -29,6 +29,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 Kind = "ConfigMap",
                 Name = "my-cm",
                 Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
                 Data = 2,
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful
             });

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/CronJobTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/CronJobTests.cs
@@ -5,37 +5,32 @@ using NUnit.Framework;
 namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
 {
     [TestFixture]
-    public class JobTests
+    public class CronJobTests
     {
         [Test]
         public void ShouldCollectCorrectProperties()
         {
             const string input = @"{
-    ""kind"": ""Job"",
+    ""kind"": ""CronJob"",
     ""metadata"": {
-        ""name"": ""my-job"",
+        ""name"": ""my-cj"",
         ""namespace"": ""default"",
         ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
     },
     ""spec"": {
-        ""backoffLimit"": 4,
-        ""completions"": 3
-    },
-    ""status"": {
-        ""succeeded"": 3,
-        ""startTime"": ""2023-03-29T00:00:00Z"",
-        ""completionTime"": ""2023-03-30T02:03:04Z""
+        ""schedule"": ""* * * * *"",
+        ""suspend"": false
     }
 }";
-            var job = ResourceFactory.FromJson(input);
+            var cronJob = ResourceFactory.FromJson(input);
             
-            job.Should().BeEquivalentTo(new
+            cronJob.Should().BeEquivalentTo(new
             {
-                Kind = "Job",
-                Name = "my-job",
+                Kind = "CronJob",
+                Name = "my-cj",
                 Namespace = "default",
-                Completions = "3/3",
-                Duration = "1.02:03:04",
+                Schedule = "* * * * *",
+                Suspend = false,
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful
             });
         }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/CronJobTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/CronJobTests.cs
@@ -29,6 +29,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 Kind = "CronJob",
                 Name = "my-cj",
                 Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
                 Schedule = "* * * * *",
                 Suspend = false,
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DaemonSetTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DaemonSetTests.cs
@@ -42,6 +42,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 Kind = "DaemonSet",
                 Name = "my-ds",
                 Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
                 Desired = 2,
                 Current = 1,
                 Ready = 1,

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DaemonSetTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DaemonSetTests.cs
@@ -1,0 +1,56 @@
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class DaemonSetTests
+    {
+        [Test]
+        public void ShouldCollectCorrectProperties()
+        {
+            const string input = @"{
+    ""kind"": ""DaemonSet"",
+    ""metadata"": {
+        ""name"": ""my-ds"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    },
+    ""spec"": {
+        ""template"": {
+            ""spec"": {
+                ""nodeSelector"": {
+                    ""os"": ""linux"",
+                    ""arch"": ""amd64""
+                }
+            }
+        }
+    },
+    ""status"": {
+        ""currentNumberScheduled"": 1,
+        ""desiredNumberScheduled"": 2,
+        ""numberAvailable"": 1,
+        ""numberReady"": 1,
+        ""updatedNumberScheduled"": 1
+    }
+}";
+            var daemonSet = ResourceFactory.FromJson(input);
+            
+            daemonSet.Should().BeEquivalentTo(new
+            {
+                Kind = "DaemonSet",
+                Name = "my-ds",
+                Namespace = "default",
+                Desired = 2,
+                Current = 1,
+                Ready = 1,
+                UpToDate = 1,
+                Available = 1,
+                NodeSelector = "arch=amd64,os=linux",
+                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
+            });
+        }
+    }
+}
+

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
@@ -1,0 +1,42 @@
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class DeploymentTests
+    {
+        [Test]
+        public void ShouldCollectCorrectProperties()
+        {
+            const string input = @"{
+    ""kind"": ""Deployment"",
+    ""metadata"": {
+        ""name"": ""nginx"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    },
+    ""status"": {
+        ""availableReplicas"": 3,
+        ""readyReplicas"": 3,
+        ""replicas"": 3,
+        ""updatedReplicas"": 1
+    }
+}";
+            var deployment = ResourceFactory.FromJson(input);
+            
+            deployment.Should().BeEquivalentTo(new
+            {
+                Kind = "Deployment",
+                Name = "nginx",
+                Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
+                UpToDate = 1,
+                Ready = "3/3",
+                Available = 3,
+                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
+            });
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/EndpointSliceTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/EndpointSliceTests.cs
@@ -1,0 +1,69 @@
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class EndpointSliceTests
+    {
+        [Test]
+        public void ShouldCollectCorrectProperties()
+        {
+            const string input = @"{
+    ""kind"": ""EndpointSlice"",
+    ""metadata"": {
+        ""name"": ""my-svc-abcde"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    },
+    ""addressType"": ""IPv4"",
+    ""ports"": [ 
+        {
+            ""name"": """",
+            ""port"": 8080,
+            ""protocol"": ""TCP""
+        }
+    ],
+    ""endpoints"": [
+        {
+            ""addresses"": [
+                ""10.244.19.164""
+            ],
+        },
+        {
+            ""addresses"": [
+                ""10.244.19.165""
+            ],
+        },
+        {
+            ""addresses"": [
+                ""10.244.19.166"",
+                ""10.244.19.167""
+            ],
+        }
+    ]
+}";
+            var service = ResourceFactory.FromJson(input);
+            
+            service.Should().BeEquivalentTo(new
+            {
+                Kind = "EndpointSlice",
+                Name = "my-svc-abcde",
+                Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
+                AddressType = "IPv4",
+                Ports = new string[] 
+                {
+                    "8080",
+                },
+                Endpoints = new string[]
+                {
+                    "10.244.19.164", "10.244.19.165", "10.244.19.166", "10.244.19.167"
+                },
+                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful
+            });
+        }
+    }
+}
+

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/IngressTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/IngressTests.cs
@@ -1,0 +1,70 @@
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class IngressTests
+    {
+        [Test]
+        public void ShouldCollectCorrectProperties()
+        {
+            const string input = @"{
+    ""kind"": ""Ingress"",
+    ""metadata"": {
+        ""name"": ""my-ingress"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    },
+    ""spec"": {
+        ""ingressClassName"": ""nginx"",
+        ""rules"": [
+            {
+                ""host"": ""host"",
+                ""http"": {
+                    ""paths"": [
+                        {
+                            ""path"": ""/"",
+                            ""pathType"": ""Exact"",
+                            ""backend"": {
+                                ""name"": ""my-svc"",
+                                ""port"": {
+                                    ""number"": 80
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    ""status"": {
+        ""loadBalancer"": {
+            ""ingress"": [
+                {
+                    ""ip"": ""192.168.49.2""
+                }
+            ]
+
+        }
+    }
+}";
+            var ingress = ResourceFactory.FromJson(input);
+            
+            ingress.Should().BeEquivalentTo(new
+            {
+                Kind = "Ingress",
+                Name = "my-ingress",
+                Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
+                Hosts = new string[] 
+                {
+                    "host"
+                },
+                Address = "192.168.49.2",
+                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful
+            });
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
@@ -10,24 +10,15 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         [Test]
         public void ShouldCollectCorrectProperties()
         {
-            const string input = @"{
-    ""kind"": ""Job"",
-    ""metadata"": {
-        ""name"": ""my-job"",
-        ""namespace"": ""default"",
-        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
-    },
-    ""spec"": {
-        ""backoffLimit"": 4,
-        ""completions"": 3
-    },
-    ""status"": {
-        ""succeeded"": 3,
-        ""startTime"": ""2023-03-29T00:00:00Z"",
-        ""completionTime"": ""2023-03-30T02:03:04Z""
-    }
-}";
-            var job = ResourceFactory.FromJson(input);
+            var jobResponse = new JobResponseBuilder()
+                .WithCompletions(3)
+                .WithBackoffLimit(4)
+                .WithSucceeded(3)
+                .WithStartTime("2023-03-29T00:00:00Z")
+                .WithCompletionTime("2023-03-30T02:03:04Z")
+                .Build();
+            
+            var job = ResourceFactory.FromJson(jobResponse);
             
             job.Should().BeEquivalentTo(new
             {
@@ -40,6 +31,119 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful
             });
         }
+
+        [Test]
+        public void ShouldHaveStatusOfFailedIfBackOffLimitHasBeenReached()
+        {
+            var jobResponse = new JobResponseBuilder()
+                .WithCompletions(3)
+                .WithBackoffLimit(4)
+                .WithFailed(4)
+                .Build();
+
+            var job = ResourceFactory.FromJson(jobResponse);
+
+            job.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Failed);
+        }
+
+        [Test]
+        public void ShouldHaveStatusOfSuccessfulIfDesiredCompletionsHaveBeenAchieved()
+        {
+            var jobResponse = new JobResponseBuilder()
+                .WithCompletions(3)
+                .WithSucceeded(3)
+                .WithFailed(1)
+                .Build();
+
+            var job = ResourceFactory.FromJson(jobResponse);
+
+            job.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
+        }
+
+        [Test]
+        public void ShouldHaveStatusOfInProgressIsDesiredCompletionsHaveNotBeenReached()
+        {
+            var jobResponse = new JobResponseBuilder()
+                .WithCompletions(3)
+                .WithSucceeded(2)
+                .WithFailed(1)
+                .Build();
+
+            var job = ResourceFactory.FromJson(jobResponse);
+
+            job.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+    }
+
+    public class JobResponseBuilder
+    {
+        private const string Template = @"{{
+    ""kind"": ""Job"",
+    ""metadata"": {{
+        ""name"": ""my-job"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    }},
+    ""spec"": {{
+        ""completions"": {0},
+        ""backoffLimit"": {1}
+    }},
+    ""status"": {{
+        ""succeeded"": {2},
+        ""failed"": {3},
+        ""startTime"": ""{4}"",
+        ""completionTime"": ""{5}""
+    }}
+}}";
+
+        private int Completions { get; set; }
+        private int BackoffLimit { get; set; }
+        private int Succeeded { get; set; }
+        private int Failed { get; set; }
+        private string StartTime { get; set; }
+        private string CompletionTime { get; set; }
+
+        public JobResponseBuilder WithCompletions(int completions)
+        {
+            Completions = completions;
+            return this;
+        }
+
+        public JobResponseBuilder WithBackoffLimit(int backoffLimit)
+        {
+            BackoffLimit = backoffLimit;
+            return this;
+        }
+
+        public JobResponseBuilder WithSucceeded(int succeeded)
+        {
+            Succeeded = succeeded;
+            return this;
+        }
+
+        public JobResponseBuilder WithFailed(int failed)
+        {
+            Failed = failed;
+            return this;
+        }
+        
+        public JobResponseBuilder WithStartTime(string startTime)
+        {
+            StartTime = startTime;
+            return this;
+        }
+
+        public JobResponseBuilder WithCompletionTime(string completionTime)
+        {
+            CompletionTime = completionTime;
+            return this;
+        }
+
+        public string Build()
+        {
+            return string.Format(Template, Completions, BackoffLimit, Succeeded, Failed, StartTime, CompletionTime);
+        }        
+        
     }
 }
 

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
@@ -1,0 +1,44 @@
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class JobTests
+    {
+        [Test]
+        public void ShouldCollectCorrectProperties()
+        {
+            const string input = @"{
+    ""kind"": ""Job"",
+    ""metadata"": {
+        ""name"": ""my-job"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    },
+    ""spec"": {
+        ""backoffLimit"": 4,
+        ""completions"": 3
+    },
+    ""status"": {
+        ""succeeded"": 3,
+        ""startTime"": ""2023-03-29T00:00:00Z"",
+        ""completionTime"": ""2023-03-30T02:03:04Z""
+    }
+}";
+            var configMap = ResourceFactory.FromJson(input);
+            
+            configMap.Should().BeEquivalentTo(new
+            {
+                Kind = "Job",
+                Name = "my-job",
+                Namespace = "default",
+                Completions = "3/3",
+                Duration = "1.02:03:04",
+                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful
+            });
+        }
+    }
+}
+

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
@@ -34,6 +34,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 Kind = "Job",
                 Name = "my-job",
                 Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
                 Completions = "3/3",
                 Duration = "1.02:03:04",
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PersistentVolumeClaimTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PersistentVolumeClaimTests.cs
@@ -1,0 +1,54 @@
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class PersistentVolumeClaimTests
+    {
+        [Test]
+        public void ShouldCollectCorrectProperties()
+        {
+            const string input = @"{
+    ""kind"": ""PersistentVolumeClaim"",
+    ""metadata"": {
+        ""name"": ""my-pvc"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    },
+    ""spec"": {
+        ""volumeName"": ""pvc-08cdb1f6-42e4-4938-b4c7-0576030a8da6"",
+        ""storageClassName"": ""standard""
+    },
+    ""status"": {
+        ""phase"": ""Bound"",
+        ""accessModes"": [
+            ""ReadWriteOnce""
+        ],
+        ""capacity"": {
+            ""storage"": ""1Mi""
+        }
+    }
+}";
+            var persistentVolumeClaim = ResourceFactory.FromJson(input);
+            
+            persistentVolumeClaim.Should().BeEquivalentTo(new
+            {
+                Kind = "PersistentVolumeClaim",
+                Name = "my-pvc",
+                Namespace = "default",
+                Status = "Bound",
+                Volume = "pvc-08cdb1f6-42e4-4938-b4c7-0576030a8da6",
+                Capacity = "1Mi",
+                AccessModes = new string []
+                {
+                    "ReadWriteOnce"
+                },
+                StorageClass = "standard",
+                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful
+            });
+        }
+    }
+}
+

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PersistentVolumeClaimTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PersistentVolumeClaimTests.cs
@@ -38,6 +38,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 Kind = "PersistentVolumeClaim",
                 Name = "my-pvc",
                 Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
                 Status = "Bound",
                 Volume = "pvc-08cdb1f6-42e4-4938-b4c7-0576030a8da6",
                 Capacity = "1Mi",

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
@@ -19,12 +19,12 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 {
                     new ContainerStatus()
                     {
-                        State = new State { Running = new Running() },
+                        State = new ContainerState { Running = new ContainerStateRunning() },
                         Ready = true
                     },
                     new ContainerStatus()
                     {
-                        State = new State { Waiting = new Waiting { Reason = "CrashLoopBackOff" } },
+                        State = new ContainerState { Waiting = new ContainerStateWaiting { Reason = "CrashLoopBackOff" } },
                         Ready = false,
                         RestartCount = 3
                     }
@@ -59,10 +59,10 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Pending")
-                .WithInitContainerStates(new State[]
+                .WithInitContainerStates(new ContainerState[]
                 {
-                    new State { Waiting = new Waiting { Reason = "PodInitializing" } },
-                    new State { Terminated = new Terminated { Reason = "Completed" } }
+                    new ContainerState { Waiting = new ContainerStateWaiting { Reason = "PodInitializing" } },
+                    new ContainerState { Terminated = new ContainerStateTerminated { Reason = "Completed" } }
                 })
                 .Build();
     
@@ -77,9 +77,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Pending")
-                .WithInitContainerStates(new State[]
+                .WithInitContainerStates(new ContainerState[]
                 {
-                    new State { Waiting = new Waiting { Reason = "ImagePullBackOff" } }
+                    new ContainerState { Waiting = new ContainerStateWaiting { Reason = "ImagePullBackOff" } }
                 })
                 .Build();
     
@@ -94,9 +94,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Pending")
-                .WithInitContainerStates(new State[]
+                .WithInitContainerStates(new ContainerState[]
                 {
-                    new State { Waiting = new Waiting { Reason = "CrashLoopBackOff" } }
+                    new ContainerState { Waiting = new ContainerStateWaiting { Reason = "CrashLoopBackOff" } }
                 })
                 .Build();
     
@@ -111,9 +111,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Pending")
-                .WithContainerStates(new State[]
+                .WithContainerStates(new ContainerState[]
                 {
-                    new State { Waiting = new Waiting { Reason = "ContainerCreating" } }
+                    new ContainerState { Waiting = new ContainerStateWaiting { Reason = "ContainerCreating" } }
                 })
                 .Build();
     
@@ -128,9 +128,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Pending")
-                .WithContainerStates(new State[]
+                .WithContainerStates(new ContainerState[]
                 {
-                    new State { Waiting = new Waiting { Reason = "ImagePullBackOff" } }
+                    new ContainerState { Waiting = new ContainerStateWaiting { Reason = "ImagePullBackOff" } }
                 })
                 .Build();
     
@@ -145,9 +145,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Pending")
-                .WithContainerStates(new State[]
+                .WithContainerStates(new ContainerState[]
                 {
-                    new State { Waiting = new Waiting { Reason = "CrashLoopBackOff" } }
+                    new ContainerState { Waiting = new ContainerStateWaiting { Reason = "CrashLoopBackOff" } }
                 })
                 .Build();
     
@@ -162,9 +162,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Failed")
-                .WithContainerStates(new State[]
+                .WithContainerStates(new ContainerState[]
                 {
-                    new State { Terminated = new Terminated { Reason = "ContainerCannotRun" } }
+                    new ContainerState { Terminated = new ContainerStateTerminated { Reason = "ContainerCannotRun" } }
                 })
                 .Build();
     
@@ -179,9 +179,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Failed")
-                .WithContainerStates(new State[]
+                .WithContainerStates(new ContainerState[]
                 {
-                    new State { Terminated = new Terminated { Reason = "Error" } }
+                    new ContainerState { Terminated = new ContainerStateTerminated { Reason = "Error" } }
                 })
                 .Build();
     
@@ -196,9 +196,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Succeeded")
-                .WithContainerStates(new State[]
+                .WithContainerStates(new ContainerState[]
                 {
-                    new State { Terminated = new Terminated { Reason = "Completed" } }
+                    new ContainerState { Terminated = new ContainerStateTerminated { Reason = "Completed" } }
                 })
                 .Build();
     
@@ -213,9 +213,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Running")
-                .WithContainerStates(new State[]
+                .WithContainerStates(new ContainerState[]
                 {
-                    new State { Running = new Running() }
+                    new ContainerState { Running = new ContainerStateRunning() }
                 })
                 .Build();
     
@@ -230,10 +230,10 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         {
             var podResponse = new PodResponseBuilder()
                 .WithPhase("Pending")
-                .WithContainerStates(new State[]
+                .WithContainerStates(new ContainerState[]
                 {
-                    new State { Waiting = new Waiting { Reason = "ImagePullBackOff" } },
-                    new State { Waiting = new Waiting { Reason = "CrashLoopBackOff" } }
+                    new ContainerState { Waiting = new ContainerStateWaiting { Reason = "ImagePullBackOff" } },
+                    new ContainerState { Waiting = new ContainerStateWaiting { Reason = "CrashLoopBackOff" } }
                 })
                 .Build();
     
@@ -275,14 +275,14 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
             return this;
         }
     
-        public PodResponseBuilder WithInitContainerStates(params State[] initContainerStates)
+        public PodResponseBuilder WithInitContainerStates(params ContainerState[] initContainerStates)
         {
             var statuses = initContainerStates.Select(state => new ContainerStatus { State = state });
             InitContainerStatuses = JsonConvert.SerializeObject(statuses);
             return this;
         }
     
-        public PodResponseBuilder WithContainerStates(params State[] containerStates)
+        public PodResponseBuilder WithContainerStates(params ContainerState[] containerStates)
         {
             var statuses = containerStates.Select(state => new ContainerStatus { State = state });
             ContainerStatuses = JsonConvert.SerializeObject(statuses);

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
@@ -35,6 +35,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
             
             pod.Should().BeEquivalentTo(new
             {
+                Kind = "Pod",
+                Name = "Test",
+                Namespace = "test",
                 Ready = "1/2",
                 Restarts = 3,
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Failed
@@ -251,6 +254,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
     ""kind"": ""Pod"",
     ""metadata"": {{
         ""name"": ""Test"",
+        ""namespace"": ""test"",
         ""uid"": ""123""
     }},
     ""status"": {{

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ReplicaSetTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ReplicaSetTests.cs
@@ -1,0 +1,41 @@
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class ReplicaSetTests
+    {
+        [Test]
+        public void ShouldCollectCorrectProperties()
+        {
+            const string input = @"{
+    ""kind"": ""ReplicaSet"",
+    ""metadata"": {
+        ""name"": ""nginx"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    },
+    ""status"": {
+        ""availableReplicas"": 2,
+        ""readyReplicas"": 2,
+        ""replicas"": 3,
+    }
+}";
+            var replicaSet = ResourceFactory.FromJson(input);
+            
+            replicaSet.Should().BeEquivalentTo(new
+            {
+                Kind = "ReplicaSet",
+                Name = "nginx",
+                Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
+                Desired = 3,
+                Ready = 2,
+                Current = 2,
+                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
+            });
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/SecretTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/SecretTests.cs
@@ -5,31 +5,33 @@ using NUnit.Framework;
 namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
 {
     [TestFixture]
-    public class ConfigMapTests
+    public class SecretTests
     {
         [Test]
         public void ShouldCollectCorrectProperties()
         {
             const string input = @"{
-    ""kind"": ""ConfigMap"",
+    ""kind"": ""Secret"",
     ""metadata"": {
-        ""name"": ""my-cm"",
+        ""name"": ""my-secret"",
         ""namespace"": ""default"",
         ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
     },
+    ""type"": ""Opaque"",
     ""data"": {
         ""x"": ""y"",
         ""a"": ""b""
     }
 }";
-            var configMap = ResourceFactory.FromJson(input);
+            var secret = ResourceFactory.FromJson(input);
             
-            configMap.Should().BeEquivalentTo(new
+            secret.Should().BeEquivalentTo(new
             {
-                Kind = "ConfigMap",
-                Name = "my-cm",
+                Kind = "Secret",
+                Name = "my-secret",
                 Namespace = "default",
                 Data = 2,
+                Type = "Opaque",
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful
             });
         }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/SecretTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/SecretTests.cs
@@ -30,6 +30,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 Kind = "Secret",
                 Name = "my-secret",
                 Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
                 Data = 2,
                 Type = "Opaque",
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ServiceTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ServiceTests.cs
@@ -18,7 +18,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
     },
     ""spec"": {
-        ""type"": ""NodePort"",
+        ""type"": ""LoadBalancer"",
         ""clusterIP"": ""10.96.0.1"",
         ""ports"": [
             {
@@ -35,6 +35,16 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 ""nodePort"": 30080
             }
         ]
+    },
+    ""status"": {
+        ""loadBalancer"": {
+            ""ingress"": [
+                {
+                    ""ip"": ""192.168.49.2""
+                }
+            ]
+
+        }
     }
 }";
             var service = ResourceFactory.FromJson(input);
@@ -45,8 +55,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 Name = "my-svc",
                 Namespace = "default",
                 Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
-                Type = "NodePort",
+                Type = "LoadBalancer",
                 ClusterIp = "10.96.0.1",
+                ExternalIp = "192.168.49.2",
                 Ports = new string[] 
                 {
                     "443/TCP",

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ServiceTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ServiceTests.cs
@@ -1,0 +1,59 @@
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class ServiceTests
+    {
+        [Test]
+        public void ShouldCollectCorrectProperties()
+        {
+            const string input = @"{
+    ""kind"": ""Service"",
+    ""metadata"": {
+        ""name"": ""my-svc"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    },
+    ""spec"": {
+        ""type"": ""NodePort"",
+        ""clusterIP"": ""10.96.0.1"",
+        ""ports"": [
+            {
+                ""name"": ""https"",
+                ""port"": 443,
+                ""protocol"": ""TCP"",
+                ""targetPort"": 8443
+            },
+            {
+                ""name"": """",
+                ""port"": 80,
+                ""protocol"": ""TCP"",
+                ""targetPort"": 8080,
+                ""nodePort"": 30080
+            }
+        ]
+    }
+}";
+            var service = ResourceFactory.FromJson(input);
+            
+            service.Should().BeEquivalentTo(new
+            {
+                Kind = "Service",
+                Name = "my-svc",
+                Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
+                Type = "NodePort",
+                ClusterIp = "10.96.0.1",
+                Ports = new string[] 
+                {
+                    "443/TCP",
+                    "80:30080/TCP"
+                },
+                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful
+            });
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/StatefulSetTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/StatefulSetTests.cs
@@ -1,0 +1,38 @@
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class StatefulSetTests
+    {
+        [Test]
+        public void ShouldCollectCorrectProperties()
+        {
+            const string input = @"{
+    ""kind"": ""StatefulSet"",
+    ""metadata"": {
+        ""name"": ""my-sts"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    },
+    ""status"": {
+        ""readyReplicas"": 2,
+        ""replicas"": 3
+    }
+}";
+            var statefulSet = ResourceFactory.FromJson(input);
+            
+            statefulSet.Should().BeEquivalentTo(new
+            {
+                Kind = "StatefulSet",
+                Name = "my-sts",
+                Namespace = "default",
+                Ready = "2/3",
+                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
+            });
+        }
+    }
+}
+

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/StatefulSetTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/StatefulSetTests.cs
@@ -29,6 +29,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 Kind = "StatefulSet",
                 Name = "my-sts",
                 Namespace = "default",
+                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
                 Ready = "2/3",
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
             });

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ConfigMap.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ConfigMap.cs
@@ -5,7 +5,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
     public class ConfigMap : Resource
     {
-        public int Data { get; set; }
+        public int Data { get; }
         
         public ConfigMap(JObject json) : base(json)
         {

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ConfigMap.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ConfigMap.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
@@ -9,7 +9,15 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         
         public ConfigMap(JObject json) : base(json)
         {
-            Data = data.SelectTokens("$.data").Count();
+            Data = (data.SelectToken("$.data")
+                ?.ToObject<Dictionary<string, string>>() ?? new Dictionary<string, string>())
+                .Count;
+        }
+
+        public override bool HasUpdate(Resource lastStatus)
+        {
+            var last = CastOrThrow<ConfigMap>(lastStatus);
+            return last.Data != Data;
         }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ContainerStatus.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ContainerStatus.cs
@@ -2,10 +2,11 @@ using Newtonsoft.Json;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
+    // Subset of: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#containerstatus-v1-core
     public class ContainerStatus
     {
         [JsonProperty("state")]
-        public State State { get; set; }
+        public ContainerState State { get; set; }
         
         [JsonProperty("ready")]
         public bool Ready { get; set; }
@@ -14,27 +15,28 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public int RestartCount { get; set; }
     }
 
-    public class State
+    // Subset of: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#containerstate-v1-core
+    public class ContainerState
     {
         [JsonProperty("running")]
-        public Running Running { get; set; }
+        public ContainerStateRunning Running { get; set; }
         
         [JsonProperty("waiting")]
-        public Waiting Waiting { get; set; }
+        public ContainerStateWaiting Waiting { get; set; }
         
         [JsonProperty("terminated")]
-        public Terminated Terminated { get; set; }
+        public ContainerStateTerminated Terminated { get; set; }
     }
     
-    public class Running {}
+    public class ContainerStateRunning {}
     
-    public class Waiting
+    public class ContainerStateWaiting
     {
         [JsonProperty("reason")]
         public string Reason { get; set; }
     }
     
-    public class Terminated
+    public class ContainerStateTerminated
     {
         [JsonProperty("reason")]
         public string Reason { get; set; }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ContainerStatus.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ContainerStatus.cs
@@ -6,6 +6,12 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     {
         [JsonProperty("state")]
         public State State { get; set; }
+        
+        [JsonProperty("ready")]
+        public bool Ready { get; set; }
+        
+        [JsonProperty("restartCount")]
+        public int RestartCount { get; set; }
     }
 
     public class State

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/CronJob.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/CronJob.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
-    public class CronJob: Resource
+    public class CronJob : Resource
     {
         public string Schedule { get; }
         public bool Suspend { get; }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/CronJob.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/CronJob.cs
@@ -1,0 +1,23 @@
+using Newtonsoft.Json.Linq;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    public class CronJob: Resource
+    {
+        public string Schedule { get; set; }
+        public bool Suspend { get; set; }
+
+        public CronJob(JObject json) : base(json)
+        {
+            Schedule = Field("$.spec.schedule");
+            Suspend = FieldOrDefault("$.spec.suspend", false);
+        }
+
+        public override bool HasUpdate(Resource lastStatus)
+        {
+            var last = CastOrThrow<CronJob>(lastStatus);
+            return last.Schedule != Schedule || last.Suspend != Suspend;
+        }
+    }
+}
+

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/CronJob.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/CronJob.cs
@@ -4,8 +4,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
     public class CronJob: Resource
     {
-        public string Schedule { get; set; }
-        public bool Suspend { get; set; }
+        public string Schedule { get; }
+        public bool Suspend { get; }
 
         public CronJob(JObject json) : base(json)
         {

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
@@ -50,7 +50,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                 .OrderBy(_ => _.Key)
                 .ThenBy(_ => _.Value)
                 .Select(_ => $"{_.Key}={_.Value}");
-            return string.Join(',', selectors);
+            return string.Join(",", selectors);
         }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    public class DaemonSet: Resource
+    {
+        public override string ChildKind => "Pod";
+
+        public int Desired { get; set; }
+        public int Current { get; set; }
+        public int Ready { get; set; }
+        public int UpToDate { get; set; }
+        public int Available { get; set; }
+        public string NodeSelector { get; set; }
+        public override ResourceStatus ResourceStatus { get; }
+
+        public DaemonSet(JObject json) : base(json)
+        {
+            Desired = FieldOrDefault("$.status.desiredNumberScheduled", 0);
+            Current = FieldOrDefault("$.status.currentNumberScheduled", 0);
+            Ready = FieldOrDefault("$.status.numberReady", 0);
+            UpToDate = FieldOrDefault("$.status.updatedNumberScheduled", 0);
+            Available = FieldOrDefault("$.status.numberAvailable", 0);
+            var selectors = data.SelectToken("$.spec.template.spec.nodeSelector")
+                ?.ToObject<Dictionary<string, string>>() ?? new Dictionary<string, string>();
+            NodeSelector = FormatNodeSelectors(selectors);
+
+            ResourceStatus = Available == Desired && UpToDate == Desired && Ready == Desired
+                ? ResourceStatus.Successful
+                : ResourceStatus.InProgress;
+        }
+
+        public override bool HasUpdate(Resource lastStatus)
+        {
+            var last = CastOrThrow<DaemonSet>(lastStatus);
+            return last.Desired != Desired
+                   || last.Current != Current
+                   || last.Ready != Ready
+                   || last.UpToDate != UpToDate
+                   || last.Available != Available
+                   || last.NodeSelector != NodeSelector;
+        }
+
+        private static string FormatNodeSelectors(Dictionary<string, string> nodeSelectors)
+        {
+            var selectors = nodeSelectors
+                .ToList()
+                .OrderBy(_ => _.Key)
+                .ThenBy(_ => _.Value)
+                .Select(_ => $"{_.Key}={_.Value}");
+            return string.Join(',', selectors);
+        }
+    }
+}
+

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
@@ -8,12 +8,12 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     {
         public override string ChildKind => "Pod";
 
-        public int Desired { get; set; }
-        public int Current { get; set; }
-        public int Ready { get; set; }
-        public int UpToDate { get; set; }
-        public int Available { get; set; }
-        public string NodeSelector { get; set; }
+        public int Desired { get; }
+        public int Current { get; }
+        public int Ready { get; }
+        public int UpToDate { get; }
+        public int Available { get; }
+        public string NodeSelector { get; }
         public override ResourceStatus ResourceStatus { get; }
 
         public DaemonSet(JObject json) : base(json)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Endpoint.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Endpoint.cs
@@ -2,7 +2,8 @@ using Newtonsoft.Json;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
-    public class EndpointEntry
+    // Subset of: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#endpoint-v1-discovery-k8s-io
+    public class Endpoint
     {
         [JsonProperty("addresses")]
         public string[] Addresses { get; set; }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointEntry.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointEntry.cs
@@ -1,0 +1,11 @@
+using Newtonsoft.Json;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    public class EndpointEntry
+    {
+        [JsonProperty("addresses")]
+        public string[] Addresses { get; set; }
+    }
+}
+

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointSlice.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointSlice.cs
@@ -6,17 +6,32 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
     public class EndpointSlice : Resource
     {
+        public string AddressType { get; }
+        public IEnumerable<string> Ports { get; }
         public IEnumerable<string> Endpoints { get; }
 
         public EndpointSlice(JObject json) : base(json)
         {
-            Endpoints = data.SelectTokens("$.endpoints[*].addresses[0]").Values<string>();
+            AddressType = Field("$.addressType");
+            
+            var ports = data.SelectToken("$.spec.ports")
+                ?.ToObject<PortEntry[]>() ?? new PortEntry[] { };
+            Ports = ports.Select(port => port.Port);
+
+            var endpoints = data.SelectToken("$.endpoints")
+                ?.ToObject<EndpointEntry[]>() ?? new EndpointEntry[] { };
+            Endpoints = FormatEndpoints(endpoints);
         }
     
         public override bool HasUpdate(Resource lastStatus)
         {
             var last = CastOrThrow<EndpointSlice>(lastStatus);
-            return !last.Endpoints.SequenceEqual(Endpoints);
+            return last.AddressType != AddressType || !last.Ports.SequenceEqual(Ports) || !last.Endpoints.SequenceEqual(Endpoints);
+        }
+
+        private static IEnumerable<string> FormatEndpoints(IEnumerable<EndpointEntry> endpoints)
+        {
+            return endpoints.SelectMany(endpoint => endpoint.Addresses);
         }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointSlice.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointSlice.cs
@@ -14,9 +14,9 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         {
             AddressType = Field("$.addressType");
             
-            var ports = data.SelectToken("$.spec.ports")
+            var ports = data.SelectToken("$.ports")
                 ?.ToObject<PortEntry[]>() ?? new PortEntry[] { };
-            Ports = ports.Select(port => port.Port);
+            Ports = ports.Select(port => port.Port.ToString());
 
             var endpoints = data.SelectToken("$.endpoints")
                 ?.ToObject<EndpointEntry[]>() ?? new EndpointEntry[] { };

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointSlice.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointSlice.cs
@@ -19,7 +19,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             Ports = ports.Select(port => port.Port.ToString());
 
             var endpoints = data.SelectToken("$.endpoints")
-                ?.ToObject<EndpointEntry[]>() ?? new EndpointEntry[] { };
+                ?.ToObject<Endpoint[]>() ?? new Endpoint[] { };
             Endpoints = FormatEndpoints(endpoints);
         }
     
@@ -29,7 +29,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             return last.AddressType != AddressType || !last.Ports.SequenceEqual(Ports) || !last.Endpoints.SequenceEqual(Endpoints);
         }
 
-        private static IEnumerable<string> FormatEndpoints(IEnumerable<EndpointEntry> endpoints)
+        private static IEnumerable<string> FormatEndpoints(IEnumerable<Endpoint> endpoints)
         {
             return endpoints.SelectMany(endpoint => endpoint.Addresses);
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointSlice.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointSlice.cs
@@ -15,7 +15,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             AddressType = Field("$.addressType");
             
             var ports = data.SelectToken("$.ports")
-                ?.ToObject<PortEntry[]>() ?? new PortEntry[] { };
+                ?.ToObject<ServicePort[]>() ?? new ServicePort[] { };
             Ports = ports.Select(port => port.Port.ToString());
 
             var endpoints = data.SelectToken("$.endpoints")

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Ingress.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Ingress.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    public class Ingress : Resource
+    {
+        public string Class { get; set; }
+        public IEnumerable<string> Hosts { get; set; }
+        public string Address { get; set; }
+
+        public Ingress(JObject json) : base(json)
+        {
+            Class = Field("$.spec.ingressClassName");
+
+            var rules = data.SelectToken("$.spec.rules")
+                ?.ToObject<IngressRule[]>() ?? new IngressRule[] { };
+            Hosts = FormatHosts(rules);            
+
+            var loadBalancerIngresses = data.SelectToken("$.status.loadBalancer.ingress")
+                ?.ToObject<LoadBalancerIngress[]>() ?? new LoadBalancerIngress[] { };
+            
+            Address = FormatAddress(loadBalancerIngresses);
+            
+        }
+
+        public override bool HasUpdate(Resource lastStatus)
+        {
+            var last = CastOrThrow<Ingress>(lastStatus);
+            return last.Class != Class
+                   || !last.Hosts.SequenceEqual(Hosts)
+                   || last.Address != Address;
+        }
+        
+        private static string FormatAddress(IEnumerable<LoadBalancerIngress> loadBalancerIngresses)
+        {
+            return string.Join(',', loadBalancerIngresses.Select(ingress => ingress.Ip));
+        }
+
+        private static IEnumerable<string> FormatHosts(IEnumerable<IngressRule> rules)
+        {
+            return rules.Select(rule => rule.Host);
+        }
+    }
+}
+

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Ingress.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Ingress.cs
@@ -35,7 +35,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         
         private static string FormatAddress(IEnumerable<LoadBalancerIngress> loadBalancerIngresses)
         {
-            return string.Join(',', loadBalancerIngresses.Select(ingress => ingress.Ip));
+            return string.Join(",", loadBalancerIngresses.Select(ingress => ingress.Ip));
         }
 
         private static IEnumerable<string> FormatHosts(IEnumerable<IngressRule> rules)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Ingress.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Ingress.cs
@@ -6,8 +6,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
     public class Ingress : Resource
     {
-        public string Class { get; set; }
-        public IEnumerable<string> Hosts { get; set; }
+        public string Class { get; }
+        public IEnumerable<string> Hosts { get; }
         public string Address { get; set; }
 
         public Ingress(JObject json) : base(json)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/IngressRule.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/IngressRule.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    // subset of: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#ingressrule-v1-networking-k8s-io
+    public class IngressRule
+    {
+        [JsonProperty("host")]
+        public string Host { get; set; }
+    }
+}
+

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
@@ -5,8 +5,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
     public class Job: Resource
     {
-        public string Completions { get; set; }
-        public string Duration { get; set; }
+        public string Completions { get; }
+        public string Duration { get; }
 
         public override ResourceStatus ResourceStatus { get; }
 

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
@@ -16,15 +16,16 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             var desired = FieldOrDefault("$.spec.completions", 0);
             Completions = $"{succeeded}/{desired}";
 
-            var completionTime = FieldOrDefault("$.status.completionTime", DateTime.Now);
-            var startTime = FieldOrDefault("$.status.startTime", DateTime.MinValue);
+            var defaultTime = DateTime.Now;
+            var completionTime = FieldOrDefault("$.status.completionTime", defaultTime);
+            var startTime = FieldOrDefault("$.status.startTime", defaultTime);
 
             Duration = $"{completionTime - startTime:c}";
 
             var backoffLimit = FieldOrDefault("$.spec.backoffLimit", 0);
             var failed = FieldOrDefault("$.status.failed", 0);
 
-            if (failed == backoffLimit)
+            if (backoffLimit != 0 && failed == backoffLimit)
             {
                 ResourceStatus = ResourceStatus.Failed;
             } 

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
@@ -1,0 +1,48 @@
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    public class Job: Resource
+    {
+        public string Completions { get; set; }
+        public string Duration { get; set; }
+
+        public override ResourceStatus ResourceStatus { get; }
+
+        public Job(JObject json) : base(json)
+        {
+            var succeeded = FieldOrDefault("$.status.succeeded", 0);
+            var desired = FieldOrDefault("$.spec.completions", 0);
+            Completions = $"{succeeded}/{desired}";
+
+            var completionTime = FieldOrDefault("$.status.completionTime", DateTime.Now);
+            var startTime = FieldOrDefault("$.status.startTime", DateTime.MinValue);
+
+            Duration = $"{completionTime - startTime:c}";
+
+            var backoffLimit = FieldOrDefault("$.spec.backoffLimit", 0);
+            var failed = FieldOrDefault("$.status.failed", 0);
+
+            if (failed == backoffLimit)
+            {
+                ResourceStatus = ResourceStatus.Failed;
+            } 
+            else if (succeeded == desired)
+            {
+                ResourceStatus = ResourceStatus.Successful;
+            }
+            else
+            {
+                ResourceStatus = ResourceStatus.InProgress;
+            }
+        }
+
+        public override bool HasUpdate(Resource lastStatus)
+        {
+            var last = CastOrThrow<Job>(lastStatus);
+            return last.Completions != Completions || last.Duration != Duration;
+        }
+    }
+}
+

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/LoadBalancerStatus.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/LoadBalancerStatus.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    // Subset of: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#loadbalancerstatus-v1-core
+    public class LoadBalancerStatus
+    {
+        [JsonProperty("ingress")]
+        public IEnumerable<LoadBalancerIngress> Ingress { get; set; }
+    }
+
+    public class LoadBalancerIngress
+    {
+        [JsonProperty("hostname")]
+        public string Hostname { get; set; }
+        
+        [JsonProperty("ip")]
+        public string Ip { get; set; }
+        
+        [JsonProperty("ports")]
+        public IEnumerable<PortStatus> Ports { get; set; }
+    }
+}
+

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/PersistentVolumeClaim.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/PersistentVolumeClaim.cs
@@ -6,11 +6,11 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
     public class PersistentVolumeClaim: Resource
     {
-        public string Status { get; set; }
-        public string Volume { get; set; }
-        public string Capacity { get; set; }
-        public IEnumerable<string> AccessModes { get; set; }
-        public string StorageClass { get; set; }
+        public string Status { get; }
+        public string Volume { get; }
+        public string Capacity { get; }
+        public IEnumerable<string> AccessModes { get; }
+        public string StorageClass { get; }
         
         public PersistentVolumeClaim(JObject json) : base(json)
         {

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/PersistentVolumeClaim.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/PersistentVolumeClaim.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    public class PersistentVolumeClaim: Resource
+    {
+        public string Status { get; set; }
+        public string Volume { get; set; }
+        public string Capacity { get; set; }
+        public IEnumerable<string> AccessModes { get; set; }
+        public string StorageClass { get; set; }
+        
+        public PersistentVolumeClaim(JObject json) : base(json)
+        {
+            Status = Field("$.status.phase");
+            Volume = Field("$.spec.volumeName");
+            Capacity = Field("$.status.capacity.storage");
+            AccessModes = data.SelectToken("$.status.accessModes")?.Values<string>() ?? new string[] { };
+            StorageClass = Field("$.spec.storageClassName");
+        }
+    }
+}
+

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/PersistentVolumeClaim.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/PersistentVolumeClaim.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
@@ -18,6 +19,16 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             Capacity = Field("$.status.capacity.storage");
             AccessModes = data.SelectToken("$.status.accessModes")?.Values<string>() ?? new string[] { };
             StorageClass = Field("$.spec.storageClassName");
+        }
+
+        public override bool HasUpdate(Resource lastStatus)
+        {
+            var last = CastOrThrow<PersistentVolumeClaim>(lastStatus);
+            return last.Status != Status
+                   || last.Volume != Volume
+                   || last.Capacity != Capacity
+                   || !last.AccessModes.SequenceEqual(AccessModes)
+                   || last.StorageClass != StorageClass;
         }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
@@ -5,6 +5,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
     public class Pod : Resource
     {
+        public string Ready { get; }
+        public int Restarts { get; }
         public string Status { get; }
         public override ResourceStatus ResourceStatus { get; }
     
@@ -19,6 +21,13 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                 ?.ToObject<ContainerStatus[]>() ?? new ContainerStatus[] { };
 
             (Status, ResourceStatus) = GetStatus(phase, initContainerStatuses, containerStatuses);
+
+            var containers = containerStatuses.Length;
+            var readyContainers = containerStatuses.Count(status => status.Ready);
+            Ready = $"{readyContainers}/{containers}";
+            Restarts = containerStatuses
+                .Select(status => status.RestartCount)
+                .Aggregate(0, (sum, count) => sum + count);
         }
     
         public override bool HasUpdate(Resource lastStatus)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/PortEntry.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/PortEntry.cs
@@ -5,10 +5,10 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     public class PortEntry
     {
         [JsonProperty("port")]
-        public string Port { get; set; }
+        public int Port { get; set; }
         
-        [JsonProperty("nodePort", Required = Required.AllowNull)]
-        public string NodePort { get; set; }
+        [JsonProperty("nodePort")]
+        public int? NodePort { get; set; }
         
         [JsonProperty("protocol")]
         public string Protocol { get; set; }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/PortEntry.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/PortEntry.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    public class PortEntry
+    {
+        [JsonProperty("port")]
+        public string Port { get; set; }
+        
+        [JsonProperty("nodePort", Required = Required.AllowNull)]
+        public string NodePort { get; set; }
+        
+        [JsonProperty("protocol")]
+        public string Protocol { get; set; }
+    }
+}

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/PortStatus.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/PortStatus.cs
@@ -2,15 +2,14 @@ using Newtonsoft.Json;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
-    public class PortEntry
+    // Subset of: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#portstatus-v1-core
+    public class PortStatus
     {
         [JsonProperty("port")]
-        public int Port { get; set; }
-        
-        [JsonProperty("nodePort")]
-        public int? NodePort { get; set; }
+        public string Port { get; set; }
         
         [JsonProperty("protocol")]
         public string Protocol { get; set; }
     }
 }
+

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ReplicaSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ReplicaSet.cs
@@ -6,19 +6,19 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     {
         public override string ChildKind => "Pod";
         
-        public int Available { get; }
+        public int Desired { get; }
+        public int Current { get; }
         public int Ready { get; }
-        public int Replicas { get; }
-    
+
         public override ResourceStatus ResourceStatus { get; }
         
         public ReplicaSet(JObject json) : base(json)
         {
-            Replicas = FieldOrDefault("$.status.replicas", 0);
+            Desired = FieldOrDefault("$.status.replicas", 0);
+            Current = FieldOrDefault($".status.availableReplicas", 0);
             Ready = FieldOrDefault("$.status.readyReplicas", 0);
-            Available = FieldOrDefault($".status.availableReplicas", 0);
-    
-            if (Ready == Replicas && Available == Replicas)
+            
+            if (Ready == Desired && Desired == Current)
             {
                 ResourceStatus = ResourceStatus.Successful;
             }
@@ -30,7 +30,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public override bool HasUpdate(Resource lastStatus)
         {
             var last = CastOrThrow<ReplicaSet>(lastStatus);
-            return last.Available != Available || last.Ready != Ready || last.Replicas != Replicas;
+            return last.Desired != Desired|| last.Ready != Ready || last.Current != Current;
         }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
@@ -49,7 +49,18 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         protected T FieldOrDefault<T>(string jsonPath, T defaultValue)
         {
             var result = data.SelectToken(jsonPath);
-            return result == null ? defaultValue : result.Value<T>();
+            if (result == null)
+            {
+                return defaultValue;
+            }
+            try
+            {
+                return result.Value<T>();
+            }
+            catch
+            {
+                return defaultValue;
+            }
         }
     
         protected static T CastOrThrow<T>(Resource resource) where T: Resource

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
@@ -30,7 +30,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public virtual string ChildKind => "";
     
         [JsonIgnore]
-        public IEnumerable<Resource> Children { get; set; }
+        public IEnumerable<Resource> Children { get; internal set; }
     
         public Resource(JObject json)
         {

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
@@ -27,6 +27,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                     return new Pod(data);
                 case "Service": 
                     return new Service(data);
+                case "Ingress":
+                    return new Ingress(data);
                 case "EndpointSlice": 
                     return new EndpointSlice(data); 
                 case "ConfigMap":

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
@@ -31,6 +31,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                     return new DaemonSet(data);
                 case "Job":
                     return new Job(data);
+                case "CronJob":
+                    return new CronJob(data);
                 case "Service": 
                     return new Service(data);
                 case "Ingress":

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
@@ -26,6 +26,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                     return new Deployment(data);
                 case "StatefulSet":
                     return new StatefulSet(data);
+                case "DaemonSet":
+                    return new DaemonSet(data);
                 case "Service": 
                     return new Service(data);
                 case "Ingress":

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
@@ -35,6 +35,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                     return new ConfigMap(data);
                 case "Secret":
                     return new Secret(data);
+                case "PersistentVolumeClaim":
+                    return new PersistentVolumeClaim(data);
                 default:
                     return new Resource(data);
             }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
@@ -18,13 +18,14 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         {
             var kind = data.SelectToken("$.kind")?.Value<string>();
             switch (kind)
-            {
-                case "Deployment":
-                    return new Deployment(data);
+            {    case "Pod": 
+                    return new Pod(data);
                 case "ReplicaSet": 
                     return new ReplicaSet(data);
-                case "Pod": 
-                    return new Pod(data);
+                case "Deployment":
+                    return new Deployment(data);
+                case "StatefulSet":
+                    return new StatefulSet(data);
                 case "Service": 
                     return new Service(data);
                 case "Ingress":

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
@@ -33,6 +33,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                     return new EndpointSlice(data); 
                 case "ConfigMap":
                     return new ConfigMap(data);
+                case "Secret":
+                    return new Secret(data);
                 default:
                     return new Resource(data);
             }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
@@ -18,7 +18,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         {
             var kind = data.SelectToken("$.kind")?.Value<string>();
             switch (kind)
-            {    case "Pod": 
+            {   
+                case "Pod": 
                     return new Pod(data);
                 case "ReplicaSet": 
                     return new ReplicaSet(data);
@@ -28,6 +29,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                     return new StatefulSet(data);
                 case "DaemonSet":
                     return new DaemonSet(data);
+                case "Job":
+                    return new Job(data);
                 case "Service": 
                     return new Service(data);
                 case "Ingress":

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Secret.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Secret.cs
@@ -5,8 +5,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 {
     public class Secret: Resource
     {
-        public int Data { get; set; }
-        public string Type { get; set; }
+        public int Data { get; }
+        public string Type { get; }
         
         public Secret(JObject json) : base(json)
         {

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Secret.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Secret.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    public class Secret: Resource
+    {
+        public int Data { get; set; }
+        public string Type { get; set; }
+        
+        public Secret(JObject json) : base(json)
+        {
+            Type = Field("$.type");
+            Data = (data.SelectToken("$.data")
+                ?.ToObject<Dictionary<string, string>>() ?? new Dictionary<string, string>())
+                .Count;
+        }
+
+        public override bool HasUpdate(Resource lastStatus)
+        {
+            var last = CastOrThrow<Secret>(lastStatus);
+            return last.Data != Data || last.Type != Type;
+        }
+    }
+}
+

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
@@ -31,7 +31,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public override bool HasUpdate(Resource lastStatus)
         {
             var last = CastOrThrow<Service>(lastStatus);
-            return last.ClusterIp != ClusterIp || last.Type != Type || last.Ports.SequenceEqual(Ports);
+            return last.ClusterIp != ClusterIp || last.ExternalIp != ExternalIp || last.Type != Type || last.Ports.SequenceEqual(Ports);
         }
 
         private static IEnumerable<string> FormatPorts(IEnumerable<ServicePort> ports)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
@@ -41,9 +41,9 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                 : $"{port.Port}:{port.NodePort}/{port.Protocol}");
         }
 
-        private static string FormatExternalIp(IEnumerable<LoadBalancerIngress> loadBalancerIngresses)
+        private static string FormatExternalIp(LoadBalancerIngress[] loadBalancerIngresses)
         {
-            return !loadBalancerIngresses.Any() ? "<none>" : string.Join(',', loadBalancerIngresses.Select(ingress => ingress.Ip));
+            return !loadBalancerIngresses.Any() ? "<none>" : string.Join(",", loadBalancerIngresses.Select(ingress => ingress.Ip));
         }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
@@ -5,18 +8,44 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     public class Service : Resource
     {
         public override string ChildKind => "EndpointSlice";
-        
+
+        public string Type { get; }
         public string ClusterIp { get; }
+        public string Ports { get; }
 
         public Service(JObject json) : base(json)
         {
+            Type = Field("$.spec.type");
             ClusterIp = Field("$.spec.clusterIP");
+
+            var ports = data.SelectToken("$.spec.ports")
+                ?.ToObject<PortEntry[]>() ?? new PortEntry[] { };
+            Ports = FormatPorts(ports);
         }
     
         public override bool HasUpdate(Resource lastStatus)
         {
             var last = CastOrThrow<Service>(lastStatus);
-            return last.ClusterIp != ClusterIp;
+            return last.ClusterIp != ClusterIp || last.Type != Type || last.Ports != Ports;
         }
+
+        private static string FormatPorts(IEnumerable<PortEntry> ports)
+        {
+            return string.Join(',', ports.Select(port => string.IsNullOrEmpty(port.NodePort)
+                ? $"{port.Port}/{port.Protocol}"
+                : $"{port.Port}:{port.NodePort}/{port.Protocol}"));
+        }
+    }
+
+    public class PortEntry
+    {
+        [JsonProperty("port")]
+        public string Port { get; set; }
+        
+        [JsonProperty("nodePort", Required = Required.AllowNull)]
+        public string NodePort { get; set; }
+        
+        [JsonProperty("protocol")]
+        public string Protocol { get; set; }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
@@ -30,7 +30,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         private static IEnumerable<string> FormatPorts(IEnumerable<PortEntry> ports)
         {
-            return ports.Select(port => string.IsNullOrEmpty(port.NodePort)
+            return ports.Select(port => port.NodePort == null
                 ? $"{port.Port}/{port.Protocol}"
                 : $"{port.Port}:{port.NodePort}/{port.Protocol}");
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
@@ -11,7 +10,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public string Type { get; }
         public string ClusterIp { get; }
-        public string Ports { get; }
+        public IEnumerable<string> Ports { get; }
 
         public Service(JObject json) : base(json)
         {
@@ -26,26 +25,14 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public override bool HasUpdate(Resource lastStatus)
         {
             var last = CastOrThrow<Service>(lastStatus);
-            return last.ClusterIp != ClusterIp || last.Type != Type || last.Ports != Ports;
+            return last.ClusterIp != ClusterIp || last.Type != Type || last.Ports.SequenceEqual(Ports);
         }
 
-        private static string FormatPorts(IEnumerable<PortEntry> ports)
+        private static IEnumerable<string> FormatPorts(IEnumerable<PortEntry> ports)
         {
-            return string.Join(',', ports.Select(port => string.IsNullOrEmpty(port.NodePort)
+            return ports.Select(port => string.IsNullOrEmpty(port.NodePort)
                 ? $"{port.Port}/{port.Protocol}"
-                : $"{port.Port}:{port.NodePort}/{port.Protocol}"));
+                : $"{port.Port}:{port.NodePort}/{port.Protocol}");
         }
-    }
-
-    public class PortEntry
-    {
-        [JsonProperty("port")]
-        public string Port { get; set; }
-        
-        [JsonProperty("nodePort", Required = Required.AllowNull)]
-        public string NodePort { get; set; }
-        
-        [JsonProperty("protocol")]
-        public string Protocol { get; set; }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ServicePort.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ServicePort.cs
@@ -1,0 +1,17 @@
+using Newtonsoft.Json;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    // Subset of: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#serviceport-v1-core
+    public class ServicePort
+    {
+        [JsonProperty("port")]
+        public int Port { get; set; }
+        
+        [JsonProperty("nodePort")]
+        public int? NodePort { get; set; }
+        
+        [JsonProperty("protocol")]
+        public string Protocol { get; set; }
+    }
+}

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/StatefulSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/StatefulSet.cs
@@ -6,7 +6,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     {
         public override string ChildKind => "Pod";
 
-        public string Ready { get; set; }
+        public string Ready { get; }
         public override ResourceStatus ResourceStatus { get; }
 
         public StatefulSet(JObject json) : base(json)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/StatefulSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/StatefulSet.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json.Linq;
+
+namespace Calamari.Kubernetes.ResourceStatus.Resources
+{
+    public class StatefulSet: Resource
+    {
+        public override string ChildKind => "Pod";
+
+        public string Ready { get; set; }
+        public override ResourceStatus ResourceStatus { get; }
+
+        public StatefulSet(JObject json) : base(json)
+        {
+            var readyReplicas = FieldOrDefault("$.status.readyReplicas", 0);
+            var replicas = FieldOrDefault("$.status.replicas", 0);
+            Ready = $"{readyReplicas}/{replicas}";
+
+            ResourceStatus = readyReplicas == replicas ? ResourceStatus.Successful : ResourceStatus.InProgress;
+        }
+
+        public override bool HasUpdate(Resource lastStatus)
+        {
+            var last = CastOrThrow<StatefulSet>(lastStatus);
+            return last.Ready != Ready;
+        }
+    }
+}
+


### PR DESCRIPTION
[sc-44238]

This PR adds the support to all kubernetes resource types that we want to support:

- Pod
- ReplicaSet
- Deployment
- StatefulSet
- DaemonSet
- Job
- CronJob
- Service
- EndpointSlice
- Ingress
- ConfigMap
- Secret
- PersistentVolumeClaim

The fields we support are documented in [this spreadsheet](https://docs.google.com/spreadsheets/d/1jO3JUnOYI4fKXRsdL7VBPur56QjM5jYQkaWnV5NNF6I/edit#gid=0) (internal).

Please also see the unit tests for each resource type which contains examples of what properties are sent.