### PR TITLE
Early exit on disabled bindings for IIS

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -436,6 +436,11 @@ if ($deployAsWebSite)
 	}
 
 	ForEach($binding in $bindingArray){
+		if(![Bool]::Parse($binding.enabled)) {
+    		Write-IISBinding "Ignore binding: " $binding
+    		return
+    	}
+
 		$sslFlagPart = @{$true=1;$false=0}[[Bool]::Parse($binding.requireSni)]  
 		$bindingIpAddress =  @{$true="*";$false=$binding.ipAddress}[[string]::IsNullOrEmpty($binding.ipAddress)]
 		$bindingInformation = $bindingIpAddress+":"+$binding.port+":"+$binding.host
@@ -457,12 +462,8 @@ if ($deployAsWebSite)
 		if ([Bool]::Parse($supportsSNI)) {
 			$bindingObj.sslFlags=$sslFlagPart;
 		}
-			
-		if([Bool]::Parse($binding.enabled)) {
-			$wsbindings.Add($bindingObj) | Out-Null
-		} else {
-			Write-IISBinding "Ignore binding: " $binding
-		}
+
+		$wsbindings.Add($bindingObj) | Out-Null
 	}
 
 	# For any HTTPS bindings, ensure the certificate is configured for the IP/port combination

--- a/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
@@ -438,7 +438,7 @@ if ($deployAsWebSite)
 	ForEach($binding in $bindingArray){
 		if(![Bool]::Parse($binding.enabled)) {
     		Write-IISBinding "Ignore binding: " $binding
-    		return
+    		continue
     	}
 
 		$sslFlagPart = @{$true=1;$false=0}[[Bool]::Parse($binding.requireSni)]  


### PR DESCRIPTION
Variable to set the binding as enabled is evaluated last, meaning we parse values unnecessarily. A customer experienced an issue where a binding was disabled and no valid values were provided in a specific environment/target scoping. These values were still being evaluated leading to failures.

Fixes https://github.com/OctopusDeploy/Issues/issues/8271

![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/dff5c341-fa9f-4223-91ec-2873692c448d)
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/95775d98-36ff-4169-a779-90632c934861)
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/903618a5-6ac9-487f-a8e7-90e1900c44a1)
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/9260b2b2-b6dd-4079-8524-f0d892a0013b)

