### PR TITLE
Fixing some logging bugs in the new kubernetes raw yaml command

### DIFF
--- a/source/Calamari/Kubernetes/Conventions/GatherAndApplyRawYamlConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/GatherAndApplyRawYamlConvention.cs
@@ -105,7 +105,7 @@ namespace Calamari.Kubernetes.Conventions
 
         private IEnumerable<Resource> ApplyBatchAndReturnResources(int index, string glob, Kubectl kubectl, string directory)
         {
-            log.Info($"Applying Batch #{index} for YAML matching '{glob}'");
+            log.Info($"Applying Batch #{index+1} for YAML matching '{glob}'");
             var result = kubectl.ExecuteCommandAndReturnOutput("apply", "-f", directory, "-o", "json");
 
             foreach (var message in result.Output.Messages)

--- a/source/Calamari/Kubernetes/Conventions/GatherAndApplyRawYamlConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/GatherAndApplyRawYamlConvention.cs
@@ -133,9 +133,21 @@ namespace Calamari.Kubernetes.Conventions
             try
             {
                 var token = JToken.Parse(outputJson);
-                var lastResources = token.Type == JTokenType.Array
-                    ? token.ToObject<List<Resource>>()
-                    : new List<Resource> { token.ToObject<Resource>() };
+
+                List<Resource> lastResources;
+                if (token.Type == JTokenType.Array)
+                {
+                    lastResources = token.ToObject<List<Resource>>();
+                }
+                else if (token["kind"]?.ToString() == "List" &&
+                    token["items"]?.ToObject<List<Resource>>() is { } resources)
+                {
+                    lastResources = resources;
+                }
+                else
+                {
+                    lastResources = new List<Resource> { token.ToObject<Resource>() };
+                }
 
                 foreach (var resource in lastResources)
                 {

--- a/source/Calamari/Kubernetes/Conventions/GatherAndApplyRawYamlConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/GatherAndApplyRawYamlConvention.cs
@@ -139,12 +139,8 @@ namespace Calamari.Kubernetes.Conventions
                 {
                     lastResources = token.ToObject<List<Resource>>();
                 }
-                else if (token["kind"]?.ToString() == "List" &&
-                    token["items"]?.ToObject<List<Resource>>() is { } resources)
-                {
-                    lastResources = resources;
-                }
-                else
+                else if (token["kind"]?.ToString() != "List" ||
+                    (lastResources = token["items"]?.ToObject<List<Resource>>()) == null)
                 {
                     lastResources = new List<Resource> { token.ToObject<Resource>() };
                 }


### PR DESCRIPTION
I noticed that when multiple yaml files are applied that the resources are returned in a custom List object in JSON which we aren't handling properly so it looks like this:
<img width="438" alt="image" src="https://user-images.githubusercontent.com/97430840/235036640-74f5d640-8938-4e31-9d4e-7033d5a78631.png">

This fix means we parse the object correctly and pull out the objects which looks like this:
<img width="440" alt="image" src="https://user-images.githubusercontent.com/97430840/235036690-b8410d0d-48ed-418e-891e-fcfd6b723ba6.png">

I have also updated the Batch numbering to be 1 based instead of 0 (zero) based:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/97430840/235037341-56f0b5b5-8c2e-4a87-b9a8-06a2f0368a12.png">
