### PR TITLE
Fix structured variable replacement

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -65,7 +65,7 @@
         <PackageReference Include="Octostache" Version="3.3.0" />
         <PackageReference Include="SharpCompress" Version="0.24.0" />
         <PackageReference Include="XPath2" Version="1.0.12" />
-        <PackageReference Include="YamlDotNet" Version="8.1.2" />
+        <PackageReference Include="YamlDotNet" Version="13.1.0" />
         <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     </ItemGroup>
 

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -66,7 +66,6 @@
         <PackageReference Include="SharpCompress" Version="0.24.0" />
         <PackageReference Include="XPath2" Version="1.0.12" />
         <PackageReference Include="YamlDotNet" Version="13.1.0" />
-        <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -105,7 +105,7 @@ namespace Calamari.Common.Features.Scripting.Bash
             File.WriteAllText(scriptFilePath, text);
         }
 
-        public static (string bootstrapFile, string[] temporaryFiles) PrepareBootstrapFile(Script script, string configurationFile, string workingDirectory, IVariables variables)
+        public static BootstrapFiles PrepareBootstrapFile(Script script, string configurationFile, string workingDirectory, IVariables variables)
         {
             var bootstrapFile = Path.Combine(workingDirectory, "Bootstrap." + Guid.NewGuid().ToString().Substring(10) + "." + Path.GetFileName(script.File));
             var scriptModulePaths = PrepareScriptModules(variables, workingDirectory).ToArray();
@@ -123,7 +123,7 @@ namespace Calamari.Common.Features.Scripting.Bash
 
             File.SetAttributes(bootstrapFile, FileAttributes.Hidden);
             EnsureValidUnixFile(script.File);
-            return (bootstrapFile, scriptModulePaths);
+            return new BootstrapFiles(bootstrapFile, scriptModulePaths);
         }
 
         static IEnumerable<string> PrepareScriptModules(IVariables variables, string workingDirectory)

--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptExecutor.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptExecutor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Calamari.Common.Features.Processes;
@@ -15,11 +14,11 @@ namespace Calamari.Common.Features.Scripting.Bash
         {
             var workingDirectory = Path.GetDirectoryName(script.File);
             var configurationFile = BashScriptBootstrapper.PrepareConfigurationFile(workingDirectory, variables);
-            var (bootstrapFile, otherTemporaryFiles) = BashScriptBootstrapper.PrepareBootstrapFile(script, configurationFile, workingDirectory, variables);
+            var bootstrapFiles = BashScriptBootstrapper.PrepareBootstrapFile(script, configurationFile, workingDirectory, variables);
 
             var invocation = new CommandLineInvocation(
                 BashScriptBootstrapper.FindBashExecutable(),
-                BashScriptBootstrapper.FormatCommandArguments(Path.GetFileName(bootstrapFile))
+                BashScriptBootstrapper.FormatCommandArguments(Path.GetFileName(bootstrapFiles.BootstrapFile))
             )
             {
                 WorkingDirectory = workingDirectory,
@@ -28,7 +27,7 @@ namespace Calamari.Common.Features.Scripting.Bash
 
             yield return new ScriptExecution(
                 invocation,
-                otherTemporaryFiles.Concat(new[] { bootstrapFile, configurationFile })
+                bootstrapFiles.TemporaryFiles.Concat(new[] { bootstrapFiles.BootstrapFile, configurationFile })
             );
         }
     }

--- a/source/Calamari.Common/Features/Scripting/BootstrapFiles.cs
+++ b/source/Calamari.Common/Features/Scripting/BootstrapFiles.cs
@@ -1,0 +1,14 @@
+namespace Calamari.Common.Features.Scripting
+{
+    public class BootstrapFiles
+    {
+        public string BootstrapFile { get; }
+        public string[] TemporaryFiles { get; }
+
+        public BootstrapFiles(string bootstrapFile, string[] temporaryFiles)
+        {
+            BootstrapFile = bootstrapFile;
+            TemporaryFiles = temporaryFiles;
+        }
+    }
+}

--- a/source/Calamari.Common/Features/Scripting/FSharp/FSharpBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/FSharp/FSharpBootstrapper.cs
@@ -48,7 +48,7 @@ namespace Calamari.Common.Features.Scripting.FSharp
             return commandArguments.ToString();
         }
 
