### PR TITLE
Prevent running s3 tests on mono

### DIFF
--- a/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
@@ -10,17 +10,17 @@ using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Integration.Packages.Download;
 using Calamari.Testing;
-using Calamari.Testing.Helpers;
+using Calamari.Testing.Requirements;
 using Calamari.Tests.AWS;
 using Calamari.Tests.Helpers;
 using FluentAssertions;
 using NUnit.Framework;
 using Octopus.Versioning;
-using InMemoryLog = Calamari.Testing.Helpers.InMemoryLog;
 using TestEnvironment = Calamari.Testing.Helpers.TestEnvironment;
 
 namespace Calamari.Tests.Fixtures.Integration.Packages
 {
+    [RequiresNonMono]
     [TestFixture]
     public class S3PackageDownloaderFixture : CalamariFixture
     {


### PR DESCRIPTION
This test case fails on version of Mono that does not support TLS 1.2. Given that Mono will be deprecated next year, we prevent this test case from running on agents with Mono runtime now because the extra safety we get from having this test on Mono does not adjust the cost.