### PR TITLE
Fix for RequiresDotNetCore attribute

### DIFF
--- a/source/Calamari.Testing/Calamari.Testing.csproj
+++ b/source/Calamari.Testing/Calamari.Testing.csproj
@@ -12,6 +12,9 @@
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+        <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+    </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Assent" Version="1.6.1" />

--- a/source/Calamari.Tests/Helpers/CodeGenerator.cs
+++ b/source/Calamari.Tests/Helpers/CodeGenerator.cs
@@ -23,15 +23,15 @@ namespace Calamari.Tests.Helpers
             }
 
             var clr = new CommandLineRunner(ConsoleLog.Instance, new CalamariVariables());
-            var result = clr.Execute(CreateCommandLineInvocation("dotnet", "new console -f net6.0"));
-            result.VerifySuccess();
             File.WriteAllText(Path.Combine(projectPath.FullName, "global.json"),
-                              @"{
+                @"{
     ""sdk"": {
             ""version"": ""6.0.10"",
             ""rollForward"": ""latestFeature""
         }
     }");
+            var result = clr.Execute(CreateCommandLineInvocation("dotnet", "new console -f net6.0"));
+            result.VerifySuccess();
             var programCS = Path.Combine(projectPath.FullName, "Program.cs");
             var newProgram = $@"using System;
 class Program


### PR DESCRIPTION
The `NETCORE` constant used by this attribute haven't been defined in the `csproj` file, this PR adds this definition.

[sc-53301]