-        public static (string bootstrapFile, string[] temporaryFiles) PrepareBootstrapFile(string scriptFilePath, string configurationFile, string workingDirectory, IVariables variables)
+        public static BootstrapFiles PrepareBootstrapFile(string scriptFilePath, string configurationFile, string workingDirectory, IVariables variables)
         {
             var bootstrapFile = Path.Combine(workingDirectory, "Bootstrap." + Guid.NewGuid().ToString().Substring(10) + "." + Path.GetFileName(scriptFilePath));
             var scriptModulePaths = PrepareScriptModules(variables, workingDirectory).ToArray();
@@ -64,7 +64,7 @@ namespace Calamari.Common.Features.Scripting.FSharp
             }
 
             File.SetAttributes(bootstrapFile, FileAttributes.Hidden);
-            return (bootstrapFile, scriptModulePaths);
+            return new BootstrapFiles(bootstrapFile, scriptModulePaths);
         }
 
         static IEnumerable<string> PrepareScriptModules(IVariables variables, string workingDirectory)

--- a/source/Calamari.Common/Features/Scripting/FSharp/FSharpExecutor.cs
+++ b/source/Calamari.Common/Features/Scripting/FSharp/FSharpExecutor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Calamari.Common.Features.Processes;
@@ -16,8 +15,8 @@ namespace Calamari.Common.Features.Scripting.FSharp
             var workingDirectory = Path.GetDirectoryName(script.File);
             var executable = FSharpBootstrapper.FindExecutable();
             var configurationFile = FSharpBootstrapper.PrepareConfigurationFile(workingDirectory, variables);
-            var (bootstrapFile, otherTemporaryFiles) = FSharpBootstrapper.PrepareBootstrapFile(script.File, configurationFile, workingDirectory, variables);
-            var arguments = FSharpBootstrapper.FormatCommandArguments(bootstrapFile, script.Parameters);
+            var bootstrapFiles = FSharpBootstrapper.PrepareBootstrapFile(script.File, configurationFile, workingDirectory, variables);
+            var arguments = FSharpBootstrapper.FormatCommandArguments(bootstrapFiles.BootstrapFile, script.Parameters);
 
             yield return new ScriptExecution(
                 new CommandLineInvocation(executable, arguments)
@@ -25,7 +24,7 @@ namespace Calamari.Common.Features.Scripting.FSharp
                     WorkingDirectory = workingDirectory,
                     EnvironmentVars = environmentVars
                 },
-                otherTemporaryFiles.Concat(new[] { bootstrapFile, configurationFile })
+                bootstrapFiles.TemporaryFiles.Concat(new[] { bootstrapFiles.BootstrapFile, configurationFile })
             );
         }
     }

--- a/source/Calamari.Common/Features/Scripting/Python/PythonBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Python/PythonBootstrapper.cs
@@ -97,7 +97,7 @@ namespace Calamari.Common.Features.Scripting.Python
             File.WriteAllText(scriptFilePath, text);
         }
 
-        public static (string bootstrapFile, string[] temporaryFiles) PrepareBootstrapFile(Script script, string workingDirectory, string configurationFile, IVariables variables)
+        public static BootstrapFiles PrepareBootstrapFile(Script script, string workingDirectory, string configurationFile, IVariables variables)
         {
             var bootstrapFile = Path.Combine(workingDirectory, "Bootstrap." + Guid.NewGuid().ToString().Substring(10) + "." + Path.GetFileName(script.File));
             var scriptModulePaths = PrepareScriptModules(variables, workingDirectory).ToArray();
@@ -113,7 +113,7 @@ namespace Calamari.Common.Features.Scripting.Python
 
             File.SetAttributes(bootstrapFile, FileAttributes.Hidden);
             EnsureValidUnixFile(script.File);
-            return (bootstrapFile, scriptModulePaths);
+            return new BootstrapFiles(bootstrapFile, scriptModulePaths);
         }
 
         static IEnumerable<string> PrepareScriptModules(IVariables variables, string workingDirectory)

--- a/source/Calamari.Common/Features/Scripting/Python/PythonScriptExecutor.cs
+++ b/source/Calamari.Common/Features/Scripting/Python/PythonScriptExecutor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Calamari.Common.Features.Processes;
@@ -30,8 +29,8 @@ namespace Calamari.Common.Features.Scripting.Python
 
             var configurationFile = PythonBootstrapper.PrepareConfigurationFile(workingDirectory, variables);
 
