### PR TITLE
Support Azure OIDC accounts for cloud target discovery

### DIFF
--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -6,7 +6,7 @@ using Calamari.CloudAccounts;
 using Calamari.Common.Features.Discovery;
 using Calamari.Common.Plumbing.Logging;
 using Microsoft.Rest.Azure;
-using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 
 namespace Calamari.Azure.Kubernetes.Discovery
 {
@@ -118,7 +118,8 @@ namespace Calamari.Azure.Kubernetes.Discovery
         {
             try
             {
-                accountType = JToken.Parse(contextJson).SelectToken("authentication").SelectToken("authenticationMethod").ToString();
+                var targetDiscoveryContext = JsonConvert.DeserializeObject<TargetDiscoveryContext<AccountAuthenticationDetails<dynamic>>>(contextJson);
+                accountType = targetDiscoveryContext?.Authentication?.AuthenticationMethod ?? throw new Exception("AuthenticationMethod is null");
                 return true;
             }
             catch (Exception e)

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyTargetDiscoveryBehaviourIntegrationTestFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyTargetDiscoveryBehaviourIntegrationTestFixture.cs
@@ -39,6 +39,7 @@ namespace Calamari.AzureAppService.Tests
         private string appName = Guid.NewGuid().ToString();
         private List<string> slotNames = new List<string> { "blue", "green" };
         private static readonly string Type = "Azure";
+        private static readonly string AuthenticationMethod = "ServicePrincipal";
         private static readonly string AccountId = "Accounts-1";
         private static readonly string Role = "my-azure-app-role";
         private static readonly string EnvironmentName = "dev";
@@ -120,6 +121,7 @@ namespace Calamari.AzureAppService.Tests
             };
 
             await CreateOrUpdateTestWebApp(tags);
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(15));
 
             await Eventually.ShouldEventually(async () =>
             {
@@ -130,7 +132,7 @@ namespace Calamari.AzureAppService.Tests
                 var serviceMessageToCreateWebAppTarget = TargetDiscoveryHelpers.CreateWebAppTargetCreationServiceMessage(resourceGroupName, appName, AccountId, Role, null, null);
                 var serviceMessageString = serviceMessageToCreateWebAppTarget.ToString();
                 log.StandardOut.Should().Contain(serviceMessageString);
-            }, log, CancellationToken.None);
+            }, log, cancellationTokenSource.Token);
         }
 
         [Test]
@@ -178,6 +180,7 @@ namespace Calamari.AzureAppService.Tests
             };
 
             await CreateOrUpdateTestWebAppSlots(tags);
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(15));
 
             await Eventually.ShouldEventually(async () =>
             {
@@ -193,7 +196,7 @@ namespace Calamari.AzureAppService.Tests
                     var serviceMessageToCreateTargetForSlot = TargetDiscoveryHelpers.CreateWebAppTargetCreationServiceMessage(resourceGroupName, appName, AccountId, Role, null, slotName);
                     log.StandardOut.Should().Contain(serviceMessageToCreateTargetForSlot.ToString());
                 }
-            }, log, CancellationToken.None);
+            }, log, cancellationTokenSource.Token);
         }
 
         [Test]
@@ -215,6 +218,7 @@ namespace Calamari.AzureAppService.Tests
 
             await CreateOrUpdateTestWebApp(tags);
             await CreateOrUpdateTestWebAppSlots(tags);
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(15));
 
             await Eventually.ShouldEventually(async () =>
             {
@@ -230,7 +234,7 @@ namespace Calamari.AzureAppService.Tests
                     var serviceMessageToCreateTargetForSlot = TargetDiscoveryHelpers.CreateWebAppTargetCreationServiceMessage(resourceGroupName, appName, AccountId, Role, null, slotName);
                     log.StandardOut.Should().Contain(serviceMessageToCreateTargetForSlot.ToString());
                 }
-            }, log, CancellationToken.None);
+            }, log, cancellationTokenSource.Token);
         }
 
         [Test]
