### PR TITLE
Use default proxy for MSAL authentication

### DIFF
--- a/source/Calamari.AzureAppService/Auth.cs
+++ b/source/Calamari.AzureAppService/Auth.cs
@@ -24,12 +24,14 @@ namespace Calamari.AzureAppService
         }
 
         public static async Task<string> GetAuthTokenAsync(string tenantId, string applicationId, string password, string managementEndPoint, string activeDirectoryEndPoint)
-        { 
+        {
+            var authClientFactory = new AuthHttpClientFactory();
             var authContext = GetContextUri(activeDirectoryEndPoint, tenantId);
 
             var app = ConfidentialClientApplicationBuilder.Create(applicationId)
                                                           .WithClientSecret(password)
                                                           .WithAuthority(authContext)
+                                                          .WithHttpClientFactory(authClientFactory)
                                                           .Build();
 
             var result = await app.AcquireTokenForClient(

--- a/source/Calamari.AzureAppService/AuthHttpClientFactory.cs
+++ b/source/Calamari.AzureAppService/AuthHttpClientFactory.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using System.Net.Http;
+using Microsoft.Identity.Client;
+
+namespace Calamari.AzureAppService
+{
+    public class AuthHttpClientFactory : IMsalHttpClientFactory
+    {
+        static readonly HttpClient _httpClient;
+
+        static AuthHttpClientFactory()
+        {
+            var proxyHttpClientHandler = new HttpClientHandler
+            {
+                Proxy = WebRequest.DefaultWebProxy,
+                UseProxy = true,
+            };
+
+            _httpClient = new HttpClient(proxyHttpClientHandler);
+        }
+
+        public HttpClient GetHttpClient()
+        {
+            return _httpClient;
+        }
+    }
+}

--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
     <LangVersion>8.0</LangVersion>
-    <NoWarn>NU5104</NoWarn>
+    <NoWarn>NU5104;DE0003</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net461;net6.0</TargetFrameworks>

--- a/source/Calamari.AzureResourceGroup/AuthHttpClientFactory.cs
+++ b/source/Calamari.AzureResourceGroup/AuthHttpClientFactory.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using System.Net.Http;
+using Microsoft.Identity.Client;
+
+namespace Calamari.AzureResourceGroup
+{
+    public class AuthHttpClientFactory : IMsalHttpClientFactory
+    {
+        static readonly HttpClient _httpClient;
+
+        static AuthHttpClientFactory()
+        {
+            var proxyHttpClientHandler = new HttpClientHandler
+            {
+                Proxy = WebRequest.DefaultWebProxy,
+                UseProxy = true,
+            };
+
+            _httpClient = new HttpClient(proxyHttpClientHandler);
+        }
+
+        public HttpClient GetHttpClient()
+        {
+            return _httpClient;
+        }
+    }
+}

--- a/source/Calamari.AzureResourceGroup/ServicePrincipal.cs
+++ b/source/Calamari.AzureResourceGroup/ServicePrincipal.cs
@@ -8,12 +8,15 @@ namespace Calamari.AzureResourceGroup
     {
         public static async Task<string> GetAuthorizationToken(string tenantId, string applicationId, string password, string managementEndPoint, string activeDirectoryEndPoint)
         {
+            var authClientFactory = new AuthHttpClientFactory();
+
             var authContext = GetContextUri(activeDirectoryEndPoint, tenantId);
             Log.Verbose($"Authentication Context: {authContext}");
 
             var app = ConfidentialClientApplicationBuilder.Create(applicationId)
                 .WithClientSecret(password)
                 .WithAuthority(authContext)
+                .WithHttpClientFactory(authClientFactory)
                 .Build();
 
             var result = await app.AcquireTokenForClient(

--- a/source/Calamari.AzureWebApp/AuthHttpClientFactory.cs
+++ b/source/Calamari.AzureWebApp/AuthHttpClientFactory.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using System.Net.Http;
+using Microsoft.Identity.Client;
+
+namespace Calamari.AzureWebApp
+{
+    public class AuthHttpClientFactory : IMsalHttpClientFactory
+    {
+        static readonly HttpClient _httpClient;
+
+        static AuthHttpClientFactory()
+        {
+            var proxyHttpClientHandler = new HttpClientHandler
+            {
+                Proxy = WebRequest.DefaultWebProxy,
+                UseProxy = true,
+            };
+
+            _httpClient = new HttpClient(proxyHttpClientHandler);
+        }
+
+        public HttpClient GetHttpClient()
+        {
+            return _httpClient;
+        }
+    }
+}

--- a/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
+++ b/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <TargetFramework>net452</TargetFramework>
+    <NoWarn>DE0003</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Calamari.AzureWebApp/ServicePrincipal.cs
+++ b/source/Calamari.AzureWebApp/ServicePrincipal.cs
@@ -8,12 +8,15 @@ namespace Calamari.AzureWebApp
     {
         public static async Task<string> GetAuthorizationToken(string tenantId, string applicationId, string password, string managementEndPoint, string activeDirectoryEndPoint)
         { 
+            var authClientFactory = new AuthHttpClientFactory();
+
             var authContext = GetContextUri(activeDirectoryEndPoint, tenantId);
             Log.Verbose($"Authentication Context: {authContext}");
 
             var app = ConfidentialClientApplicationBuilder.Create(applicationId)
                                                           .WithClientSecret(password)
                                                           .WithAuthority(authContext)
+                                                          .WithHttpClientFactory(authClientFactory)
                                                           .Build();
 
             var result = await app.AcquireTokenForClient(

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
@@ -1,6 +1,6 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
@@ -1,5 +1,5 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
@@ -1,5 +1,5 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
@@ -1,5 +1,5 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=my-special-namespace --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
@@ -1,5 +1,5 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-cluster octocluster --certificate-authority=<certificateAuthorityPath> --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
@@ -1,5 +1,5 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
@@ -1,6 +1,6 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "az" cloud set --name AzureCloud
 [Verbose] Azure CLI: Authenticating with Service Principal

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
@@ -1,5 +1,5 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "az" cloud set --name AzureCloud
 [Verbose] Azure CLI: Authenticating with Service Principal

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
@@ -1,6 +1,6 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileExists.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileExists.approved.txt
@@ -1,5 +1,5 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "<customkubectl>" version --client --short --request-timeout=1m
+[Verbose] "<customkubectl>" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "<customkubectl>" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "<customkubectl>" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
@@ -1,6 +1,6 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=https://someHash.gr7.ap-southeast-2.eks.amazonaws.com --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
@@ -1,6 +1,6 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenBothZoneAndRegionAreProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenBothZoneAndRegionAreProvided.approved.txt
@@ -1,5 +1,5 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] Authenticating to gcloud with key file
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenRegionIsProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenRegionIsProvided.approved.txt
@@ -1,5 +1,5 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] Authenticating to gcloud with key file
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenZoneIsProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenZoneIsProvided.approved.txt
@@ -1,5 +1,5 @@
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] Authenticating to gcloud with key file
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithUsernamePassword.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithUsernamePassword.approved.txt
@@ -1,6 +1,6 @@
 [Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
 [Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
-[Verbose] "kubectl" version --client --short --request-timeout=1m
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari/Kubernetes/Integration/Kubectl.cs
+++ b/source/Calamari/Kubernetes/Integration/Kubectl.cs
@@ -50,7 +50,7 @@ namespace Calamari.Kubernetes.Integration
                 ExecutableLocation = customKubectlExecutable;
             }
 
-            if (TryExecuteKubectlCommand("version", "--client", "--short"))
+            if (TryExecuteKubectlCommand("version", "--client", "--output=yaml"))
             {
                 log.Verbose($"Found kubectl and successfully verified it can be executed.");
                 return true;


### PR DESCRIPTION
Uses a default proxy when authenticating to Azure.

Steps to check whether proxy is being used:
* Create an ARM template
* Configure Octopus server to use a custom proxy with your local proxy
* Verify access logs

**ARM deploy**
![image](https://github.com/OctopusDeploy/Calamari/assets/97423717/34b354e2-0b12-48ff-9a25-e9ae46aa73c1)

**Azure webapp (although deployment has failed for different reason)**
<img width="1203" alt="image" src="https://github.com/OctopusDeploy/Calamari/assets/97423717/f70f52b5-1cd2-47b4-8071-7ce0c97d6b89">


Also cherry-picks a commit which hasn't been applied to `release/2023.2` (but has been released as 25.5.9-hotfix3) in order to make sure it's not dropped.

Relates to https://github.com/OctopusDeploy/Issues/issues/8353