### PR TITLE
Fix logger causing null ref exception when logging null

### DIFF
--- a/source/Calamari.Common/Plumbing/Logging/Log.cs
+++ b/source/Calamari.Common/Plumbing/Logging/Log.cs
@@ -91,8 +91,9 @@ namespace Calamari.Common.Plumbing.Logging
         protected abstract void StdOut(string message);
         protected abstract void StdErr(string message);
 
-        protected string ProcessRedactions(string message)
+        protected string ProcessRedactions(string? message)
         {
+            message = message ?? string.Empty;
             lock (sync)
             {
                 return redactionMap.Aggregate(message, (current, pair) => current.Replace(pair.Key, pair.Value));

--- a/source/Calamari.Common/Plumbing/Logging/Log.cs
+++ b/source/Calamari.Common/Plumbing/Logging/Log.cs
@@ -93,7 +93,9 @@ namespace Calamari.Common.Plumbing.Logging
 
         protected string ProcessRedactions(string? message)
         {
-            message = message ?? string.Empty;
+            if (message == null)
+                return string.Empty;
+
             lock (sync)
             {
                 return redactionMap.Aggregate(message, (current, pair) => current.Replace(pair.Key, pair.Value));


### PR DESCRIPTION
Found a bug in my travels where if you log `null` it will blow up with a null ref which is obviously pretty bad 😅 

[sc-47324]