### PR TITLE
Handle child steps naming differently

### DIFF
--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Calamari.Common.Plumbing.Logging;
@@ -64,11 +65,21 @@ namespace Calamari.Kubernetes.ResourceStatus
 
         private void SendServiceMessage(Resource resource, bool removed, int checkCount)
         {
+            var actionNumber = variables.Get("Octopus.Action.Number", string.Empty);
+            var stepNumber = variables.Get("Octopus.Step.Number");
+            var stepName = variables.Get("Octopus.Step.Name");
+            
+            if (actionNumber.IndexOf(".", StringComparison.Ordinal) > 0)
+            {
+                stepNumber = actionNumber;
+                stepName = variables.Get("Octopus.Action.Name");
+            }
+            
             var parameters = new Dictionary<string, string>
             {
                 {"type", "k8s-status"},
                 {"actionId", variables.Get("Octopus.Action.Id")},
-                {"stepName", $"Step {variables.Get("Octopus.Step.Number")}: {variables.Get("Octopus.Step.Name")}"},
+                {"stepName", $"Step {stepNumber}: {stepName}"},
                 {"taskId", variables.Get(KnownVariables.ServerTask.Id)},
                 {"targetId", variables.Get("Octopus.Machine.Id")},
                 {"targetName", variables.Get("Octopus.Machine.Name")},


### PR DESCRIPTION
In this PR we are handling child steps a bit differently.
We are checking whether the current executing step is a child step or not by looking at the `Octopus.Action.Number` variable, this will give us a whole number eg 1, 3, 4 if it is a normal step but if it is a child step the value will be a fraction number eg 1.2, 1.3, 1.5.
So we use this distinction to select a different code path to build the step name.
For a normal step, we use `Octopus.Step.Number` concatenated with `Octopus.Step.Name` but for a child step we use `Octopus.Action.Number` concatenated with `Octopus.Action.Name`

Fixes https://github.com/OctopusDeploy/Issues/issues/8219