### PR TITLE
Enforce C# compiler version to 7.3

### DIFF
--- a/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>default</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/Calamari.Scripting.Tests/Calamari.Scripting.Tests.csproj
+++ b/source/Calamari.Scripting.Tests/Calamari.Scripting.Tests.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <IsPackable>false</IsPackable>
+        <LangVersion>default</LangVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.1.0" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -10,6 +10,7 @@
     <ApplicationIcon />
     <StartupObject />
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net461;net6.0</TargetFrameworks>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -10,7 +10,6 @@
     <ApplicationIcon />
     <StartupObject />
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
-    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net461;net6.0</TargetFrameworks>

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -184,7 +184,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "awsAssumeRole", bool.FalseString }
             };
 
-            if (scope.HealthCheckContainer is not null)
+            if (scope.HealthCheckContainer != null)
             {
                 serviceMessageProperties.Add("healthCheckContainerImageFeedIdOrName", scope.HealthCheckContainer.FeedIdOrName);
                 serviceMessageProperties.Add("healthCheckContainerImage", scope.HealthCheckContainer.ImageNameAndTag);

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+ <PropertyGroup>
+   <LangVersion>7.3</LangVersion>
+ </PropertyGroup>
+</Project>


### PR DESCRIPTION
Calamari is build with .Net Framework 4.0 and 4.5.2 as well as .Net 6.0.

On Mac and linux this translates to only building with .Net 6.0 which is fine except that Rider just then uses the latest compatible C# compiler version which is higher than what is compatible with .Net Framework.

This change enforces the compiler version to 7.3 so that it doesn't trip people up who are developing for Calamari on a Mac.

You can see [here](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version#defaults) that all .Net framework versions max out at v7.3 but .Net 6 uses c# 10.