### PR TITLE
Fixing small typo in warning message when a glob path doesn't match anything

### DIFF
--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -144,7 +144,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             var files = fileSystem.EnumerateFilesRecursively(globDirectory.Directory).ToArray();
             if (!files.Any())
             {
-                log.Warn($"No files found matching '{globDirectory.Glob}");
+                log.Warn($"No files found matching '{globDirectory.Glob}'");
                 return Enumerable.Empty<Resource>();
             }
 


### PR DESCRIPTION
I found this small typo so just fixing it here.