### PR TITLE
Expose Kubernetes authentication and Object status as commands

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
@@ -1,3 +1,4 @@
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
@@ -1,3 +1,4 @@
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
@@ -1,3 +1,4 @@
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
@@ -1,3 +1,4 @@
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
@@ -1,3 +1,4 @@
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
@@ -1,3 +1,4 @@
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileExists.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileExists.approved.txt
@@ -1,3 +1,4 @@
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "<customkubectl>" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
@@ -1,4 +1,3 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
@@ -1,4 +1,3 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -69,6 +69,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionShouldFailWhenAccountTypeNotValid()
         {
             variables.Set(Deployment.SpecialVariables.Account.AccountType, "not valid");
@@ -79,9 +80,9 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionShouldApplyChmodInBash()
         {
-            variables.Set(ScriptVariables.Syntax, ScriptSyntax.Bash.ToString());
             variables.Set(PowerShellVariables.Edition, "Desktop");
             variables.Set(Deployment.SpecialVariables.Account.AccountType, "Token");
             variables.Set(Deployment.SpecialVariables.Account.Token, ClusterToken);
@@ -90,6 +91,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionShouldUseGivenNamespace()
         {
             variables.Set(ScriptVariables.Syntax, ScriptSyntax.PowerShell.ToString());
@@ -102,6 +104,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionShouldOutputKubeConfig()
         {
             variables.Set(ScriptVariables.Syntax, ScriptSyntax.PowerShell.ToString());
@@ -114,6 +117,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionWithCustomKubectlExecutable_FileDoesNotExist()
         {
             variables.Set(ScriptVariables.Syntax, ScriptSyntax.Bash.ToString());
@@ -126,6 +130,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionWithAzureServicePrincipal()
         {
             variables.Set(ScriptVariables.Syntax, ScriptSyntax.Bash.ToString());
@@ -143,6 +148,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionWithAzureServicePrincipalWithAdmin()
         {
             variables.Set(ScriptVariables.Syntax, ScriptSyntax.PowerShell.ToString());
@@ -160,6 +166,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionUsingPodServiceAccount_WithoutServerCert()
         {
             variables.Set(ScriptVariables.Syntax, ScriptSyntax.PowerShell.ToString());
@@ -176,6 +183,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionUsingPodServiceAccount_WithServerCert()
         {
             variables.Set(ScriptVariables.Syntax, ScriptSyntax.PowerShell.ToString());
@@ -196,6 +204,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionWithClientAndCertificateAuthority()
         {
             variables.Set(ScriptVariables.Syntax, ScriptSyntax.Bash.ToString());
@@ -212,6 +221,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionWithUsernamePassword()
         {
             variables.Set(ScriptVariables.Syntax, ScriptSyntax.Bash.ToString());
@@ -338,6 +348,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
+        [NonWindowsTest]
         public void ExecutionWithCustomKubectlExecutable_FileExists()
         {
             variables.Set(ScriptVariables.Syntax, ScriptSyntax.PowerShell.ToString());

--- a/source/Calamari/Commands/KubernetesAuthenticationCommand.cs
+++ b/source/Calamari/Commands/KubernetesAuthenticationCommand.cs
@@ -61,7 +61,7 @@ namespace Calamari.Commands
                 throw new CommandException(ex.Message);
             }
             
-            variables.Set("Octopus.KubeConfig.Path", fileSystem.GetFullPath(environmentVars["KUBECONFIG"]));
+            variables.Set(SpecialVariables.KubeConfig, fileSystem.GetFullPath(environmentVars["KUBECONFIG"]));
         }
     }
     

--- a/source/Calamari/Commands/KubernetesAuthenticationCommand.cs
+++ b/source/Calamari/Commands/KubernetesAuthenticationCommand.cs
@@ -1,0 +1,70 @@
+#if !NET40
+using System.Collections.Generic;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes;
+using Calamari.Kubernetes.Integration;
+
+namespace Calamari.Commands
+{
+    [Command("authenticate-to-kubernetes")]
+    public class KubernetesAuthenticationCommand: Command<KubernetesAuthenticationCommandInput>
+    {
+        private readonly ILog log;
+        private readonly IVariables variables;
+        private readonly ICalamariFileSystem fileSystem;
+        private readonly ICommandLineRunner commandLineRunner;
+        private readonly Kubectl kubectl;
+
+        public KubernetesAuthenticationCommand(
+            ILog log,
+            IVariables variables,
+            ICalamariFileSystem fileSystem,
+            ICommandLineRunner commandLineRunner,
+            Kubectl kubectl)
+        {
+            this.log = log;
+            this.variables = variables;
+            this.fileSystem = fileSystem;
+            this.commandLineRunner = commandLineRunner;
+            this.kubectl = kubectl;
+        }
+
+        protected override void Execute(KubernetesAuthenticationCommandInput inputs)
+        {
+            log.Info("Setting up KubeConfig authentication.");
+            var environmentVars = new Dictionary<string, string>();
+            var runningDeployment = new RunningDeployment(variables);
+            
+            kubectl.SetEnvironmentVariables(environmentVars);
+            kubectl.SetWorkingDirectory(runningDeployment.CurrentDirectory);
+            
+            var setupKubectlAuthentication = new SetupKubectlAuthentication(variables,
+                log,
+                commandLineRunner,
+                kubectl,
+                environmentVars,
+                runningDeployment.CurrentDirectory);
+            var accountType = variables.Get("Octopus.Account.AccountType");
+
+            try
+            {
+                var result = setupKubectlAuthentication.Execute(accountType);
+                result.VerifySuccess();
+            }
+            catch (CommandLineException ex)
+            {
+                log.Error("KubeConfig authentication failed.");
+                throw new CommandException(ex.Message);
+            }
+            
+            variables.Set("Octopus.KubeConfig.Path", fileSystem.GetFullPath(environmentVars["KUBECONFIG"]));
+        }
+    }
+    
+    public class KubernetesAuthenticationCommandInput { }
+}
+#endif

--- a/source/Calamari/Commands/KubernetesObjectStatusReporterCommand.cs
+++ b/source/Calamari/Commands/KubernetesObjectStatusReporterCommand.cs
@@ -62,7 +62,7 @@ namespace Calamari.Commands
                 
                 ConfigureKubectl();
 
-                var manifestPath = variables.Get("Octopus.Manifest.Path");
+                var manifestPath = variables.Get("Octopus.Kustomize.Manifest.Path");
                 var resources = KubernetesYaml.GetDefinedResources(new[] {manifestPath}, "default");
                 var statusResult = statusReportExecutor.Start(resources).WaitForCompletionOrTimeout()
                     .GetAwaiter().GetResult();

--- a/source/Calamari/Commands/KubernetesObjectStatusReporterCommand.cs
+++ b/source/Calamari/Commands/KubernetesObjectStatusReporterCommand.cs
@@ -1,0 +1,95 @@
+#if !NET40
+using System;
+using System.Collections.Generic;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Proxies;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes;
+using Calamari.Kubernetes.Integration;
+using Calamari.Kubernetes.ResourceStatus;
+
+namespace Calamari.Commands
+{
+    [Command("kubernetes-object-status")]
+    public class KubernetesObjectStatusReporterCommand: Command<KubernetesObjectStatusReporterCommandInput>
+    {
+        private readonly ILog log;
+        private readonly IVariables variables;
+        private readonly IResourceStatusReportExecutor statusReportExecutor;
+        private readonly Kubectl kubectl;
+
+        public KubernetesObjectStatusReporterCommand(
+            ILog log,
+            IVariables variables,
+            IResourceStatusReportExecutor statusReportExecutor,
+            Kubectl kubectl)
+        {
+            this.log = log;
+            this.variables = variables;
+            this.statusReportExecutor = statusReportExecutor;
+            this.kubectl = kubectl;
+        }
+
+        private bool IsEnabled()
+        {
+            var resourceStatusEnabled = variables.GetFlag(SpecialVariables.ResourceStatusCheck);
+            var isBlueGreen = variables.Get(SpecialVariables.DeploymentStyle) == "bluegreen";
+            var isWaitDeployment = variables.Get(SpecialVariables.DeploymentWait) == "wait";
+            if (!resourceStatusEnabled || isBlueGreen || isWaitDeployment)
+            {
+                return false;
+            }
+
+            var hasClusterUrl = !string.IsNullOrEmpty(variables.Get(SpecialVariables.ClusterUrl));
+            var hasClusterName = !string.IsNullOrEmpty(variables.Get(SpecialVariables.AksClusterName)) ||
+                                 !string.IsNullOrEmpty(variables.Get(SpecialVariables.EksClusterName)) ||
+                                 !string.IsNullOrEmpty(variables.Get(SpecialVariables.GkeClusterName));
+            return hasClusterUrl || hasClusterName;
+        }
+        
+        protected override void Execute(KubernetesObjectStatusReporterCommandInput inputs)
+        {
+            if (!IsEnabled())
+            {
+                log.Info("Kubernetes Object Status reporting has been skipped.");
+                return;
+            }
+            
+            try
+            {
+                log.Info("Starting Kubernetes Object Status reporting.");
+                
+                ConfigureKubectl();
+
+                var manifestPath = variables.Get("Octopus.Manifest.Path");
+                var resources = KubernetesYaml.GetDefinedResources(new[] {manifestPath}, "default");
+                var statusResult = statusReportExecutor.Start(resources).WaitForCompletionOrTimeout()
+                    .GetAwaiter().GetResult();
+                if (!statusResult)
+                {
+                    throw new CommandException("Unable to complete Kubernetes Report Status.");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new CommandException("Failed to complete Kubernetes Report Status.", ex);
+            }
+        }
+
+        private void ConfigureKubectl()
+        {
+            var kubeConfig = variables.Get("Octopus.KubeConfig.Path");
+            var environmentVars = new Dictionary<string, string> {{"KUBECONFIG", kubeConfig}};
+            foreach (var proxyVariable in ProxyEnvironmentVariablesGenerator.GenerateProxyEnvironmentVariables())
+            {
+                environmentVars[proxyVariable.Key] = proxyVariable.Value;
+            }
+
+            kubectl.SetEnvironmentVariables(environmentVars);
+        }
+    }
+    
+    public class KubernetesObjectStatusReporterCommandInput { }
+}
+#endif

--- a/source/Calamari/Commands/KubernetesObjectStatusReporterCommand.cs
+++ b/source/Calamari/Commands/KubernetesObjectStatusReporterCommand.cs
@@ -46,7 +46,7 @@ namespace Calamari.Commands
                 
                 ConfigureKubectl();
 
-                var manifestPath = variables.Get("Octopus.Kustomize.Manifest.Path");
+                var manifestPath = variables.Get(SpecialVariables.KustomizeManifest);
                 var defaultNamespace = variables.Get(SpecialVariables.Namespace, "default");
                 // When the namespace on a target was set and then cleared, it's going to be "" instead of null
                 if (string.IsNullOrEmpty(defaultNamespace))
@@ -72,7 +72,7 @@ namespace Calamari.Commands
 
         private void ConfigureKubectl()
         {
-            var kubeConfig = variables.Get("Octopus.KubeConfig.Path");
+            var kubeConfig = variables.Get(SpecialVariables.KubeConfig);
             var environmentVars = new Dictionary<string, string> {{"KUBECONFIG", kubeConfig}};
             foreach (var proxyVariable in ProxyEnvironmentVariablesGenerator.GenerateProxyEnvironmentVariables())
             {

--- a/source/Calamari/Commands/SubstituteInFilesCommand.cs
+++ b/source/Calamari/Commands/SubstituteInFilesCommand.cs
@@ -1,5 +1,8 @@
-﻿using Calamari.Common.Commands;
+﻿using System;
+using Calamari.Commands.Support;
+using Calamari.Common.Commands;
 using Calamari.Common.Features.Substitutions;
+using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Commands
@@ -18,18 +21,10 @@ namespace Calamari.Commands
 
         protected override void Execute(SubstituteInFilesCommandInputs inputs)
         {
-            var runningDeployment = new RunningDeployment(variables);
-            var targetPath = runningDeployment.CurrentDirectory;
-            
-            if (!string.IsNullOrEmpty(inputs.TargetPathVariable))
+            var targetPath = variables.GetRaw(inputs.TargetPathVariable);
+            if (targetPath == null)
             {
-                targetPath = variables.GetRaw(inputs.TargetPathVariable);
-
-                if (targetPath == null)
-                {
-                    throw new CommandException(
-                        $"Could not locate target path from variable {inputs.TargetPathVariable} for {nameof(SubstituteInFilesCommand)}");
-                }
+                throw new CommandException($"Could not locate target path from variable {inputs.TargetPathVariable} for {nameof(SubstituteInFilesCommand)}");
             }
 
             substituteInFiles.Substitute(targetPath, inputs.FilesToTarget);

--- a/source/Calamari/Commands/SubstituteInFilesCommand.cs
+++ b/source/Calamari/Commands/SubstituteInFilesCommand.cs
@@ -18,10 +18,18 @@ namespace Calamari.Commands
 
         protected override void Execute(SubstituteInFilesCommandInputs inputs)
         {
-            var targetPath = variables.GetRaw(inputs.TargetPathVariable);
-            if (targetPath == null)
+            var runningDeployment = new RunningDeployment(variables);
+            var targetPath = runningDeployment.CurrentDirectory;
+            
+            if (!string.IsNullOrEmpty(inputs.TargetPathVariable))
             {
-                throw new CommandException($"Could not locate target path from variable {inputs.TargetPathVariable} for {nameof(SubstituteInFilesCommand)}");
+                targetPath = variables.GetRaw(inputs.TargetPathVariable);
+
+                if (targetPath == null)
+                {
+                    throw new CommandException(
+                        $"Could not locate target path from variable {inputs.TargetPathVariable} for {nameof(SubstituteInFilesCommand)}");
+                }
             }
 
             substituteInFiles.Substitute(targetPath, inputs.FilesToTarget);

--- a/source/Calamari/Commands/SubstituteInFilesCommand.cs
+++ b/source/Calamari/Commands/SubstituteInFilesCommand.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using Calamari.Commands.Support;
-using Calamari.Common.Commands;
+﻿using Calamari.Common.Commands;
 using Calamari.Common.Features.Substitutions;
-using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Commands

--- a/source/Calamari/Commands/SubstituteVariablesInFilesCommand.cs
+++ b/source/Calamari/Commands/SubstituteVariablesInFilesCommand.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Substitutions;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Commands
+{
+    [Command("substitute-variables-in-files")]
+    public class SubstituteVariablesInFilesCommand : Command<SubstituteVariablesInFilesCommandInputs>
+    {
+        readonly IVariables variables;
+        readonly ISubstituteInFiles substituteInFiles;
+
+        public SubstituteVariablesInFilesCommand(IVariables variables, ISubstituteInFiles substituteInFiles)
+        {
+            this.variables = variables;
+            this.substituteInFiles = substituteInFiles;
+        }
+
+        protected override void Execute(SubstituteVariablesInFilesCommandInputs inputs)
+        {
+            var runningDeployment = new RunningDeployment(variables);
+            var targetPath = runningDeployment.CurrentDirectory;
+            
+            substituteInFiles.Substitute(targetPath, inputs.FilesToTarget.Split(new []{'\n', '\r', ';'}, StringSplitOptions.RemoveEmptyEntries));
+        }
+    }
+
+    public class SubstituteVariablesInFilesCommandInputs
+    {
+        public string FilesToTarget { get; set; }
+    }
+}

--- a/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
@@ -60,7 +60,10 @@ namespace Calamari.Kubernetes.Commands
                 return await gatherAndApplyRawYamlExecutor.Execute(runningDeployment);
             }
 
-            var statusCheck = statusReporter.Start();
+            var timeoutSeconds = variables.GetInt32(SpecialVariables.Timeout) ?? 0;
+            var waitForJobs = variables.GetFlag(SpecialVariables.WaitForJobs);
+            
+            var statusCheck = statusReporter.Start(timeoutSeconds, waitForJobs);
 
             return await gatherAndApplyRawYamlExecutor.Execute(runningDeployment, statusCheck.AddResources) &&
                 await statusCheck.WaitForCompletionOrTimeout();

--- a/source/Calamari/Kubernetes/Conventions/KubernetesAuthContextConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/KubernetesAuthContextConvention.cs
@@ -28,7 +28,6 @@ namespace Calamari.Kubernetes.Conventions
         {
             var setupKubectlAuthentication = new SetupKubectlAuthentication(deployment.Variables,
                 log,
-                ScriptSyntax.PowerShell,
                 commandLineRunner,
                 kubectl,
                 deployment.EnvironmentVariables,

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -57,7 +57,6 @@ namespace Calamari.Kubernetes
             var kubectl = new Kubectl(variables, log, commandLineRunner, workingDirectory, environmentVars);
             var setupKubectlAuthentication = new SetupKubectlAuthentication(variables,
                                                                             log,
-                                                                            scriptSyntax,
                                                                             commandLineRunner,
                                                                             kubectl,
                                                                             environmentVars,

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
@@ -10,7 +10,7 @@ namespace Calamari.Kubernetes.ResourceStatus
 {
     public interface IResourceStatusReportExecutor
     {
-        IRunningResourceStatusCheck Start(IEnumerable<ResourceIdentifier> initialResources = null);
+        IRunningResourceStatusCheck Start(int timeoutSeconds, bool waitForJobs, IEnumerable<ResourceIdentifier> initialResources = null);
     }
     
     public class ResourceStatusReportExecutor : IResourceStatusReportExecutor
@@ -26,12 +26,10 @@ namespace Calamari.Kubernetes.ResourceStatus
             this.runningResourceStatusCheckFactory = runningResourceStatusCheckFactory;
         }
 
-        public IRunningResourceStatusCheck Start(IEnumerable<ResourceIdentifier> initialResources)
+        public IRunningResourceStatusCheck Start(int timeoutSeconds, bool waitForJobs, IEnumerable<ResourceIdentifier> initialResources = null)
         {
             initialResources = initialResources ?? Enumerable.Empty<ResourceIdentifier>();
-            var timeoutSeconds = variables.GetInt32(SpecialVariables.Timeout) ?? 0;
-            var waitForJobs = variables.GetFlag(SpecialVariables.WaitForJobs);
-
+            
             var timeout = timeoutSeconds == 0
                 ? Timeout.InfiniteTimeSpan
                 : TimeSpan.FromSeconds(timeoutSeconds);

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -73,7 +73,9 @@ namespace Calamari.Kubernetes.ResourceStatus
             try
             {
                 var resources = resourceFinder.FindResources(workingDirectory);
-                var statusResult = statusReportExecutor.Start(resources).WaitForCompletionOrTimeout()
+                var timeoutSeconds = variables.GetInt32(SpecialVariables.Timeout) ?? 0;
+                var waitForJobs = variables.GetFlag(SpecialVariables.WaitForJobs);
+                var statusResult = statusReportExecutor.Start(timeoutSeconds, waitForJobs, resources).WaitForCompletionOrTimeout()
                                                        .GetAwaiter().GetResult();
                 if (!statusResult)
                 {

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Calamari.Common.Features.Processes;
-using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Proxies;
@@ -21,7 +20,6 @@ namespace Calamari.Kubernetes
     {
         readonly IVariables variables;
         readonly ILog log;
-        readonly ScriptSyntax scriptSyntax;
         readonly ICommandLineRunner commandLineRunner;
         private readonly Kubectl kubectl;
         readonly Dictionary<string, string> environmentVars;
@@ -30,7 +28,6 @@ namespace Calamari.Kubernetes
 
         public SetupKubectlAuthentication(IVariables variables,
             ILog log,
-            ScriptSyntax scriptSyntax,
             ICommandLineRunner commandLineRunner,
             Kubectl kubectl,
             Dictionary<string, string> environmentVars,
@@ -38,7 +35,6 @@ namespace Calamari.Kubernetes
         {
             this.variables = variables;
             this.log = log;
-            this.scriptSyntax = scriptSyntax;
             this.commandLineRunner = commandLineRunner;
             this.kubectl = kubectl;
             this.environmentVars = environmentVars;
@@ -443,7 +439,7 @@ namespace Calamari.Kubernetes
 
             environmentVars.Add("KUBECONFIG", kubeConfig);
 
-            if (scriptSyntax == ScriptSyntax.Bash)
+            if (CalamariEnvironment.IsRunningOnNix || CalamariEnvironment.IsRunningOnMac)
             {
                 ExecuteCommand("chmod", "u=rw,g=,o=", $"\"{kubeConfig}\"");
             }

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -19,7 +19,10 @@
         public const string GroupedYamlDirectories = "Octopus.Action.KubernetesContainers.YamlDirectories";
         public const string Timeout = "Octopus.Action.Kubernetes.DeploymentTimeout";
         public const string WaitForJobs = "Octopus.Action.Kubernetes.WaitForJobs";
-
+        
+        public const string KubeConfig = "Octopus.KubeConfig.Path";
+        public const string KustomizeManifest = "Octopus.Kustomize.Manifest.Path";
+            
         public const string KubernetesResourceStatusServiceMessageName = "k8s-status";
 
         public static class Helm

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -11,9 +11,9 @@
         public const string Namespace = "Octopus.Action.Kubernetes.Namespace";
         public const string SkipTlsVerification = "Octopus.Action.Kubernetes.SkipTlsVerification";
         public const string OutputKubeConfig = "Octopus.Action.Kubernetes.OutputKubeConfig";
-        public const string CustomKubectlExecutable = "Octopus.Action.Kubernetes.CustomKubectlExecutable";
+        public const string CustomKubectlExecutable = "Octopus.Action.Kubernetes.CustomKubectlExecutable"; 
         public const string ResourceStatusCheck = "Octopus.Action.Kubernetes.ResourceStatusCheck";
-        public const string DeploymentStyle = "Octopus.Action.KubernetesContainers.DeploymentStyle";
+        public const string DeploymentStyle = "Octopus.Action.KubernetesContainers.DeploymentStyle"; 
         public const string DeploymentWait = "Octopus.Action.KubernetesContainers.DeploymentWait";
         public const string CustomResourceYamlFileName = "Octopus.Action.KubernetesContainers.CustomResourceYamlFileName";
         public const string GroupedYamlDirectories = "Octopus.Action.KubernetesContainers.YamlDirectories";


### PR DESCRIPTION
I have created a new `substitute-in-files` so that the base path can be defaulted to the current directory instead of being read from a variable.

These commands are needed by project Kustomize so we can re-use existing functionality when using the new steps framework.
This is related to this change on the [Server](https://github.com/OctopusDeploy/OctopusDeploy/pull/19123).