### PR TITLE
Remove feature toggle for kos

### DIFF
--- a/source/Calamari.Shared/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Shared/FeatureToggles/FeatureToggle.cs
@@ -7,7 +7,6 @@
     /// </summary>
     public enum FeatureToggle {
         SkunkworksFeatureToggle,
-        KubernetesDeploymentStatusFeatureToggle,
         MultiGlobPathsForRawYamlFeatureToggle
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -110,9 +110,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Kubernetes.DeploymentTimeout", "180");
             variables.Set("Octopus.Action.Kubernetes.StabilizationTimeout", "10");
 
-            variables.SetFeatureToggles(
-                FeatureToggle.KubernetesDeploymentStatusFeatureToggle,
-                FeatureToggle.MultiGlobPathsForRawYamlFeatureToggle);
+            variables.SetFeatureToggles(FeatureToggle.MultiGlobPathsForRawYamlFeatureToggle);
 
             var fileSystem = new TestCalamariPhysicalFileSystem();
 

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportExecutorTests.cs
@@ -229,7 +229,6 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
 
          private static void AddKubernetesStatusCheckVariables(IVariables variables)
          {
-             variables.Set(Deployment.SpecialVariables.EnabledFeatureToggles, "KubernetesDeploymentStatusFeatureToggle");
              variables.Set(SpecialVariables.ClusterUrl, "https://localhost");
              variables.Set(SpecialVariables.ResourceStatusCheck, "True");
          }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -25,11 +25,6 @@ namespace Calamari.Kubernetes.ResourceStatus
 
         public bool IsEnabled(ScriptSyntax syntax)
         {
-            if (!FeatureToggle.KubernetesDeploymentStatusFeatureToggle.IsEnabled(variables))
-            {
-                return false;
-            }
-
             var resourceStatusEnabled = variables.GetFlag(SpecialVariables.ResourceStatusCheck);
             var isBlueGreen = variables.Get(SpecialVariables.DeploymentStyle) == "bluegreen";
             var isWaitDeployment = variables.Get(SpecialVariables.DeploymentWait) == "wait";


### PR DESCRIPTION
Part of [sc-47429]

This PR removes the feature toggle for Kubernetes Object Status Checks, so it is enabled by default in Calamari.