### PR TITLE
Adding Oidc for Terraform accounts & cleanup

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -76,16 +76,7 @@ namespace Calamari.AzureAppService.Tests
                                  .GetResourceGroups()
                                  .CreateOrUpdateAsync(WaitUntil.Completed,
                                                       ResourceGroupName,
-                                                      new ResourceGroupData(new AzureLocation(ResourceGroupLocation))
-                                                      {
-                                                          Tags =
-                                                          {
-                                                              // give them an expiry of 14 days so if the tests fail to clean them up
-                                                              // they will be automatically cleaned up by the Sandbox cleanup process
-                                                              // We keep them for 14 days just in case we need to do debugging/investigation
-                                                              ["LifetimeInDays"] = "14"
-                                                          }
-                                                      });
+                                                      new ResourceGroupData(new AzureLocation(ResourceGroupLocation)));
 
             ResourceGroupResource = response.Value;
 

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
@@ -67,16 +67,7 @@ namespace Calamari.AzureAppService.Tests
 
             resourceGroupClient = resourcesClient.ResourceGroups;
 
-            var resourceGroup = new ResourceGroup(resourceGroupLocation)
-            {
-                Tags =
-                {
-                    // give them an expiry of 14 days so if the tests fail to clean them up
-                    // they will be automatically cleaned up by the Sandbox cleanup process
-                    // We keep them for 14 days just in case we need to do debugging/investigation
-                    ["LifetimeInDays"] = "14"
-                }
-            };
+            var resourceGroup = new ResourceGroup(resourceGroupLocation);
             resourceGroup = await resourceGroupClient.CreateOrUpdateAsync(resourceGroupName, resourceGroup);
 
             webMgmtClient = new WebSiteManagementClient(new TokenCredentials(authToken))

