### PR TITLE
Fix default namespace for empty string

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -167,6 +167,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Compile Remove="Fixtures\StructuredVariables\CalamariFlavourProgramReplacerSelectionFixture.cs" />
+    <None Update="KubernetesFixtures\ResourceStatus\assets\no-namespace\deployment.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Remove="TestResults\**" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -167,9 +167,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Compile Remove="Fixtures\StructuredVariables\CalamariFlavourProgramReplacerSelectionFixture.cs" />
-    <None Update="KubernetesFixtures\ResourceStatus\assets\no-namespace\deployment.yml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <None Remove="TestResults\**" />

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportWrapperTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportWrapperTests.cs
@@ -195,8 +195,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
              }
          }
 
-         [Test]
-         public void SetNamespaceToDefaultWhenTheDefaultNamespaceIsAnEmptyString()
+         [TestCase(null)]
+         [TestCase("")]
+         public void SetNamespaceToDefaultWhenTheDefaultNamespaceIsNullOrAnEmptyString(string @namespace)
          {
              var variables = new CalamariVariables();
              var log = new SilentLog();
@@ -204,7 +205,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
              var statusChecker = new MockResourceStatusChecker();
 
              AddKubernetesStatusCheckVariables(variables);
-             variables.Set(SpecialVariables.Namespace, "");
+             variables.Set(SpecialVariables.Namespace, @namespace);
 
              var testDirectory =
                  TestEnvironment.GetTestPath("KubernetesFixtures", "ResourceStatus", "assets", "no-namespace");

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/no-namespace/deployment.yml
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/no-namespace/deployment.yml
@@ -1,0 +1,3 @@
+kind: Deployment
+metadata:
+  name: deployment

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
@@ -31,6 +31,11 @@ namespace Calamari.Kubernetes.ResourceStatus
         {
             var customKubectlExecutable = variables.Get(SpecialVariables.CustomKubectlExecutable);
             var defaultNamespace = variables.Get(SpecialVariables.Namespace, "default");
+            // When the namespace on a target was set and then cleared, it's going to be "" instead of null
+            if (string.IsNullOrEmpty(defaultNamespace))
+            {
+                defaultNamespace = "default";
+            }
             var deploymentTimeoutSeconds = variables.GetInt32(SpecialVariables.DeploymentTimeout) ?? 0;
             var stabilizationTimeoutSeconds = variables.GetInt32(SpecialVariables.StabilizationTimeout) ?? 0;
 


### PR DESCRIPTION
When the namespace on the Kubernetes cluster target is previously set to a string and then reset to empty, instead of setting `Octopus.Action.Kubernetes.Namespace` to `null`, it sets it to an empty string. This caused that the namespace not being set to `default` correctly in this scenario. As a result, the status checker cannot correctly find the resource because the namespace argument is not given to `kubectl`.

This PR corrected the default value handling, so it sets the namespace to `default` if `Octopus.Action.Kubernetes.Namespace` is empty or null.