### PR TITLE
Reverse the script wrapper order

### DIFF
--- a/source/Calamari.Common/Features/Scripting/ScriptWrapperPriorities.cs
+++ b/source/Calamari.Common/Features/Scripting/ScriptWrapperPriorities.cs
@@ -8,14 +8,14 @@ namespace Calamari.Common.Features.Scripting
     public static class ScriptWrapperPriorities
     {
         /// <summary>
-        /// The priority for script wrappers that configure kubernetes authentication
-        /// </summary>
-        public const int KubernetesContextPriority = 1002;
-        
-        /// <summary>
         /// The priority for the script wrapper that checks deployed Kubernetes resources status
         /// </summary>
-        public const int KubernetesStatusCheckPriority = 1001;
+        public const int KubernetesStatusCheckPriority = 1002;
+        
+        /// <summary>
+        /// The priority for script wrappers that configure kubernetes authentication
+        /// </summary>
+        public const int KubernetesContextPriority = 1001;
         
         /// <summary>
         /// The priority for script wrappers that configure cloud authentication

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -48,6 +48,11 @@ namespace Calamari.Kubernetes
         {
             var workingDirectory = Path.GetDirectoryName(script.File);
 
+            if (environmentVars == null)
+            {
+                environmentVars = new Dictionary<string, string>();
+            }
+            
             var setupKubectlAuthentication = new SetupKubectlAuthentication(variables,
                                                                             log,
                                                                             scriptSyntax,

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -48,11 +48,6 @@ namespace Calamari.Kubernetes
         {
             var workingDirectory = Path.GetDirectoryName(script.File);
 
-            if (environmentVars == null)
-            {
-                environmentVars = new Dictionary<string, string>();
-            }
-            
             var setupKubectlAuthentication = new SetupKubectlAuthentication(variables,
                                                                             log,
                                                                             scriptSyntax,

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
-using Calamari.Common.Plumbing.Proxies;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.Integration;
 using Calamari.Kubernetes.ResourceStatus.Resources;
@@ -66,19 +64,6 @@ namespace Calamari.Kubernetes.ResourceStatus
             foreach (var resourceIdentifier in definedResources)
             {
                 log.Verbose($" - {resourceIdentifier.Kind}/{resourceIdentifier.Name} in namespace {resourceIdentifier.Namespace}");
-            }
-
-            var kubeConfig = Path.Combine(workingDirectory, "kubectl-octo.yml");
-
-            if (environmentVars == null)
-            {
-                environmentVars = new Dictionary<string, string>();
-            }
-            environmentVars.Add("KUBECONFIG", kubeConfig);
-
-            foreach (var proxyVariable in ProxyEnvironmentVariablesGenerator.GenerateProxyEnvironmentVariables())
-            {
-                environmentVars[proxyVariable.Key] = proxyVariable.Value;
             }
 
             var kubectl = new Kubectl(customKubectlExecutable, log, commandLineRunner, workingDirectory, environmentVars);


### PR DESCRIPTION
## Issue

When deploying to EKS, a customer saw an exception thrown, complaining `KUBECONFIG` variable added twice to a Dictionary.

![Octopus K8S Object Status Error](https://github.com/OctopusDeploy/Calamari/assets/97418140/9da3e4dd-e0bb-4603-a226-9d8ecf8cc9c0)


## Reason

This issue was related to https://github.com/OctopusDeploy/Calamari/pull/1011 which we put in earlier in order to fix the bug where the `KUBECONFIG` variable isn't set for kubernetes resource status check. It turns out that fix wasn't a proper one, but rather shadows the actual underlying problem.

The actual cause is that the resource status check wrapper runs BEFORE the kubernetes context wrapper. The order did not matter because the first thing the resource status check wrapper does is to invoke the next wrapper.

However, the resource status check wrapper actually need access the environment variables set by the kubernetes context wrapper, which includes `KUBECONFIG`. When the resource status check wrapper runs first, these variables are not populated yet, causing errors connecting to remote kubernetes clusters.

In #1011 we duplicated the variable setup code, so we were able to use the correct kubeconfig file to authenticate. For local and Azure clusters this worked fine without errors. This is because the  resource status check wrapper is the first in the chain, and here the `environmentVars` variable is `null`. This is passed to the next wrapper, which is the kubernetes context wrapper. Because in both wrappers this parameter was `null`, they created separate Dictionary instances and added their variables. There's no clashes.

However when the status check runs on AWS, the AWS script wrapper was added before these. In the AWS script wrapper, the `environmentVars` have been set to a non-null value. Therefore, when this value is passed to the resource status check wrapper and then the kubernetes context wrapper, they are using the same Dictionary instance, and both will attempt to add the same key `KUBECONFIG`, causing an exception.

## Fix

The proper fix for this is to swap the order of status check wrapper and kubernetes context wrapper. Then we don't need to set up those variables for a second time.

### Before

<img width="1554" alt="Screenshot 2023-05-19 at 3 31 01 PM" src="https://github.com/OctopusDeploy/Calamari/assets/97418140/bb68afd4-a9f2-4cd7-aa96-86c99be7c044">
<img width="1196" alt="Screenshot 2023-05-19 at 3 36 04 PM" src="https://github.com/OctopusDeploy/Calamari/assets/97418140/8ab417ee-af0a-4863-bcd2-90116d816dc4">


### After

<img width="1578" alt="Screenshot 2023-05-19 at 3 21 19 PM" src="https://github.com/OctopusDeploy/Calamari/assets/97418140/0a4c1708-4e70-4772-92b0-95e0747cc66c">
