### PR TITLE
Fix flakey tests which use AppServiceIntegrationTest

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -43,7 +43,7 @@ namespace Calamari.AzureAppService.Tests
                 Environment.GetEnvironmentVariable(AccountVariables.ActiveDirectoryEndPoint) ??
                 DefaultVariables.ActiveDirectoryEndpoint;
 
-            resourceGroupName = Randomizer.CreateRandomizer().GetString(36);
+            resourceGroupName = Randomizer.CreateRandomizer().GetString(34, "abcdefghijklmnopqrstuvwxyz1234567890");
 
             clientId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId);
             clientSecret = ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword);

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviorFixture.cs
@@ -48,14 +48,14 @@ namespace Calamari.AzureAppService.Tests
         public async Task Setup()
         {
             resourceGroupName = Guid.NewGuid().ToString();
-
+        
             clientId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId);
             clientSecret = ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword);
             tenantId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId);
             subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
 
             var resourceGroupLocation = Environment.GetEnvironmentVariable("AZURE_NEW_RESOURCE_REGION") ?? "eastus";
-
+            
             authToken = await GetAuthToken(tenantId, clientId, clientSecret);
 
             var resourcesClient = new ResourcesManagementClient(subscriptionId,
@@ -99,7 +99,7 @@ namespace Calamari.AzureAppService.Tests
                         AlwaysOn = true
                     }
                 });
-
+            
             webappName = site.Name;
 
             await AssertSetupSuccessAsync();
@@ -118,7 +118,6 @@ namespace Calamari.AzureAppService.Tests
             //}
         }
 
-        [Ignore("This test is flaky and muting it doesn't work. Will be fixed by #team-modern-deployments-requests-and-discussion")]
         [Test]
         public async Task AzureLinuxContainerDeploy()
         {
@@ -132,12 +131,11 @@ namespace Calamari.AzureAppService.Tests
             await AssertDeploySuccessAsync(AzureWebAppHelper.GetAzureTargetSite(site.Name, "", resourceGroupName));
         }
 
-        [Ignore("This test is flaky and muting it doesn't work. Will be fixed by #team-modern-deployments-requests-and-discussion")]
         [Test]
         public async Task AzureLinuxContainerSlotDeploy()
         {
             var slotName = "stage";
-
+            
             newVariables = new CalamariVariables();
             AddVariables(newVariables);
             newVariables.Add("Octopus.Action.Azure.DeploymentSlot", slotName);
@@ -156,7 +154,7 @@ namespace Calamari.AzureAppService.Tests
             var result = await client.GetAsync($@"https://{webappName}.azurewebsites.net");
             var recievedContent = await result.Content.ReadAsStringAsync();
 
-            recievedContent.Should().Contain(@"<title>Welcome to Azure Container Instances!</title>");
+            recievedContent.Should().Contain(@"<title>Welcome to Azure Container Instances!</title>"); 
             Assert.IsTrue(result.IsSuccessStatusCode);
         }
 

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviorFixture.cs
@@ -48,14 +48,14 @@ namespace Calamari.AzureAppService.Tests
         public async Task Setup()
         {
             resourceGroupName = Guid.NewGuid().ToString();
-        
+
             clientId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId);
             clientSecret = ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword);
             tenantId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId);
             subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
 
             var resourceGroupLocation = Environment.GetEnvironmentVariable("AZURE_NEW_RESOURCE_REGION") ?? "eastus";
-            
+
             authToken = await GetAuthToken(tenantId, clientId, clientSecret);
 
             var resourcesClient = new ResourcesManagementClient(subscriptionId,
@@ -99,7 +99,7 @@ namespace Calamari.AzureAppService.Tests
                         AlwaysOn = true
                     }
                 });
-            
+
             webappName = site.Name;
 
             await AssertSetupSuccessAsync();
@@ -118,6 +118,7 @@ namespace Calamari.AzureAppService.Tests
             //}
         }
 
+        [Ignore("This test is flaky and muting it doesn't work. Will be fixed by #team-modern-deployments-requests-and-discussion")]
         [Test]
         public async Task AzureLinuxContainerDeploy()
         {
@@ -131,11 +132,12 @@ namespace Calamari.AzureAppService.Tests
             await AssertDeploySuccessAsync(AzureWebAppHelper.GetAzureTargetSite(site.Name, "", resourceGroupName));
         }
 
+        [Ignore("This test is flaky and muting it doesn't work. Will be fixed by #team-modern-deployments-requests-and-discussion")]
         [Test]
         public async Task AzureLinuxContainerSlotDeploy()
         {
             var slotName = "stage";
-            
+
             newVariables = new CalamariVariables();
             AddVariables(newVariables);
             newVariables.Add("Octopus.Action.Azure.DeploymentSlot", slotName);
@@ -154,7 +156,7 @@ namespace Calamari.AzureAppService.Tests
             var result = await client.GetAsync($@"https://{webappName}.azurewebsites.net");
             var recievedContent = await result.Content.ReadAsStringAsync();
 
-            recievedContent.Should().Contain(@"<title>Welcome to Azure Container Instances!</title>"); 
+            recievedContent.Should().Contain(@"<title>Welcome to Azure Container Instances!</title>");
             Assert.IsTrue(result.IsSuccessStatusCode);
         }
 


### PR DESCRIPTION
I had to fix these tests because the OneTimeSetup was intermittently failing which means you can't just mute them.

Changing the way the name is generated seems to have fixed the problem.

Flakey tests story: [[sc-49124](https://app.shortcut.com/octopusdeploy/story/49124/calamari-flakey-tests)]