### PR TITLE
Remove ReleaseNotes from PackCalamariConsolidatedNugetPackage

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -478,16 +478,13 @@ namespace Calamari.Build
         Target PackCalamariConsolidatedNugetPackage =>
             _ => _.DependsOn(PackageConsolidatedCalamariZip)
                   .Executes(() =>
-                            {
-                                var releaseNotes = IsLocalBuild ? "Local" : File.ReadAllText(RootDirectory / "releasenotes" / "ReleaseNotes.md");
-                                
-                                NuGetPack(s => s.SetTargetPath(BuildDirectory / "Calamari.Consolidated.nuspec")
-                                            .SetProperty("releaseNotes", releaseNotes)
-                                            .SetBasePath(BuildDirectory)
-                                            .SetVersion(NugetVersion.Value)
-                                            .SetOutputDirectory(ArtifactsDirectory));
-                            });
-        
+                  {
+                      NuGetPack(s => s.SetTargetPath(BuildDirectory / "Calamari.Consolidated.nuspec")
+                                      .SetBasePath(BuildDirectory)
+                                      .SetVersion(NugetVersion.Value)
+                                      .SetOutputDirectory(ArtifactsDirectory));
+                  });
+
         Target UpdateCalamariVersionOnOctopusServer =>
             _ =>
                 _.OnlyWhenStatic(() => SetOctopusServerVersion)


### PR DESCRIPTION
This should fix the build after the ReleaseNotes snapshot dependency and artifact dependency were removed from the team city build.