### PR TITLE
Use local manifest instead of global install

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "gitversion.tool": {
+      "version": "5.12.0",
+      "commands": [
+        "dotnet-gitversion"
+      ]
+    }
+  }
+}

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "octonotes"
       ]
+    },
+    "dotnet-affected": {
+      "version": "3.1.1",
+      "commands": [
+        "dotnet-affected"
+      ]
     }
   }
 }

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "dotnet-gitversion"
       ]
+    },
+    "octonotes.tool": {
+      "version": "0.1.171",
+      "commands": [
+        "octonotes"
+      ]
     }
   }
 }


### PR DESCRIPTION
We have a few steps that install tools globally onto the build agent. This is fragile in various ways.

- The agent could have a different version already installed that prevents our required version from being installed
- Other projects might require different versions of these tools

This PR follows the advise from https://octopusdeploy.slack.com/archives/C01HH8T16G3/p1685416563390079 and installs `gitversion`,  `octonotes` and `dotnet-affected` using a tool-manifest. These are used in different build steps.

Ideally we should improve the existing nuke build and just use that. This'll need some work first.

The global installs will continue to work so branches created before this change have time to pass and merge. After some time we need to update TC steps to use the manifest.