### PR TITLE
Make sure we don't check for config maps and secrets that do not exist

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -478,15 +478,12 @@ namespace Calamari.Build
         Target PackCalamariConsolidatedNugetPackage =>
             _ => _.DependsOn(PackageConsolidatedCalamariZip)
                   .Executes(() =>
-                            {
-                                var releaseNotes = IsLocalBuild ? "Local" : File.ReadAllText(RootDirectory / "releasenotes" / "ReleaseNotes.md");
-                                
-                                NuGetPack(s => s.SetTargetPath(BuildDirectory / "Calamari.Consolidated.nuspec")
-                                            .SetProperty("releaseNotes", releaseNotes)
-                                            .SetBasePath(BuildDirectory)
-                                            .SetVersion(NugetVersion.Value)
-                                            .SetOutputDirectory(ArtifactsDirectory));
-                            });
+                  {
+                      NuGetPack(s => s.SetTargetPath(BuildDirectory / "Calamari.Consolidated.nuspec")
+                          .SetBasePath(BuildDirectory)
+                          .SetVersion(NugetVersion.Value)
+                          .SetOutputDirectory(ArtifactsDirectory));
+                  });
         
         Target UpdateCalamariVersionOnOctopusServer =>
             _ =>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -399,6 +399,7 @@ namespace Calamari.Build
                               var publishedLocation =
                                   DoPublish("Calamari.Tests", Frameworks.Net60, nugetVersion, rid);
                               var zipName = $"Calamari.Tests.{rid}.{nugetVersion}.zip";
+                              File.Copy(RootDirectory / "global.json", publishedLocation / "global.json");
                               CompressionTasks.Compress(publishedLocation, ArtifactsDirectory / zipName);
                           });
 

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportExecutorTests.cs
@@ -120,7 +120,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
          }
 
          [Test]
-         public void FindsConfigMapsDeployedInADeployContainerStep()
+         public void FindsConfigMapsDeployedInADeployContainerStepWhenConfigMapDataIsNotEmpty()
          {
              var variables = new CalamariVariables();
              var log = new SilentLog();
@@ -131,6 +131,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
              AddKubernetesStatusCheckVariables(variables);
              variables.Set("Octopus.Action.KubernetesContainers.KubernetesConfigMapEnabled", "True");
              variables.Set("Octopus.Action.KubernetesContainers.ComputedConfigMapName", configMapName);
+             variables.Set("Octopus.Action.KubernetesContainers.ConfigMapData[1].FileName", "1");
 
              var tempDirectory = fileSystem.CreateTemporaryDirectory();
              try
@@ -156,9 +157,83 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                  fileSystem.DeleteDirectory(tempDirectory);
              }
          }
+         
+         [Test]
+         public void SkipsConfigMapsInADeployContainerStepWhenConfigMapDataIsNotSet()
+         {
+             var variables = new CalamariVariables();
+             var log = new SilentLog();
+             var fileSystem = new TestCalamariPhysicalFileSystem();
+             var statusChecker = new MockResourceStatusChecker();
+
+             const string configMapName = "ConfigMap-Deployment-01";
+             AddKubernetesStatusCheckVariables(variables);
+             variables.Set("Octopus.Action.KubernetesContainers.KubernetesConfigMapEnabled", "True");
+             variables.Set("Octopus.Action.KubernetesContainers.ComputedConfigMapName", configMapName);
+
+             var tempDirectory = fileSystem.CreateTemporaryDirectory();
+             try
+             {
+                 fileSystem.SetFileBasePath(tempDirectory);
+
+                 var wrapper = new ResourceStatusReportWrapper(variables, new ResourceStatusReportExecutor(variables, log, fileSystem, statusChecker));
+                 wrapper.NextWrapper = new StubScriptWrapper().Enable();
+
+                 wrapper.ExecuteScript(
+                     new Script("stub"),
+                     Syntax,
+                     new CommandLineRunner(log, variables),
+                     new Dictionary<string, string>());
+
+                 statusChecker.CheckedResources.Should().BeEmpty();
+             }
+             finally
+             {
+                 fileSystem.DeleteDirectory(tempDirectory);
+             }
+         }
 
          [Test]
