### PR TITLE
Add logging to test output when running discovery tests

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -63,10 +63,7 @@ namespace Calamari.Tests.KubernetesFixtures
         {
             var calamariResult = ExecuteScriptInternal(new CommandLineRunner(Log, variables), wrapper, scriptName);
 
-            foreach (var message in Log.Messages)
-            {
-                Console.WriteLine($"[{message.Level}] {message.FormattedMessage}");
-            }
+            WriteLogMessagesToTestOutput();
 
             return calamariResult;
         }
@@ -181,12 +178,17 @@ namespace Calamari.Tests.KubernetesFixtures
                        .Argument("variables", variablesFile.FilePath)
                        .Argument("extensions", string.Join(',', extensions)));
 
-                foreach (var message in Log.Messages)
-                {
-                    Console.WriteLine($"[{message.Level}] {message.FormattedMessage}");
-                }
+                WriteLogMessagesToTestOutput();
 
                 return result;
+            }
+        }
+
+        private void WriteLogMessagesToTestOutput()
+        {
+            foreach (var message in Log.Messages)
+            {
+                Console.WriteLine($"[{message.Level}] {message.FormattedMessage}");
             }
         }
     }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -176,10 +176,17 @@ namespace Calamari.Tests.KubernetesFixtures
 
                 variables.Save(variablesFile.FilePath);
 
-                return InvokeInProcess(Calamari()
-                                       .Action(KubernetesDiscoveryCommand.Name)
-                                       .Argument("variables", variablesFile.FilePath)
-                                       .Argument("extensions", string.Join(',', extensions)));
+                var result = InvokeInProcess(Calamari()
+                       .Action(KubernetesDiscoveryCommand.Name)
+                       .Argument("variables", variablesFile.FilePath)
+                       .Argument("extensions", string.Join(',', extensions)));
+
+                foreach (var message in Log.Messages)
+                {
+                    Console.WriteLine($"[{message.Level}] {message.FormattedMessage}");
+                }
+
+                return result;
             }
         }
     }


### PR DESCRIPTION
I realised when looking at a flakey test that the output doesn't include the discovery code logging because of the way logging is setup for these tests.

The only time the InMemoryLogs are logged to the test output are when a script is executed but discovery doesn't use a script so it's never logged.

I've added in some code which will log the discovery code logs to test output after discovery has been executed.