### PR TITLE
Make python's get_octopusvariable return empty string if not existing

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Python/Configuration.py
+++ b/source/Calamari.Common/Features/Scripting/Python/Configuration.py
@@ -21,7 +21,7 @@ def decrypt(encrypted, iv):
     return decrypted.decode('utf-8')
 
 def get_octopusvariable(key):
-    return octopusvariables[key]
+    return octopusvariables.get(key, "")
 
 def set_octopusvariable(name, value, sensitive=False):
     octopusvariables[name] = value


### PR DESCRIPTION
Python and bash have different behaviours with `get_octopusvariable`; If the variable doesn't exist, bash will return an empty string whereas python will throw an error, failing the script. 

To replicate, use the following scripts for Run a Script:
```
# python script
print("Color from pound-braces #{Color}")
print("Color from get_octopusvariable "+get_octopusvariable("Color"))
```
```
# bash script
echo "Color from pound-braces #{Color}"
echo "Get Octopus Variable for Color: " $(get_octopusvariable "Color")
```

This is a simple fix to make the behaviour consistent in python. Related: #217

[sc-49511]

**Before**
![image](https://github.com/OctopusDeploy/Calamari/assets/97423717/808ff3f1-aa50-412d-8f72-a4cb3babc0cf)

**After**
<img width="1439" alt="image" src="https://github.com/OctopusDeploy/Calamari/assets/97423717/777c2143-2026-4f0a-9374-c6615b84afe6">