### PR TITLE
Add asynchronous Azure zip deployment support using new feature toggle

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -67,7 +67,7 @@ namespace Calamari.AzureAppService.Tests
 
             var runningContext = new RunningDeployment("", newVariables);
 
-            await new AzureAppServiceDeployContainerBehaviour(new InMemoryLog()).Execute(runningContext);
+            await new AzureAppServiceContainerDeployBehaviour(new InMemoryLog()).Execute(runningContext);
 
             var targetSite = new AzureTargetSite(SubscriptionId, 
                                             ResourceGroupName, 
@@ -91,7 +91,7 @@ namespace Calamari.AzureAppService.Tests
 
             var runningContext = new RunningDeployment("", newVariables);
 
-            await new AzureAppServiceDeployContainerBehaviour(new InMemoryLog()).Execute(runningContext);
+            await new AzureAppServiceContainerDeployBehaviour(new InMemoryLog()).Execute(runningContext);
             
             var targetSite = new AzureTargetSite(SubscriptionId, 
                                             ResourceGroupName, 

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/IPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/IPackageProvider.cs
@@ -7,6 +7,8 @@ namespace Calamari.AzureAppService
     {
         string UploadUrlPath { get; }
 
+        bool SupportsAsynchronousDeployment { get; }
+
         Task<FileInfo> PackageArchive(string sourceDirectory, string targetDirectory);
 
         Task<FileInfo> ConvertToAzureSupportedFile(FileInfo sourceFile);

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/NugetPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/NugetPackageProvider.cs
@@ -8,6 +8,7 @@ namespace Calamari.AzureAppService
 {
     class NugetPackageProvider : IPackageProvider
     {
+        public bool SupportsAsynchronousDeployment => true;
         public string UploadUrlPath => @"/api/zipdeploy";
 
         public async Task<FileInfo> PackageArchive(string sourceDirectory, string targetDirectory)

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/WarPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/WarPackageProvider.cs
@@ -12,6 +12,7 @@ namespace Calamari.AzureAppService
 {
     public class WarPackageProvider : IPackageProvider
     {
+        public bool SupportsAsynchronousDeployment => false;
         private ILog Log { get; }
         private IVariables Variables { get; }
         private RunningDeployment Deployment { get; }
@@ -31,7 +32,7 @@ namespace Calamari.AzureAppService
             var jarTool = new JarTool(cmdLineRunner, Log, Variables);
 
             var packageMetadata = PackageName.FromFile(Deployment.PackageFilePath);
-            
+
             var customPackageFileName = Variables.Get(PackageVariables.CustomPackageFileName);
 
             if (!string.IsNullOrWhiteSpace(customPackageFileName))

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/ZipPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/ZipPackageProvider.cs
@@ -9,6 +9,7 @@ namespace Calamari.AzureAppService
     public class ZipPackageProvider : IPackageProvider
     {
         public string UploadUrlPath => @"/api/zipdeploy";
+        public bool SupportsAsynchronousDeployment => true;
 
         public async Task<FileInfo> PackageArchive(string sourceDirectory, string targetDirectory)
         {

--- a/source/Calamari.AzureAppService/Behaviors/AppDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AppDeployBehaviour.cs
@@ -10,16 +10,16 @@ namespace Calamari.AzureAppService.Behaviors
 {
     public class AppDeployBehaviour : IDeployBehaviour
     {
-        readonly AzureAppServiceContainerDeployBehaviour behaviour;
-        readonly AzureAppServiceZipDeployBehaviour appServiceZipDeployBehaviour;
+        readonly AzureAppServiceContainerDeployBehaviour containerBehaviour;
+        readonly AzureAppServiceZipDeployBehaviour zipDeployBehaviour;
 
         ILog Log { get; }
 
         public AppDeployBehaviour(ILog log)
         {
             Log = log;
-            behaviour = new AzureAppServiceContainerDeployBehaviour(log);
-            appServiceZipDeployBehaviour = new AzureAppServiceZipDeployBehaviour(log);
+            containerBehaviour = new AzureAppServiceContainerDeployBehaviour(log);
+            zipDeployBehaviour = new AzureAppServiceZipDeployBehaviour(log);
         }
 
         public bool IsEnabled(RunningDeployment context) => FeatureToggle.ModernAzureAppServiceSdkFeatureToggle.IsEnabled(context.Variables);
@@ -31,8 +31,8 @@ namespace Calamari.AzureAppService.Behaviors
 
             return deploymentType switch
                    {
-                       "Container" => behaviour.Execute(context),
-                       _ => appServiceZipDeployBehaviour.Execute(context)
+                       "Container" => containerBehaviour.Execute(context),
+                       _ => zipDeployBehaviour.Execute(context)
                    };
         }
     }

--- a/source/Calamari.AzureAppService/Behaviors/AppDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AppDeployBehaviour.cs
@@ -10,16 +10,16 @@ namespace Calamari.AzureAppService.Behaviors
 {
     public class AppDeployBehaviour : IDeployBehaviour
     {
-        readonly AzureAppServiceDeployContainerBehaviour containerBehaviour;
-        readonly AzureAppServiceBehaviour appServiceBehaviour;
+        readonly AzureAppServiceContainerDeployBehaviour behaviour;
+        readonly AzureAppServiceZipDeployBehaviour appServiceZipDeployBehaviour;
 
         ILog Log { get; }
 
         public AppDeployBehaviour(ILog log)
         {
             Log = log;
-            containerBehaviour = new AzureAppServiceDeployContainerBehaviour(log);
-            appServiceBehaviour = new AzureAppServiceBehaviour(log);
+            behaviour = new AzureAppServiceContainerDeployBehaviour(log);
+            appServiceZipDeployBehaviour = new AzureAppServiceZipDeployBehaviour(log);
         }
 
         public bool IsEnabled(RunningDeployment context) => FeatureToggle.ModernAzureAppServiceSdkFeatureToggle.IsEnabled(context.Variables);
@@ -31,8 +31,8 @@ namespace Calamari.AzureAppService.Behaviors
 
             return deploymentType switch
                    {
-                       "Container" => containerBehaviour.Execute(context),
-                       _ => appServiceBehaviour.Execute(context)
+                       "Container" => behaviour.Execute(context),
+                       _ => appServiceZipDeployBehaviour.Execute(context)
                    };
         }
     }

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceContainerDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceContainerDeployBehaviour.cs
@@ -8,11 +8,11 @@ using Calamari.Common.Plumbing.Pipeline;
 
 namespace Calamari.AzureAppService.Behaviors
 {
-    class AzureAppServiceDeployContainerBehaviour : IDeployBehaviour
+    class AzureAppServiceContainerDeployBehaviour : IDeployBehaviour
     {
         private ILog Log { get; }
 
-        public AzureAppServiceDeployContainerBehaviour(ILog log)
+        public AzureAppServiceContainerDeployBehaviour(ILog log)
         {
             Log = log;
         }

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -305,6 +306,11 @@ namespace Calamari.AzureAppService.Behaviors
                                                                                                              return r;
                                                                                                          },
                                                                                                          ct1),
+                                                                    //pass the logger so we can log the retries
+                                                                    new Context(Guid.NewGuid().ToString(), new Dictionary<string, object>
+                                                                    {
+                                                                        [nameof(RetryPolicies.ContextKeys.Log)] = Log
+                                                                    }),
                                                                     timeoutCancellationToken.Token);
 
             if (result.Outcome == OutcomeType.Failure)
@@ -322,7 +328,7 @@ namespace Calamari.AzureAppService.Behaviors
             if (!result.Result.IsSuccessStatusCode)
                 throw new Exception($"Zip deployment check failed with HTTP Status {(int)result.FinalHandledResult.StatusCode} '{result.FinalHandledResult.ReasonPhrase}'.");
 
-            Log.Verbose("Finished deploying");
+            Log.Verbose("Finished zip deployment");
         }
     }
 }

--- a/source/Calamari.AzureAppService/DeployAzureAppServiceCommand.cs
+++ b/source/Calamari.AzureAppService/DeployAzureAppServiceCommand.cs
@@ -32,7 +32,7 @@ namespace Calamari.AzureAppService
             yield return resolver.Create<LegacyAzureAppServiceBehaviour>();
 
             //Modern behaviour
-            yield return resolver.Create<AzureAppServiceBehaviour>();
+            yield return resolver.Create<AzureAppServiceZipDeployBehaviour>();
         }
     }
 }

--- a/source/Calamari.AzureAppService/RetryPolicies.cs
+++ b/source/Calamari.AzureAppService/RetryPolicies.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using Calamari.Common.Plumbing.Logging;
 using Polly;
 using Polly.Retry;
+using Polly.Timeout;
 
 namespace Calamari.AzureAppService
 {

--- a/source/Calamari.AzureAppService/RetryPolicies.cs
+++ b/source/Calamari.AzureAppService/RetryPolicies.cs
@@ -32,7 +32,7 @@ namespace Calamari.AzureAppService
                                                                                                                                            {
                                                                                                                                                if (ctx.TryGetValue(ContextKeys.Log, out var logObj) && logObj is ILog log)
                                                                                                                                                {
-                                                                                                                                                   log.Verbose($"Zip deployment not completed. Received HTTP {(int)response.Result.StatusCode}. Next check in {timeout}.");
+                                                                                                                                                   log.Verbose($"Zip deployment not completed. Received HTTP {(int)response.Result.StatusCode}. Next attempt in {timeout}.");
                                                                                                                                                }
                                                                                                                                            });
     }

--- a/source/Calamari.AzureAppService/RetryPolicies.cs
+++ b/source/Calamari.AzureAppService/RetryPolicies.cs
@@ -18,5 +18,8 @@ namespace Calamari.AzureAppService
                                                                                                   .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.RequestTimeout)
                                                                                                   .WaitAndRetryAsync(5,
                                                                                                                      retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 1000)));
