### PR TITLE
Fix log levels for raw yaml deployments

### DIFF
--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -177,7 +177,7 @@ namespace Calamari.Kubernetes.Commands.Executors
 
                 if (resources.Any())
                 {
-                    log.Info("Created Resources:");
+                    log.Verbose("Created Resources:");
                     log.LogResources(resources);
                 }
 


### PR DESCRIPTION
Simple change to make logs levels more consistent.

Reported [here](https://octopusdeploy.slack.com/archives/C04V68JCM1B/p1688081472295929).