-            var (bootstrapFile, otherTemporaryFiles) = PythonBootstrapper.PrepareBootstrapFile(script, workingDirectory, configurationFile, variables);
-            var arguments = PythonBootstrapper.FormatCommandArguments(bootstrapFile, script.Parameters);
+            var bootstrapFiles = PythonBootstrapper.PrepareBootstrapFile(script, workingDirectory, configurationFile, variables);
+            var arguments = PythonBootstrapper.FormatCommandArguments(bootstrapFiles.BootstrapFile, script.Parameters);
 
             yield return new ScriptExecution(
                 new CommandLineInvocation(executable, arguments)
@@ -39,7 +38,7 @@ namespace Calamari.Common.Features.Scripting.Python
                     WorkingDirectory = workingDirectory,
                     EnvironmentVars = environmentVars
                 },
-                otherTemporaryFiles.Concat(new[] { bootstrapFile, configurationFile }));
+                bootstrapFiles.TemporaryFiles.Concat(new[] { bootstrapFiles.BootstrapFile, configurationFile }));
         }
     }
 }

--- a/source/Calamari.Common/Features/Scripting/ScriptCS/ScriptCSBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/ScriptCS/ScriptCSBootstrapper.cs
@@ -58,7 +58,7 @@ namespace Calamari.Common.Features.Scripting.ScriptCS
                 .Trim();
         }
 
-        public static (string bootstrapFile, string[] temporaryFiles) PrepareBootstrapFile(string scriptFilePath, string configurationFile, string workingDirectory, IVariables variables)
+        public static BootstrapFiles PrepareBootstrapFile(string scriptFilePath, string configurationFile, string workingDirectory, IVariables variables)
         {
             var bootstrapFile = Path.Combine(workingDirectory, "Bootstrap." + Guid.NewGuid().ToString().Substring(10) + "." + Path.GetFileName(scriptFilePath));
             var scriptModulePaths = PrepareScriptModules(variables, workingDirectory).ToArray();
@@ -73,7 +73,7 @@ namespace Calamari.Common.Features.Scripting.ScriptCS
             }
 
             File.SetAttributes(bootstrapFile, FileAttributes.Hidden);
-            return (bootstrapFile, scriptModulePaths);
+            return new BootstrapFiles(bootstrapFile, scriptModulePaths);
         }
 
         static IEnumerable<string> PrepareScriptModules(IVariables variables, string workingDirectory)

--- a/source/Calamari.Common/Features/Scripting/ScriptCS/ScriptCSScriptExecutor.cs
+++ b/source/Calamari.Common/Features/Scripting/ScriptCS/ScriptCSScriptExecutor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Calamari.Common.Features.Processes;
@@ -16,8 +15,8 @@ namespace Calamari.Common.Features.Scripting.ScriptCS
             var workingDirectory = Path.GetDirectoryName(script.File);
             var executable = ScriptCSBootstrapper.FindExecutable();
             var configurationFile = ScriptCSBootstrapper.PrepareConfigurationFile(workingDirectory, variables);
-            var (bootstrapFile, otherTemporaryFiles) = ScriptCSBootstrapper.PrepareBootstrapFile(script.File, configurationFile, workingDirectory, variables);
-            var arguments = ScriptCSBootstrapper.FormatCommandArguments(bootstrapFile, script.Parameters);
+            var bootstrapFiles = ScriptCSBootstrapper.PrepareBootstrapFile(script.File, configurationFile, workingDirectory, variables);
+            var arguments = ScriptCSBootstrapper.FormatCommandArguments(bootstrapFiles.BootstrapFile, script.Parameters);
 
             yield return new ScriptExecution(
                 new CommandLineInvocation(executable, arguments)
@@ -25,7 +24,7 @@ namespace Calamari.Common.Features.Scripting.ScriptCS
                     WorkingDirectory = workingDirectory,
                     EnvironmentVars = environmentVars
                 },
-                otherTemporaryFiles.Concat(new[] { bootstrapFile, configurationFile })
+                bootstrapFiles.TemporaryFiles.Concat(new[] { bootstrapFiles.BootstrapFile, configurationFile })
             );
         }
     }