@@ -256,6 +260,7 @@ namespace Calamari.AzureAppService.Tests
 
             await CreateOrUpdateTestWebApp(webAppTags);
             await CreateOrUpdateTestWebAppSlots(slotTags);
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(15));
 
             await Eventually.ShouldEventually(async () =>
             {
@@ -277,7 +282,7 @@ namespace Calamari.AzureAppService.Tests
                     log.StandardOut.Should().NotContain(serviceMessageToCreateTargetForSlot.ToString(),
                         "A target should not be created for the web app slot as the tags directly on the slot do not match, even though when combined with the web app tags they do");
                 }
-            }, log, CancellationToken.None);
+            }, log, cancellationTokenSource.Token);
         }
 
         private async Task CreateOrUpdateTestWebApp(Dictionary<string, string> tags = null)
@@ -313,6 +318,7 @@ namespace Calamari.AzureAppService.Tests
     ""authentication"": {{
         ""type"": ""{Type}"",
         ""accountId"": ""{AccountId}"",
+        ""authenticationMethod"": ""{AuthenticationMethod}"",
         ""accountDetails"": {{
             ""subscriptionNumber"": ""{subscriptionId}"",
             ""clientId"": ""{clientId}"",

--- a/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
@@ -75,6 +75,7 @@ namespace Calamari.AzureAppService.Tests
             };
 
             await CreateOrUpdateTestWebApp(tags);
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(15));
 
             await Eventually.ShouldEventually(async () =>
                                               {
@@ -92,7 +93,7 @@ namespace Calamari.AzureAppService.Tests
                                                   log.StandardOut.Should().Contain(serviceMessageString);
                                               },
                                               log,
-                                              CancellationToken.None);
+                                              cancellationTokenSource.Token);
         }
 
         [Test]
@@ -145,6 +146,7 @@ namespace Calamari.AzureAppService.Tests
             };
 
             await CreateOrUpdateTestWebAppSlots(WebSiteResource, tags);
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(15));
 
             await Eventually.ShouldEventually(async () =>
                                               {
@@ -172,7 +174,7 @@ namespace Calamari.AzureAppService.Tests
                                                   }
                                               },
                                               log,
-                                              CancellationToken.None);
+                                              cancellationTokenSource.Token);
         }
 
         [Test]
@@ -194,6 +196,7 @@ namespace Calamari.AzureAppService.Tests
 
             var webSiteResource =await CreateOrUpdateTestWebApp(tags);
             await CreateOrUpdateTestWebAppSlots(webSiteResource,tags);
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(15));
 
             await Eventually.ShouldEventually(async () =>
                                               {
@@ -221,7 +224,7 @@ namespace Calamari.AzureAppService.Tests
                                                   }
                                               },
                                               log,
-                                              CancellationToken.None);
+                                              cancellationTokenSource.Token);
         }
 
         [Test]
@@ -247,6 +250,7 @@ namespace Calamari.AzureAppService.Tests
 
             var webSiteResource = await CreateOrUpdateTestWebApp(webAppTags);
             await CreateOrUpdateTestWebAppSlots(webSiteResource, slotTags);
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(15));
 
             await Eventually.ShouldEventually(async () =>
                                               {
@@ -280,7 +284,7 @@ namespace Calamari.AzureAppService.Tests
                                                   }
                                               },
                                               log,
-                                              CancellationToken.None);
+                                              cancellationTokenSource.Token);
         }
 
         private async Task<WebSiteResource> CreateOrUpdateTestWebApp(IDictionary<string, string> tags = null)
