### PR TITLE
Fix countdown timer with 0 duration

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/CountdownTimerTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/CountdownTimerTests.cs
@@ -3,7 +3,7 @@ using Calamari.Kubernetes.ResourceStatus;
 using FluentAssertions;
 using NUnit.Framework;
 
-namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
 {
     [TestFixture]
     public class CountdownTimerTests

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/CountdownTimerTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/CountdownTimerTests.cs
@@ -1,0 +1,18 @@
+using System;
+using Calamari.Kubernetes.ResourceStatus;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
+{
+    [TestFixture]
+    public class CountdownTimerTests
+    {
+        [Test]
+        public void ZeroDurationCountdownTimer_ShouldNotCompleteBeforeItIsStarted()
+        {
+            var timer = new CountdownTimer(TimeSpan.Zero);
+            timer.HasCompleted().Should().BeFalse();
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/ResourceStatus/CountdownTimer.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/CountdownTimer.cs
@@ -31,7 +31,7 @@ namespace Calamari.Kubernetes.ResourceStatus
         public void Start() => stopwatch.Start();
         public void Reset() => stopwatch.Reset();
         public bool HasStarted() => stopwatch.IsRunning;
-        public bool HasCompleted() => stopwatch.Elapsed >= duration;
+        public bool HasCompleted() => stopwatch.Elapsed > duration;
     }
 
     /// <summary>

--- a/source/Calamari/Kubernetes/ResourceStatus/CountdownTimer.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/CountdownTimer.cs
@@ -31,7 +31,7 @@ namespace Calamari.Kubernetes.ResourceStatus
         public void Start() => stopwatch.Start();
         public void Reset() => stopwatch.Reset();
         public bool HasStarted() => stopwatch.IsRunning;
-        public bool HasCompleted() => stopwatch.Elapsed > duration;
+        public bool HasCompleted() => HasStarted() && stopwatch.Elapsed >= duration;
     }
 
     /// <summary>


### PR DESCRIPTION
[sc-48027]

There is a bug in the timer so if it is configured with 0 timeout, the `HasCompleted` method will return true due to the way we do the comparison.

This caused steps configured with 0 stabilisation timeouts to fail immediately while some resources are still in-progress.