### PR TITLE
Remove test from Mono

### DIFF
--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWebPackageFixture.cs
@@ -287,6 +287,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         }
 
         [Test]
+        [RequiresNonMono]
         public void ShouldDeployInParallel()
         {
             var locker = new object();


### PR DESCRIPTION
Removing a flaky test from Mono, given that Mono is deprecated soon.