### PR TITLE
Backport - get_octopusvariable safely for python

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Python/Configuration.py
+++ b/source/Calamari.Common/Features/Scripting/Python/Configuration.py
@@ -21,7 +21,7 @@ def decrypt(encrypted, iv):
     return decrypted.decode('utf-8')
 
 def get_octopusvariable(key):
-    return octopusvariables[key]
+    return octopusvariables.get(key, "")
 
 def set_octopusvariable(name, value, sensitive=False):
     octopusvariables[name] = value


### PR DESCRIPTION
Backport of #1043, which is already present in 2023.3+ onwards.