### PR TITLE
Wait until all Pods are removed

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
@@ -21,6 +21,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         ""replicas"": 3
     },
     ""status"": {
+        ""replicas"": 4,
         ""availableReplicas"": 3,
         ""readyReplicas"": 3,
         ""updatedReplicas"": 1

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
@@ -17,10 +17,12 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         ""namespace"": ""default"",
         ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
     },
+    ""spec"": {
+        ""replicas"": 3
+    },
     ""status"": {
         ""availableReplicas"": 3,
         ""readyReplicas"": 3,
-        ""replicas"": 3,
         ""updatedReplicas"": 1
     }
 }";

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Calamari.Kubernetes.ResourceStatus.Resources;
 using FluentAssertions;
 using NUnit.Framework;
@@ -10,23 +11,13 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         [Test]
         public void ShouldCollectCorrectProperties()
         {
-            const string input = @"{
-    ""kind"": ""Deployment"",
-    ""metadata"": {
-        ""name"": ""nginx"",
-        ""namespace"": ""default"",
-        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
-    },
-    ""spec"": {
-        ""replicas"": 3
-    },
-    ""status"": {
-        ""replicas"": 4,
-        ""availableReplicas"": 3,
-        ""readyReplicas"": 3,
-        ""updatedReplicas"": 1
-    }
-}";
+            var input = new DeploymentResponseBuilder()
+                .WithDesiredReplicas(3)
+                .WithTotalReplicas(4)
+                .WithAvailableReplicas(3)
+                .WithReadyReplicas(3)
+                .WithUpdatedReplicas(1)
+                .Build();
             var deployment = ResourceFactory.FromJson(input);
             
             deployment.Should().BeEquivalentTo(new
@@ -40,6 +31,123 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 Available = 3,
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
             });
