### PR TITLE
Revert inversion of glob paths group support feature toggle

### DIFF
--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -8,6 +8,6 @@
     public enum FeatureToggle {
         SkunkworksFeatureToggle,
         KubernetesAksKubeloginFeatureToggle,
-        GlobPathsGroupSupportInvertedFeatureToggle
+        GlobPathsGroupSupportFeatureToggle
     }
 }

--- a/source/Calamari.Common/Plumbing/FileSystem/GlobMode.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/GlobMode.cs
@@ -13,9 +13,9 @@ namespace Calamari.Common.Plumbing.FileSystem.GlobExpressions
     {
         public static GlobMode GetFromVariables(IVariables variables)
         {
-            return FeatureToggle.GlobPathsGroupSupportInvertedFeatureToggle.IsEnabled(variables)
-                ? GlobMode.LegacyMode
-                : GlobMode.GroupExpansionMode;
+            return FeatureToggle.GlobPathsGroupSupportFeatureToggle.IsEnabled(variables)
+                ? GlobMode.GroupExpansionMode
+                : GlobMode.LegacyMode;
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Deployment/Conventions/CopyPackageToCustomInstallationDirectoryConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Conventions/CopyPackageToCustomInstallationDirectoryConventionFixture.cs
@@ -54,9 +54,9 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
         [TestCase(GlobMode.LegacyMode)]
         public void ShouldPurgeCustomInstallationDirectoryWhenFlagIsSet(GlobMode globMode)
         {
-            if (globMode == GlobMode.LegacyMode)
+            if (globMode == GlobMode.GroupExpansionMode)
             {
-                variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportInvertedFeatureToggle);
+                variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportFeatureToggle);
             }
             variables.Set(PackageVariables.CustomInstallationDirectory, customInstallationDirectory);
             variables.Set(PackageVariables.CustomInstallationDirectoryShouldBePurgedBeforeDeployment, true.ToString());
@@ -72,9 +72,9 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
         [TestCase(GlobMode.LegacyMode)]
         public void ShouldPassGlobsToPurgeWhenSet(GlobMode globMode)
         {
-            if (globMode == GlobMode.LegacyMode)
+            if (globMode == GlobMode.GroupExpansionMode)
             {
-                variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportInvertedFeatureToggle);
+                variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportFeatureToggle);
             }
             variables.Set(PackageVariables.CustomInstallationDirectory, customInstallationDirectory);
             variables.Set(PackageVariables.CustomInstallationDirectoryShouldBePurgedBeforeDeployment, true.ToString());

--- a/source/Calamari.Tests/Fixtures/Deployment/Conventions/SubstituteInFilesFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Conventions/SubstituteInFilesFixture.cs
@@ -1,10 +1,12 @@
 ﻿using System.IO;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Substitutions;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.FileSystem.GlobExpressions;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing.Helpers;
+using Calamari.Tests.Helpers;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -23,6 +25,7 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
 
 
             var variables = new CalamariVariables();
+            variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportFeatureToggle);
             variables.Set(PackageVariables.SubstituteInFilesTargets, glob);
             variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.SubstituteInFiles);
 
@@ -40,5 +43,7 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
 
             substituter.Received().PerformSubstitution(Path.Combine(StagingDirectory, actualMatch), variables);
         }
+
+
     }
 }

--- a/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
+++ b/source/Calamari.Tests/Fixtures/StructuredVariables/StructuredConfigVariablesServiceFixture.cs
@@ -2,12 +2,14 @@
 using System.IO;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.StructuredVariables;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Deployment;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.FileSystem.GlobExpressions;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing.Helpers;
+using Calamari.Tests.Helpers;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -43,6 +45,7 @@ namespace Calamari.Tests.Fixtures.StructuredVariables
 
             var log = new InMemoryLog();
             var variables = new CalamariVariables();
+            variables.AddFeatureToggles(FeatureToggle.GlobPathsGroupSupportFeatureToggle);
             variables.Set(ActionVariables.AdditionalPaths, AdditionalPath);
             variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.StructuredConfigurationVariables);
             variables.Set(ActionVariables.StructuredConfigurationVariablesTargets, FileName);


### PR DESCRIPTION
Reverting [this PR](https://github.com/OctopusDeploy/Calamari/pull/1105) which inverts glob paths group support feature toggle as we have decided not to release that to GA.