### PR TITLE
Add kubelogin to AKS cluster auth

### DIFF
--- a/source/Calamari.Shared/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Shared/FeatureToggles/FeatureToggle.cs
@@ -7,6 +7,7 @@
     /// </summary>
     public enum FeatureToggle {
         SkunkworksFeatureToggle,
-        MultiGlobPathsForRawYamlFeatureToggle
+        MultiGlobPathsForRawYamlFeatureToggle,
+        KubernetesAksKubeloginFeatureToggle
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
@@ -11,4 +11,5 @@
 [Info] Creating kubectl context to AKS Cluster in resource group clusterRG called asCluster (namespace calamari-testing) using a AzureServicePrincipal
 [Verbose] "az" aks get-credentials --resource-group clusterRG --name asCluster --file "<path>kubectl-octo.yml" --overwrite-existing
 [Verbose] "kubectl" config set-context asCluster --namespace=calamari-testing --request-timeout=1m
+[Verbose] "kubelogin" convert-kubeconfig -l azurecli
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
@@ -11,5 +11,5 @@
 [Info] Creating kubectl context to AKS Cluster in resource group clusterRG called asCluster (namespace calamari-testing) using a AzureServicePrincipal
 [Verbose] "az" aks get-credentials --resource-group clusterRG --name asCluster --file "<path>kubectl-octo.yml" --overwrite-existing
 [Verbose] "kubectl" config set-context asCluster --namespace=calamari-testing --request-timeout=1m
-[Verbose] "kubelogin" convert-kubeconfig -l azurecli
+[Verbose] "kubelogin" convert-kubeconfig -l azurecli --kubeconfig "<path>kubectl-octo.yml"
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
@@ -10,4 +10,5 @@
 [Info] Creating kubectl context to AKS Cluster in resource group clusterRG called asCluster (namespace calamari-testing) using a AzureServicePrincipal
 [Verbose] "az" aks get-credentials --resource-group clusterRG --name asCluster --file "<path>kubectl-octo.yml" --overwrite-existing --admin
 [Verbose] "kubectl" config set-context asCluster-admin --namespace=calamari-testing --request-timeout=1m
+[Verbose] "kubelogin" convert-kubeconfig -l azurecli
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
@@ -10,5 +10,5 @@
 [Info] Creating kubectl context to AKS Cluster in resource group clusterRG called asCluster (namespace calamari-testing) using a AzureServicePrincipal
 [Verbose] "az" aks get-credentials --resource-group clusterRG --name asCluster --file "<path>kubectl-octo.yml" --overwrite-existing --admin
 [Verbose] "kubectl" config set-context asCluster-admin --namespace=calamari-testing --request-timeout=1m
-[Verbose] "kubelogin" convert-kubeconfig -l azurecli
+[Verbose] "kubelogin" convert-kubeconfig -l azurecli --kubeconfig "<path>kubectl-octo.yml"
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -396,7 +396,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 executableName = "kubelogin.exe";
             else
                 executableName = "kubelogin";
-            return Path.Combine(extractPath, "bin", CalamariEnvironment.IsRunningOnWindows ? "windows_amd64" : "kubelogin-linux-amd64" , executableName);
+            return Path.Combine(extractPath, "bin", CalamariEnvironment.IsRunningOnWindows ? "windows_amd64" : "linux-amd64", executableName);
         }
 
         static async Task Download(string path,

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -396,7 +396,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 executableName = "kubelogin.exe";
             else
                 executableName = "kubelogin";
-            return Path.Combine(extractPath, "bin", "windows_amd64", executableName);
+            return Path.Combine(extractPath, "bin", CalamariEnvironment.IsRunningOnWindows ? "windows_amd64" : "kubelogin-linux-amd64" , executableName);
         }
 
         static async Task Download(string path,

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -210,7 +210,7 @@ namespace Calamari.Tests.KubernetesFixtures
                         var downloadUrl = GetGcloudDownloadLink(tuple.version);
                         var fileName = GetGcloudZipFileName(tuple.version);
 
-                        await DownloadGcloud(fileName,
+                        await DownloadAndExtractToDestination(fileName,
                             client,
                             downloadUrl,
                             destinationDirectoryName);
@@ -224,19 +224,19 @@ namespace Calamari.Tests.KubernetesFixtures
         {
             using (var client = new HttpClient())
             {
-                GcloudExecutable = await DownloadCli("kubelogin",
+                KubeloginExecutable = await DownloadCli("kubelogin",
                                                      () => Task.FromResult<(string, string)>(("v0.0.25", string.Empty)),
                                                      async (destinationDirectoryName, tuple) =>
                                                      {
                                                          var downloadUrl = GetKubeloginDownloadLink(tuple.version);
                                                          var fileName = GetKubeloginZipFileName();
 
-                                                         await DownloadGcloud(fileName,
+                                                         await DownloadAndExtractToDestination(fileName,
                                                                               client,
                                                                               downloadUrl,
                                                                               destinationDirectoryName);
 
-                                                         return GetGcloudExecutablePath(destinationDirectoryName);
+                                                         return GetKubeloginExecutablePath(destinationDirectoryName);
                                                      });
             }
         } 
@@ -353,10 +353,10 @@ namespace Calamari.Tests.KubernetesFixtures
         {
             if (CalamariEnvironment.IsRunningOnNix)
             {
-                return $"https://github.com/Azure/kubelogin/releases/download/${currentVersion}";
+                return $"https://github.com/Azure/kubelogin/releases/download/{currentVersion}/kubelogin-linux-amd64.zip";
             }
 
-            return $"https://github.com/Azure/kubelogin/releases/download/${currentVersion}";
+            return $"https://github.com/Azure/kubelogin/releases/download/{currentVersion}/kubelogin-win-amd64.zip";
         }
 
         public string GetKubeloginZipFileName()
@@ -387,6 +387,16 @@ namespace Calamari.Tests.KubernetesFixtures
             else
                 executableName = "gcloud";
             return Path.Combine(extractPath, "google-cloud-sdk", "bin", executableName);
+        }
+
+        static string GetKubeloginExecutablePath(string extractPath)
+        {
+            var executableName = string.Empty;
+            if (CalamariEnvironment.IsRunningOnWindows)
+                executableName = "kubelogin.exe";
+            else
+                executableName = "kubelogin";
+            return Path.Combine(extractPath, "bin", "windows_amd64", executableName);
         }
 
         static async Task Download(string path,
@@ -423,7 +433,7 @@ namespace Calamari.Tests.KubernetesFixtures
             return $"{downloadBaseUrl}{fileName}";
         }
 
-        static async Task DownloadGcloud(string fileName,
+        static async Task DownloadAndExtractToDestination(string fileName,
                                          HttpClient client,
                                          string downloadUrl,
                                          string destination)

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -361,12 +361,18 @@ namespace Calamari.Tests.KubernetesFixtures
 
         public string GetKubeloginZipFileName()
         {
-            if (CalamariEnvironment.IsRunningOnNix)
+            if (CalamariEnvironment.IsRunningOnWindows)
             {
-                return $"kubelogin-linux-amd64.zip";
+                return $"kubelogin.zip";
             }
 
-            return $"kubelogin.zip";
+            return $"kubelogin-linux-amd64.zip";
+        }
+
+        static string GetKubeloginExecutablePath(string extractPath)
+        {
+            var executableName = CalamariEnvironment.IsRunningOnWindows ? "kubelogin.exe" : "kubelogin";
+            return Path.Combine(extractPath, "bin", CalamariEnvironment.IsRunningOnWindows ? "windows_amd64" : "linux_amd64", executableName);
         }
 
         static string GetGcloudZipFileName(string currentVersion)
@@ -387,16 +393,6 @@ namespace Calamari.Tests.KubernetesFixtures
             else
                 executableName = "gcloud";
             return Path.Combine(extractPath, "google-cloud-sdk", "bin", executableName);
-        }
-
-        static string GetKubeloginExecutablePath(string extractPath)
-        {
-            var executableName = string.Empty;
-            if (CalamariEnvironment.IsRunningOnWindows)
-                executableName = "kubelogin.exe";
-            else
-                executableName = "kubelogin";
-            return Path.Combine(extractPath, "bin", CalamariEnvironment.IsRunningOnWindows ? "windows_amd64" : "linux-amd64", executableName);
         }
 
         static async Task Download(string path,
@@ -477,6 +473,12 @@ namespace Calamari.Tests.KubernetesFixtures
                 {
                     path = GetAwsCliExecutablePath(destinationDirectoryName);
                 }
+
+                if (toolName == "kubelogin")
+                {
+                    path = GetKubeloginExecutablePath(destinationDirectoryName);
+                }
+
                 if (path == null || !File.Exists(path))
                 {
                     return null;

--- a/source/Calamari.Tests/KubernetesFixtures/JObjectExtensionMethods.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/JObjectExtensionMethods.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace Calamari.Tests.KubernetesFixtures
+{
+    public static class JObjectExtensionMethods
+    {
+        public static T Get<T>(this JObject jsonOutput, params string[] paths)
+        {
+            JToken result = jsonOutput;
+            
+            foreach (var path in paths)
+            {
+                result = result[path];
+                if (result is null)
+                {
+                    return default;
+                }
+            }
+
+            return result.Value<T>();
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Calamari.Azure;
 using Calamari.Common.Features.Discovery;
 using Calamari.Common.Plumbing.FileSystem;
@@ -33,7 +34,12 @@ namespace Calamari.Tests.KubernetesFixtures
 
         protected override IEnumerable<string> ToolsToAddToPath(InstallTools tools)
         {
-            yield break;
+            yield return tools.KubeloginExecutable;
+        }
+        
+        protected override async Task InstallOptionalTools(InstallTools tools)
+        {
+            await tools.InstallKubelogin();
         }
 
         protected override void ExtractVariablesFromTerraformOutput(JObject jsonOutput)

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -219,7 +219,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 serviceMessageProperties);
 
             Log.ServiceMessages.Should()
-                .ContainSingle(s => s.Properties["name"] == targetName)
+                .ContainSingle(s => s.Properties.ContainsKey("name") && s.Properties["name"] == targetName)
                 .Which.Should()
                 .BeEquivalentTo(expectedServiceMessage);
         }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using Calamari.Aws.Integration;
 using Calamari.Aws.Kubernetes.Discovery;
 using Calamari.Commands;
 using Calamari.Common.Features.Discovery;
@@ -89,6 +91,41 @@ namespace Calamari.Tests.KubernetesFixtures
                 else
                 {
                     output.AssertFailure();
+                }
+            }
+        }
+
+        protected void TestKubectlCommand(IScriptWrapper wrapper, string command)
+        {
+            using (var dir = TemporaryDirectory.Create())
+            {
+                var folderPath = Path.Combine(dir.DirectoryPath, "Folder with spaces");
+
+                using (var temp = new TemporaryFile(Path.Combine(folderPath, $"kubectl-script.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
+                {
+                    Directory.CreateDirectory(folderPath);
+                    File.WriteAllText(temp.FilePath, $"kubectl {command}");
+
+                    var output = ExecuteScript(wrapper, temp.FilePath);
+                    output.AssertSuccess();
+                }
+            }
+        }
+        
+        protected void TestKubectlCommands(IScriptWrapper wrapper, params string[] commands)
+        {
+            using (var dir = TemporaryDirectory.Create())
+            {
+                var folderPath = Path.Combine(dir.DirectoryPath, "Folder with spaces");
+
+                using (var temp = new TemporaryFile(Path.Combine(folderPath, $"kubectl-script.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
+                {
+                    Directory.CreateDirectory(folderPath);
+                    var lines = commands.Select(c => $"kubectl {c}").ToArray();
+                    File.WriteAllText(temp.FilePath, string.Join("\n", lines));
+
+                    var output = ExecuteScript(wrapper, temp.FilePath);
+                    output.AssertSuccess();
                 }
             }
         }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -10,6 +10,8 @@ using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.ServiceMessages;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.FeatureToggles;
+using Calamari.Kubernetes;
 using Calamari.Kubernetes.Commands;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Helpers;
@@ -38,6 +40,7 @@ namespace Calamari.Tests.KubernetesFixtures
         public void Setup()
         {
             variables = new CalamariVariables();
+            variables.Set(Deployment.SpecialVariables.EnabledFeatureToggles, FeatureToggle.KubernetesAksKubeloginFeatureToggle.ToString());
 
             Log = new DoNotDoubleLog();
 

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Calamari.Aws.Integration;
 using Calamari.Aws.Kubernetes.Discovery;
 using Calamari.Commands;
 using Calamari.Common.Features.Discovery;
@@ -13,7 +11,6 @@ using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.ServiceMessages;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.FeatureToggles;
-using Calamari.Kubernetes;
 using Calamari.Kubernetes.Commands;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Helpers;
@@ -91,41 +88,6 @@ namespace Calamari.Tests.KubernetesFixtures
                 else
                 {
                     output.AssertFailure();
-                }
-            }
-        }
-
-        protected void TestKubectlCommand(IScriptWrapper wrapper, string command)
-        {
-            using (var dir = TemporaryDirectory.Create())
-            {
-                var folderPath = Path.Combine(dir.DirectoryPath, "Folder with spaces");
-
-                using (var temp = new TemporaryFile(Path.Combine(folderPath, $"kubectl-script.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
-                {
-                    Directory.CreateDirectory(folderPath);
-                    File.WriteAllText(temp.FilePath, $"kubectl {command}");
-
-                    var output = ExecuteScript(wrapper, temp.FilePath);
-                    output.AssertSuccess();
-                }
-            }
-        }
-        
-        protected void TestKubectlCommands(IScriptWrapper wrapper, params string[] commands)
-        {
-            using (var dir = TemporaryDirectory.Create())
-            {
-                var folderPath = Path.Combine(dir.DirectoryPath, "Folder with spaces");
-
-                using (var temp = new TemporaryFile(Path.Combine(folderPath, $"kubectl-script.{(variables.Get(ScriptVariables.Syntax) == ScriptSyntax.Bash.ToString() ? "sh" : "ps1")}")))
-                {
-                    Directory.CreateDirectory(folderPath);
-                    var lines = commands.Select(c => $"kubectl {c}").ToArray();
-                    File.WriteAllText(temp.FilePath, string.Join("\n", lines));
-
-                    var output = ExecuteScript(wrapper, temp.FilePath);
-                    output.AssertSuccess();
                 }
             }
         }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -427,6 +427,11 @@ namespace Calamari.Tests.KubernetesFixtures
                     ExecuteCommand(invocation, invocation.Executable);
                 }
 
+                if (new[] { "kubelogin" }.Contains(invocation.Executable))
+                {
+                    ExecuteCommand(invocation, invocation.Executable);
+                }
+
                 // We only want to output executable string. eg. ExecuteCommandAndReturnOutput("where", "kubectl.exe")
                 if (new[] { "kubectl", "az", "gcloud", "kubectl.exe", "az.cmd", "gcloud.cmd", "aws", "aws.exe", "aws-iam-authenticator", "aws-iam-authenticator.exe" }.Contains(invocation.Arguments))
                     invocation.AdditionalInvocationOutputSink?.WriteInfo(Path.GetFileNameWithoutExtension(invocation.Arguments));

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -15,6 +15,7 @@ using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.FeatureToggles;
 using Calamari.Kubernetes;
 using Calamari.Testing;
 using Calamari.Testing.Helpers;
@@ -41,6 +42,7 @@ namespace Calamari.Tests.KubernetesFixtures
         public void Setup()
         {
             variables = new CalamariVariables();
+            variables.Set(Deployment.SpecialVariables.EnabledFeatureToggles, FeatureToggle.KubernetesAksKubeloginFeatureToggle.ToString());
             log = new DoNotDoubleLog();
             redactMap = new Dictionary<string, string>();
             SetTestClusterVariables();

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -433,7 +433,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 }
 
                 // We only want to output executable string. eg. ExecuteCommandAndReturnOutput("where", "kubectl.exe")
-                if (new[] { "kubectl", "az", "gcloud", "kubectl.exe", "az.cmd", "gcloud.cmd", "aws", "aws.exe", "aws-iam-authenticator", "aws-iam-authenticator.exe" }.Contains(invocation.Arguments))
+                if (new[] { "kubectl", "az", "gcloud", "kubectl.exe", "az.cmd", "gcloud.cmd", "aws", "aws.exe", "aws-iam-authenticator", "aws-iam-authenticator.exe", "kubelogin" }.Contains(invocation.Arguments))
                     invocation.AdditionalInvocationOutputSink?.WriteInfo(Path.GetFileNameWithoutExtension(invocation.Arguments));
                 return new CommandResult(invocation.ToString(), 0);
             }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -427,13 +427,8 @@ namespace Calamari.Tests.KubernetesFixtures
                     ExecuteCommand(invocation, invocation.Executable);
                 }
 
-                if (new[] { "kubelogin" }.Contains(invocation.Executable))
-                {
-                    ExecuteCommand(invocation, invocation.Executable);
-                }
-
                 // We only want to output executable string. eg. ExecuteCommandAndReturnOutput("where", "kubectl.exe")
-                if (new[] { "kubectl", "az", "gcloud", "kubectl.exe", "az.cmd", "gcloud.cmd", "aws", "aws.exe", "aws-iam-authenticator", "aws-iam-authenticator.exe", "kubelogin" }.Contains(invocation.Arguments))
+                if (new[] { "kubectl", "az", "gcloud", "kubectl.exe", "az.cmd", "gcloud.cmd", "aws", "aws.exe", "aws-iam-authenticator", "aws-iam-authenticator.exe", "kubelogin", "kubelogin.exe" }.Contains(invocation.Arguments))
                     invocation.AdditionalInvocationOutputSink?.WriteInfo(Path.GetFileNameWithoutExtension(invocation.Arguments));
                 return new CommandResult(invocation.ToString(), 0);
             }

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/aks.kubernetes.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/aks.kubernetes.tf
@@ -1,0 +1,7 @@
+provider "kubernetes" {
+  alias                  = "aks"
+  host                   = azurerm_kubernetes_cluster.default.kube_config.0.host
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.default.kube_config.0.cluster_ca_certificate)
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.default.kube_config.0.client_certificate)
+  client_key             = base64decode(azurerm_kubernetes_cluster.default.kube_config.0.client_key)
+}

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/aks.tf
@@ -1,0 +1,35 @@
+resource "azurerm_resource_group" "default" {
+  name     = "${random_pet.prefix.id}-rg"
+  location = "Australia East"
+}
+
+resource "azurerm_kubernetes_cluster" "default" {
+  name                = "${random_pet.prefix.id}-aks"
+  resource_group_name = azurerm_resource_group.default.name
+  location            = "Australia East"
+  dns_prefix          = "${random_pet.prefix.id}-k8s"
+  
+  tags = {
+    octopus-environment = "Staging"
+    octopus-role = "discovery-role"
+  }
+
+  default_node_pool {
+    name            = "default"
+    vm_size         = "Standard_B2s"
+    node_count      = 1
+    os_disk_size_gb = 30
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  role_based_access_control_enabled = true
+  local_account_disabled            = true
+
+  azure_active_directory_role_based_access_control {
+    managed            = true
+    azure_rbac_enabled = true
+  }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/main.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/main.tf
@@ -1,0 +1,14 @@
+variable "test_namespace" {
+  type = string
+}
+
+variable "aks_client_id" {
+  type = string
+}
+
+variable "aks_client_secret" {
+  type = string
+  sensitive = true
+}
+
+resource "random_pet" "prefix" {}

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/outputs.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/outputs.tf
@@ -1,0 +1,41 @@
+output "aks_cluster_host" {
+  description = "Endpoint for AKS control plane."
+  value       = azurerm_kubernetes_cluster.default.kube_config.0.host
+  sensitive   = true
+}
+
+
+output "aks_cluster_username" {
+  value     = azurerm_kubernetes_cluster.default.kube_config.0.username
+  sensitive = true
+}
+
+output "aks_cluster_password" {
+  value     = azurerm_kubernetes_cluster.default.kube_config.0.password
+  sensitive = true
+}
+
+output "aks_cluster_client_certificate" {
+  value     = base64decode(azurerm_kubernetes_cluster.default.kube_config.0.client_certificate)
+  sensitive = true
+}
+
+output "aks_cluster_client_key" {
+  value     = base64decode(azurerm_kubernetes_cluster.default.kube_config.0.client_key)
+  sensitive = true
+}
+
+output "aks_cluster_ca_certificate" {
+  value     = base64decode(azurerm_kubernetes_cluster.default.kube_config.0.cluster_ca_certificate)
+  sensitive = true
+}
+
+output "aks_cluster_name" {
+  description = "AKS name."
+  value       = azurerm_kubernetes_cluster.default.name
+}
+
+output "aks_rg_name" {
+  description = "RG name."
+  value       = azurerm_resource_group.default.name
+}

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/providers.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/providers.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 2.78.0" 
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.3.2"
+    }
+  }
+  required_version = ">= 0.15"
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
@@ -9,6 +9,7 @@ namespace Calamari.Kubernetes.Authentication
     {
         readonly AzureCli azureCli;
         readonly Kubectl kubectlCli;
+        readonly KubeLogin kubeLogin;
         readonly IVariables deploymentVariables;
 
         /// <summary>
@@ -16,12 +17,14 @@ namespace Calamari.Kubernetes.Authentication
         /// </summary>
         /// <param name="azureCli"></param>
         /// <param name="kubectlCli"></param>
+        /// <param name="KubeLogin"></param>
         /// <param name="deploymentVariables"></param>
-        public AzureKubernetesServicesAuth(AzureCli azureCli, Kubectl kubectlCli, IVariables deploymentVariables)
+        public AzureKubernetesServicesAuth(AzureCli azureCli, Kubectl kubectlCli, KubeLogin kubeloginCli, IVariables deploymentVariables)
         {
             this.azureCli = azureCli;
             this.kubectlCli = kubectlCli;
             this.deploymentVariables = deploymentVariables;
+            this.kubeLogin = kubeloginCli;
         }
 
         public bool TryConfigure(string @namespace, string kubeConfig)
@@ -43,6 +46,7 @@ namespace Calamari.Kubernetes.Authentication
                 var azureCluster = deploymentVariables.Get(SpecialVariables.AksClusterName);
                 var azureAdmin = deploymentVariables.GetFlag("Octopus.Action.Kubernetes.AksAdminLogin");
                 azureCli.ConfigureAksKubeCtlAuthentication(kubectlCli, azureResourceGroup, azureCluster, @namespace, kubeConfig, azureAdmin);
+                kubeLogin.ConfigureAksKubeLogin();
             }
 
             return true;

--- a/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.FeatureToggles;
 using Calamari.Kubernetes.Integration;
 
 namespace Calamari.Kubernetes.Authentication
@@ -32,8 +33,11 @@ namespace Calamari.Kubernetes.Authentication
             if (!azureCli.TrySetAz())
                 return false;
 
-            if (!kubeLogin.TrySetKubeLogin())
-                return false;
+            if (FeatureToggle.KubernetesAksKubeloginFeatureToggle.IsEnabled(deploymentVariables))
+            {
+                if (!kubeLogin.TrySetKubeLogin())
+                    return false;
+            }
 
             var disableAzureCli = deploymentVariables.GetFlag("OctopusDisableAzureCLI");
             if (!disableAzureCli)
@@ -49,7 +53,10 @@ namespace Calamari.Kubernetes.Authentication
                 var azureCluster = deploymentVariables.Get(SpecialVariables.AksClusterName);
                 var azureAdmin = deploymentVariables.GetFlag("Octopus.Action.Kubernetes.AksAdminLogin");
                 azureCli.ConfigureAksKubeCtlAuthentication(kubectlCli, azureResourceGroup, azureCluster, @namespace, kubeConfig, azureAdmin);
-                kubeLogin.ConfigureAksKubeLogin(kubeConfig);
+                if (FeatureToggle.KubernetesAksKubeloginFeatureToggle.IsEnabled(deploymentVariables))
+                {
+                    kubeLogin.ConfigureAksKubeLogin(kubeConfig);
+                }
             }
 
             return true;

--- a/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
@@ -49,7 +49,7 @@ namespace Calamari.Kubernetes.Authentication
                 var azureCluster = deploymentVariables.Get(SpecialVariables.AksClusterName);
                 var azureAdmin = deploymentVariables.GetFlag("Octopus.Action.Kubernetes.AksAdminLogin");
                 azureCli.ConfigureAksKubeCtlAuthentication(kubectlCli, azureResourceGroup, azureCluster, @namespace, kubeConfig, azureAdmin);
-                kubeLogin.ConfigureAksKubeLogin();
+                kubeLogin.ConfigureAksKubeLogin(kubeConfig);
             }
 
             return true;

--- a/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
@@ -32,6 +32,9 @@ namespace Calamari.Kubernetes.Authentication
             if (!azureCli.TrySetAz())
                 return false;
 
+            if (!kubeLogin.TrySetKubeLogin())
+                return false;
+
             var disableAzureCli = deploymentVariables.GetFlag("OctopusDisableAzureCLI");
             if (!disableAzureCli)
             {

--- a/source/Calamari/Kubernetes/Integration/Kubelogin.cs
+++ b/source/Calamari/Kubernetes/Integration/Kubelogin.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing;
+using Calamari.Common.Plumbing.Logging;
+
+namespace Calamari.Kubernetes.Integration
+{
+    public class KubeLogin : CommandLineTool
+    {
+        public KubeLogin(ILog log, ICommandLineRunner commandLineRunner, string workingDirectory, Dictionary<string, string> environmentVars)
+            : base(log, commandLineRunner, workingDirectory, environmentVars)
+        {
+        }
+
+        public bool TrySetKubeLogin()
+        {
+            var result = CalamariEnvironment.IsRunningOnWindows
+                ? ExecuteCommandAndReturnOutput("where", "kubelogin.cmd")
+                : ExecuteCommandAndReturnOutput("which", "kubelogin");
+            
+            var foundExecutable = result.Output.InfoLogs.FirstOrDefault();
+            if (string.IsNullOrEmpty(foundExecutable))
+            {
+                log.Error("Could not find kubelogin. Make sure kubelogin is on the PATH.");
+                return false;
+            }
+
+            ExecutableLocation = foundExecutable.Trim();
+            return true;
+        }
+
+        public void ConfigureAksKubeLogin()
+        {
+            var arguments = new List<string>(new[]
+            {
+                "convert-kubeconfig",
+                "-l",
+                "azurecli"
+            });
+
+            ExecuteCommandAndAssertSuccess(arguments.ToArray());
+        }
+
+        public CommandResult ExecuteCommand(params string[] arguments)
+        {
+            var commandInvocation = new CommandLineInvocation(ExecutableLocation, arguments);
+            return ExecuteCommandAndLogOutput(commandInvocation);
+        }
+        
+        void ExecuteCommandAndAssertSuccess(params string[] arguments)
+        {
+            var result = ExecuteCommand(arguments);
+            result.VerifySuccess();
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Integration/Kubelogin.cs
+++ b/source/Calamari/Kubernetes/Integration/Kubelogin.cs
@@ -39,7 +39,7 @@ namespace Calamari.Kubernetes.Integration
                 "-l",
                 "azurecli",
                 "--kubeconfig",
-                $"{kubeConfigPath}"
+                $"\"{kubeConfigPath}\"",
             });
 
             ExecuteCommandAndAssertSuccess(arguments.ToArray());

--- a/source/Calamari/Kubernetes/Integration/Kubelogin.cs
+++ b/source/Calamari/Kubernetes/Integration/Kubelogin.cs
@@ -31,13 +31,15 @@ namespace Calamari.Kubernetes.Integration
             return true;
         }
 
-        public void ConfigureAksKubeLogin()
+        public void ConfigureAksKubeLogin(string kubeConfigPath)
         {
             var arguments = new List<string>(new[]
             {
                 "convert-kubeconfig",
                 "-l",
-                "azurecli"
+                "azurecli",
+                "--kubeconfig",
+                $"{kubeConfigPath}"
             });
 
             ExecuteCommandAndAssertSuccess(arguments.ToArray());

--- a/source/Calamari/Kubernetes/Integration/Kubelogin.cs
+++ b/source/Calamari/Kubernetes/Integration/Kubelogin.cs
@@ -17,7 +17,7 @@ namespace Calamari.Kubernetes.Integration
         public bool TrySetKubeLogin()
         {
             var result = CalamariEnvironment.IsRunningOnWindows
-                ? ExecuteCommandAndReturnOutput("where", "kubelogin.cmd")
+                ? ExecuteCommandAndReturnOutput("where", "kubelogin")
                 : ExecuteCommandAndReturnOutput("which", "kubelogin");
             
             var foundExecutable = result.Output.InfoLogs.FirstOrDefault();

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -153,7 +153,8 @@ namespace Calamari.Kubernetes
             if (isUsingAzureServicePrincipalAuth)
             {
                 var azureCli = new AzureCli(log, commandLineRunner, workingDirectory, environmentVars);
-                var azureAuth = new AzureKubernetesServicesAuth(azureCli, kubectl, variables);
+                var kubeloginCli = new KubeLogin(log, commandLineRunner, workingDirectory, environmentVars);
+                var azureAuth = new AzureKubernetesServicesAuth(azureCli, kubectl, kubeloginCli, variables);
 
                 if (!azureAuth.TryConfigure(@namespace, kubeConfig))
                     return false;


### PR DESCRIPTION
Adds support for [Kubelogin](https://github.com/Azure/kubelogin) to AKS cluster authentication. This is done using the [convert-kubeconfig](https://azure.github.io/kubelogin/cli/convert-kubeconfig.html) command and will require kubelogin to be on path for all AKS deployments. 

Kubelogin can be installed simply by running `az aks install-cli`, for further details see https://azure.github.io/kubelogin/install.html. 

## Results
Executing locally with kubelogin for aad-rbac aks cluster
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/c1e61693-375c-4ce3-9275-63d1408482c4)

In Execution containers (Windows 5.1.0) for AAD rbac and rbac 
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/36f5ad3f-4c19-4b43-a68d-91c88141f33f)

Execution containers (Ubuntu 5.1.0) 
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/3fc63dab-cc28-42cc-b5ad-2a2b3582bba3)