+        }
+
+        [Test]
+        public void ShouldNotBeSuccessfulIfSomeChildrenPodsAreStillRunning()
+        {
+            var input = new DeploymentResponseBuilder()
+                .WithDesiredReplicas(3)
+                .WithTotalReplicas(3)
+                .WithAvailableReplicas(3)
+                .WithReadyReplicas(3)
+                .WithUpdatedReplicas(3)
+                .Build();
+            var deployment = ResourceFactory.FromJson(input);
+            
+            var pod = new PodResponseBuilder().Build();
+            // More pods remaining than desired
+            var children = Enumerable.Range(0, 4) 
+                .Select(_ => ResourceFactory.FromJson(pod));
+            
+            var replicaSet = ResourceFactory.FromJson("{}");
+            replicaSet.UpdateChildren(children);
+            
+            deployment.UpdateChildren(new Resource[] { replicaSet });
+
+            deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+        
+        [Test]
+        public void ShouldBeSuccessfulIfOnlyDesiredPodsAreRunning()
+        {
+            var input = new DeploymentResponseBuilder()
+                .WithDesiredReplicas(3)
+                .WithTotalReplicas(3)
+                .WithAvailableReplicas(3)
+                .WithReadyReplicas(3)
+                .WithUpdatedReplicas(3)
+                .Build();
+            var deployment = ResourceFactory.FromJson(input);
+            
+            var pod = new PodResponseBuilder().Build();
+            var children = Enumerable.Range(0, 3)
+                .Select(_ => ResourceFactory.FromJson(pod));
+            
+            var replicaSet = ResourceFactory.FromJson("{}");
+            replicaSet.UpdateChildren(children);
+            
+            deployment.UpdateChildren(new Resource[] { replicaSet });
+
+            deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
+        }
+    }
+
+    internal class DeploymentResponseBuilder
+    {
+        private const string Template = @"{{
+    ""kind"": ""Deployment"",
+    ""metadata"": {{
+        ""name"": ""nginx"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+    }},
+    ""spec"": {{
+        ""replicas"": {0}
+    }},
+    ""status"": {{
+        ""replicas"": {1},
+        ""availableReplicas"": {2},
+        ""readyReplicas"": {3},
+        ""updatedReplicas"": {4}
+    }}
+}}";
+
+        private int DesiredReplicas { get; set; }
+        private int TotalReplicas { get; set; }
+        private int AvailableReplicas { get; set; }
+        private int ReadyReplicas { get; set; }
+        private int UpdatedReplicas { get; set; }
+
+        public DeploymentResponseBuilder WithDesiredReplicas(int replicas)
+        {
+            DesiredReplicas = replicas;
+            return this;
+        }
+        
+        public DeploymentResponseBuilder WithTotalReplicas(int replicas)
+        {
+            TotalReplicas = replicas;
+            return this;
+        }
+        
+        public DeploymentResponseBuilder WithAvailableReplicas(int replicas)
+        {
+            AvailableReplicas = replicas;
+            return this;
+        }
+        
+        public DeploymentResponseBuilder WithReadyReplicas(int replicas)
+        {
+            ReadyReplicas = replicas;
+            return this;
+        }
+        
+        public DeploymentResponseBuilder WithUpdatedReplicas(int replicas)
+        {
+            UpdatedReplicas = replicas;
+            return this;
+        }
+        
+        public string Build()
+        {
+            return string.Format(
+                Template, 
+                DesiredReplicas, 
+                TotalReplicas, 
+                AvailableReplicas, 
+                ReadyReplicas,
+                UpdatedReplicas);
         }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
@@ -35,7 +35,7 @@ namespace Calamari.Kubernetes.ResourceStatus
 
             foreach (var resource in resources)
             {
-                resource.Children = GetChildrenResources(resource, kubectl);
+                resource.UpdateChildren(GetChildrenResources(resource, kubectl));
             }
 
             return resources;
@@ -60,7 +60,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             return resources.Where(resource => resource.OwnerUids.Contains(parentResource.Uid))
                 .Select(child =>
                 {
-                    child.Children = GetChildrenResources(child, kubectl);
+                    child.UpdateChildren(GetChildrenResources(child, kubectl));
                     return child;
                 }).ToList();
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
@@ -14,7 +14,6 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public int UpToDate { get; }
         public int Available { get; }
         public string NodeSelector { get; }
-        public override ResourceStatus ResourceStatus { get; }
 
         public DaemonSet(JObject json) : base(json)
         {

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
@@ -21,7 +21,9 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             Available = FieldOrDefault("$.status.availableReplicas", 0);
             UpToDate = FieldOrDefault("$.status.updatedReplicas", 0);
 
-            var foundReplicas = Children.SelectMany(child => child?.Children ?? Enumerable.Empty<Resource>()).Count();
+            var foundReplicas = Children
+                ?.SelectMany(child => child?.Children ?? Enumerable.Empty<Resource>())
+                .Count() ?? 0;
             
             ResourceStatus = foundReplicas == desiredReplicas
                              && totalReplicas == desiredReplicas 

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
@@ -14,12 +14,12 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public Deployment(JObject json) : base(json)
         {
             var readyReplicas = FieldOrDefault("$.status.readyReplicas", 0);
-            var replicas = FieldOrDefault("$.status.replicas", 0);
-            Ready = $"{readyReplicas}/{replicas}";
+            var desiredReplicas = FieldOrDefault("$.spec.replicas", 0);
+            Ready = $"{readyReplicas}/{desiredReplicas}";
             Available = FieldOrDefault("$.status.availableReplicas", 0);
             UpToDate = FieldOrDefault("$.status.updatedReplicas", 0);
 
-            ResourceStatus = UpToDate == replicas && Available == replicas && readyReplicas == replicas 
+            ResourceStatus = UpToDate == desiredReplicas && Available == desiredReplicas && readyReplicas == desiredReplicas 
                 ? ResourceStatus.Successful 
                 : ResourceStatus.InProgress;
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
@@ -15,11 +15,15 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         {
             var readyReplicas = FieldOrDefault("$.status.readyReplicas", 0);
             var desiredReplicas = FieldOrDefault("$.spec.replicas", 0);
+            var totalReplicas = FieldOrDefault("$.status.replicas", 0);
             Ready = $"{readyReplicas}/{desiredReplicas}";
             Available = FieldOrDefault("$.status.availableReplicas", 0);
             UpToDate = FieldOrDefault("$.status.updatedReplicas", 0);
 
-            ResourceStatus = UpToDate == desiredReplicas && Available == desiredReplicas && readyReplicas == desiredReplicas 
+            ResourceStatus = totalReplicas == desiredReplicas 
+                             && UpToDate == desiredReplicas 
+                             && Available == desiredReplicas 
+                             && readyReplicas == desiredReplicas 
                 ? ResourceStatus.Successful 
                 : ResourceStatus.InProgress;
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
@@ -20,7 +21,10 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             Available = FieldOrDefault("$.status.availableReplicas", 0);
             UpToDate = FieldOrDefault("$.status.updatedReplicas", 0);
 
-            ResourceStatus = totalReplicas == desiredReplicas 
+            var foundReplicas = Children.SelectMany(child => child?.Children ?? Enumerable.Empty<Resource>()).Count();
+            
+            ResourceStatus = foundReplicas == desiredReplicas
+                             && totalReplicas == desiredReplicas 
                              && UpToDate == desiredReplicas 
                              && Available == desiredReplicas 
                              && readyReplicas == desiredReplicas 

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
@@ -8,8 +8,6 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public string Completions { get; }
         public string Duration { get; }
 
-        public override ResourceStatus ResourceStatus { get; }
-
         public Job(JObject json) : base(json)
         {
             var succeeded = FieldOrDefault("$.status.succeeded", 0);

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
@@ -8,8 +8,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public string Ready { get; }
         public int Restarts { get; }
         public string Status { get; }
-        public override ResourceStatus ResourceStatus { get; }
-    
+
         public Pod(JObject json) : base(json)
         {
             var phase = Field("$.status.phase");

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ReplicaSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ReplicaSet.cs
@@ -10,8 +10,6 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public int Current { get; }
         public int Ready { get; }
 
-        public override ResourceStatus ResourceStatus { get; }
-        
         public ReplicaSet(JObject json) : base(json)
         {
             Desired = FieldOrDefault("$.status.replicas", 0);

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
@@ -10,22 +10,17 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     /// </summary>
     public class Resource
     {
-        [JsonIgnore] 
-        protected JObject data;
-        
-        [JsonIgnore]
-        public IEnumerable<string> OwnerUids { get; }
-        
-        [JsonIgnore]
-        public string Uid { get; }
-        [JsonIgnore]
-        public string Kind { get; }
-        [JsonIgnore]
-        public string Name { get; }
-        [JsonIgnore]
-        public string Namespace { get; }
-        [JsonIgnore]
-        public virtual ResourceStatus ResourceStatus => ResourceStatus.Successful;
+        [JsonIgnore] protected JObject data;
+
+        [JsonIgnore] public IEnumerable<string> OwnerUids { get; }
+
+        [JsonIgnore] public string Uid { get; }
+        [JsonIgnore] public string Kind { get; }
+        [JsonIgnore] public string Name { get; }
+        [JsonIgnore] public string Namespace { get; }
+
+        [JsonIgnore] public virtual ResourceStatus ResourceStatus { get; set; } = ResourceStatus.Successful;
+
         [JsonIgnore]
         public virtual string ChildKind => "";
     
@@ -43,7 +38,9 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         }
     
         public virtual bool HasUpdate(Resource lastStatus) => false;
-    
+
+        public virtual void UpdateChildren(IEnumerable<Resource> children) => Children = children;
+        
         protected string Field(string jsonPath) => FieldOrDefault(jsonPath, "");
         
         protected T FieldOrDefault<T>(string jsonPath, T defaultValue)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/StatefulSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/StatefulSet.cs
@@ -7,7 +7,6 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public override string ChildKind => "Pod";
 
         public string Ready { get; }
-        public override ResourceStatus ResourceStatus { get; }
 
         public StatefulSet(JObject json) : base(json)
         {


### PR DESCRIPTION
[sc-46519]

This PR makes sure that all exceeding Pods associated with a Deployments are completely removed before we mark the deployment as successful. Previously we do not wait for these Pods to go away, as a result, at the time the deployment has been successful, there are still Pods displayed on the screen.