### PR TITLE
Add extra check to ensure that the AWSScriptWrapper runs for aws script steps

### DIFF
--- a/source/Calamari.Aws/Deployment/AwsSpecialVariables.cs
+++ b/source/Calamari.Aws/Deployment/AwsSpecialVariables.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Calamari.Aws.Deployment
+﻿namespace Calamari.Aws.Deployment
 {
     public static class AwsSpecialVariables
     {
@@ -13,6 +7,7 @@ namespace Calamari.Aws.Deployment
         public static class Authentication
         {
             public static readonly string UseInstanceRole = "Octopus.Action.AwsAccount.UseInstanceRole";
+            public static readonly string AwsAccountVariable = "Octopus.Action.AwsAccount.Variable";
         }
 
         public static class S3

--- a/source/Calamari.Aws/Integration/AwsScriptWrapper.cs
+++ b/source/Calamari.Aws/Integration/AwsScriptWrapper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Calamari.Aws.Deployment;
 using Calamari.CloudAccounts;
@@ -11,6 +10,7 @@ using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment;
+using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Aws.Integration
 {
@@ -23,8 +23,10 @@ namespace Calamari.Aws.Integration
         bool IScriptWrapper.IsEnabled(ScriptSyntax syntax)
         {
             var accountType = variables.Get(SpecialVariables.Account.AccountType);
+            var awsAccountVariable = variables.Get(AwsSpecialVariables.Authentication.AwsAccountVariable);
             var useAwsInstanceRole = variables.Get(AwsSpecialVariables.Authentication.UseInstanceRole);
             return accountType == "AmazonWebServicesAccount" ||
+                !awsAccountVariable.IsNullOrEmpty() ||
                 string.Equals(useAwsInstanceRole, bool.TrueString, StringComparison.InvariantCultureIgnoreCase);
         }
 


### PR DESCRIPTION
A Windows E2E test started failing after I merged my change to remove Extensions into master because it was deploying an AWS Script. 

The AWS Script utilises the `AwsScriptWrapper` where before it was always enabled if it was side loaded via an extension, now it's always loaded but won't execute unless the right variables are set. The Aws Script Step doesn't set the AccountType variable so I also have to check the AwsAccount.Variable variable, to ensure that there is account creds there so that the script wrapper can run.

Removal of Extensions PRs:
Server: https://github.com/OctopusDeploy/OctopusDeploy/pull/18227
Calamari: https://github.com/OctopusDeploy/Calamari/pull/1035