### PR TITLE
Fix issue where global glob will load kubectl-octo.yml context file

### DIFF
--- a/source/Calamari.Common/Features/Behaviours/ConfigurationTransformsBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/ConfigurationTransformsBehaviour.cs
@@ -11,6 +11,7 @@ using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Variables;
+using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Common.Features.Behaviours
 {
@@ -21,14 +22,22 @@ namespace Calamari.Common.Features.Behaviours
         readonly IConfigurationTransformer configurationTransformer;
         readonly ITransformFileLocator transformFileLocator;
         readonly ILog log;
+        private readonly string subdirectory;
 
-        public ConfigurationTransformsBehaviour(ICalamariFileSystem fileSystem, IVariables variables, IConfigurationTransformer configurationTransformer, ITransformFileLocator transformFileLocator, ILog log)
+        public ConfigurationTransformsBehaviour(
+            ICalamariFileSystem fileSystem,
+            IVariables variables,
+            IConfigurationTransformer configurationTransformer,
+            ITransformFileLocator transformFileLocator,
+            ILog log,
+            string subdirectory = "")
         {
             this.fileSystem = fileSystem;
             this.variables = variables;
             this.configurationTransformer = configurationTransformer;
             this.transformFileLocator = transformFileLocator;
             this.log = log;
+            this.subdirectory = subdirectory;
         }
 
         public bool IsEnabled(RunningDeployment deployment)
@@ -38,7 +47,7 @@ namespace Calamari.Common.Features.Behaviours
 
         public Task Execute(RunningDeployment deployment)
         {
-            DoTransforms(deployment.CurrentDirectory);
+            DoTransforms(Path.Combine(deployment.CurrentDirectory, subdirectory));
 
             return this.CompletedTask();
         }

--- a/source/Calamari.Common/Features/Behaviours/ConfigurationVariablesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/ConfigurationVariablesBehaviour.cs
@@ -25,7 +25,7 @@ namespace Calamari.Common.Features.Behaviours
             IVariables variables,
             IConfigurationVariablesReplacer replacer,
             ILog log,
-            string? subdirectory = "")
+            string subdirectory = "")
         {
             this.fileSystem = fileSystem;
             this.variables = variables;

--- a/source/Calamari.Common/Features/Behaviours/ConfigurationVariablesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/ConfigurationVariablesBehaviour.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
@@ -8,6 +8,7 @@ using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Variables;
+using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Common.Features.Behaviours
 {
@@ -17,13 +18,20 @@ namespace Calamari.Common.Features.Behaviours
         readonly IVariables variables;
         readonly IConfigurationVariablesReplacer replacer;
         readonly ILog log;
+        private readonly string subdirectory;
 
-        public ConfigurationVariablesBehaviour(ICalamariFileSystem fileSystem, IVariables variables, IConfigurationVariablesReplacer replacer, ILog log)
+        public ConfigurationVariablesBehaviour(
+            ICalamariFileSystem fileSystem,
+            IVariables variables,
+            IConfigurationVariablesReplacer replacer,
+            ILog log,
+            string? subdirectory = "")
         {
             this.fileSystem = fileSystem;
             this.variables = variables;
             this.replacer = replacer;
             this.log = log;
+            this.subdirectory = subdirectory;
         }
 
         public bool IsEnabled(RunningDeployment context)
@@ -34,7 +42,7 @@ namespace Calamari.Common.Features.Behaviours
 
         public Task Execute(RunningDeployment context)
         {
-            DoTransforms(context.CurrentDirectory);
+            DoTransforms(Path.Combine(context.CurrentDirectory, subdirectory));
 
             return this.CompletedTask();
         }

--- a/source/Calamari.Common/Features/Behaviours/StructuredConfigurationVariablesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/StructuredConfigurationVariablesBehaviour.cs
@@ -1,20 +1,24 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Variables;
+using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Common.Features.Behaviours
 {
     public class StructuredConfigurationVariablesBehaviour : IBehaviour
     {
         readonly IStructuredConfigVariablesService structuredConfigVariablesService;
+        private readonly string subdirectory;
 
-        public StructuredConfigurationVariablesBehaviour(IStructuredConfigVariablesService structuredConfigVariablesService)
+        public StructuredConfigurationVariablesBehaviour(IStructuredConfigVariablesService structuredConfigVariablesService, string subdirectory = "")
         {
             this.structuredConfigVariablesService = structuredConfigVariablesService;
+            this.subdirectory = subdirectory;
         }
 
         public bool IsEnabled(RunningDeployment context)
@@ -24,7 +28,7 @@ namespace Calamari.Common.Features.Behaviours
 
         public Task Execute(RunningDeployment context)
         {
-            structuredConfigVariablesService.ReplaceVariables(context.CurrentDirectory);
+            structuredConfigVariablesService.ReplaceVariables(Path.Combine(context.CurrentDirectory, subdirectory));
 
             return this.CompletedTask();
         }

--- a/source/Calamari.Common/Features/Behaviours/SubstituteInFilesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/SubstituteInFilesBehaviour.cs
@@ -1,20 +1,26 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Variables;
+using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Common.Features.Behaviours
 {
     public class SubstituteInFilesBehaviour : IBehaviour
     {
         readonly ISubstituteInFiles substituteInFiles;
+        private readonly string subdirectory;
 
-        public SubstituteInFilesBehaviour(ISubstituteInFiles substituteInFiles)
+        public SubstituteInFilesBehaviour(
+            ISubstituteInFiles substituteInFiles,
+            string subdirectory = "")
         {
             this.substituteInFiles = substituteInFiles;
+            this.subdirectory = subdirectory;
         }
 
         public bool IsEnabled(RunningDeployment context)
@@ -24,7 +30,7 @@ namespace Calamari.Common.Features.Behaviours
 
         public Task Execute(RunningDeployment context)
         {
-            substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(context.CurrentDirectory);
+            substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(Path.Combine(context.CurrentDirectory, subdirectory));
             return this.CompletedTask();
         }
     }

--- a/source/Calamari.Common/Features/Packages/ExtractPackage.cs
+++ b/source/Calamari.Common/Features/Packages/ExtractPackage.cs
@@ -23,18 +23,25 @@ namespace Calamari.Common.Features.Packages
             this.log = log;
         }
 
+        public void ExtractToCustomDirectory(PathToPackage? pathToPackage, string directory)
+        {
+            ExtractToCustomSubDirectory(pathToPackage, directory, null, null);
+        }
+
         public void ExtractToStagingDirectory(PathToPackage? pathToPackage, IPackageExtractor? customPackageExtractor = null)
         {
-            var targetPath = Path.Combine(Environment.CurrentDirectory, "staging");
-            fileSystem.EnsureDirectoryExists(targetPath);
-            Extract(pathToPackage, targetPath, PackageVariables.Output.InstallationDirectoryPath, customPackageExtractor);
+            ExtractToCustomSubDirectory(pathToPackage,
+                Path.Combine(Environment.CurrentDirectory, "staging"),
+                customPackageExtractor, null);
         }
 
         public void ExtractToStagingDirectory(PathToPackage? pathToPackage, string extractedToPathOutputVariableName)
         {
-            var targetPath = Path.Combine(Environment.CurrentDirectory, "staging");
-            fileSystem.EnsureDirectoryExists(targetPath);
-            Extract(pathToPackage, targetPath, extractedToPathOutputVariableName, null);
+            ExtractToCustomSubDirectory(
+                pathToPackage,
+                Path.Combine(Environment.CurrentDirectory, "staging"),
+                null,
+                extractedToPathOutputVariableName);
         }
 
         public void ExtractToEnvironmentCurrentDirectory(PathToPackage pathToPackage)
@@ -48,6 +55,12 @@ namespace Calamari.Common.Features.Packages
             var metadata = PackageName.FromFile(pathToPackage);
             var targetPath = ApplicationDirectory.GetApplicationDirectory(metadata, variables, fileSystem);
             Extract(pathToPackage, targetPath, PackageVariables.Output.InstallationDirectoryPath, customPackageExtractor);
+        }
+
+        void ExtractToCustomSubDirectory(PathToPackage? pathToPackage, string directory, IPackageExtractor? customPackageExtractor, string? extractedToPathOutputVariableName)
+        {
+            fileSystem.EnsureDirectoryExists(directory);
+            Extract(pathToPackage, directory, extractedToPathOutputVariableName ?? PackageVariables.Output.InstallationDirectoryPath, customPackageExtractor);
         }
 
         void Extract(PathToPackage? pathToPackage, string targetPath, string extractedToPathOutputVariableName,  IPackageExtractor? customPackageExtractor)

--- a/source/Calamari.Common/Features/Packages/ExtractPackage.cs
+++ b/source/Calamari.Common/Features/Packages/ExtractPackage.cs
@@ -10,6 +10,7 @@ namespace Calamari.Common.Features.Packages
 {
     public class ExtractPackage : IExtractPackage
     {
+        public const string StagingDirectoryName = "staging";
         readonly ICombinedPackageExtractor combinedPackageExtractor;
         readonly ICalamariFileSystem fileSystem;
         readonly IVariables variables;
@@ -31,7 +32,7 @@ namespace Calamari.Common.Features.Packages
         public void ExtractToStagingDirectory(PathToPackage? pathToPackage, IPackageExtractor? customPackageExtractor = null)
         {
             ExtractToCustomSubDirectory(pathToPackage,
-                Path.Combine(Environment.CurrentDirectory, "staging"),
+                Path.Combine(Environment.CurrentDirectory, StagingDirectoryName),
                 customPackageExtractor, null);
         }
 
@@ -39,7 +40,7 @@ namespace Calamari.Common.Features.Packages
         {
             ExtractToCustomSubDirectory(
                 pathToPackage,
-                Path.Combine(Environment.CurrentDirectory, "staging"),
+                Path.Combine(Environment.CurrentDirectory, StagingDirectoryName),
                 null,
                 extractedToPathOutputVariableName);
         }

--- a/source/Calamari.Common/Features/Packages/IExtractPackage.cs
+++ b/source/Calamari.Common/Features/Packages/IExtractPackage.cs
@@ -5,6 +5,7 @@ namespace Calamari.Common.Features.Packages
 {
     public interface IExtractPackage
     {
+        void ExtractToCustomDirectory(PathToPackage? pathToPackage, string directory);
         void ExtractToStagingDirectory(PathToPackage? pathToPackage, IPackageExtractor? customPackageExtractor = null);
         void ExtractToStagingDirectory(PathToPackage? pathToPackage, string extractedToPathOutputVariableName);
         void ExtractToEnvironmentCurrentDirectory(PathToPackage pathToPackage);

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -164,7 +164,7 @@ namespace Calamari.Kubernetes.Commands.Executors
                     case Level.Error:
                         //Files in the error are shown with the full path in their batch directory,
                         //so we'll remove that for the user.
-                        log.Error(message.Text.Replace($"{directory}{Path.DirectorySeparatorChar}", ""));
+                        log.Error(message.Text.Replace($"{directory}", ""));
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -25,6 +25,8 @@ namespace Calamari.Kubernetes.Commands.Executors
 
     public class GatherAndApplyRawYamlExecutor : IGatherAndApplyRawYamlExecutor
     {
+        private const string GroupedDirectoryName = "grouped";
+
         private readonly ILog log;
         private readonly ICalamariFileSystem fileSystem;
         private readonly Kubectl kubectl;
@@ -100,14 +102,14 @@ namespace Calamari.Kubernetes.Commands.Executors
         {
             var stagingDirectory = deployment.CurrentDirectory;
             var packageDirectory =
-                Path.Combine(stagingDirectory, KubernetesDeploymentCommandBase.PackageDirectoryPath) +
+                Path.Combine(stagingDirectory, KubernetesDeploymentCommandBase.PackageDirectoryName) +
                 Path.DirectorySeparatorChar;
 
             var directories = new List<GlobDirectory>();
             for (var i = 0; i < globs.Length; i ++)
             {
                 var glob = globs[i];
-                var directoryPath = Path.Combine(stagingDirectory, "grouped", i.ToString());
+                var directoryPath = Path.Combine(stagingDirectory, GroupedDirectoryName, i.ToString());
                 var directory = new GlobDirectory(i, glob, directoryPath);
                 fileSystem.CreateDirectory(directoryPath);
 

--- a/source/Calamari/Kubernetes/Commands/KubernetesDeploymentCommandBase.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesDeploymentCommandBase.cs
@@ -29,6 +29,10 @@ namespace Calamari.Kubernetes.Commands
 {
     public abstract class KubernetesDeploymentCommandBase  : Command
     {
+        public const string PackageDirectoryPath = "package";
+        private const string StagingDirectoryPath = "staging";
+        private const string InlineYamlFileName = "customresource.yml";
+
         private readonly ILog log;
         private readonly IDeploymentJournalWriter deploymentJournalWriter;
         private readonly IVariables variables;
@@ -80,36 +84,36 @@ namespace Calamari.Kubernetes.Commands
             {
                 new DelegateInstallConvention(d =>
                 {
+                    var workingDirectory = d.CurrentDirectory;
+                    var stagingDirectory = Path.Combine(workingDirectory, StagingDirectoryPath);
+                    var packageDirectory = Path.Combine(stagingDirectory, PackageDirectoryPath);
+                    fileSystem.EnsureDirectoryExists(packageDirectory);
                     if (pathToPackage != null)
                     {
-                        extractPackage.ExtractToStagingDirectory(pathToPackage);
+                        extractPackage.ExtractToCustomDirectory(pathToPackage, packageDirectory);
                     }
                     else
                     {
                         //If using the inline yaml, copy it to the staging directory.
-                        var inlineFile = Path.Combine(d.CurrentDirectory, "customresource.yml");
-                        var stagingDirectory = Path.Combine(d.CurrentDirectory, "staging");
-                        fileSystem.EnsureDirectoryExists(stagingDirectory);
+                        var inlineFile = Path.Combine(workingDirectory, InlineYamlFileName);
                         if (fileSystem.FileExists(inlineFile))
                         {
-                            fileSystem.MoveFile(inlineFile, Path.Combine(stagingDirectory, "customresource.yml"));
+                            fileSystem.MoveFile(inlineFile, Path.Combine(packageDirectory, InlineYamlFileName));
                         }
-
-                        d.StagingDirectory = stagingDirectory;
-                        d.CurrentDirectoryProvider = DeploymentWorkingDirectory.StagingDirectory;
                     }
-
-                    kubectl.SetWorkingDirectory(d.CurrentDirectory);
+                    d.StagingDirectory = stagingDirectory;
+                    d.CurrentDirectoryProvider = DeploymentWorkingDirectory.StagingDirectory;
+                    kubectl.SetWorkingDirectory(stagingDirectory);
                     kubectl.SetEnvironmentVariables(d.EnvironmentVariables);
                 }),
-                new SubstituteInFilesConvention(new SubstituteInFilesBehaviour(substituteInFiles)),
+                new SubstituteInFilesConvention(new SubstituteInFilesBehaviour(substituteInFiles, PackageDirectoryPath)),
                 new ConfigurationTransformsConvention(new ConfigurationTransformsBehaviour(fileSystem, variables,
                     ConfigurationTransformer.FromVariables(variables, log),
-                    new TransformFileLocator(fileSystem, log), log)),
+                    new TransformFileLocator(fileSystem, log), log, PackageDirectoryPath)),
                 new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, variables,
-                    new ConfigurationVariablesReplacer(variables, log), log)),
+                    new ConfigurationVariablesReplacer(variables, log), log, PackageDirectoryPath)),
                 new StructuredConfigurationVariablesConvention(
-                    new StructuredConfigurationVariablesBehaviour(structuredConfigVariablesService))
+                    new StructuredConfigurationVariablesBehaviour(structuredConfigVariablesService, PackageDirectoryPath))
             };
 
             if (variables.Get(Deployment.SpecialVariables.Account.AccountType) == "AmazonWebServicesAccount")

--- a/source/Calamari/Kubernetes/Commands/KubernetesDeploymentCommandBase.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesDeploymentCommandBase.cs
@@ -29,8 +29,7 @@ namespace Calamari.Kubernetes.Commands
 {
     public abstract class KubernetesDeploymentCommandBase  : Command
     {
-        public const string PackageDirectoryPath = "package";
-        private const string StagingDirectoryPath = "staging";
+        public const string PackageDirectoryName = "package";
         private const string InlineYamlFileName = "customresource.yml";
 
         private readonly ILog log;
@@ -85,8 +84,8 @@ namespace Calamari.Kubernetes.Commands
                 new DelegateInstallConvention(d =>
                 {
                     var workingDirectory = d.CurrentDirectory;
-                    var stagingDirectory = Path.Combine(workingDirectory, StagingDirectoryPath);
-                    var packageDirectory = Path.Combine(stagingDirectory, PackageDirectoryPath);
+                    var stagingDirectory = Path.Combine(workingDirectory, ExtractPackage.StagingDirectoryName);
+                    var packageDirectory = Path.Combine(stagingDirectory, PackageDirectoryName);
                     fileSystem.EnsureDirectoryExists(packageDirectory);
                     if (pathToPackage != null)
                     {
@@ -106,14 +105,14 @@ namespace Calamari.Kubernetes.Commands
                     kubectl.SetWorkingDirectory(stagingDirectory);
                     kubectl.SetEnvironmentVariables(d.EnvironmentVariables);
                 }),
-                new SubstituteInFilesConvention(new SubstituteInFilesBehaviour(substituteInFiles, PackageDirectoryPath)),
+                new SubstituteInFilesConvention(new SubstituteInFilesBehaviour(substituteInFiles, PackageDirectoryName)),
                 new ConfigurationTransformsConvention(new ConfigurationTransformsBehaviour(fileSystem, variables,
                     ConfigurationTransformer.FromVariables(variables, log),
-                    new TransformFileLocator(fileSystem, log), log, PackageDirectoryPath)),
+                    new TransformFileLocator(fileSystem, log), log, PackageDirectoryName)),
                 new ConfigurationVariablesConvention(new ConfigurationVariablesBehaviour(fileSystem, variables,
-                    new ConfigurationVariablesReplacer(variables, log), log, PackageDirectoryPath)),
+                    new ConfigurationVariablesReplacer(variables, log), log, PackageDirectoryName)),
                 new StructuredConfigurationVariablesConvention(
-                    new StructuredConfigurationVariablesBehaviour(structuredConfigVariablesService, PackageDirectoryPath))
+                    new StructuredConfigurationVariablesBehaviour(structuredConfigVariablesService, PackageDirectoryName))
             };
 
             if (variables.Get(Deployment.SpecialVariables.Account.AccountType) == "AmazonWebServicesAccount")


### PR DESCRIPTION
Originally we were extracting the package directly to the staging area which is fine if you're directly referencing a single file but now that we are using glob patterns, we need to extract the package into it's own folder so that a global glob won't load any other files that happen to be in the staging directory.

In this PR I've updated the step to extract the to a package folder inside the staging directory. I needed to update some other dependencies so that they could accept a subfolder to check, rather than just using the current directory on the `DeploymentProcess`.

[sc-52814]