-         public void FindsSecretsDeployedInADeployContainerStep()
+         public void FindsSecretsDeployedInADeployContainerStepWhenSecretDataIsSet()
+         {
+             var variables = new CalamariVariables();
+             var log = new SilentLog();
+             var fileSystem = new TestCalamariPhysicalFileSystem();
+             var statusChecker = new MockResourceStatusChecker();
+
+             const string secret = "Secret-Deployment-01";
+             AddKubernetesStatusCheckVariables(variables);
+             variables.Set("Octopus.Action.KubernetesContainers.KubernetesSecretEnabled", "True");
+             variables.Set("Octopus.Action.KubernetesContainers.ComputedSecretName", secret);             
+             variables.Set("Octopus.Action.KubernetesContainers.SecretData[1].FileName", "1");
+
+             var tempDirectory = fileSystem.CreateTemporaryDirectory();
+             try
+             {
+                 fileSystem.SetFileBasePath(tempDirectory);
+
+                 var wrapper = new ResourceStatusReportWrapper(variables, new ResourceStatusReportExecutor(variables, log, fileSystem, statusChecker));
+                 wrapper.NextWrapper = new StubScriptWrapper().Enable();
+
+                 wrapper.ExecuteScript(
+                     new Script("stub"),
+                     Syntax,
+                     new CommandLineRunner(log, variables),
+                     new Dictionary<string, string>());
+
+                 statusChecker.CheckedResources.Should().BeEquivalentTo(new[]
+                 {
+                     new ResourceIdentifier("Secret", secret, "default")
+                 });
+             }
+             finally
+             {
+                 fileSystem.DeleteDirectory(tempDirectory);
+             }
+         }
+         
+         [Test]
+         public void SkipsSecretsInADeployContainerStepWhenSecretDataIsNotSet()
          {
              var variables = new CalamariVariables();
              var log = new SilentLog();
@@ -184,10 +259,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                      new CommandLineRunner(log, variables),
                      new Dictionary<string, string>());
 
-                 statusChecker.CheckedResources.Should().BeEquivalentTo(new[]
-                 {
-                     new ResourceIdentifier("Secret", secret, "default")
-                 });
+                 statusChecker.CheckedResources.Should().BeEmpty();
              }
              finally
              {
@@ -237,7 +309,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
 
     internal class MockResourceStatusChecker : IResourceStatusChecker
     {
-        public List<ResourceIdentifier> CheckedResources { get; private set; }
+        public List<ResourceIdentifier> CheckedResources { get; private set; } = new List<ResourceIdentifier>();
 
         public bool CheckStatusUntilCompletionOrTimeout(
             IEnumerable<ResourceIdentifier> resourceIdentifiers,

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
@@ -114,7 +114,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             }
 
             // Skip it if the user did not input configmap data
-            if (string.IsNullOrEmpty(variables.Get("Octopus.Action.KubernetesContainers.ConfigMapName")))
+            if (!variables.GetIndexes("Octopus.Action.KubernetesContainers.ConfigMapData").Any())
             {
                 return null;
             }
@@ -131,7 +131,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             }
             
             // Skip it if the user did not input secret data
-            if (string.IsNullOrEmpty(variables.Get("Octopus.Action.KubernetesContainers.SecretName")))
+            if (!variables.GetIndexes("Octopus.Action.KubernetesContainers.SecretData").Any())
             {
                 return null;
             }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
@@ -112,6 +112,13 @@ namespace Calamari.Kubernetes.ResourceStatus
             {
                 return null;
             }
+
+            // Skip it if the user did not input configmap data
+            if (string.IsNullOrEmpty(variables.Get("Octopus.Action.KubernetesContainers.ConfigMapName")))
+            {
+                return null;
+            }
+            
             var configMapName = variables.Get("Octopus.Action.KubernetesContainers.ComputedConfigMapName");
             return string.IsNullOrEmpty(configMapName) ? null : new ResourceIdentifier("ConfigMap", configMapName, defaultNamespace);
         }
@@ -122,6 +129,13 @@ namespace Calamari.Kubernetes.ResourceStatus
             {
                 return null;
             }
+            
+            // Skip it if the user did not input secret data
+            if (string.IsNullOrEmpty(variables.Get("Octopus.Action.KubernetesContainers.SecretName")))
+            {
+                return null;
+            }
+
             var secretName = variables.Get("Octopus.Action.KubernetesContainers.ComputedSecretName");
             return string.IsNullOrEmpty(secretName) ? null : new ResourceIdentifier("Secret", secretName, defaultNamespace);
         }


### PR DESCRIPTION
When a Kubernetes user uses the Deploy a Kubernetes Container step, and have the ConfigMap and/or Secret features enabled (which is the default), if the user does not actually include the config map or secret (leaving the configuration section empty), the object status check will pass successfully, because it attempts to find the config map or secret that was never created.

<img width="822" alt="Screenshot 2023-06-14 at 3 47 59 PM" src="https://github.com/OctopusDeploy/Calamari/assets/97418140/c9f281f9-4fdc-4a19-bd77-38796c5dec0e">

This PR adds some checks that are equivalent to the counterpart in the script which actually does the deployment: https://github.com/OctopusDeploy/OctopusDeploy/blob/d30286031e3970f6f468cdc12a2d2526b5aa0e98/source/Octopus.Kubernetes/ActionHandler/Scripts/KubernetesDeployment.sh#L124-L128

After the change we no longer attempt to do checks on configmaps or secrets that have not been created.

<img width="665" alt="Screenshot 2023-06-14 at 3 46 07 PM" src="https://github.com/OctopusDeploy/Calamari/assets/97418140/bdfb300f-67db-4584-9fbd-ec33bcd56c43">
