### PR TITLE
Check if KOS is enabled before we do status check from the command

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Commands/KubernetesApplyRawYamlCommandFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/KubernetesApplyRawYamlCommandFixture.cs
@@ -37,7 +37,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands
         }
         
         [Test]
-        public void WhenResourceStatusIsEnabled_ShouldNotRunStatusChecks()
+        public void WhenResourceStatusIsEnabled_ShouldRunStatusChecks()
         {
             var variables = new CalamariVariables()
             {

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/KubernetesApplyRawYamlCommandFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/KubernetesApplyRawYamlCommandFixture.cs
@@ -1,0 +1,74 @@
+using Calamari.Common.Features.Packages;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Features.StructuredVariables;
+using Calamari.Common.Features.Substitutions;
+using Calamari.Common.Plumbing.Deployment.Journal;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes;
+using Calamari.Kubernetes.Commands;
+using Calamari.Kubernetes.Commands.Executors;
+using Calamari.Kubernetes.Integration;
+using Calamari.Kubernetes.ResourceStatus;
+using Calamari.Testing.Helpers;
+using Calamari.Tests.Fixtures.Integration.FileSystem;
+using FluentAssertions;
+using NUnit.Framework;
+using NSubstitute;
+
+namespace Calamari.Tests.KubernetesFixtures.Commands
+{
+    [TestFixture]
+    public class KubernetesApplyRawYamlCommandFixture
+    {
+        [Test]
+        public void WhenResourceStatusIsDisabled_ShouldNotRunStatusChecks()
+        {
+            var variables = new CalamariVariables()
+            {
+                [Deployment.SpecialVariables.EnabledFeatureToggles] = "MultiGlobPathsForRawYamlFeatureToggle",
+                [SpecialVariables.ResourceStatusCheck] = "False"
+            };
+            var resourceStatusCheck = Substitute.For<IResourceStatusReportExecutor>();
+            var command = CreateCommand(variables, resourceStatusCheck);
+            
+            command.Execute(new string[]{ });
+
+            resourceStatusCheck.ReceivedCalls().Should().BeEmpty();
+        }
+        
+        [Test]
+        public void WhenResourceStatusIsEnabled_ShouldNotRunStatusChecks()
+        {
+            var variables = new CalamariVariables()
+            {
+                [Deployment.SpecialVariables.EnabledFeatureToggles] = "MultiGlobPathsForRawYamlFeatureToggle",
+                [SpecialVariables.ResourceStatusCheck] = "True"
+            };
+            var resourceStatusCheck = Substitute.For<IResourceStatusReportExecutor>();
+            var command = CreateCommand(variables, resourceStatusCheck);
+            
+            command.Execute(new string[]{ });
+
+            resourceStatusCheck.ReceivedCalls().Should().HaveCount(1);
+        }
+
+        private KubernetesApplyRawYamlCommand CreateCommand(IVariables variables, IResourceStatusReportExecutor resourceStatusCheck)
+        {
+            var log = new InMemoryLog();
+            var fs = new TestCalamariPhysicalFileSystem();
+            var kubectl = new Kubectl(variables, log, Substitute.For<ICommandLineRunner>());
+
+            return new KubernetesApplyRawYamlCommand(
+                log,
+                Substitute.For<IDeploymentJournalWriter>(),
+                variables,
+                fs,
+                Substitute.For<IExtractPackage>(),
+                Substitute.For<ISubstituteInFiles>(),
+                Substitute.For<IStructuredConfigVariablesService>(),
+                Substitute.For<IGatherAndApplyRawYamlExecutor>(),
+                resourceStatusCheck,
+                kubectl);
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -35,7 +35,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             this.kubectl = kubectl;
         }
 
-        public async Task<bool> Execute(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback)
+        public async Task<bool> Execute(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback = null)
         {
             try
             {
@@ -48,7 +48,10 @@ namespace Calamari.Kubernetes.Commands.Executors
                 foreach (var directory in directories)
                 {
                     var res = ApplyBatchAndReturnResources(directory).ToList();
-                    await appliedResourcesCallback(res.Select(r => r.ToResourceIdentifier()).ToArray());
+                    if (appliedResourcesCallback != null)
+                    {
+                        await appliedResourcesCallback(res.Select(r => r.ToResourceIdentifier()).ToArray());
+                    }
                     resources.UnionWith(res);
                 }
 

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -19,7 +19,12 @@ using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Kubernetes.Commands.Executors
 {
-    public class GatherAndApplyRawYamlExecutor
+    public interface IGatherAndApplyRawYamlExecutor
+    {
+        Task<bool> Execute(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback = null);
+    }
+    
+    public class GatherAndApplyRawYamlExecutor : IGatherAndApplyRawYamlExecutor
     {
         private readonly ILog log;
         private readonly ICalamariFileSystem fileSystem;
@@ -35,7 +40,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             this.kubectl = kubectl;
         }
 
-        public async Task<bool> Execute(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback = null)
+        public async Task<bool> Execute(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback)
         {
             try
             {

--- a/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
@@ -61,6 +61,11 @@ namespace Calamari.Kubernetes.Commands
             var gatherAndApplyRawYamlExecutor =
                 new GatherAndApplyRawYamlExecutor(log, fileSystem, kubectl);
 
+            if (!variables.GetFlag(SpecialVariables.ResourceStatusCheck))
+            {
+                return await gatherAndApplyRawYamlExecutor.Execute(runningDeployment);
+            }
+            
             var statusCheck = statusReporter.Start();
 
             return await gatherAndApplyRawYamlExecutor.Execute(runningDeployment, statusCheck.AddResources) &&

--- a/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
@@ -24,7 +24,8 @@ namespace Calamari.Kubernetes.Commands
         private readonly ILog log;
         private readonly IVariables variables;
         private readonly ICalamariFileSystem fileSystem;
-        private readonly ResourceStatusReportExecutor statusReporter;
+        private readonly IResourceStatusReportExecutor statusReporter;
+        private readonly IGatherAndApplyRawYamlExecutor gatherAndApplyRawYamlExecutor;
         private readonly Kubectl kubectl;
 
         public KubernetesApplyRawYamlCommand(
@@ -35,7 +36,8 @@ namespace Calamari.Kubernetes.Commands
             IExtractPackage extractPackage,
             ISubstituteInFiles substituteInFiles,
             IStructuredConfigVariablesService structuredConfigVariablesService,
-            ResourceStatusReportExecutor statusReporter,
+            IGatherAndApplyRawYamlExecutor gatherAndApplyRawYamlExecutor,
+            IResourceStatusReportExecutor statusReporter,
             Kubectl kubectl)
             : base(log, deploymentJournalWriter, variables, fileSystem, extractPackage,
             substituteInFiles, structuredConfigVariablesService, kubectl)
@@ -44,6 +46,7 @@ namespace Calamari.Kubernetes.Commands
             this.variables = variables;
             this.fileSystem = fileSystem;
             this.statusReporter = statusReporter;
+            this.gatherAndApplyRawYamlExecutor = gatherAndApplyRawYamlExecutor;
             this.kubectl = kubectl;
         }
 
@@ -58,9 +61,6 @@ namespace Calamari.Kubernetes.Commands
 
         protected override async Task<bool> ExecuteCommand(RunningDeployment runningDeployment)
         {
-            var gatherAndApplyRawYamlExecutor =
-                new GatherAndApplyRawYamlExecutor(log, fileSystem, kubectl);
-
             if (!variables.GetFlag(SpecialVariables.ResourceStatusCheck))
             {
                 return await gatherAndApplyRawYamlExecutor.Execute(runningDeployment);

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
@@ -8,7 +8,12 @@ using Calamari.Kubernetes.ResourceStatus.Resources;
 
 namespace Calamari.Kubernetes.ResourceStatus
 {
-    public class ResourceStatusReportExecutor
+    public interface IResourceStatusReportExecutor
+    {
+        IRunningResourceStatusCheck Start(IEnumerable<ResourceIdentifier> initialResources = null);
+    }
+    
+    public class ResourceStatusReportExecutor : IResourceStatusReportExecutor
     {
         private readonly IVariables variables;
         private readonly RunningResourceStatusCheck.Factory runningResourceStatusCheckFactory;
@@ -21,7 +26,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             this.runningResourceStatusCheckFactory = runningResourceStatusCheckFactory;
         }
 
-        public IRunningResourceStatusCheck Start(IEnumerable<ResourceIdentifier> initialResources = null)
+        public IRunningResourceStatusCheck Start(IEnumerable<ResourceIdentifier> initialResources)
         {
             initialResources = initialResources ?? Enumerable.Empty<ResourceIdentifier>();
             var timeoutSeconds = variables.GetInt32(SpecialVariables.Timeout) ?? 0;

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -16,13 +16,13 @@ namespace Calamari.Kubernetes.ResourceStatus
         private readonly Kubectl kubectl;
         private readonly IVariables variables;
         private readonly ICalamariFileSystem fileSystem;
-        private readonly ResourceStatusReportExecutor statusReportExecutor;
+        private readonly IResourceStatusReportExecutor statusReportExecutor;
 
         public ResourceStatusReportWrapper(
             Kubectl kubectl,
             IVariables variables,
             ICalamariFileSystem fileSystem,
-            ResourceStatusReportExecutor statusReportExecutor)
+            IResourceStatusReportExecutor statusReportExecutor)
         {
             this.kubectl = kubectl;
             this.variables = variables;

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -26,6 +26,7 @@ using IContainer = Autofac.IContainer;
 #if !NET40
 using Calamari.Aws.Deployment;
 using Calamari.Azure;
+using Calamari.Kubernetes.Commands.Executors;
 #endif
 
 namespace Calamari
@@ -72,7 +73,8 @@ namespace Calamari
             builder.RegisterType<RunningResourceStatusCheck>().As<IRunningResourceStatusCheck>().SingleInstance();
             builder.RegisterType<ResourceStatusCheckTask>().AsSelf();
             builder.RegisterType<ResourceUpdateReporter>().As<IResourceUpdateReporter>().SingleInstance();
-            builder.RegisterType<ResourceStatusReportExecutor>().AsSelf();
+            builder.RegisterType<ResourceStatusReportExecutor>().As<IResourceStatusReportExecutor>();
+            builder.RegisterType<GatherAndApplyRawYamlExecutor>().As<IGatherAndApplyRawYamlExecutor>();
             builder.RegisterType<Timer>().As<ITimer>();
 #endif
             builder.RegisterType<Kubectl>().AsSelf().As<IKubectl>().InstancePerLifetimeScope();


### PR DESCRIPTION
This PR addresses https://github.com/OctopusDeploy/Issues/issues/8236.

We did not check if we should run status checks if the status check is done via a Raw YAML command. This PR adds this check.

See discussions in: https://octopusdeploy.slack.com/archives/C03SG0LFJHX/p1687989153045139 (internal link).