### PR TITLE
Remove split by ';' as it is no longer required

### DIFF
--- a/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
+++ b/source/Calamari.Common/Features/StructuredVariables/StructuredConfigVariablesService.cs
@@ -62,8 +62,7 @@ namespace Calamari.Common.Features.StructuredVariables
         public void ReplaceVariables(string currentDirectory)
         {
             ReplaceVariables(currentDirectory,
-                variables.GetPaths(ActionVariables.StructuredConfigurationVariablesTargets)
-                         .SelectMany(v => v.Split(';')).ToList());
+                variables.GetPaths(ActionVariables.StructuredConfigurationVariablesTargets));
         }
 
         public void ReplaceVariables(string currentDirectory, List<string> targets)

--- a/source/Calamari.Common/Plumbing/FileSystem/SubstituteInFiles.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/SubstituteInFiles.cs
@@ -25,8 +25,7 @@ namespace Calamari.Common.Plumbing.FileSystem
 
         public void SubstituteBasedSettingsInSuppliedVariables(string currentDirectory)
         {
-            var filesToTarget = variables.GetPaths(PackageVariables.SubstituteInFilesTargets)
-                                         .SelectMany(v => v.Split(';')).ToArray();
+            var filesToTarget = variables.GetPaths(PackageVariables.SubstituteInFilesTargets);
             Substitute(currentDirectory, filesToTarget);
         }
 

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -261,7 +261,9 @@ namespace Calamari.Tests.KubernetesFixtures
 
             SetVariablesForKubernetesResourceStatusCheck(30);
 
-            SetVariablesForRawYamlCommand($"deployments/**/*;services/{ServiceFileName};configmaps/*.yml");
+            SetVariablesForRawYamlCommand($@"deployments/**/*
+                                             services/{ServiceFileName}
+                                             configmaps/*.yml");
 
             string CreatePackageWithMultipleYamlFiles(string directory)
             {

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -46,8 +46,8 @@ namespace Calamari.Kubernetes.Commands.Executors
             try
             {
                 var variables = deployment.Variables;
-                var globs = variables.Get(SpecialVariables.CustomResourceYamlFileName)?.Split(';');
-                if (globs == null || globs.All(g => g.IsNullOrEmpty()))
+                var globs = variables.GetPaths(SpecialVariables.CustomResourceYamlFileName);
+                if (globs.IsNullOrEmpty())
                     return true;
                 var directories = GroupFilesIntoDirectories(deployment, globs, variables);
                 var resources = new HashSet<Resource>();
@@ -98,7 +98,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             }
         }
 
-        private IEnumerable<GlobDirectory> GroupFilesIntoDirectories(RunningDeployment deployment, string[] globs, IVariables variables)
+        private IEnumerable<GlobDirectory> GroupFilesIntoDirectories(RunningDeployment deployment, List<string> globs, IVariables variables)
         {
             var stagingDirectory = deployment.CurrentDirectory;
             var packageDirectory =
@@ -106,7 +106,7 @@ namespace Calamari.Kubernetes.Commands.Executors
                 Path.DirectorySeparatorChar;
 
             var directories = new List<GlobDirectory>();
-            for (var i = 0; i < globs.Length; i ++)
+            for (var i = 0; i < globs.Count; i ++)
             {
                 var glob = globs[i];
                 var directoryPath = Path.Combine(stagingDirectory, GroupedDirectoryName, i.ToString());


### PR DESCRIPTION
To align with the way other steps specify multiple paths, we are going to save paths as new line separated, rather than with a semicolon `;`. In this case, I can roll back extra handling I put into Calamari before which would split paths by `;` when getting the value from the `VariableDictionary`. The `GetPaths` method automatically splits by new line separators `\r` and `\n` and it trims the paths and only returns non-empty entries.

Related to [this change](https://github.com/OctopusDeploy/OctopusDeploy/pull/19325) in Server.

[sc-54749]
[sc-52829]