### PR TITLE
Fix the bug in KOS which caused unexpected config maps and secrets to be checked against

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportWrapperTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportWrapperTests.cs
@@ -120,7 +120,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
          }
 
          [Test]
-         public void FindsConfigMapsDeployedInADeployContainerStep()
+         public void FindsConfigMapsDeployedInADeployContainerStepWhenConfigMapDataIsNotEmpty()
          {
              var variables = new CalamariVariables();
              var log = new SilentLog();
@@ -131,6 +131,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
              AddKubernetesStatusCheckVariables(variables);
              variables.Set("Octopus.Action.KubernetesContainers.KubernetesConfigMapEnabled", "True");
              variables.Set("Octopus.Action.KubernetesContainers.ComputedConfigMapName", configMapName);
+             variables.Set("Octopus.Action.KubernetesContainers.ConfigMapData[1].FileName", "1");
 
              var tempDirectory = fileSystem.CreateTemporaryDirectory();
              try
@@ -156,9 +157,83 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                  fileSystem.DeleteDirectory(tempDirectory);
              }
          }
+         
+         [Test]
+         public void SkipsConfigMapsInADeployContainerStepWhenConfigMapDataIsNotSet()
+         {
+             var variables = new CalamariVariables();
+             var log = new SilentLog();
+             var fileSystem = new TestCalamariPhysicalFileSystem();
+             var statusChecker = new MockResourceStatusChecker();
+
+             const string configMapName = "ConfigMap-Deployment-01";
+             AddKubernetesStatusCheckVariables(variables);
+             variables.Set("Octopus.Action.KubernetesContainers.KubernetesConfigMapEnabled", "True");
+             variables.Set("Octopus.Action.KubernetesContainers.ComputedConfigMapName", configMapName);
+
+             var tempDirectory = fileSystem.CreateTemporaryDirectory();
+             try
+             {
+                 fileSystem.SetFileBasePath(tempDirectory);
+
+                 var wrapper = new ResourceStatusReportWrapper(variables, new ResourceStatusReportExecutor(variables, log, fileSystem, statusChecker));
+                 wrapper.NextWrapper = new StubScriptWrapper().Enable();
+
+                 wrapper.ExecuteScript(
+                     new Script("stub"),
+                     Syntax,
+                     new CommandLineRunner(log, variables),
+                     new Dictionary<string, string>());
+
+                 statusChecker.CheckedResources.Should().BeEmpty();
+             }
+             finally
+             {
+                 fileSystem.DeleteDirectory(tempDirectory);
+             }
+         }
 
          [Test]
-         public void FindsSecretsDeployedInADeployContainerStep()
+         public void FindsSecretsDeployedInADeployContainerStepWhenSecretDataIsSet()
+         {
+             var variables = new CalamariVariables();
+             var log = new SilentLog();
+             var fileSystem = new TestCalamariPhysicalFileSystem();
+             var statusChecker = new MockResourceStatusChecker();
+
+             const string secret = "Secret-Deployment-01";
+             AddKubernetesStatusCheckVariables(variables);
+             variables.Set("Octopus.Action.KubernetesContainers.KubernetesSecretEnabled", "True");
+             variables.Set("Octopus.Action.KubernetesContainers.ComputedSecretName", secret);             
+             variables.Set("Octopus.Action.KubernetesContainers.SecretData[1].FileName", "1");
+
+             var tempDirectory = fileSystem.CreateTemporaryDirectory();
+             try
+             {
+                 fileSystem.SetFileBasePath(tempDirectory);
+
+                 var wrapper = new ResourceStatusReportWrapper(variables, new ResourceStatusReportExecutor(variables, log, fileSystem, statusChecker));
+                 wrapper.NextWrapper = new StubScriptWrapper().Enable();
+
+                 wrapper.ExecuteScript(
+                     new Script("stub"),
+                     Syntax,
+                     new CommandLineRunner(log, variables),
+                     new Dictionary<string, string>());
+
+                 statusChecker.CheckedResources.Should().BeEquivalentTo(new[]
+                 {
+                     new ResourceIdentifier("Secret", secret, "default")
+                 });
+             }
+             finally
+             {
+                 fileSystem.DeleteDirectory(tempDirectory);
+             }
+         }
+         
+         [Test]
+         public void SkipsSecretsInADeployContainerStepWhenSecretDataIsNotSet()
          {
              var variables = new CalamariVariables();
              var log = new SilentLog();
@@ -184,10 +259,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                      new CommandLineRunner(log, variables),
                      new Dictionary<string, string>());
 
