### PR TITLE
Remove multi-glob feature toggle

### DIFF
--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -7,7 +7,6 @@
     /// </summary>
     public enum FeatureToggle {
         SkunkworksFeatureToggle,
-        MultiGlobPathsForRawYamlFeatureToggle,
         KubernetesAksKubeloginFeatureToggle,
         GlobPathsGroupSupportFeatureToggle
     }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -120,13 +120,13 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
-        [TestCase(true, true)]
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        [TestCase(false, false)]
-        public void DeployRawYaml_WithRawYamlDeploymentScriptOrCommand_OutputShouldIndicateSuccessfulDeployment(bool runAsScript, bool usePackage)
+        [TestCase(true)]
+        [TestCase(false)]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void DeployRawYaml_WithRawYamlDeploymentScriptOrCommand_OutputShouldIndicateSuccessfulDeployment(bool usePackage)
         {
-            SetupAndRunKubernetesRawYamlDeployment(runAsScript, usePackage, SimpleDeploymentResource);
+            SetupAndRunKubernetesRawYamlDeployment(usePackage, SimpleDeploymentResource);
 
             var rawLogs = Log.Messages.Select(m => m.FormattedMessage).ToArray();
 
@@ -134,7 +134,7 @@ namespace Calamari.Tests.KubernetesFixtures
 
             this.Assent(scrubbedJson, configuration: AssentConfiguration.Default);
 
-            AssertObjectStatusMonitoringStarted(runAsScript, rawLogs, (SimpleDeploymentResourceType, SimpleDeploymentResourceName));
+            AssertObjectStatusMonitoringStarted(rawLogs, (SimpleDeploymentResourceType, SimpleDeploymentResourceName));
 
             var objectStatusUpdates = Log.Messages.GetServiceMessagesOfType("k8s-status");
 
@@ -144,11 +144,9 @@ namespace Calamari.Tests.KubernetesFixtures
                 m.Contains("Resource status check completed successfully because all resources are deployed successfully"));
         }
 
