### PR TITLE
Add space to test folder to test bug fix

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -72,12 +72,12 @@ namespace Calamari.Tests.KubernetesFixtures
             using (var dir = TemporaryDirectory.Create())
             {
                 var directoryPath = dir.DirectoryPath;
-                var folderPath = Path.Combine(directoryPath, "TestFolder");
+                var folderPath = Path.Combine(directoryPath, "Test Folder");
                 Directory.CreateDirectory(folderPath);
 
-                var packagePath = addFilesOrPackageFunc?.Invoke(directoryPath);
+                var packagePath = addFilesOrPackageFunc?.Invoke(folderPath);
 
-                var output = ExecuteCommand(commandName, directoryPath, packagePath);
+                var output = ExecuteCommand(commandName, folderPath, packagePath);
 
                 WriteLogMessagesToTestOutput();
 

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -73,7 +73,7 @@ namespace Calamari.Tests.KubernetesFixtures
             {
                 var directoryPath = dir.DirectoryPath;
                 // Note: the "Test Folder" has a space in it to test that working directories
-                // with spaces are handled correctly by the Raw Yaml Step.
+                // with spaces are handled correctly by Kubernetes Steps.
                 var folderPath = Path.Combine(directoryPath, "Test Folder");
                 Directory.CreateDirectory(folderPath);
 

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureBase.cs
@@ -72,6 +72,8 @@ namespace Calamari.Tests.KubernetesFixtures
             using (var dir = TemporaryDirectory.Create())
             {
                 var directoryPath = dir.DirectoryPath;
+                // Note: the "Test Folder" has a space in it to test that working directories
+                // with spaces are handled correctly by the Raw Yaml Step.
                 var folderPath = Path.Combine(directoryPath, "Test Folder");
                 Directory.CreateDirectory(folderPath);
 


### PR DESCRIPTION
I forgot to commit this change in my [previous PR](https://github.com/OctopusDeploy/Calamari/pull/1109) which makes all k8s tests run with a working directory that contains a space effectively testing that this fix works correctly.