### PR TITLE
Add some logging

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/StabilizingTimerTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/StabilizingTimerTests.cs
@@ -1,4 +1,6 @@
 using Calamari.Kubernetes.ResourceStatus;
+using Calamari.Testing.Helpers;
+using Calamari.Tests.Helpers;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -17,7 +19,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         {
             var deploymentTimer = new MockCountdownTimer();
             var stabilizationTimer = new MockCountdownTimer();
-            var timer = new StabilizingTimer(deploymentTimer, stabilizationTimer);
+            var timer = new StabilizingTimer(deploymentTimer, stabilizationTimer, new InMemoryLog());
             
             timer.Start();
             
@@ -38,7 +40,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         {
             var deploymentTimer = new MockCountdownTimer();
             var stabilizationTimer = new MockCountdownTimer();
-            var timer = new StabilizingTimer(deploymentTimer, stabilizationTimer);
+            var timer = new StabilizingTimer(deploymentTimer, stabilizationTimer, new InMemoryLog());
 
             timer.Start();
             
@@ -57,7 +59,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         {
             var deploymentTimer = new MockCountdownTimer();
             var stabilizationTimer = new MockCountdownTimer();
-            var timer = new StabilizingTimer(deploymentTimer, stabilizationTimer);
+            var timer = new StabilizingTimer(deploymentTimer, stabilizationTimer, new InMemoryLog());
             
             timer.Start();
             
@@ -80,7 +82,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         {
             var deploymentTimer = new MockCountdownTimer();
             var stabilizationTimer = new MockCountdownTimer();
-            var timer = new StabilizingTimer(deploymentTimer, stabilizationTimer);
+            var timer = new StabilizingTimer(deploymentTimer, stabilizationTimer, new InMemoryLog());
             
             timer.Start();
             
@@ -101,7 +103,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         {
             var deploymentTimer = new MockCountdownTimer();
             var stabilizationTimer = new MockCountdownTimer();
-            var timer = new StabilizingTimer(deploymentTimer, stabilizationTimer);
+            var timer = new StabilizingTimer(deploymentTimer, stabilizationTimer, new InMemoryLog());
 
             timer.Start();
             

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -88,9 +88,16 @@ namespace Calamari.Kubernetes.ResourceStatus
 
             if (!definedResources.Any())
             {
+                log.Verbose("No defined resources are found, skipping resource status check");
                 return result;
             }
 
+            log.Verbose("Performing resource status checks on the following resources:");
+            foreach (var resourceIdentifier in definedResources)
+            {
+                log.Verbose($" - {resourceIdentifier.Kind}/{resourceIdentifier.Name} in namespace {resourceIdentifier.Namespace}");
+            }
+            
             var kubeConfig = Path.Combine(workingDirectory, "kubectl-octo.yml");
 
             if (environmentVars == null)
@@ -116,7 +123,7 @@ namespace Calamari.Kubernetes.ResourceStatus
 
             var stabilizationTimer = new CountdownTimer(TimeSpan.FromSeconds(stabilizationTimeoutSeconds));
 
-            var stabilizingTimer = new StabilizingTimer(deploymentTimer, stabilizationTimer);
+            var stabilizingTimer = new StabilizingTimer(deploymentTimer, stabilizationTimer, log);
             
             var completedSuccessfully = statusChecker.CheckStatusUntilCompletionOrTimeout(definedResources, stabilizingTimer, kubectl);
             

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Calamari.Common.Plumbing.Logging;
@@ -33,15 +32,19 @@ namespace Calamari.Kubernetes.ResourceStatus
         
         public void ReportUpdatedResources(IDictionary<string, Resource> originalStatuses, IDictionary<string, Resource> newStatuses)
         {
-            foreach (var resource in GetCreatedOrUpdatedResources(originalStatuses, newStatuses))
+            var createdOrUpdatedResources = GetCreatedOrUpdatedResources(originalStatuses, newStatuses).ToList();
+            foreach (var resource in createdOrUpdatedResources)
             {
                 SendServiceMessage(resource, false);
             }
-            
-            foreach (var resource in GetRemovedResources(originalStatuses, newStatuses))
+
+            var removedResources = GetRemovedResources(originalStatuses, newStatuses).ToList();
+            foreach (var resource in removedResources)
             {
                 SendServiceMessage(resource, true);
             }
+            
+            log.Verbose($"Resource status reported: {createdOrUpdatedResources.Count} updates, {removedResources.Count} removals");
         }
         
         private static IEnumerable<Resource> GetCreatedOrUpdatedResources(IDictionary<string, Resource> originalStatuses, IDictionary<string, Resource> newStatuses)


### PR DESCRIPTION
This PR adds verbose level logs:
- For each defined resources in yaml or secrets and configmaps found with the project
- Every time stabilisation period is entered or exited
- At the completion of the deployment explaining the end status
- Every time updates are sent to Server with the count of modified resources