### PR TITLE
Update Raw Yaml Step to use existing Glob Implementation

### DIFF
--- a/source/Calamari.Common/Plumbing/FileSystem/Glob.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/Glob.cs
@@ -55,7 +55,7 @@ namespace Calamari.Common.Plumbing.FileSystem
         ///     </item>
         ///     <item>
         ///         <term>**</term>
-        ///         <description>Matches zero or more recursve directories.</description>
+        ///         <description>Matches zero or more recursive directories.</description>
         ///     </item>
         ///     <item>
         ///         <term>[...]</term>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -39,8 +39,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />
     <ProjectReference Include="..\Calamari.Azure\Calamari.Azure.csproj" />
-    <!--This is built-in in .net6.0-->
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.0.0-preview2-final" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj" />

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -12,8 +12,6 @@ using Calamari.Common.Plumbing.ServiceMessages;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.Integration;
 using Calamari.Kubernetes.ResourceStatus.Resources;
-using Microsoft.Extensions.FileSystemGlobbing;
-using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Newtonsoft.Json.Linq;
 using Octopus.CoreUtilities.Extensions;
 

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -23,7 +23,7 @@ namespace Calamari.Kubernetes.Commands.Executors
     {
         Task<bool> Execute(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback = null);
     }
-    
+
     public class GatherAndApplyRawYamlExecutor : IGatherAndApplyRawYamlExecutor
     {
         private readonly ILog log;
@@ -107,12 +107,10 @@ namespace Calamari.Kubernetes.Commands.Executors
                 var directory = new GlobDirectory(i, glob, directoryPath);
                 fileSystem.CreateDirectory(directoryPath);
 
-                var matcher = new Matcher();
-                matcher.AddInclude(glob);
-                var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(deployment.CurrentDirectory)));
-                foreach (var file in result.Files)
+                var results = fileSystem.EnumerateFilesWithGlob(deployment.CurrentDirectory, glob);
+                foreach (var file in results)
                 {
-                    var relativeFilePath = file.Path ?? file.Stem;
+                    var relativeFilePath = fileSystem.GetRelativePath(deployment.CurrentDirectory, file);
                     var fullPath = Path.Combine(deployment.CurrentDirectory, relativeFilePath);
                     var targetPath = Path.Combine(directoryPath, relativeFilePath);
                     var targetDirectory = Path.GetDirectoryName(targetPath);

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -108,7 +108,12 @@ namespace Calamari.Kubernetes.Commands.Executors
                 var results = fileSystem.EnumerateFilesWithGlob(deployment.CurrentDirectory, glob);
                 foreach (var file in results)
                 {
-                    var relativeFilePath = fileSystem.GetRelativePath(deployment.CurrentDirectory, file);
+                    // This is required because the current implementation of fileSystem.GetRelativePath
+                    // will not recognise the last part of a path as a directory unless the path ends with
+                    // Path.DirectorySeparatorChar.
+                    var currentDirectory = deployment.CurrentDirectory.TrimEnd(Path.DirectorySeparatorChar) +
+                        Path.DirectorySeparatorChar;
+                    var relativeFilePath = fileSystem.GetRelativePath(currentDirectory, file);
                     var fullPath = Path.Combine(deployment.CurrentDirectory, relativeFilePath);
                     var targetPath = Path.Combine(directoryPath, relativeFilePath);
                     var targetDirectory = Path.GetDirectoryName(targetPath);


### PR DESCRIPTION
Simply updating the Raw Yaml Step to use the existing Glob implementation so that it aligns with the implementation used by Variable Substitution etc.

There are some limitations with the Glob implementation where it basically just supports wildcards (eg: ** and *).

At this stage it's the only option without a lot of rework and testing.