-        private static void AssertObjectStatusMonitoringStarted(bool runAsScript, string[] rawLogs, params (string Type, string Name)[] resources)
+        private static void AssertObjectStatusMonitoringStarted(string[] rawLogs, params (string Type, string Name)[] resources)
         {
-            var resourceStatusCheckLog = runAsScript
-                ? "Resource Status Check: Performing resource status checks on the following resources:"
-                : "Resource Status Check: 1 new resources have been added:";
+            const string resourceStatusCheckLog = "Resource Status Check: 1 new resources have been added:";
             var idx = Array.IndexOf(rawLogs, resourceStatusCheckLog);
             foreach (var (i, type, name) in resources.Select((t, i) => (i, t.Type, t.Name)))
             {
@@ -176,13 +174,13 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
-        [TestCase(true, true)]
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        [TestCase(false, false)]
-        public void DeployRawYaml_WithInvalidYaml_OutputShouldIndicateFailure(bool runAsScript, bool usePackage)
+        [TestCase(true)]
+        [TestCase(false)]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void DeployRawYaml_WithInvalidYaml_OutputShouldIndicateFailure(bool usePackage)
         {
-            SetupAndRunKubernetesRawYamlDeployment(runAsScript, usePackage, InvalidDeploymentResource, shouldSucceed: false);
+            SetupAndRunKubernetesRawYamlDeployment(usePackage, InvalidDeploymentResource, shouldSucceed: false);
 
             var rawLogs = Log.Messages.Select(m => m.FormattedMessage).Where(m => !m.StartsWith("##octopus") && m != string.Empty).ToArray();
 
@@ -233,13 +231,11 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
-        [TestCase(true, true)]
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        [TestCase(false, false)]
-        public void DeployRawYaml_WithYamlThatWillNotSucceed_OutputShouldIndicateFailure(bool runAsScript, bool usePackage)
+        [TestCase(true)]
+        [TestCase(false)]
+        public void DeployRawYaml_WithYamlThatWillNotSucceed_OutputShouldIndicateFailure(bool usePackage)
         {
-            SetupAndRunKubernetesRawYamlDeployment(runAsScript, usePackage, FailToDeploymentResource, shouldSucceed: false);
+            SetupAndRunKubernetesRawYamlDeployment(usePackage, FailToDeploymentResource, shouldSucceed: false);
 
             var rawLogs = Log.Messages.Select(m => m.FormattedMessage).ToArray();
 
@@ -247,7 +243,7 @@ namespace Calamari.Tests.KubernetesFixtures
 
             this.Assent(scrubbedJson, configuration: AssentConfiguration.Default);
 
-            AssertObjectStatusMonitoringStarted(runAsScript, rawLogs, (SimpleDeploymentResourceType, SimpleDeploymentResourceName));
+            AssertObjectStatusMonitoringStarted(rawLogs, (SimpleDeploymentResourceType, SimpleDeploymentResourceName));
 
             rawLogs.Should().ContainSingle(l =>
                 l ==
@@ -335,20 +331,11 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public void AuthorisingWithAmazonAccount(bool runAsScript)
+        public void AuthorisingWithAmazonAccount()
         {
             SetVariablesToAuthoriseWithAmazonAccount();
 
-            if (runAsScript)
-            {
-                DeployWithKubectlTestScriptAndVerifyResult();
-            }
-            else
-            {
-                ExecuteCommandAndVerifyResult(TestableKubernetesDeploymentCommand.Name);
-            }
+            ExecuteCommandAndVerifyResult(TestableKubernetesDeploymentCommand.Name);
         }
 
         [Test]
@@ -658,29 +645,19 @@ namespace Calamari.Tests.KubernetesFixtures
                    "Unable to authorise credentials, see verbose log for details.");
         }
 
-        private void SetupAndRunKubernetesRawYamlDeployment(bool runAsScript, bool usePackage, string resource, bool shouldSucceed = true)
+        private void SetupAndRunKubernetesRawYamlDeployment(bool usePackage, string resource, bool shouldSucceed = true)
         {
             SetVariablesToAuthoriseWithAmazonAccount();
 
             SetVariablesForKubernetesResourceStatusCheck(shouldSucceed ? 30 : 5);
 
-            SetVariablesForRawYamlCommand(runAsScript ? null : "**/*.{yml,yaml}");
+            SetVariablesForRawYamlCommand("**/*.{yml,yaml}");
 
-            if (runAsScript)
-            {
-                DeployWithDeploymentScriptAndVerifyResult(usePackage
-                        ? CreateAddPackageFunc(resource)
-                        : CreateAddCustomResourceFileFunc(resource),
-                    shouldSucceed);
-            }
-            else
-            {
-                ExecuteCommandAndVerifyResult(KubernetesApplyRawYamlCommand.Name,
-                    usePackage
-                        ? CreateAddPackageFunc(resource)
-                        : CreateAddCustomResourceFileFunc(resource),
-                    shouldSucceed);
-            }
+            ExecuteCommandAndVerifyResult(KubernetesApplyRawYamlCommand.Name,
+                usePackage
+                    ? CreateAddPackageFunc(resource)
+                    : CreateAddCustomResourceFileFunc(resource),
+                shouldSucceed);
         }
 
         private void SetVariablesToAuthoriseWithAmazonAccount()
@@ -702,7 +679,6 @@ namespace Calamari.Tests.KubernetesFixtures
         private void SetVariablesForRawYamlCommand(string globPaths = null)
         {
             variables.Set("Octopus.Action.KubernetesContainers.Namespace", "nginx");
-            variables.AddFeatureToggles(FeatureToggle.MultiGlobPathsForRawYamlFeatureToggle);
             variables.Set(KnownVariables.Package.JsonConfigurationVariablesTargets, globPaths ?? "**/*.{yml,yaml}");
             if (globPaths != null)
             {

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
@@ -36,7 +36,9 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
-        public void AuthoriseWithAmazonEC2Role()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void AuthoriseWithAmazonEC2Role(bool runAsScript)
         {
             variables.Set(Deployment.SpecialVariables.Account.AccountType, "AmazonWebServicesAccount");
             variables.Set(SpecialVariables.ClusterUrl, eksClusterEndpoint);
@@ -45,7 +47,14 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Aws.AssumeRole", Boolean.FalseString);
             variables.Set("Octopus.Action.Aws.Region", region);
 
-            ExecuteCommandAndVerifyResult(TestableKubernetesDeploymentCommand.Name);
+            if (runAsScript)
+            {
+                DeployWithKubectlTestScriptAndVerifyResult();
+            }
+            else
+            {
+                ExecuteCommandAndVerifyResult(TestableKubernetesDeploymentCommand.Name);
+            }
         }
 
         [Test]

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
@@ -36,9 +36,7 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public void AuthoriseWithAmazonEC2Role(bool runAsScript)
+        public void AuthoriseWithAmazonEC2Role()
         {
             variables.Set(Deployment.SpecialVariables.Account.AccountType, "AmazonWebServicesAccount");
             variables.Set(SpecialVariables.ClusterUrl, eksClusterEndpoint);
@@ -47,14 +45,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Aws.AssumeRole", Boolean.FalseString);
             variables.Set("Octopus.Action.Aws.Region", region);
 
-            if (runAsScript)
-            {
-                DeployWithKubectlTestScriptAndVerifyResult();
-            }
-            else
-            {
-                ExecuteCommandAndVerifyResult(TestableKubernetesDeploymentCommand.Name);
-            }
+            ExecuteCommandAndVerifyResult(TestableKubernetesDeploymentCommand.Name);
         }
 
         [Test]

--- a/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
@@ -1,11 +1,9 @@
 #if !NET40
-using System;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
@@ -42,15 +40,6 @@ namespace Calamari.Kubernetes.Commands
             this.variables = variables;
             this.statusReporter = statusReporter;
             this.gatherAndApplyRawYamlExecutor = gatherAndApplyRawYamlExecutor;
-        }
-
-        public override int Execute(string[] commandLineArguments)
-        {
-            if (!FeatureToggle.MultiGlobPathsForRawYamlFeatureToggle.IsEnabled(variables))
-                throw new InvalidOperationException(
-                    "Unable to execute the Kubernetes Apply Raw YAML Command because the appropriate feature has not been enabled.");
-
-            return base.Execute(commandLineArguments);
         }
 
         protected override async Task<bool> ExecuteCommand(RunningDeployment runningDeployment)


### PR DESCRIPTION
Removing multi-glob feature toggle from Calamari as we're changing it in Server to an inverted toggle and it doesn't add much value in here anyway, so just removing it.

This change is required in the Server PR: https://github.com/OctopusDeploy/OctopusDeploy/pull/19806

This will be merged into the release branch for 2023.3 as a hotfix and then merged forward to master.