### PR TITLE
Add tags to Azure resource groups in tests to give an expiry of 14 days

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -76,7 +76,16 @@ namespace Calamari.AzureAppService.Tests
                                  .GetResourceGroups()
                                  .CreateOrUpdateAsync(WaitUntil.Completed,
                                                       ResourceGroupName,
-                                                      new ResourceGroupData(new AzureLocation(ResourceGroupLocation)));
+                                                      new ResourceGroupData(new AzureLocation(ResourceGroupLocation))
+                                                      {
+                                                          Tags =
+                                                          {
+                                                              // give them an expiry of 14 days so if the tests fail to clean them up
+                                                              // they will be automatically cleaned up by the Sandbox cleanup process
+                                                              // We keep them for 14 days just in case we need to do debugging/investigation
+                                                              ["LifetimeInDays"] = "14"
+                                                          }
+                                                      });
 
             ResourceGroupResource = response.Value;
 

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
@@ -67,7 +67,17 @@ namespace Calamari.AzureAppService.Tests
 
             resourceGroupClient = resourcesClient.ResourceGroups;
 
-            var resourceGroup = new ResourceGroup(resourceGroupLocation);
+            var resourceGroup = new ResourceGroup(resourceGroupLocation)
+            {
+                Tags =
+                {
+                    // give them an expiry of 14 days so if the tests fail to clean them up
+                    // they will be automatically cleaned up by the Sandbox cleanup process
+                    // We keep them for 14 days just in case we need to do debugging/investigation
+                    ["LifetimeInDays"] = "14"
+                }
+            };
+            
             resourceGroup = await resourceGroupClient.CreateOrUpdateAsync(resourceGroupName, resourceGroup);
 
             webMgmtClient = new WebSiteManagementClient(new TokenCredentials(authToken))


### PR DESCRIPTION
This PR adds tags to test Azure resource groups to give an expiry of 14 days.  This means that if tests fail to clean them up, they will be automatically cleaned up by the sandbox clean-up process.

We keep the groups for 14 days just in case we need to do debugging/investigation.

Credit to @APErebus for the actual code (taken from PR https://github.com/OctopusDeploy/Calamari/pull/1091)