### PR TITLE
Add support for WaitForDebugger to CalamariFlavourProgramAsync

### DIFF
--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -65,7 +65,7 @@ namespace Calamari.Common
 #if DEBUG
                 var waitForDebugger = container.Resolve<IVariables>().Get(KnownVariables.Calamari.WaitForDebugger);
 
-                if (string.Equals(waitForDebugger, "true", StringComparison.CurrentCultureIgnoreCase))
+                if (string.Equals(waitForDebugger, "true", StringComparison.OrdinalIgnoreCase))
                 {
                     using var proc = Process.GetCurrentProcess();
                     Log.Info($"Waiting for debugger to attach... (PID: {proc.Id})");


### PR DESCRIPTION
When discussing how to debug calamari locally with @scme0, we realised that the async calamari don't support the `Octopus.Calamari.WaitForDebugger` variable.

This PR just adds the same loop as is in the non-async program.