### PR TITLE
Invert glob paths group support feature toggle

### DIFF
--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -8,6 +8,6 @@
     public enum FeatureToggle {
         SkunkworksFeatureToggle,
         KubernetesAksKubeloginFeatureToggle,
-        GlobPathsGroupSupportFeatureToggle
+        GlobPathsGroupSupportInvertedFeatureToggle
     }
 }

--- a/source/Calamari.Common/Plumbing/FileSystem/GlobMode.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/GlobMode.cs
@@ -13,9 +13,9 @@ namespace Calamari.Common.Plumbing.FileSystem.GlobExpressions
     {
         public static GlobMode GetFromVariables(IVariables variables)
         {
-            return FeatureToggle.GlobPathsGroupSupportFeatureToggle.IsEnabled(variables)
-                ? GlobMode.GroupExpansionMode
-                : GlobMode.LegacyMode;
+            return FeatureToggle.GlobPathsGroupSupportInvertedFeatureToggle.IsEnabled(variables)
+                ? GlobMode.LegacyMode
+                : GlobMode.GroupExpansionMode;
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Deployment/Conventions/CopyPackageToCustomInstallationDirectoryConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Conventions/CopyPackageToCustomInstallationDirectoryConventionFixture.cs
@@ -54,9 +54,9 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
         [TestCase(GlobMode.LegacyMode)]
         public void ShouldPurgeCustomInstallationDirectoryWhenFlagIsSet(GlobMode globMode)
         {
-            if (globMode == GlobMode.GroupExpansionMode)
+            if (globMode == GlobMode.LegacyMode)
             {
-                variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportFeatureToggle);
+                variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportInvertedFeatureToggle);
             }
             variables.Set(PackageVariables.CustomInstallationDirectory, customInstallationDirectory);
             variables.Set(PackageVariables.CustomInstallationDirectoryShouldBePurgedBeforeDeployment, true.ToString());
@@ -72,9 +72,9 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
         [TestCase(GlobMode.LegacyMode)]
         public void ShouldPassGlobsToPurgeWhenSet(GlobMode globMode)
         {
-            if (globMode == GlobMode.GroupExpansionMode)
+            if (globMode == GlobMode.LegacyMode)
             {
-                variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportFeatureToggle);
+                variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportInvertedFeatureToggle);
             }
             variables.Set(PackageVariables.CustomInstallationDirectory, customInstallationDirectory);
             variables.Set(PackageVariables.CustomInstallationDirectoryShouldBePurgedBeforeDeployment, true.ToString());

--- a/source/Calamari.Tests/Fixtures/Deployment/Conventions/SubstituteInFilesFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Conventions/SubstituteInFilesFixture.cs
@@ -1,12 +1,10 @@
 ﻿using System.IO;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Substitutions;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.FileSystem.GlobExpressions;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing.Helpers;
-using Calamari.Tests.Helpers;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -25,7 +23,6 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
 
 
             var variables = new CalamariVariables();
-            variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportFeatureToggle);
             variables.Set(PackageVariables.SubstituteInFilesTargets, glob);
             variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.SubstituteInFiles);
 
@@ -43,7 +40,5 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
 
             substituter.Received().PerformSubstitution(Path.Combine(StagingDirectory, actualMatch), variables);
         }
-
-
     }
 }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
@@ -2,14 +2,12 @@
 using System.IO;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.StructuredVariables;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Deployment;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.FileSystem.GlobExpressions;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing.Helpers;
-using Calamari.Tests.Helpers;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -45,7 +43,6 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
 
             var log = new InMemoryLog();
             var variables = new CalamariVariables();
-            variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportFeatureToggle);
             variables.Set(ActionVariables.AdditionalPaths, AdditionalPath);
             variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
             variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, FileName);


### PR DESCRIPTION
The last phase of the Git Manifest project was the implementation of group support for glob paths.

This is currently behind a normal feature toggle but to make sure it's available in GA, we are changing it to an inverted feature toggle.

Server PR to invert the feature toggle depends on this PR: https://github.com/OctopusDeploy/OctopusDeploy/pull/19795