### PR TITLE
Fix structured variable replacement

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/YamlFormatVariableReplacer.cs
@@ -92,7 +92,7 @@ namespace Calamari.Common.Features.StructuredVariables
                             else if (node is YamlNode<SequenceStart> sequenceStart
                                      && variablesByKey.TryGetValue(sequenceStart.Path, out var sequenceReplacement))
                                 structureWeAreReplacing = (sequenceStart, sequenceReplacement());
-                            else if (node is YamlNode<Comment> comment && comment.Event.IsInline)
+                            else if (node is YamlNode<Comment> comment)
                                 structureWeAreReplacing = (comment, null);
                             else
                                 outputEvents.Add(node.Event);

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
@@ -17,7 +17,8 @@ environment: # inline at top level
       arch: x86
 skip_tags: false
 branches:
-  only:
-  - main
-  # - alt
-  - aux
+  # block between mapping key and value
+  only: # inline between mapping key and value
+    - main
+    # - alt
+    - aux

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveComments.approved.yaml
@@ -17,7 +17,7 @@ environment: # inline at top level
       arch: x86
 skip_tags: false
 branches:
-  # block between mapping key and value
+# block between mapping key and value
   only: # inline between mapping key and value
     - main
     # - alt

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveTopLevelBlockComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveTopLevelBlockComments.approved.yaml
@@ -1,0 +1,3 @@
+hello:
+  # this is a test
+  - world

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveTopLevelBlockComments.approved.yaml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Approved/YamlVariableReplacerFixture.ShouldPreserveTopLevelBlockComments.approved.yaml
@@ -1,3 +1,0 @@
-hello:
-  # this is a test
-  - world

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/Samples/comments.yml
@@ -17,7 +17,8 @@ environment: # inline at top level
     arch: x86
 skip_tags: false
 branches:
-  only:
+  # block between mapping key and value
+  only: # inline between mapping key and value
   - main
   # - alt
   - aux


### PR DESCRIPTION
[sc-46778]

When a YAML comment is inserted between a mapping key and its value, the YamlDotNet library does not handle the emission of YAML document correctly. Examples are:

```yaml
hello: # comment
  - world
 ```

becomes

```yaml
hello # this is a comment:
- world
```

and

```yaml
hello:
  # comment
  - world
```

becomes

```yaml
hello
# this is a comment
:
- world
```

This is an issue with YamlDotNet itself, see: https://github.com/aaubry/YamlDotNet/issues/812.

We were aware of this issue when this piece of code was first written, we used a workaround of reversing the order of the comment node event and the mapping value node event, so that the YamlDotNet emitter emits the correct code.

However, this workaround was only applied to the inline comment case, not the block comment case. So this PR extends the fix to block comments as well.