### PR TITLE
Add countOfChecks to the service message

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceUpdateReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceUpdateReporterTests.cs
@@ -46,7 +46,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                     bool.FalseString
                 });
             
-            serviceMessages.Select(message => message.Properties["countOfChecks"])
+            serviceMessages.Select(message => message.Properties["checkCount"])
                 .Should().BeEquivalentTo(new string[]
                 {
                     "1",
@@ -80,7 +80,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                 {
                     new KeyValuePair<string, string>("name", "nginx"),
                     new KeyValuePair<string, string>("removed", bool.FalseString),
-                    new KeyValuePair<string, string>("countOfChecks", "1")
+                    new KeyValuePair<string, string>("checkCount", "1")
                 });
         }
         
@@ -110,7 +110,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                 {
                     new KeyValuePair<string, string>("name", "redis"),
                     new KeyValuePair<string, string>("removed", bool.TrueString),
-                    new KeyValuePair<string, string>("countOfChecks", "1"),
+                    new KeyValuePair<string, string>("checkCount", "1"),
                 });
         }
     }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceUpdateReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceUpdateReporterTests.cs
@@ -26,7 +26,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                 .FromListJson(TestFileLoader.Load("two-deployments.json")) 
                 .ToDictionary(resource => resource.Uid, resource => resource);
             
-            reporter.ReportUpdatedResources(originalStatuses, newStatuses);
+            reporter.ReportUpdatedResources(originalStatuses, newStatuses, 1);
 
             var serviceMessages = log.ServiceMessages
                 .Where(message => message.Name == SpecialVariables.KubernetesResourceStatusServiceMessageName)
@@ -45,6 +45,13 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                     bool.FalseString,
                     bool.FalseString
                 });
+            
+            serviceMessages.Select(message => message.Properties["countOfChecks"])
+                .Should().BeEquivalentTo(new string[]
+                {
+                    "1",
+                    "1"
+                });
         }
         
         [Test]
@@ -62,7 +69,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                 .FromListJson(TestFileLoader.Load("one-old-deployment-and-one-new-deployment.json"))
                 .ToDictionary(resource => resource.Uid, resource => resource);
             
-            reporter.ReportUpdatedResources(originalStatuses, newStatuses);
+            reporter.ReportUpdatedResources(originalStatuses, newStatuses, 1);
             
             var serviceMessages = log.ServiceMessages
                 .Where(message => message.Name == SpecialVariables.KubernetesResourceStatusServiceMessageName)
@@ -73,6 +80,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                 {
                     new KeyValuePair<string, string>("name", "nginx"),
                     new KeyValuePair<string, string>("removed", bool.FalseString),
+                    new KeyValuePair<string, string>("countOfChecks", "1")
                 });
         }
         
@@ -91,7 +99,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                 .FromListJson(TestFileLoader.Load("one-deployment.json"))
                 .ToDictionary(resource => resource.Uid, resource => resource);
             
-            reporter.ReportUpdatedResources(originalStatuses, newStatuses);
+            reporter.ReportUpdatedResources(originalStatuses, newStatuses, 1);
             
             var serviceMessages = log.ServiceMessages
                 .Where(message => message.Name == SpecialVariables.KubernetesResourceStatusServiceMessageName)
@@ -102,6 +110,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                 {
                     new KeyValuePair<string, string>("name", "redis"),
                     new KeyValuePair<string, string>("removed", bool.TrueString),
+                    new KeyValuePair<string, string>("countOfChecks", "1"),
                 });
         }
     }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusChecker.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusChecker.cs
@@ -50,7 +50,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             var resourceStatuses = new Dictionary<string, Resource>();
             var deploymentStatus = DeploymentStatus.InProgress;
             var shouldContinue = true;
-            var countOfChecks = 0;
+            var checkCount = 0;
             
             stabilizingTimer.Start();
             
@@ -63,7 +63,7 @@ namespace Calamari.Kubernetes.ResourceStatus
 
                 var newDeploymentStatus = GetDeploymentStatus(newResourceStatuses.Values.ToList());
 
