### PR TITLE
Prefer AzModules over AzRmContext on Windows Powershell

### DIFF
--- a/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
+++ b/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
@@ -116,7 +116,9 @@ function Initialize-AzContext {
 
     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
     Write-Host "##octopus[stdout-verbose]"
+    Set-Item -Path Env:\SuppressAzureRmModulesRetiringWarning -Value $true
     Disable-AzContextAutosave -Scope Process
+    Set-Item -Path Env:\SuppressAzureRmModulesRetiringWarning -Value $false
     Write-Host "##octopus[stdout-default]"
 
     $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment

--- a/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
+++ b/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
@@ -104,6 +104,7 @@ function Initialize-AzContext {
     # Authenticate via Service Principal
     $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
     $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
+    
     $tempWarningPreference = $WarningPreference
     $WarningPreference = 'SilentlyContinue'
     if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))

--- a/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
+++ b/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
@@ -158,11 +158,11 @@ Execute-WithRetry{
             }            
             else { 
                 # Windows Powershell
-                if (Get-AzureRmModuleInstalled) {
-                    Initialize-AzureRmContext
-                }
-                elseif (Get-AzModuleInstalled) {
+                if (Get-AzModuleInstalled) {
                     Initialize-AzContext
+                }
+                elseif (Get-AzureRmModuleInstalled) {
+                    Initialize-AzureRmContext
                 }
             }
             

--- a/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
+++ b/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
@@ -104,21 +104,22 @@ function Initialize-AzContext {
     # Authenticate via Service Principal
     $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
     $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
-
+    $tempWarningPreference = $WarningPreference
+    $WarningPreference = 'SilentlyContinue'
     if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
     {
+        $WarningPreference = $tempWarningPreference
         Write-Verbose "Enabling AzureRM aliasing"
 
         # Turn on AzureRm aliasing
         # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
         Enable-AzureRmAlias -Scope Process
     }
+    $WarningPreference = $tempWarningPreference
 
     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
     Write-Host "##octopus[stdout-verbose]"
-    Set-Item -Path Env:\SuppressAzureRmModulesRetiringWarning -Value $true
     Disable-AzContextAutosave -Scope Process
-    Set-Item -Path Env:\SuppressAzureRmModulesRetiringWarning -Value $false
     Write-Host "##octopus[stdout-default]"
 
     $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment

--- a/source/Calamari/Kubernetes/Scripts/AzurePowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/AzurePowershellContext.ps1
@@ -42,7 +42,7 @@ function Initialize-AzureRmContext
 
     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
     Write-Host "##octopus[stdout-verbose]"
-    Disable-AzContextAutosave -Scope Process
+    Disable-AzureRMContextAutosave -Scope Process
     Write-Host "##octopus[stdout-default]"
 
     $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
@@ -66,18 +66,22 @@ function Initialize-AzContext
     $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
     $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
 
+    $tempWarningPreference = $WarningPreference
+    $WarningPreference = 'SilentlyContinue'
     if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
     {
+        $WarningPreference = $tempWarningPreference
         Write-Verbose "Enabling AzureRM aliasing"
 
         # Turn on AzureRm aliasing
         # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
         Enable-AzureRmAlias -Scope Process
     }
+    $WarningPreference = $tempWarningPreference
 
     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
     Write-Host "##octopus[stdout-verbose]"
-    Disable-AzureRMContextAutosave -Scope Process
+    Disable-AzContextAutosave -Scope Process
     Write-Host "##octopus[stdout-default]"
 
     $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment

--- a/source/Calamari/Kubernetes/Scripts/AzurePowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/AzurePowershellContext.ps1
@@ -42,7 +42,9 @@ function Initialize-AzureRmContext
 
     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
     Write-Host "##octopus[stdout-verbose]"
-    Disable-AzureRMContextAutosave -Scope Process
+    Set-Item -Path Env:\SuppressAzureRmModulesRetiringWarning -Value $true
+    Disable-AzContextAutosave -Scope Process
+    Set-Item -Path Env:\SuppressAzureRmModulesRetiringWarning -Value $false
     Write-Host "##octopus[stdout-default]"
 
     $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment

--- a/source/Calamari/Kubernetes/Scripts/AzurePowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/AzurePowershellContext.ps1
@@ -42,9 +42,7 @@ function Initialize-AzureRmContext
 
     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
     Write-Host "##octopus[stdout-verbose]"
-    Set-Item -Path Env:\SuppressAzureRmModulesRetiringWarning -Value $true
     Disable-AzContextAutosave -Scope Process
-    Set-Item -Path Env:\SuppressAzureRmModulesRetiringWarning -Value $false
     Write-Host "##octopus[stdout-default]"
 
     $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
@@ -79,7 +77,7 @@ function Initialize-AzContext
 
     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
     Write-Host "##octopus[stdout-verbose]"
-    Disable-AzContextAutosave -Scope Process
+    Disable-AzureRMContextAutosave -Scope Process
     Write-Host "##octopus[stdout-default]"
 
     $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment

--- a/source/Calamari/Kubernetes/Scripts/AzurePowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/AzurePowershellContext.ps1
@@ -120,13 +120,13 @@ function ConnectAzAccount
     else
     {
         # Windows Powershell
-        if (Get-AzureRmModuleInstalled)
-        {
-            Initialize-AzureRmContext
-        }
-        elseif (Get-AzModuleInstalled)
+        if (Get-AzModuleInstalled)
         {
             Initialize-AzContext
+        }
+        elseif (Get-AzureRmModuleInstalled)
+        {
+            Initialize-AzureRmContext
         }
     }
 }


### PR DESCRIPTION
If available, prefer using AzModules over AzRM for Windows PowerShell, see https://github.com/OctopusDeploy/Issues/issues/7732 for details. 

**For context:**
In `Initialize-AzContext` (PowerShell Core path) when holding both AzureRM and Azure PowerShell modules, we check to see if AzureRM is available with `Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue`, this throws the warning we're seeing. This is to use [Enable-AzureRmAlias](https://learn.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-9.6.0#option-2-use-compatibility-mode-with-enable-azurermalias) for compatibility with older commands. These modules contain overlapping commands, so to install, you have to -AllowClobber `Install-Module -Force -Name Az -AllowClobber`. We do this in WorkerTools. 

Using AzureRM exclusively, does not print to the warning, but does log a warning
![image](https://user-images.githubusercontent.com/101079287/232363672-9f6964e4-08e5-4ade-af5c-1ec0691130d3.png)

When both are available, we turn off context autosave, without this, all authentication occurs in memory and isolates each session from the context changes in other sessions. This is done using `Disable-AzRMContextAutosave -Scope Process`, the warning we're seeing.

There's two paths to this issue:
* Using Windows PowerShell, we use AzureRM modules
* Using PowerShell Core we check for the `Disable-AzureRMContextAutosave` command, this writes to stdwarning

This change prefers Azure PowerShell modules over AzureRM if available and suppresses the warning when checking for `Disable-AzureRMContextAutosave`

[sc-41867]
Fixes https://github.com/OctopusDeploy/Issues/issues/7732

**Before:** 
Windows Worker Tools, using PowerShell Core:
![image](https://user-images.githubusercontent.com/101079287/232358089-eef21a27-1667-4ca2-8ea7-8aff75f499e8.png)

Using Windows PowerShell shows no warning.

**After:** 
Windows Worker Tools, using PowerShell Core:
![image](https://user-images.githubusercontent.com/101079287/232680371-7329ec4d-8815-4692-a05a-6ebf1248705c.png)

Windows Worker Tools, using Windows PowerShell:
![image](https://user-images.githubusercontent.com/101079287/232680311-fb4053f9-139b-4457-bb80-9e6ec6e895c0.png)

Linux Worker Tools, using PowerShell Core: 
![image](https://user-images.githubusercontent.com/101079287/233219014-3b6b6459-7704-4f7e-bcf3-b33a2a30f5ba.png)

TODO: Spinning up in a cloud environment to test on Linux workers before merging (unlikely to cause any issues).