--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/PowerShellScriptExecutor.cs
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/PowerShellScriptExecutor.cs
@@ -20,11 +20,11 @@ namespace Calamari.Common.Features.Scripting.WindowsPowerShell
         {
             var powerShellBootstrapper = GetPowerShellBootstrapper(variables);
 
-            var (bootstrapFile, otherTemporaryFiles) = powerShellBootstrapper.PrepareBootstrapFile(script, variables);
+            var bootstrapFiles = powerShellBootstrapper.PrepareBootstrapFile(script, variables);
             var debuggingBootstrapFile = powerShellBootstrapper.PrepareDebuggingBootstrapFile(script);
 
             var executable = powerShellBootstrapper.PathToPowerShellExecutable(variables);
-            var arguments = powerShellBootstrapper.FormatCommandArguments(bootstrapFile, debuggingBootstrapFile, variables);
+            var arguments = powerShellBootstrapper.FormatCommandArguments(bootstrapFiles.BootstrapFile, debuggingBootstrapFile, variables);
 
             var invocation = new CommandLineInvocation(executable, arguments)
             {
@@ -38,7 +38,7 @@ namespace Calamari.Common.Features.Scripting.WindowsPowerShell
             {
                 new ScriptExecution(
                     invocation,
-                    otherTemporaryFiles.Concat(new[] { bootstrapFile, debuggingBootstrapFile })
+                    bootstrapFiles.TemporaryFiles.Concat(new[] { bootstrapFiles.BootstrapFile, debuggingBootstrapFile })
                 )
             };
         }

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -92,7 +92,7 @@ namespace Calamari.Common.Features.StructuredVariables
                             else if (node is YamlNode<SequenceStart> sequenceStart
                                      && variablesByKey.TryGetValue(sequenceStart.Path, out var sequenceReplacement))
                                 structureWeAreReplacing = (sequenceStart, sequenceReplacement());
-                            else if (node is YamlNode<Comment> comment && comment.Event.IsInline)
+                            else if (node is YamlNode<Comment> comment)
                                 structureWeAreReplacing = (comment, null);
                             else
                                 outputEvents.Add(node.Event);

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -106,8 +106,8 @@ namespace Calamari.Common.Features.StructuredVariables
                                 && structureWeAreReplacing.Value.startEvent.Path == node.Path)
                             {
                                 outputEvents.AddRange(ParseFragment(structureWeAreReplacing.Value.replacementValue,
-                                                                    mappingStart.Event.Anchor,
-                                                                    mappingStart.Event.Tag));
+                                                                    mappingStart.Event.Anchor.Value,
+                                                                    mappingStart.Event.Tag.Value));
                                 structureWeAreReplacing = null;
                             }
                             else if (node is YamlNode<SequenceEnd>
@@ -115,8 +115,8 @@ namespace Calamari.Common.Features.StructuredVariables
                                      && structureWeAreReplacing.Value.startEvent.Path == node.Path)
                             {
                                 outputEvents.AddRange(ParseFragment(structureWeAreReplacing.Value.replacementValue,
-                                                                    sequenceStart.Event.Anchor,
-                                                                    sequenceStart.Event.Tag));
+                                                                    sequenceStart.Event.Anchor.Value,
+                                                                    sequenceStart.Event.Tag.Value));
                                 structureWeAreReplacing = null;
                             }
                             else if ((node is YamlNode<MappingStart> || node is YamlNode<SequenceStart>)

--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -93,6 +93,7 @@ namespace Calamari.Common.Features.StructuredVariables
                                      && variablesByKey.TryGetValue(sequenceStart.Path, out var sequenceReplacement))
                                 structureWeAreReplacing = (sequenceStart, sequenceReplacement());
                             else if (node is YamlNode<Comment> comment)
+                                // TODO: remove this hack when https://github.com/aaubry/YamlDotNet/issues/812 is fixed
                                 structureWeAreReplacing = (comment, null);
                             else
                                 outputEvents.Add(node.Event);
