### PR TITLE
Make python script outputs unbuffered

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Python/PythonBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Python/PythonBootstrapper.cs
@@ -33,7 +33,7 @@ namespace Calamari.Common.Features.Scripting.Python
         {
             var encryptionKey = ToHex(AesEncryption.GetEncryptionKey(SensitiveVariablePassword));
             var commandArguments = new StringBuilder();
-            commandArguments.Append($"\"{bootstrapFile}\" {scriptParameters} \"{encryptionKey}\"");
+            commandArguments.Append($"\"-u\" \"{bootstrapFile}\" {scriptParameters} \"{encryptionKey}\"");
             return commandArguments.ToString();
         }
 


### PR DESCRIPTION
Python's output is buffered by default. This causes confusing logs, and octopus-provided functions, such as `update_progress()` to not function correctly from buffering.

To solve this issue, there are a two notable solutions:
1. Passing in the `-u` flag to the python executable when executing scripts
2. Setting the environment variable `PYTHONUNBUFFERED` to a non-empty string on the execution environment.

Option 1 is chosen to mimic the behaviours of other script outputs in Octopus.

[sc-38940]