### PR TITLE
Handle 429's from Azure Management API in AppService tests

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -14,6 +14,8 @@ using Microsoft.Azure.Management.WebSites.Models;
 using Microsoft.Rest;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using Polly;
+using Polly.Retry;
 
 namespace Calamari.AzureAppService.Tests
 {
@@ -32,6 +34,8 @@ namespace Calamari.AzureAppService.Tests
 
         private ResourceGroupsOperations resourceGroupClient;
         private readonly HttpClient client = new HttpClient();
+        
+        protected RetryPolicy RetryPolicy { get; private set; }
 
         [OneTimeSetUp]
         public async Task Setup()
@@ -69,6 +73,31 @@ namespace Calamari.AzureAppService.Tests
             };
 
             await ConfigureTestResources(resourceGroup);
+            
+            
+            //Create a retry policy that retries on 429 errors. This is because we've been getting a number of flaky test failures
+            RetryPolicy = Policy
+                          .Handle<DefaultErrorResponseException>(ex => (int)ex.Response.StatusCode == 429)
+                          .WaitAndRetryAsync(5,
+                                             SleepDurationProvider,
+                                             (ex, ts, i, ctx) => Task.CompletedTask);
+            
+            
+            TimeSpan SleepDurationProvider(int retryAttempt, Exception ex, Context ctx)
+            {
+                //the azure API returns a Retry-After header that contains the number of seconds because you should try again
+                //so we try and read that header
+                if (ex is DefaultErrorResponseException responseException && responseException.Response.Headers.TryGetValue("Retry-After", out var values))
+                {
+                    var retryAfterValue = values.FirstOrDefault();
+
+                    if (int.TryParse(retryAfterValue, out var secondsToRetryAfter))
+                        return TimeSpan.FromSeconds(secondsToRetryAfter);
+                }
+
+                //fall back on just an exponential increase  based on the retry attempt
+                return TimeSpan.FromSeconds(Math.Pow(2, retryAttempt));
+            }
         }
 
         protected abstract Task ConfigureTestResources(ResourceGroup resourceGroup);

--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -71,33 +71,31 @@ namespace Calamari.AzureAppService.Tests
                 SubscriptionId = subscriptionId,
                 HttpClient = { BaseAddress = new Uri(DefaultVariables.ResourceManagementEndpoint) },
             };
-
-            await ConfigureTestResources(resourceGroup);
-            
             
             //Create a retry policy that retries on 429 errors. This is because we've been getting a number of flaky test failures
             RetryPolicy = Policy
                           .Handle<DefaultErrorResponseException>(ex => (int)ex.Response.StatusCode == 429)
                           .WaitAndRetryAsync(5,
-                                             SleepDurationProvider,
+                                             CalculateRetryDelay,
                                              (ex, ts, i, ctx) => Task.CompletedTask);
-            
-            
-            TimeSpan SleepDurationProvider(int retryAttempt, Exception ex, Context ctx)
+
+            await ConfigureTestResources(resourceGroup);
+        }
+
+        static TimeSpan CalculateRetryDelay(int retryAttempt, Exception ex, Context ctx)
+        {
+            //the azure API returns a Retry-After header that contains the number of seconds because you should try again
+            //so we try and read that header
+            if (ex is DefaultErrorResponseException responseException && responseException.Response.Headers.TryGetValue("Retry-After", out var values))
             {
-                //the azure API returns a Retry-After header that contains the number of seconds because you should try again
-                //so we try and read that header
-                if (ex is DefaultErrorResponseException responseException && responseException.Response.Headers.TryGetValue("Retry-After", out var values))
-                {
-                    var retryAfterValue = values.FirstOrDefault();
+                var retryAfterValue = values.FirstOrDefault();
 
-                    if (int.TryParse(retryAfterValue, out var secondsToRetryAfter))
-                        return TimeSpan.FromSeconds(secondsToRetryAfter);
-                }
-
-                //fall back on just an exponential increase  based on the retry attempt
-                return TimeSpan.FromSeconds(Math.Pow(2, retryAttempt));
+                if (int.TryParse(retryAfterValue, out var secondsToRetryAfter))
+                    return TimeSpan.FromSeconds(secondsToRetryAfter);
             }
+
+            //fall back on just an exponential increase  based on the retry attempt
+            return TimeSpan.FromSeconds(Math.Pow(2, retryAttempt));
         }
 
         protected abstract Task ConfigureTestResources(ResourceGroup resourceGroup);

--- a/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
+++ b/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Polly" Version="5.6.1" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
We were seeing flaky tests due to 429 (too many requests/rate limiting) errors being returned from the azure management API.

My suspicion is this is flaky due to other test suites making api management calls.

This PR uses a polly retry policy to retry all management API calls in the test fixture. The policy looks at the `Retry-After` header of the response to get the correct number of seconds to retry after.