@@ -122,6 +123,8 @@ namespace Calamari.Common.Features.StructuredVariables
                             else if ((node is YamlNode<MappingStart> || node is YamlNode<SequenceStart>)
                                      && structureWeAreReplacing.Value.startEvent is YamlNode<Comment>)
                             {
+                                // TODO: remove this hack when https://github.com/aaubry/YamlDotNet/issues/812 is fixed
+                                
                                 // We aren't doing any replacement here, YamlDotNet gives us the comment and the
                                 // mapping/sequence start element in a different order to what we would expect
                                 // (comment first, start element second instead of the other way around),

--- a/source/Calamari.Common/Plumbing/ServiceMessages/ServiceMessage.cs
+++ b/source/Calamari.Common/Plumbing/ServiceMessages/ServiceMessage.cs
@@ -18,17 +18,17 @@ namespace Calamari.Common.Plumbing.ServiceMessages
             this.properties = properties ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
         
-        private ServiceMessage(string name, params (string, string)[] parameters)
+        private ServiceMessage(string name, params KeyValuePair<string, string>[] parameters)
         {
             this.Name = name;
-            this.properties = parameters.ToDictionary(kvp => kvp.Item1, kvp => kvp.Item2);
+            this.properties = parameters.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
         public string Name { get; }
 
         public IDictionary<string, string> Properties => properties;
 
-        public static ServiceMessage Create(string name, params (string, string)[] parameters) =>
+        public static ServiceMessage Create(string name, params KeyValuePair<string, string>[] parameters) =>
             new ServiceMessage(name, parameters);
 
         public string? GetValue(string key)

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -61,7 +61,6 @@
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="Sprache" Version="2.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/source/Calamari.Tests/Fixtures/Logging/LoggingFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Logging/LoggingFixture.cs
@@ -17,7 +17,7 @@ namespace Calamari.Tests.Fixtures.Logging
         public void WriteServiceMessage_CorrectlyFormatsMessages()
         {
             // Arrange
-            var serviceMessage = ServiceMessage.Create("do-it", ("foo", "1"), ("bar", null));
+            var serviceMessage = ServiceMessage.Create("do-it", new KeyValuePair<string, string>("foo", "1"), new KeyValuePair<string, string>("bar", null));
 
             // Testing functionality from abstract base class, so it doesn't matter that this is a test class.
             var sut = new InMemoryLog();

--- a/source/Calamari.Tests/Fixtures/ServiceMessages/ServiceMessageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ServiceMessages/ServiceMessageFixture.cs
@@ -16,7 +16,7 @@ namespace Calamari.Tests.Fixtures.ServiceMessages
         public void ToString_FormatsMessageCorrectly()
         {
             // Arrange
-            var sut = ServiceMessage.Create("my-message-name", ("foo", "my-parameter-value"));
+            var sut = ServiceMessage.Create("my-message-name", new KeyValuePair<string, string>("foo", "my-parameter-value"));
 
             // Act
             var text = sut.ToString();
@@ -30,7 +30,7 @@ namespace Calamari.Tests.Fixtures.ServiceMessages
         public void ToString_IgnoresNullParameters()
         {
             // Arrange
-            var sut = ServiceMessage.Create("my-message-name", ("foo", "1"), ("bar", null));
+            var sut = ServiceMessage.Create("my-message-name", new KeyValuePair<string, string>("foo", "1"), new KeyValuePair<string, string>("bar", null));
 
             // Act
             var text = sut.ToString();

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
@@ -17,7 +17,8 @@ environment: # inline at top level
       arch: x86
 skip_tags: false
 branches:
-  only:
-  - main
-  # - alt
-  - aux
+  # block between mapping key and value
+  only: # inline between mapping key and value
+    - main
+    # - alt
+    - aux

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveTopLevelBlockComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveTopLevelBlockComments.approved.yaml
@@ -1,0 +1,3 @@
+hello:
+  # this is a test
+  - world

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveTopLevelBlockComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveTopLevelBlockComments.approved.yaml
@@ -1,3 +1,0 @@
-hello:
-  # this is a test
-  - world

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
@@ -17,7 +17,8 @@ environment: # inline at top level
     arch: x86
 skip_tags: false
 branches:
-  only:
+  # block between mapping key and value
+  only: # inline between mapping key and value
   - main
   # - alt
   - aux

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -62,7 +62,6 @@
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
-    <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">


### PR DESCRIPTION
[sc-46778]

When a YAML comment is inserted between a mapping key and its value, the YamlDotNet library does not handle the emission of YAML document correctly. Examples are:

```yaml
hello: # comment
  - world
```

becomes 

```yaml
hello # this is a comment:
- world
```

and

```yaml
hello:
  # comment
  - world
```

becomes

```yaml
hello
# this is a comment
:
- world
```

This is an issue with YamlDotNet itself, see: https://github.com/aaubry/YamlDotNet/issues/812.

We were aware of this issue when this piece of code was first written, we used a workaround of reversing the order of the comment node event and the mapping value node event, so that the YamlDotNet emitter emits the correct code.

However, this workaround was only applied to the inline comment case, not the block comment case. So this PR extends the fix to block comments as well.

This PR also bumps the YamlDotNet library to the latest version.
