### PR TITLE
Fix environment variable

### DIFF
--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -96,6 +96,15 @@ namespace Calamari.Kubernetes.ResourceStatus
                 return result;
             }
 
+            
+            var kubeConfig = Path.Combine(workingDirectory, "kubectl-octo.yml");
+
+            if (environmentVars == null)
+            {
+                environmentVars = new Dictionary<string, string>();
+            }
+            environmentVars.Add("KUBECONFIG", kubeConfig);
+            
             foreach (var proxyVariable in ProxyEnvironmentVariablesGenerator.GenerateProxyEnvironmentVariables())
             {
                 environmentVars[proxyVariable.Key] = proxyVariable.Value;


### PR DESCRIPTION
This is to fix a bug in Kubernetes resources status check. We need to set the environment variable for kubeconfig to be the correct location. Without this the authentication will not be set up properly unless deploying to a local cluster.