### PR TITLE
Properly name S3 buckets in integration tests

### DIFF
--- a/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
@@ -32,7 +32,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         public S3PackageDownloaderFixture()
         {
             region = RegionRandomiser.GetARegion();
-            bucketName = Guid.NewGuid().ToString("N");
+            bucketName = $"calamari-e2e-{Guid.NewGuid():N}";
         }
 
         [OneTimeSetUp]


### PR DESCRIPTION
Makes it easier to identify the buckets in AWS for automatic cleanup (if they don't get cleaned up by the test)