@@ -336,6 +340,7 @@ namespace Calamari.AzureAppService.Tests
     ""authentication"": {{
         ""type"": ""{Type}"",
         ""accountId"": ""{AccountId}"",
+        ""authenticationMethod"": ""ServicePrincipal"",
         ""accountDetails"": {{
             ""subscriptionNumber"": ""{SubscriptionId}"",
             ""clientId"": ""{ClientId}"",

--- a/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
@@ -24,6 +24,7 @@ namespace Calamari.AzureAppService.Tests
         private readonly string appName = Guid.NewGuid().ToString();
         private readonly List<string> slotNames = new List<string> { "blue", "green" };
         private static readonly string Type = "Azure";
+        private static readonly string AuthenticationMethod = "ServicePrincipal";
         private static readonly string AccountId = "Accounts-1";
         private static readonly string Role = "my-azure-app-role";
         private static readonly string EnvironmentName = "dev";
@@ -340,7 +341,7 @@ namespace Calamari.AzureAppService.Tests
     ""authentication"": {{
         ""type"": ""{Type}"",
         ""accountId"": ""{AccountId}"",
-        ""authenticationMethod"": ""ServicePrincipal"",
+        ""authenticationMethod"": ""{AuthenticationMethod}"",
         ""accountDetails"": {{
             ""subscriptionNumber"": ""{SubscriptionId}"",
             ""clientId"": ""{ClientId}"",

--- a/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourUnitTestFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourUnitTestFixture.cs
@@ -60,7 +60,7 @@ namespace Calamari.AzureAppService.Tests
             await sut.Execute(context);
 
             // Assert
-            log.StandardOut.Should().Contain(line => line.Contains("Could not read authentication method from target discovery context, Octopus.TargetDiscovery.Context is in wrong format: Unexpected character encountered while parsing value: b. Path '', line 0, position 0."));
+            log.StandardOut.Should().Contain(line => line.Contains("Could not read authentication method from target discovery context, Octopus.TargetDiscovery.Context is in wrong format, Unexpected character encountered while parsing value: b. Path '', line 0, position 0."));
             log.StandardOut.Should().Contain(line => line.Contains("Aborting target discovery."));
         }
 

--- a/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourUnitTestFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourUnitTestFixture.cs
@@ -34,7 +34,7 @@ namespace Calamari.AzureAppService.Tests
             // Arrange
             var variables = new CalamariVariables();
             var context = new RunningDeployment(variables);
-            context.Variables.Add("Octopus.TargetDiscovery.Context", "bogus json");
+            context.Variables.Add("Octopus.TargetDiscovery.Context", @"{ authentication: { authenticationMethod: ""ServicePrincipal""}}");
             var log = new InMemoryLog();
             var sut = new TargetDiscoveryBehaviour(log);
 
@@ -43,6 +43,24 @@ namespace Calamari.AzureAppService.Tests
 
             // Assert
             log.StandardOut.Should().Contain(line => line.Contains("Target discovery context from variable Octopus.TargetDiscovery.Context is in wrong format"));
+            log.StandardOut.Should().Contain(line => line.Contains("Aborting target discovery."));
+        }
+
+        [Test]
+        public async Task Exectute_LogsError_WhenContextIsInIncorrectFormat_AuthenticationMethod()
+        {
+            // Arrange
+            var variables = new CalamariVariables();
+            var context = new RunningDeployment(variables);
+            context.Variables.Add("Octopus.TargetDiscovery.Context", "bogus json");
+            var log = new InMemoryLog();
+            var sut = new TargetDiscoveryBehaviour(log);
+
+            // Act
+            await sut.Execute(context);
+
+            // Assert
+            log.StandardOut.Should().Contain(line => line.Contains("Could not read authentication method from target discovery context, Octopus.TargetDiscovery.Context is in wrong format: Unexpected character encountered while parsing value: b. Path '', line 0, position 0."));
             log.StandardOut.Should().Contain(line => line.Contains("Aborting target discovery."));
         }
 

--- a/source/Calamari.AzureAppService/Behaviors/TargetDiscoveryBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/TargetDiscoveryBehaviour.cs
@@ -125,13 +125,13 @@ namespace Calamari.AzureAppService.Behaviors
         {
             try
             {
-                var jsonObj = JsonConvert.DeserializeObject<dynamic>(json);
-                authenticationMethod = jsonObj!.authentication.authenticationMethod;
+                var targetDiscoveryContext = JsonConvert.DeserializeObject<TargetDiscoveryContext<AccountAuthenticationDetails<dynamic>>>(json);
+                authenticationMethod = targetDiscoveryContext?.Authentication?.AuthenticationMethod ?? throw new Exception("AuthenticationMethod is null");
                 return true;
             }
             catch (JsonException ex)
             {
-                Log.Warn($"Could not read authentication method from target discovery context, {contextVariableName} is in wrong format: {ex.Message}");
+                Log.Warn($"Could not read authentication method from target discovery context, {contextVariableName} is in wrong format, {ex.Message}");
                 Log.Warn("Aborting target discovery.");
                 authenticationMethod = null;
                 return false;

--- a/source/Calamari.AzureAppService/Behaviors/TargetDiscoveryBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/TargetDiscoveryBehaviour.cs
@@ -49,12 +49,12 @@ namespace Calamari.AzureAppService.Behaviors
                 return;
             }
 
-            if (!TryGetAuthenticationMethod(json, contextVariableName, out string? authenticationMethod))
+            if (!TryGetAuthenticationMethod(json!, contextVariableName, out string? authenticationMethod))
                 return;
 
             TargetDiscoveryContext<AccountAuthenticationDetails<IAzureAccount>>? targetDiscoveryContext = authenticationMethod == "AzureOidc"
-                ? GetTargetDiscoveryContext<AzureOidcAccount>(json)
-                : GetTargetDiscoveryContext<AzureServicePrincipalAccount>(json);
+                ? GetTargetDiscoveryContext<AzureOidcAccount>(json!)
+                : GetTargetDiscoveryContext<AzureServicePrincipalAccount>(json!);
             
             if (targetDiscoveryContext?.Authentication == null || targetDiscoveryContext.Scope == null)
             {

--- a/source/Calamari.AzureAppService/Behaviors/TargetDiscoveryBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/TargetDiscoveryBehaviour.cs
@@ -58,6 +58,7 @@ namespace Calamari.AzureAppService.Behaviors
             
             if (targetDiscoveryContext?.Authentication == null || targetDiscoveryContext.Scope == null)
             {
+                Log.Warn($"Target discovery context from variable {contextVariableName} is in wrong format");
                 Log.Warn("Aborting target discovery.");
                 return;
             }
@@ -131,6 +132,7 @@ namespace Calamari.AzureAppService.Behaviors
             catch (JsonException ex)
             {
                 Log.Warn($"Could not read authentication method from target discovery context, {contextVariableName} is in wrong format: {ex.Message}");
+                Log.Warn("Aborting target discovery.");
                 authenticationMethod = null;
                 return false;
             }

--- a/source/Calamari.AzureAppService/Behaviors/TargetDiscoveryBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/TargetDiscoveryBehaviour.cs
@@ -170,7 +170,7 @@ namespace Calamari.AzureAppService.Behaviors
                 if (context?.Authentication != null)
                 {
                     var accountAuthentication = context.Authentication;
-                    var accountDetails = new AccountAuthenticationDetails<IAzureAccount>(accountAuthentication.Type, accountAuthentication.AccountId, accountAuthentication.AccountDetails);
+                    var accountDetails = new AccountAuthenticationDetails<IAzureAccount>(accountAuthentication.Type, accountAuthentication.AccountId, accountAuthentication.AuthenticationMethod, accountAuthentication.AccountDetails);
                     var targetDiscoveryContext = new TargetDiscoveryContext<AccountAuthenticationDetails<IAzureAccount>>(context.Scope, accountDetails);
                     return targetDiscoveryContext;
                 }

--- a/source/Calamari.CloudAccounts/AzureOidcAccountExtensions.cs
+++ b/source/Calamari.CloudAccounts/AzureOidcAccountExtensions.cs
@@ -22,7 +22,7 @@ namespace Calamari.CloudAccounts
 
         public static async Task<string> GetAuthorizationToken(string tenantId, string applicationId, string token, string managementEndPoint, string activeDirectoryEndPoint, string aureEnvironment, CancellationToken cancellationToken)
         {
-            var authContext = GetOidcContextUri(activeDirectoryEndPoint, tenantId);
+            var authContext = GetOidcContextUri(string.IsNullOrEmpty(activeDirectoryEndPoint) ? "https://login.microsoftonline.com/" : activeDirectoryEndPoint, tenantId);
             Log.Verbose($"Authentication Context: {authContext}");
 
             var app = ConfidentialClientApplicationBuilder.Create(applicationId)

--- a/source/Calamari.CloudAccounts/AzureOidcAccountExtensions.cs
+++ b/source/Calamari.CloudAccounts/AzureOidcAccountExtensions.cs
@@ -32,7 +32,7 @@ namespace Calamari.CloudAccounts
 
             var result = await app.AcquireTokenForClient(
                                                          // Default values set on a per cloud basis on AzureOidcAccount, if managementEndPoint is set on the account /.default is required.
-                                                         new[] { managementEndPoint == DefaultVariables.ResourceManagementEndpoint ? AzureOidcAccount.GetDefaultScope(aureEnvironment) : managementEndPoint.EndsWith(".default") ? managementEndPoint : $"{managementEndPoint}/.default" })
+                                                         new[] { managementEndPoint == DefaultVariables.ResourceManagementEndpoint || string.IsNullOrEmpty(managementEndPoint) ? AzureOidcAccount.GetDefaultScope(aureEnvironment) : managementEndPoint.EndsWith(".default") ? managementEndPoint : $"{managementEndPoint}/.default" })
                                   .WithTenantId(tenantId)
                                   .ExecuteAsync(cancellationToken)
                                   .ConfigureAwait(false);

--- a/source/Calamari.Common/Features/Discovery/AccountAuthenticationDetails.cs
+++ b/source/Calamari.Common/Features/Discovery/AccountAuthenticationDetails.cs
@@ -9,14 +9,17 @@ namespace Calamari.Common.Features.Discovery
     {
         [JsonConstructor]
         public AccountAuthenticationDetails
-            (string type, string accountId, TAccountDetails accountDetails)
+            (string type, string accountId, string authenticationMethod, TAccountDetails accountDetails)
         {
             Type = type;
             AccountId = accountId;
+            AuthenticationMethod = authenticationMethod;
             AccountDetails = accountDetails;
         }
 
         public string Type { get; set; }
+
+        public string AuthenticationMethod { get; }
 
         public string AccountId { get; set; }
 

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -185,6 +185,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 new AccountAuthenticationDetails<AzureServicePrincipalAccount>(
                                                                                "Azure",
                                                                                "Accounts-1",
+                                                                               "ServicePrincipal",
                                                                                account);
 
             var targetDiscoveryContext =

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAksLocalAccessDisabled.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAksLocalAccessDisabled.cs
@@ -106,6 +106,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 new AccountAuthenticationDetails<AzureServicePrincipalAccount>(
                                                                                "Azure",
                                                                                "Accounts-1",
+                                                                               "ServicePrincipal",
                                                                                account);
 
             var targetDiscoveryContext =


### PR DESCRIPTION
Adds support for Azure OIDC accounts on cloud target discovery for K8s and Az App Service
![k8soidccts](https://github.com/OctopusDeploy/Calamari/assets/101079287/b11a2c71-5280-4254-b046-a7b26aeee8e4)
![image (16)](https://github.com/OctopusDeploy/Calamari/assets/101079287/65d555b7-8352-4c0a-b9c2-84d87952f070)

Re-tested with latest changes
OIDC:
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/fa75ee58-db5f-46dd-9d92-25b599a82cfc)

Without valid subject in AD:
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/4e9f8d27-6377-4da7-ba88-e64041e1ca91)

SP:
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/f6310207-101f-4354-992f-3d2a16aeb435)


