### PR TITLE
Filter service messages when checking for command result errors

### DIFF
--- a/source/Calamari.Common/Features/Processes/CommandResult.cs
+++ b/source/Calamari.Common/Features/Processes/CommandResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace Calamari.Common.Features.Processes
 {
@@ -19,7 +20,7 @@ namespace Calamari.Common.Features.Processes
 
         public string? Errors { get; }
 
-        public bool HasErrors => !string.IsNullOrWhiteSpace(Errors);
+        public bool HasErrors => !string.IsNullOrWhiteSpace(Errors) && ErrorsExcludeServiceMessages(Errors);
 
         public void VerifySuccess()
         {
@@ -30,5 +31,10 @@ namespace Calamari.Common.Features.Processes
                     Errors,
                     workingDirectory);
         }
+
+        static bool ErrorsExcludeServiceMessages(string s) =>
+            s.Split(new[] {Environment.NewLine}, StringSplitOptions.None)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Any(s => !s.StartsWith("##octopus"));
     }
 }

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Calamari.Deployment;
-using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
 using Calamari.Tests.Helpers;
 using NUnit.Framework;
@@ -143,6 +141,16 @@ namespace Calamari.Tests.Fixtures.Bash
 
             output.AssertFailure();
             output.AssertErrorOutput("hello");
+        }
+
+        [Test]
+        [RequiresBashDotExeIfOnWindows]
+        public void ShouldNotFailOnStdErrFromServiceMessagesWithTreatScriptWarningsAsErrors()
+        {
+            var (output, _) = RunScript("hello.sh", new Dictionary<string, string>()
+            {[SpecialVariables.Action.FailScriptOnErrorOutput] = "True"});
+
+            output.AssertSuccess();
         }
 
         [Test]


### PR DESCRIPTION
There was a recent change related to send masking messages to stderr to fix sensitive variables leaking - https://github.com/OctopusDeploy/Calamari/pull/1008.

This, however, introduced a bug which caused any bash scripts to fail when `Octopus.Action.FailScriptOnErrorOutput` was set to `true`, since as part of the bootstrapping, errors were being sent to `stderr`. This change filters out service messages to determine whether a script has any errors.

[sc-52118]