### PR TITLE
NuGet packages containing a plus symbol now hit the package cache

### DIFF
--- a/source/Calamari.Common/Features/Packages/PackageFileNameMetadata.cs
+++ b/source/Calamari.Common/Features/Packages/PackageFileNameMetadata.cs
@@ -5,15 +5,17 @@ namespace Calamari.Common.Features.Packages
 {
     public class PackageFileNameMetadata
     {
-        public PackageFileNameMetadata(string packageId, IVersion version, string extension)
+        public PackageFileNameMetadata(string packageId, IVersion version, IVersion fileVersion, string extension)
         {
             PackageId = packageId;
             Version = version;
+            FileVersion = fileVersion;
             Extension = extension;
         }
 
         public string PackageId { get; }
         public IVersion Version { get; }
+        public IVersion FileVersion { get; }
         public string Extension { get; }
     }
 }

--- a/source/Calamari.Common/Features/Packages/PackageName.cs
+++ b/source/Calamari.Common/Features/Packages/PackageName.cs
@@ -157,10 +157,11 @@ namespace Calamari.Common.Features.Packages
         {
             var fileName = Path.GetFileName(path) ?? "";
 
-            if (!TryParseEncodedFileName(fileName, out var packageId, out var version, out var extension) &&
-                !TryParseUnsafeFileName(fileName, out packageId, out version, out extension))
+            if (!TryParseEncodedFileName(fileName, out var packageId, out var fileVersion, out var extension) &&
+                !TryParseUnsafeFileName(fileName, out packageId, out fileVersion, out extension))
                 throw new Exception($"Unexpected file format in {fileName}.\nExpected Octopus cached file format: `<PackageId>{SectionDelimiter}<Version>{SectionDelimiter}<CacheBuster>.<Extension>` or `<PackageId>.<SemverVersion>.<Extension>`");
 
+            var version = fileVersion;
             //TODO: Extract... Obviously _could_ be an issue for .net core
             if (extension.Equals(".nupkg", StringComparison.OrdinalIgnoreCase) && File.Exists(path))
             {
@@ -172,7 +173,7 @@ namespace Calamari.Common.Features.Packages
                 packageId = metaData.Id;
             }
 
-            return new PackageFileNameMetadata(packageId, version, extension);
+            return new PackageFileNameMetadata(packageId, version, fileVersion, extension);
         }
         
         public static bool TryMatchTarExtensions(string fileName, out string strippedFileName, out string extension)

--- a/source/Calamari.Common/Features/Packages/PackagePhysicalFileMetadata.cs
+++ b/source/Calamari.Common/Features/Packages/PackagePhysicalFileMetadata.cs
@@ -7,7 +7,7 @@ namespace Calamari.Common.Features.Packages
     public class PackagePhysicalFileMetadata : PackageFileNameMetadata
     {
         public PackagePhysicalFileMetadata(PackageFileNameMetadata identity, string fullFilePath, string hash, long size)
-            : base(identity.PackageId, identity.Version, identity.Extension)
+            : base(identity.PackageId, identity.Version, identity.FileVersion, identity.Extension)
         {
             FullFilePath = fullFilePath;
             Hash = hash;

--- a/source/Calamari.Shared/Integration/Certificates/FileSystem/PackageStore.cs
+++ b/source/Calamari.Shared/Integration/Certificates/FileSystem/PackageStore.cs
@@ -46,8 +46,10 @@ namespace Calamari.Integration.FileSystem
                 if (packageNameMetadata == null)
                     continue;
 
-                if (!string.Equals(packageNameMetadata.PackageId, packageId, StringComparison.OrdinalIgnoreCase) ||
-                    !packageNameMetadata.Version.Equals(version))
+                if (!string.Equals(packageNameMetadata.PackageId, packageId, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                
+                if (!packageNameMetadata.Version.Equals(version) && !packageNameMetadata.FileVersion.Equals(version))
                     continue;
 
                 var physicalPackageMetadata = PackagePhysicalFileMetadata.Build(file, packageNameMetadata);

--- a/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
@@ -78,7 +78,7 @@ namespace Calamari.Integration.Packages.Download
             PerformPull(fullImageName);
             
             var (hash, size) = GetImageDetails(fullImageName);
-            return new PackagePhysicalFileMetadata(new PackageFileNameMetadata(packageId, version, ""), string.Empty, hash, size);
+            return new PackagePhysicalFileMetadata(new PackageFileNameMetadata(packageId, version, version, ""), string.Empty, hash, size);
         }
 
         static string GetFullImageName(string packageId, IVersion version, Uri feedUri)

--- a/source/Calamari/Commands/FindPackageCommand.cs
+++ b/source/Calamari/Commands/FindPackageCommand.cs
@@ -94,7 +94,7 @@ namespace Calamari.Commands
                 log.VerboseFormat("  - {0}: {1}", nearestPackage.Version, nearestPackage.FullFilePath);
                 LogPackageFound(
                     nearestPackage.PackageId,
-                    nearestPackage.Version,
+                    nearestPackage.FileVersion,
                     nearestPackage.Hash,
                     nearestPackage.Extension,
                     nearestPackage.FullFilePath,

--- a/source/Calamari/Commands/FindPackageCommand.cs
+++ b/source/Calamari/Commands/FindPackageCommand.cs
@@ -69,7 +69,7 @@ namespace Calamari.Commands
             log.VerboseFormat("Package {0} {1} hash {2} has already been uploaded", package.PackageId, package.Version, package.Hash);
             LogPackageFound(
                 package.PackageId,
-                package.Version,
+                package.FileVersion,
                 package.Hash,
                 package.Extension,
                 package.FullFilePath,


### PR DESCRIPTION
NuGet packages with a + in their version were not hitting the package cache. This is because we crack open the NuGet manifest and retrieve the package version from there, which does not support build metadata in versions. So, a version like `1.0.0-alpha+test` would be parsed as `1.0.0-alpha`.
Our cache uses a file naming convention that includes the semantic version in the name of the file. We use this method for all package types other than NuGet. This PR adds new property that stores the version as parsed from the file name and uses that instead of the NuGet version when searching the package cache. The change is additive, so existing code paths that rely on the version parsed from the manifest remain intact.

Exact matches now work:
```
Package Plus 1.0.0-alpha.6 hash c553f4112095502bd73d38f1de487c4a69879fc8 has already been uploaded
```

Performing deltas also work:
```
 Found 1 earlier version of Plus on this Tentacle
      - 1.0.0-alpha.6: C:\Octopus\Files\Plus@S1.0.0-alpha.6+test@B5CD92FFE87F0D41A4968B9DC6271902.nupkg
Found matching version 1.0.0-alpha.6+test: C:\OctopusDev\master\Server\Packages\Spaces-1\feeds-builtin\Plus\Plus.1.0.0-alpha.6+test.nupkg
```