-                 statusChecker.CheckedResources.Should().BeEquivalentTo(new[]
-                 {
-                     new ResourceIdentifier("Secret", secret, "default")
-                 });
+                 statusChecker.CheckedResources.Should().BeEmpty();
              }
              finally
              {
@@ -236,7 +308,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
 
     internal class MockResourceStatusChecker : IResourceStatusChecker
     {
-        public List<ResourceIdentifier> CheckedResources { get; private set; }
+        public List<ResourceIdentifier> CheckedResources { get; private set; } = new List<ResourceIdentifier>();
 
         public bool CheckStatusUntilCompletionOrTimeout(
             IEnumerable<ResourceIdentifier> resourceIdentifiers,

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportWrapperTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportWrapperTests.cs
@@ -176,7 +176,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
              {
                  fileSystem.SetFileBasePath(tempDirectory);
 
-                 var wrapper = new ResourceStatusReportWrapper(variables, new ResourceStatusReportExecutor(variables, log, fileSystem, statusChecker));
+                 var wrapper = new ResourceStatusReportWrapper(log, variables, fileSystem, statusChecker);
                  wrapper.NextWrapper = new StubScriptWrapper().Enable();
 
                  wrapper.ExecuteScript(
@@ -212,7 +212,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
              {
                  fileSystem.SetFileBasePath(tempDirectory);
 
-                 var wrapper = new ResourceStatusReportWrapper(variables, new ResourceStatusReportExecutor(variables, log, fileSystem, statusChecker));
+                 var wrapper = new ResourceStatusReportWrapper(log, variables, fileSystem, statusChecker);
                  wrapper.NextWrapper = new StubScriptWrapper().Enable();
 
                  wrapper.ExecuteScript(

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
@@ -129,6 +129,13 @@ namespace Calamari.Kubernetes.ResourceStatus
             {
                 return null;
             }
+
+            // Skip it if the user did not input configmap data
+            if (string.IsNullOrEmpty(variables.Get("Octopus.Action.KubernetesContainers.ConfigMapName")))
+            {
+                return null;
+            }
+            
             var configMapName = variables.Get("Octopus.Action.KubernetesContainers.ComputedConfigMapName");
             return string.IsNullOrEmpty(configMapName) ? null : new ResourceIdentifier("ConfigMap", configMapName, defaultNamespace);
         }
@@ -139,6 +146,13 @@ namespace Calamari.Kubernetes.ResourceStatus
             {
                 return null;
             }
+            
+            // Skip it if the user did not input secret data
+            if (string.IsNullOrEmpty(variables.Get("Octopus.Action.KubernetesContainers.SecretName")))
+            {
+                return null;
+            }
+
             var secretName = variables.Get("Octopus.Action.KubernetesContainers.ComputedSecretName");
             return string.IsNullOrEmpty(secretName) ? null : new ResourceIdentifier("Secret", secretName, defaultNamespace);
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
@@ -131,7 +131,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             }
 
             // Skip it if the user did not input configmap data
-            if (string.IsNullOrEmpty(variables.Get("Octopus.Action.KubernetesContainers.ConfigMapName")))
+            if (!variables.GetIndexes("Octopus.Action.KubernetesContainers.ConfigMapData").Any())
             {
                 return null;
             }
@@ -148,7 +148,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             }
             
             // Skip it if the user did not input secret data
-            if (string.IsNullOrEmpty(variables.Get("Octopus.Action.KubernetesContainers.SecretName")))
+            if (!variables.GetIndexes("Octopus.Action.KubernetesContainers.SecretData").Any())
             {
                 return null;
             }


### PR DESCRIPTION
When a Kubernetes user uses the Deploy a Kubernetes Container step, and have the ConfigMap and/or Secret features enabled (which is the default), if the user does not actually include the config map or secret (leaving the configuration section empty), the object status check will pass successfully, because it attempts to find the config map or secret that was never created.

See https://github.com/OctopusDeploy/Calamari/pull/1064 for more details.