### PR TITLE
Do not return early if the manifests are empty

### DIFF
--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -72,11 +72,6 @@ namespace Calamari.Kubernetes.ResourceStatus
             }
 
             var manifests = ReadManifestFiles().ToList();
-            if (!manifests.Any())
-            {
-                return result;
-            }
-            
             var definedResources = KubernetesYaml.GetDefinedResources(manifests, defaultNamespace).ToList();
             
             var secret = GetSecret(defaultNamespace);
@@ -91,12 +86,11 @@ namespace Calamari.Kubernetes.ResourceStatus
                 definedResources.Add(configMap);
             }
 
-            if (definedResources.Count == 0)
+            if (!definedResources.Any())
             {
                 return result;
             }
 
-            
             var kubeConfig = Path.Combine(workingDirectory, "kubectl-octo.yml");
 
             if (environmentVars == null)


### PR DESCRIPTION
Fixes [sc-46510]

We use to return early when there are nothing in the manifests file. This does not work if the only resources that are deployed are not coming from manifest files. eg secrets and configMaps have their computed names saved in variables rather than in manifest files.

### Before
<img width="1659" alt="Screenshot 2023-04-17 at 11 51 26 AM" src="https://user-images.githubusercontent.com/97418140/232350664-ff97d36a-ed7c-4ed5-a104-72e3a8f09de8.png">

### After
<img width="1675" alt="Screenshot 2023-04-17 at 11 52 00 AM" src="https://user-images.githubusercontent.com/97418140/232350669-32f2db19-8f68-497f-8429-fe1654079aaf.png">