### PR TITLE
Remove unused env var: SSH_OctopusAPITester_PrivateKey

### DIFF
--- a/source/Calamari.Testing/EnvironmentVariables.cs
+++ b/source/Calamari.Testing/EnvironmentVariables.cs
@@ -13,9 +13,6 @@ namespace Calamari.Testing
         [EnvironmentVariable("AWS_OctopusAPITester_Secret", "AWS - OctopusAPITester")]
         AwsSecretKey,
 
-        [EnvironmentVariable("SSH_OctopusAPITester_PrivateKey", "SSH - OctopusAPITester")]
-        SshPrivateKey,
-
         [EnvironmentVariable("Azure_OctopusAPITester_SubscriptionId", "Azure - OctopusAPITester")]
         AzureSubscriptionId,
 


### PR DESCRIPTION
I noticed a reference to an environment variable that is not used: `SSH_OctopusAPITester_PrivateKey`.

This PR removes such variable.