--- a/source/Calamari.AzureScripting/AzureContextScriptWrapper.cs
+++ b/source/Calamari.AzureScripting/AzureContextScriptWrapper.cs
@@ -65,13 +65,12 @@ namespace Calamari.AzureScripting
             {
                 if (variables.Get(SpecialVariables.Account.AccountType) == "AzureServicePrincipal" || variables.Get(SpecialVariables.Account.AccountType) == "AzureOidc")
                 {
-                    SetOutputVariable("OctopusAzSpOrOidc", bool.TrueString);
+                    SetOutputVariable("OctopusAzureServicePrincipalOrOidc ", bool.TrueString);
                     SetOutputVariable("OctopusAzureADTenantId", variables.Get(SpecialVariables.Action.Azure.TenantId)!);
                     SetOutputVariable("OctopusAzureADClientId", variables.Get(SpecialVariables.Action.Azure.ClientId)!);
 
                     if (variables.Get(SpecialVariables.Account.AccountType) == "AzureServicePrincipal")
                     {
-                        variables.Set("OctopusUseServicePrincipal", bool.TrueString);
                         variables.Set("OctopusAzureADPassword", variables.Get(SpecialVariables.Action.Azure.Password));
                     }
                     else
@@ -83,8 +82,7 @@ namespace Calamari.AzureScripting
                 }
 
                 //otherwise use management certificate
-                SetOutputVariable("OctopusUseServicePrincipal", false.ToString());
-                SetOutputVariable("OctopusAzSpOrOidc", false.ToString());
+                SetOutputVariable("OctopusAzureServicePrincipalOrOidc", false.ToString());
                 using (new TemporaryFile(CreateAzureCertificate(workingDirectory)))
                 {
                     return NextWrapper!.ExecuteScript(new Script(contextScriptFile.FilePath), scriptSyntax, commandLineRunner, environmentVars);

--- a/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
+++ b/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
@@ -7,7 +7,6 @@
 ##
 ##   $OctopusAzureTargetScript = "..."
 ##   $OctopusAzureTargetScriptParameters = "..."
-##   $OctopusUseServicePrincipal = "false"
 ##   $OctopusAzureSubscriptionId = "..."
 ##   $OctopusAzureStorageAccountName = "..."
 ##   $OctopusAzureCertificateFileName = "..."
@@ -160,7 +159,7 @@ function Initialize-AzContext {
 Execute-WithRetry{
     pushd $env:OctopusCalamariWorkingDirectory
     try {
-        If ([System.Convert]::ToBoolean($OctopusAzSpOrOidc)) {
+        If ([System.Convert]::ToBoolean($OctopusAzureServicePrincipalOrOidc )) {
 
             # Depending on which version of Powershell we are running under will change which module context we want to initialize.            
             #   Powershell Core: Check Az then AzureRM (provide a warning and do nothing if AzureRM is installed)
@@ -279,7 +278,7 @@ try {
     Invoke-Expression ". `"$OctopusAzureTargetScript`" $OctopusAzureTargetScriptParameters"
 } catch {
     # Warn if FIPS 140 compliance required when using Service Management SDK
-    if ([System.Security.Cryptography.CryptoConfig]::AllowOnlyFipsAlgorithms -and ![System.Convert]::ToBoolean($OctopusAzSpOrOidc)) {
+    if ([System.Security.Cryptography.CryptoConfig]::AllowOnlyFipsAlgorithms -and ![System.Convert]::ToBoolean($OctopusAzureServicePrincipalOrOidc)) {
         Write-Warning "The Azure Service Management SDK is not FIPS 140 compliant. http://g.octopushq.com/FIPS"
     }
 

--- a/source/Calamari.AzureScripting/Scripts/AzureContext.sh
+++ b/source/Calamari.AzureScripting/Scripts/AzureContext.sh
@@ -5,8 +5,6 @@ Octopus_Azure_ADClientId=$(get_octopusvariable "Octopus.Action.Azure.ClientId")
 Octopus_Azure_ADPassword=$(get_octopusvariable "Octopus.Action.Azure.Password")
 Octopus_Azure_ADTenantId=$(get_octopusvariable "Octopus.Action.Azure.TenantId")
 Octopus_Azure_SubscriptionId=$(get_octopusvariable "Octopus.Action.Azure.SubscriptionId")
-Octopus_Azure_OctopusUseOidc=$(get_octopusvariable "OctopusUseOidc")
-Octopus_Azure_OctopusUseServicePrincipal=$(get_octopusvariable "OctopusUseServicePrincipal")
 Octopus_Open_Id_Jwt=$(get_octopusvariable "OctopusOpenIdJwt")
 
 function check_app_exists {
@@ -44,7 +42,7 @@ function setup_context {
         loginArgs=()
         # Use the full argument because of https://github.com/Azure/azure-cli/issues/12105
 
-        if [ $Octopus_Azure_OctopusUseOidc ]
+        if [ -n $Octopus_Open_Id_Jwt ]
         then
           echo "Azure CLI: Authenticating with OpenID Connect Access Token"
           loginArgs+=("--username=$Octopus_Azure_ADClientId")

--- a/source/Calamari.CloudAccounts/AzureAccountVariables.cs
+++ b/source/Calamari.CloudAccounts/AzureAccountVariables.cs
@@ -8,6 +8,7 @@ namespace Calamari.CloudAccounts
         public static readonly string ClientId = "Octopus.Action.Azure.ClientId";   
         public static readonly string TenantId = "Octopus.Action.Azure.TenantId";
         public static readonly string Password = "Octopus.Action.Azure.Password";
+        public static readonly string OpenIDJwt = "Octopus.OpenIdConnect.Jwt";
         public static readonly string ResourceManagementEndPoint = "Octopus.Action.Azure.ResourceManagementEndPoint";
         public static readonly string ActiveDirectoryEndPoint = "Octopus.Action.Azure.ActiveDirectoryEndPoint";
     }


### PR DESCRIPTION
Adds support for Terraform to Azure OIDC Accounts. Note terraform/azure docs list support from 3.7.0. This is not the case, as service principal logins are not supported until 3.22. Running a CLI login is an alternative approach here, however, this would require a similar configuration/setup to AzureScripting, and I don't see enough value add in supporting the older azurerm provider versions to justify this. Docs/blog post will call this version support discrepancy out. 

![TerraformAzRM](https://github.com/OctopusDeploy/Calamari/assets/101079287/99a35871-fa67-4e1c-9ce2-887dfb8c7245)
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/b7278df5-4201-4de7-a402-3ae15463f718)