-                reporter.ReportUpdatedResources(resourceStatuses, newResourceStatuses, ++countOfChecks);
+                reporter.ReportUpdatedResources(resourceStatuses, newResourceStatuses, ++checkCount);
                 
                 shouldContinue = stabilizingTimer.ShouldContinue(deploymentStatus, newDeploymentStatus);
 

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusChecker.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusChecker.cs
@@ -50,7 +50,8 @@ namespace Calamari.Kubernetes.ResourceStatus
             var resourceStatuses = new Dictionary<string, Resource>();
             var deploymentStatus = DeploymentStatus.InProgress;
             var shouldContinue = true;
-
+            var countOfChecks = 0;
+            
             stabilizingTimer.Start();
             
             while (shouldContinue)
@@ -62,7 +63,7 @@ namespace Calamari.Kubernetes.ResourceStatus
 
                 var newDeploymentStatus = GetDeploymentStatus(newResourceStatuses.Values.ToList());
 
-                reporter.ReportUpdatedResources(resourceStatuses, newResourceStatuses);
+                reporter.ReportUpdatedResources(resourceStatuses, newResourceStatuses, ++countOfChecks);
                 
                 shouldContinue = stabilizingTimer.ShouldContinue(deploymentStatus, newDeploymentStatus);
 

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
@@ -13,7 +13,7 @@ namespace Calamari.Kubernetes.ResourceStatus
         /// <summary>
         /// Reports the difference of the originalStatuses and newStatuses to server.
         /// </summary>
-        void ReportUpdatedResources(IDictionary<string, Resource> originalStatuses, IDictionary<string, Resource> newStatuses, int countOfChecks);
+        void ReportUpdatedResources(IDictionary<string, Resource> originalStatuses, IDictionary<string, Resource> newStatuses, int checkCount);
     }
     
     /// <summary>
@@ -30,18 +30,18 @@ namespace Calamari.Kubernetes.ResourceStatus
             this.log = log;
         }
         
-        public void ReportUpdatedResources(IDictionary<string, Resource> originalStatuses, IDictionary<string, Resource> newStatuses, int countOfChecks)
+        public void ReportUpdatedResources(IDictionary<string, Resource> originalStatuses, IDictionary<string, Resource> newStatuses, int checkCount)
         {
             var createdOrUpdatedResources = GetCreatedOrUpdatedResources(originalStatuses, newStatuses).ToList();
             foreach (var resource in createdOrUpdatedResources)
             {
-                SendServiceMessage(resource, false, countOfChecks);
+                SendServiceMessage(resource, false, checkCount);
             }
 
             var removedResources = GetRemovedResources(originalStatuses, newStatuses).ToList();
             foreach (var resource in removedResources)
             {
-                SendServiceMessage(resource, true, countOfChecks);
+                SendServiceMessage(resource, true, checkCount);
             }
             
             log.Verbose($"Resource status reported: {createdOrUpdatedResources.Count} updates, {removedResources.Count} removals");
@@ -62,7 +62,7 @@ namespace Calamari.Kubernetes.ResourceStatus
                 .Select(resource => resource.Value);
         }
         
-        private void SendServiceMessage(Resource resource, bool removed, int countOfChecks)
+        private void SendServiceMessage(Resource resource, bool removed, int checkCount)
         {
             var parameters = new Dictionary<string, string>
             {
@@ -80,7 +80,7 @@ namespace Calamari.Kubernetes.ResourceStatus
                 {"status", resource.ResourceStatus.ToString()},
                 {"data", JsonConvert.SerializeObject(resource)},
                 {"removed", removed.ToString()},
-                {"countOfChecks", countOfChecks.ToString()}
+                {"checkCount", checkCount.ToString()}
             };
     
             var message = new ServiceMessage(SpecialVariables.KubernetesResourceStatusServiceMessageName, parameters);


### PR DESCRIPTION
This PR adds a `countOfChecks` field to the service message for kubernetes object status check. This field reflects which round of check this service message belongs to. It will be used by server to prevent updating a newer kubernetes resource record with a stale one.