### PR TITLE
Fix kubectl get command when namespace is empty

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/one-deployment-and-one-namespace.json
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/one-deployment-and-one-namespace.json
@@ -1,0 +1,63 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "Namespace",
+      "metadata": {
+        "creationTimestamp": "2023-08-31T01:19:33Z",
+        "labels": {
+          "kubernetes.io/metadata.name": "my-namespace"
+        },
+        "name": "my-namespace",
+        "resourceVersion": "10414202",
+        "uid": "8bef1152-20fb-4900-b171-3d0836bcef73"
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    },
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "labels": {
+          "app": "app"
+        },
+        "name": "app",
+        "namespace": "default"
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app": "app"
+          }
+        },
+        "strategy": {},
+        "template": {
+          "metadata": {
+            "labels": {
+              "app": "app"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "image": "nginx",
+                "name": "nginx"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/source/Calamari/Kubernetes/ResourceLoggingExtensionMethods.cs
+++ b/source/Calamari/Kubernetes/ResourceLoggingExtensionMethods.cs
@@ -11,6 +11,8 @@ namespace Calamari.Kubernetes
             foreach (var resourceIdentifier in resourceToLog)
             {
                 log.Verbose($" - {resourceIdentifier.Kind}/{resourceIdentifier.Name} in namespace {resourceIdentifier.Namespace}");
+                var hasNamespace = !string.IsNullOrEmpty(resourceIdentifier.Namespace);
+                log.Verbose($" - {resourceIdentifier.Kind}/{resourceIdentifier.Name} {(hasNamespace ? $"in namespace {resourceIdentifier.Namespace}" : "")}");
             }
         }
     }

--- a/source/Calamari/Kubernetes/ResourceLoggingExtensionMethods.cs
+++ b/source/Calamari/Kubernetes/ResourceLoggingExtensionMethods.cs
@@ -10,7 +10,6 @@ namespace Calamari.Kubernetes
         {
             foreach (var resourceIdentifier in resourceToLog)
             {
-                log.Verbose($" - {resourceIdentifier.Kind}/{resourceIdentifier.Name} in namespace {resourceIdentifier.Namespace}");
                 var hasNamespace = !string.IsNullOrEmpty(resourceIdentifier.Namespace);
                 log.Verbose($" - {resourceIdentifier.Kind}/{resourceIdentifier.Name} {(hasNamespace ? $"in namespace {resourceIdentifier.Namespace}" : "")}");
             }

--- a/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
@@ -16,7 +16,7 @@ namespace Calamari.Kubernetes.ResourceStatus
         {
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
-                "get", kind, name, "-o json", $"-n {@namespace}"
+                "get", kind, name, "-o json", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
             }).Output.InfoLogs.Join(string.Empty);
         }
 
@@ -24,7 +24,7 @@ namespace Calamari.Kubernetes.ResourceStatus
         {
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
-                "get", kind, "-o json", $"-n {@namespace}"
+                "get", kind, "-o json", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
             }).Output.InfoLogs.Join(string.Empty);
         }
     }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusCheckTask.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusCheckTask.cs
@@ -43,10 +43,10 @@ namespace Calamari.Kubernetes.ResourceStatus
 
             var definedResources = resources.ToArray();
             var checkCount = 0;
+            var result = new Result();
             return await Task.Run(async () =>
             {
                 timer.Start();
-                var result = new Result();
                 do
                 {
                     if (cancellationToken.IsCancellationRequested)

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusCheckTask.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusCheckTask.cs
@@ -43,10 +43,10 @@ namespace Calamari.Kubernetes.ResourceStatus
 
             var definedResources = resources.ToArray();
             var checkCount = 0;
-            var result = new Result();
             return await Task.Run(async () =>
             {
                 timer.Start();
+                var result = new Result();
                 do
                 {
                     if (cancellationToken.IsCancellationRequested)

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
@@ -65,6 +65,11 @@ namespace Calamari.Kubernetes.ResourceStatus
 
         private void SendServiceMessage(Resource resource, bool removed, int checkCount)
         {
+            if (string.IsNullOrEmpty(resource.Namespace))
+            {
+                return;
+            }
+            
             var actionNumber = variables.Get("Octopus.Action.Number", string.Empty);
             var stepNumber = variables.Get("Octopus.Step.Number");
             var stepName = variables.Get("Octopus.Step.Name");


### PR DESCRIPTION
When the resource to be deployed is cluster-scoped (i.e. it doesn't have a namespace), in KOS we current produce a command similar to `kubectl get <kind> <name> -n` with the argument to `-n` being empty. Because this command is invalid, the kubectl command is unable to retrieve the resource status and this causes the resource status check unable to terminate. This PR fixed the command so that it handles both resource with and without a namespace.