### PR TITLE
Reduce deployment journal size

### DIFF
--- a/source/Calamari.Common/Features/Deployment/Journal/DeploymentJournal.cs
+++ b/source/Calamari.Common/Features/Deployment/Journal/DeploymentJournal.cs
@@ -26,7 +26,7 @@ namespace Calamari.Common.Features.Deployment.Journal
 
         string? JournalPath => variables.Get(TentacleVariables.Agent.JournalPath);
 
-        public void AddJournalEntry(JournalEntry entry)
+        internal void AddJournalEntry(JournalEntry entry)
         {
             using (semaphore.Acquire(SemaphoreName, "Another process is using the deployment journal"))
             {

--- a/source/Calamari.Common/Features/Deployment/Journal/IDeploymentJournal.cs
+++ b/source/Calamari.Common/Features/Deployment/Journal/IDeploymentJournal.cs
@@ -5,7 +5,6 @@ namespace Calamari.Common.Features.Deployment.Journal
 {
     public interface IDeploymentJournal
     {
-        void AddJournalEntry(JournalEntry entry);
         List<JournalEntry> GetAllJournalEntries();
         void RemoveJournalEntries(IEnumerable<string> ids);
         JournalEntry GetLatestInstallation(string retentionPolicySubset);

--- a/source/Calamari.Common/Plumbing/Deployment/Journal/DeploymentJournalWriter.cs
+++ b/source/Calamari.Common/Plumbing/Deployment/Journal/DeploymentJournalWriter.cs
@@ -42,7 +42,7 @@ namespace Calamari.Common.Plumbing.Deployment.Journal
                 return;
 
             var journalEntry = new JournalEntry(deployment, wasSuccessful);
-            if (journalEntry.ExtractedTo == null)
+            if (string.IsNullOrEmpty(journalEntry.ExtractedTo))
                 return;
 
             journal.AddJournalEntry(new JournalEntry(deployment, wasSuccessful));

--- a/source/Calamari.Tests/Fixtures/Deployment/CleanFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/CleanFixture.cs
@@ -5,6 +5,7 @@ using System.Xml.Linq;
 using Calamari.Common.Features.Deployment.Journal;
 using Calamari.Common.Features.Processes.Semaphores;
 using Calamari.Common.Plumbing.Commands;
+using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Integration.FileSystem;
@@ -19,7 +20,7 @@ namespace Calamari.Tests.Fixtures.Deployment
     {
         CalamariResult result;
         ICalamariFileSystem fileSystem;
-        IDeploymentJournal deploymentJournal;
+        DeploymentJournal deploymentJournal;
         IVariables variables;
         string tentacleDirectory;
         string packagesDirectory;

--- a/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
@@ -10,6 +10,7 @@ using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing.Commands;
+using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
@@ -142,7 +143,8 @@ namespace Calamari.Tests.Java.Fixtures.Deployment
                     new XmlFormatVariableReplacer(fileSystem, log),
                     new YamlFormatVariableReplacer(fileSystem, log),
                     new PropertiesFormatVariableReplacer(fileSystem, log),
-                }, variables, fileSystem, log)
+                }, variables, fileSystem, log),
+                new DeploymentJournalWriter(fileSystem)
             );
             returnCode = command.Execute(new[] { "--archive", $"{packageName}" });
         }

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -131,11 +131,11 @@ namespace Calamari.Commands
             try
             {
                 conventionRunner.RunConventions();
-                deploymentJournalWriter.AddJournalEntry(deployment, true);
+                deploymentJournalWriter.AddJournalEntry(deployment, true, pathToPackage);
             }
             catch (Exception)
             {
-                deploymentJournalWriter.AddJournalEntry(deployment, false);
+                deploymentJournalWriter.AddJournalEntry(deployment, false, pathToPackage);
                 throw;
             }
 

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -17,6 +17,7 @@ using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Deployment;
+using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -40,6 +41,7 @@ namespace Calamari.Commands
         readonly ISubstituteInFiles substituteInFiles;
         readonly IExtractPackage extractPackage;
         readonly IStructuredConfigVariablesService structuredConfigVariablesService;
+        readonly IDeploymentJournalWriter deploymentJournalWriter;
         PathToPackage pathToPackage;
 
         public DeployPackageCommand(
@@ -50,8 +52,8 @@ namespace Calamari.Commands
             ICommandLineRunner commandLineRunner,
             ISubstituteInFiles substituteInFiles,
             IExtractPackage extractPackage,
-            IStructuredConfigVariablesService structuredConfigVariablesService
-        )
+            IStructuredConfigVariablesService structuredConfigVariablesService,
+            IDeploymentJournalWriter deploymentJournalWriter)
         {
             Options.Add("package=", "Path to the deployment package to install.", v => pathToPackage = new PathToPackage(Path.GetFullPath(v)));
 
@@ -63,6 +65,7 @@ namespace Calamari.Commands
             this.substituteInFiles = substituteInFiles;
             this.extractPackage = extractPackage;
             this.structuredConfigVariablesService = structuredConfigVariablesService;
+            this.deploymentJournalWriter = deploymentJournalWriter;
         }
 
         public override int Execute(string[] commandLineArguments)
@@ -128,13 +131,11 @@ namespace Calamari.Commands
             try
             {
                 conventionRunner.RunConventions();
-                if (!deployment.SkipJournal)
-                    journal.AddJournalEntry(new JournalEntry(deployment, true));
+                deploymentJournalWriter.AddJournalEntry(deployment, true);
             }
             catch (Exception)
             {
-                if (!deployment.SkipJournal)
-                    journal.AddJournalEntry(new JournalEntry(deployment, false));
+                deploymentJournalWriter.AddJournalEntry(deployment, false);
                 throw;
             }
 

--- a/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
+++ b/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
@@ -128,11 +128,11 @@ namespace Calamari.Commands.Java
             try
             {
                 conventionRunner.RunConventions();
-                deploymentJournalWriter.AddJournalEntry(deployment, true);
+                deploymentJournalWriter.AddJournalEntry(deployment, true, archiveFile);
             }
             catch (Exception)
             {
-                deploymentJournalWriter.AddJournalEntry(deployment, false);
+                deploymentJournalWriter.AddJournalEntry(deployment, false, archiveFile);
                 throw;
             }
 


### PR DESCRIPTION
The deployment journal records deployments to clean them up at a later date.
In the beginning, the deployment journal recorded everything because everything was a package being deployed.
These days, work is done that does not involve deploying a package, especially in the age of workers. With workers being involved in every deployment (instead of just the ones to the environment a deployment target is in), the deployment journal is exploding. 

This PR makes the deployment journal more selective about what it records. It no longer records journal entries not used for retention: entries where a package is not deployed to the disk. This greatly reduces the size of the journal on frequently used workers, speeding up deployments.


