### PR TITLE
Fix null check in Azure Oidc auth flow for bash

### DIFF
--- a/source/Calamari.AzureScripting/Scripts/AzureContext.sh
+++ b/source/Calamari.AzureScripting/Scripts/AzureContext.sh
@@ -42,7 +42,7 @@ function setup_context {
         loginArgs=()
         # Use the full argument because of https://github.com/Azure/azure-cli/issues/12105
 
-        if [ -n $Octopus_Open_Id_Jwt ]
+        if [ -n "$Octopus_Open_Id_Jwt" ]
         then
           echo "Azure CLI: Authenticating with OpenID Connect Access Token"
           loginArgs+=("--username=$Octopus_Azure_ADClientId")


### PR DESCRIPTION
This PR fixes an issue where the null/empty check on Oidc tokens fails and causes the OIDC az login flow rather than the Service Principal.