### PR TITLE
Fix resource status on raw yaml command

### DIFF
--- a/source/Calamari/Kubernetes/Conventions/ResourceStatusReportConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/ResourceStatusReportConvention.cs
@@ -18,7 +18,7 @@ namespace Calamari.Kubernetes.Conventions
 
         public void Install(RunningDeployment deployment)
         {
-            statusReportExecutor.ReportStatus(deployment.CurrentDirectory, commandLineRunner);
+            statusReportExecutor.ReportStatus(deployment.CurrentDirectory, commandLineRunner, deployment.EnvironmentVariables);
         }
     }
 }


### PR DESCRIPTION
After [this change](https://github.com/OctopusDeploy/Calamari/pull/1034), we need to ensure that the existing EnvironmentVariables are passed in as the `KUBECONFIG` variable is no long set again in the Resource Status Executor.