+
+        public static RetryPolicy<HttpResponseMessage> AsynchronousZipDeploymentOperationPolicy { get; } = Policy.HandleResult<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Accepted)
+                                                                                                                 .WaitAndRetryForeverAsync(_ => TimeSpan.FromSeconds(2));
     }
 }

--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -10,6 +10,7 @@
         KubernetesAksKubeloginFeatureToggle,
         GlobPathsGroupSupportInvertedFeatureToggle,
         ModernAzureAppServiceSdkFeatureToggle,
-        OidcAccountsFeatureToggle
+        OidcAccountsFeatureToggle,
+        AsynchronousAzureZipDeployFeatureToggle
     }
 }


### PR DESCRIPTION
Microsoft has added the ability to specify a zip deployment as asynchronous, meaning the original request just performs the upload, not the unpacking of the zip archive.

[Documentation](https://learn.microsoft.com/en-us/azure/azure-functions/deployment-zip-push#asynchronous-zip-deployment)
> You will receive a response as soon as the zip file is uploaded with a Location header pointing to the pollable deployment status URL. When polling the URL provided in the Location header, you will receive a HTTP 202 (Accepted) response while the process is ongoing and a HTTP 200 (OK) response once the archive has been expanded and the deployment has completed successfully.

This PR adds a new feature toggle `AsynchronousAzureZipDeployFeatureToggle`, that changes _all_ zip deployments to asynchronous deployments.

We first perform the upload as per normal, but then run a Polly retry policy to monitor the operation for 3 minutes to confirm it's finished.

I chose to implement this using a `RetryAndWaitForever` policy + `Timeout` policy (which is cancellation token driven) rather than write the loop myself. Happy to take feedback on this one if people don't like it, more a personal preference, but happy to change if desired.

I picked 3min because that felt reasonable,

This is the log messages

```
Zip upload succeeded. Monitoring for deployment completion
Zip deployment not completed. Received HTTP 202. Next check in 00:00:02.
Zip deployment not completed. Received HTTP 202. Next check in 00:00:02.
Zip deployment not completed. Received HTTP 202. Next check in 00:00:02.
Finished zip deployment
```

Shortcut story: [sc-57940]