### PR TITLE
Update AKS discoverer to better handle scenario's where resource group doesn't exist

### DIFF
--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using Calamari.Common.Features.Discovery;
 using Calamari.Common.Plumbing.Logging;
+using Microsoft.Rest.Azure;
 
 namespace Calamari.Azure.Kubernetes.Discovery
 {
@@ -34,14 +36,44 @@ namespace Calamari.Azure.Kubernetes.Discovery
             Log.Verbose($"  Client ID: {account.ClientId}");
             var azureClient = account.CreateAzureClient();
 
-            return azureClient.KubernetesClusters
-                              .List()
-                              .Select(c => KubernetesCluster.CreateForAks(
-                                  $"aks/{account.SubscriptionNumber}/{c.ResourceGroupName}/{c.Name}",
-                                  c.Name,
-                                  c.ResourceGroupName,
-                                  authenticationDetails.AccountId,
-                                  c.Tags.ToTargetTags()));
+            var discoveredClusters = new List<KubernetesCluster>();
+
+            // There appears to be an issue where the azure client returns stale data
+            // We need to upgrade this to use the newer SDK, but we need to upgrade to .NET 4.6.2 to support that.
+            var resourceGroups = azureClient.ResourceGroups.List();
+            //we don't care about resource groups that are being deleted 
+            foreach (var resourceGroup in resourceGroups.Where(rg => rg.ProvisioningState != "Deleting"))
+            {
+                try
+                {
+                    // There appears to be an issue where the azure client returns stale data
+                    // to mitigate this, specifically for scenario's where the resource group doesn't exist anymore
+                    // we specifically list the clusters in each resource group
+                    var clusters = azureClient.KubernetesClusters.ListByResourceGroup(resourceGroup.Name);
+
+                    discoveredClusters.AddRange(
+                                                clusters
+                                                    .Select(c => KubernetesCluster.CreateForAks(
+                                                                                                $"aks/{account.SubscriptionNumber}/{c.ResourceGroupName}/{c.Name}",
+                                                                                                c.Name,
+                                                                                                c.ResourceGroupName,
+                                                                                                authenticationDetails.AccountId,
+                                                                                                c.Tags.ToTargetTags())));
+                }
+                catch (CloudException ex)
+                {
+                    Log.Verbose($"Failed to list kubernetes clusters for resource group {resourceGroup.Name}. Response message: {ex.Message}, Status code: {ex.Response.StatusCode}");
+                    
+                    // if the resource group was not found, we don't care and move on
+                    if (ex.Response.StatusCode == HttpStatusCode.NotFound && ex.Message.StartsWith("Resource group"))
+                        continue;
+
+                    //throw in all other scenario's
+                    throw;
+                }
+            }
+
+            return discoveredClusters;
         }
     }
 }

--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -34,7 +34,8 @@ namespace Calamari.Azure.Kubernetes.Discovery
             Log.Verbose($"  Client ID: {account.ClientId}");
             var azureClient = account.CreateAzureClient();
 
-            return azureClient.KubernetesClusters.List()
+            return azureClient.KubernetesClusters
+                              .List()
                               .Select(c => KubernetesCluster.CreateForAks(
                                   $"aks/{account.SubscriptionNumber}/{c.ResourceGroupName}/{c.Name}",
                                   c.Name,

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/outputs.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/outputs.tf
@@ -40,7 +40,7 @@ output "aks_rg_name" {
   value       = azurerm_resource_group.default.name
 }
 
-output "ak_rg_id" {
+output "aks_rg_id" {
   description = "Resource group Id"
   value       = azurerm_resource_group.default.id
 }

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/outputs.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/outputs.tf
@@ -40,6 +40,11 @@ output "aks_rg_name" {
   value       = azurerm_resource_group.default.name
 }
 
+output "ak_rg_id" {
+  description = "Resource group Id"
+  value       = azurerm_resource_group.default.id
+}
+
 output "aks_service_account_token" {
   value     = kubernetes_secret.default.data.token
   sensitive = true


### PR DESCRIPTION
The AKS discoverer is using the old Fluent Management API SDK, which seems to have some issues where other test suites are adding/remove resource groups.

This code does similar logic to the SDK internally where it lists all the resource groups and then gets all the clusters for each resource group. We do the same logic, but we just better handle the errors when the resource group doesn't exist

Shortcut story: [sc-44622]