### PR TITLE
update-sharpcompress version

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="NuGet.Commands" Version="3.5.0" />
         <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.3.0" />
         <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
-        <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
+        <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
         <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
         <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
     </ItemGroup>
@@ -63,7 +63,7 @@
         <PackageReference Include="Octopus.Versioning" Version="5.1.155" />
         <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
         <PackageReference Include="Octostache" Version="3.3.0" />
-        <PackageReference Include="SharpCompress" Version="0.24.0" />
+        <PackageReference Include="SharpCompress" Version="0.28.2" />
         <PackageReference Include="XPath2" Version="1.0.12" />
         <PackageReference Include="YamlDotNet" Version="8.1.2" />
         <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="Octostache" Version="3.3.0" />
-    <PackageReference Include="SharpCompress" Version="0.24.0" />
+    <PackageReference Include="SharpCompress" Version="0.28.2" />
     <PackageReference Include="Sprache" Version="2.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
@@ -72,7 +72,7 @@
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.IO.Packaging" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
     <PackageReference Include="Polly" Version="5.4.0" />
   </ItemGroup>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -61,7 +61,7 @@
     <PackageReference Include="Octopus.Versioning" Version="5.1.155" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
-    <PackageReference Include="SharpCompress" Version="0.24.0" />
+    <PackageReference Include="SharpCompress" Version="0.28.2" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>


### PR DESCRIPTION
Update sharp compress to fix issues on unzipping packages larger than 4GB.