### PR TITLE
Fix download on target for S3 feeds

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
@@ -64,6 +64,7 @@ namespace Calamari.Integration.Packages.Download
             }
 
             var cacheDirectory = PackageDownloaderUtils.GetPackageRoot(feedId);
+            fileSystem.EnsureDirectoryExists(cacheDirectory);
 
             if (!forcePackageDownload)
             {

--- a/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
@@ -88,7 +88,8 @@ namespace Calamari.Integration.Packages.Download
                     using (var s3Client = GetS3Client(feedUsername, feedPassword, region))
                     {
                         bool fileExists = false;
-                        string fileName = "";
+                        string fileName = string.Empty;
+                        string knownExtension = string.Empty;
                         for (int i = 0; i < knownFileExtensions.Length && !fileExists; i++)
                         {
                             fileName = BuildFileName(prefix, version.ToString(), knownFileExtensions[i]);
@@ -99,12 +100,16 @@ namespace Calamari.Integration.Packages.Download
                                          .GetAwaiter()
                                          .GetResult();
 #endif
+                            if (fileExists)
+                            {
+                                knownExtension = knownFileExtensions[i];
+                            }
                         }
 
                         if (!fileExists)
                             throw new Exception($"Unable to download package {packageId} {version}: file not found");
 
-                        var localDownloadName = Path.Combine(cacheDirectory, PackageName.ToCachedFileName(packageId, version, "." + Path.GetExtension(fileName)));
+                        var localDownloadName = Path.Combine(cacheDirectory, PackageName.ToCachedFileName(packageId, version, knownExtension));
 
 #if NET40
                         var response = s3Client.GetObject(bucketName, fileName);

--- a/source/Calamari/Commands/DownloadPackageCommand.cs
+++ b/source/Calamari/Commands/DownloadPackageCommand.cs
@@ -147,7 +147,10 @@ namespace Calamari.Commands
             Guard.NotNullOrWhiteSpace(packageId, "No package ID was specified. Please pass --packageId YourPackage");
             Guard.NotNullOrWhiteSpace(packageVersion, "No package version was specified. Please pass --packageVersion 1.0.0.0");
             Guard.NotNullOrWhiteSpace(feedId, "No feed ID was specified. Please pass --feedId feed-id");
-            Guard.NotNullOrWhiteSpace(feedUri, "No feed URI was specified. Please pass --feedUri https://url/to/nuget/feed");
+            if (feedType != FeedType.S3)
+            {
+                Guard.NotNullOrWhiteSpace(feedUri, "No feed URI was specified. Please pass --feedUri https://url/to/nuget/feed");
+            }
 
             version = VersionFactory.TryCreateVersion(packageVersion, versionFormat);
             if (version == null)
@@ -155,7 +158,11 @@ namespace Calamari.Commands
                 throw new CommandException($"Package version '{packageVersion}' specified is not a valid {versionFormat.ToString()} version string");
             }
 
-            if (!Uri.TryCreate(feedUri, UriKind.Absolute, out uri))
+            if (feedType == FeedType.S3)
+            {
+                uri = null;
+            }
+            else if (!Uri.TryCreate(feedUri, UriKind.Absolute, out uri))
                 throw new CommandException($"URI specified '{feedUri}' is not a valid URI");
 
             if (!String.IsNullOrWhiteSpace(feedUsername) && String.IsNullOrWhiteSpace(feedPassword))


### PR DESCRIPTION
Note this will need to be backported. The affected customer is on 2023.2.

Fixes an issue with downloading packages from S3 feeds on the target.

Fixes https://github.com/OctopusDeploy/Issues/issues/8188

### Before

```shell
13:22:07   Fatal    |       The remote script failed with exit code 1
13:22:07   Verbose  |       at Octopus.Server.Orchestration.ServerTasks.Deploy.ActionDispatch.SuccessArbitrator.ThrowIfNotSuccessful(IActionHandlerResult result) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/ActionDispatch/SuccessArbitrator.cs:line 22
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.ActionDispatch.AdHocActionDispatcher.Dispatch(Machine machine, ActionHandlerInvocation actionHandler, ITaskLog taskLog, CancellationToken cancellationToken, VariableCollection variables) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/ActionDispatch/AdHocActionDispatcher.cs:line 80
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.Steps.Acquire.PackageAcquisitionExecutionHandlers.Invoke(ActionHandlerInvocation invocation, ITaskLog taskLog, CancellationToken cancellationToken) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/Steps/Acquire/PackageAcquisitionExecutionHandlers.cs:line 150
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.Steps.Acquire.PackageAcquisitionExecutionHandlers.DownloadPackage(String packageId, IVersion version, IFeed feed, ITaskLog taskLog, CancellationToken cancellationToken, PackageCachePolicy packageCachePolicy) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/Steps/Acquire/PackageAcquisitionExecutionHandlers.cs:line 125
                    |       at Octopus.Server.Orchestration.Targets.Common.PackageStagingMediator.DownloadPackageOnAgent(PackageIdentity packageIdentity, IDeploymentPackageDownloader deploymentPackageDownloader, PackageAcquisitionExecutionHandlers execs, ITaskLog taskLog, CancellationToken cancellationToken) in ./source/Octopus.Server/Orchestration/Targets/Common/PackageStagingMediator.cs:line 76
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.Steps.Acquire.AcquireMachinePackageTask.StagePackage(PackageAcquisitionExecutionHandlers packageAcquisitionHandlers, ITaskLog stepTaskLog, ITaskLog deploymentTargetTaskLog, CancellationToken cancellationToken) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/Steps/Acquire/AcquireMachinePackageTask.cs:line 251
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.Steps.Acquire.AcquireMachinePackageTask.<>c__DisplayClass28_0.<<Acquire>b__0>d.MoveNext() in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/Steps/Acquire/AcquireMachinePackageTask.cs:line 143
                    |       --- End of stack trace from previous location ---
                    |       at Octopus.Core.Threading.SingleResultProcess`1.Perform(Func`2 workerTask, Action logAction, CancellationToken cancellationToken) in ./source/Octopus.Core/Threading/SingleResultProcess.cs:line 45
                    |       at Octopus.Core.Threading.SingleWorkerDoesWorkCoordinator`1.DoWork(String key, Func`2 workerTask, Action logAction, CancellationToken cancellationToken) in ./source/Octopus.Core/Threading/SingleWorkerDoesWorkCoordinator.cs:line 43
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.Steps.Acquire.AcquireMachinePackageTask.Acquire(AcquiredPackageMap acquiredPackageMap, ITaskLog stepTaskLog, ITaskLog deploymentTargetTaskLog, CancellationToken cancellationToken) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/Steps/Acquire/AcquireMachinePackageTask.cs:line 141
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.Steps.Acquire.AcquireMachinePackageTask.Acquire(AcquiredPackageMap acquiredPackageMap, ITaskLog stepTaskLog, ITaskLog deploymentTargetTaskLog, CancellationToken cancellationToken) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/Steps/Acquire/AcquireMachinePackageTask.cs:line 165
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.Steps.Acquire.AcquireMachinePackageTask.Acquire(AcquiredPackageMap acquiredPackageMap, ITaskLog stepTaskLog, ITaskLog deploymentTargetTaskLog, CancellationToken cancellationToken) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/Steps/Acquire/AcquireMachinePackageTask.cs:line 210
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.PlannedStepControllers.AcquirePackagesStepController.<>c__DisplayClass4_3`3.<<Execute>b__5>d.MoveNext() in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/PlannedStepControllers/AcquirePackagesStepController.cs:line 73
                    |       --- End of stack trace from previous location ---
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.Guidance.ExecuteWithoutGuidance(Func`2 callback, String actionName, Boolean actionIsRequiredToRun, ITaskLog taskLog, CancellationToken cancellationToken) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/Guidance.cs:line 144
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.Guidance.Execute(Func`2 callback, String actionName, Boolean actionIsRequiredToRun, ITaskLog taskLog, Action callbackOnExclude, CancellationToken cancellationToken) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/Guidance.cs:line 74
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.PlannedStepControllers.AcquirePackagesStepController.<>c__DisplayClass4_3`3.<<Execute>b__4>d.MoveNext() in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/PlannedStepControllers/AcquirePackagesStepController.cs:line 80
                    |       --- End of stack trace from previous location ---
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.TransientErrorDetectionExecutor.Execute(Func`2 action, ExecutionPlan plan, ITaskLog taskLog, CancellationToken cancellationToken, DeploymentTarget deploymentTarget) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/TransientErrorDetectionExecutor.cs:line 50
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.TransientErrorDetectionExecutor.Execute(Func`2 action, ExecutionPlan plan, ITaskLog taskLog, CancellationToken cancellationToken, DeploymentTarget deploymentTarget) in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/TransientErrorDetectionExecutor.cs:line 50
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.PlannedStepControllers.AcquirePackagesStepController.<>c__DisplayClass4_2`3.<<Execute>b__3>d.MoveNext() in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/PlannedStepControllers/AcquirePackagesStepController.cs:line 84
                    |       --- End of stack trace from previous location ---
                    |       at Octopus.Server.Infrastructure.Orchestration.UnitsOfWork.UnitOfWorkExecutor.<>c__DisplayClass6_0`3.<<Execute>b__0>d.MoveNext() in ./source/Octopus.Server/Infrastructure/Orchestration/UnitsOfWork/UnitOfWorkExecutor.cs:line 94
                    |       --- End of stack trace from previous location ---
                    |       at Octopus.Core.Infrastructure.UnitsOfWork.UnitOfWorkExtensionMethods.Do(IUnitOfWork unitOfWork, Func`1 action, CancellationToken cancellationToken, String name) in ./source/Octopus.Core/Infrastructure/UnitsOfWork/UnitOfWorkExtensionMethods.cs:line 92
                    |       at Octopus.Core.Infrastructure.UnitsOfWork.UnitOfWorkExtensionMethods.Do(IUnitOfWork unitOfWork, Func`1 action, CancellationToken cancellationToken, String name) in ./source/Octopus.Core/Infrastructure/UnitsOfWork/UnitOfWorkExtensionMethods.cs:line 92
                    |       at Octopus.Server.Infrastructure.Orchestration.UnitsOfWork.UnitOfWorkExecutor.Execute[T1,T2,T3](Func`5 action, CancellationToken cancellationToken, String name) in ./source/Octopus.Server/Infrastructure/Orchestration/UnitsOfWork/UnitOfWorkExecutor.cs:line 97
                    |       at Octopus.Server.Orchestration.ServerTasks.Deploy.PlannedStepControllers.AcquirePackagesStepController.<>c__DisplayClass4_1`3.<<Execute>b__2>d.MoveNext() in ./source/Octopus.Server/Orchestration/ServerTasks/Deploy/PlannedStepControllers/AcquirePackagesStepController.cs:line 87
                    |       --- End of stack trace from previous location ---
                    |       at Octopus.Server.Orchestration.ServerTasks.ParallelWorkOrderAsync`1.<>c__DisplayClass7_1.<<Execute>b__3>d.MoveNext() in ./source/Octopus.Server/Orchestration/ServerTasks/ParallelWorkOrderAsync.cs:line 61
                    |       --- End of stack trace from previous location ---
                    |       at Octopus.Server.Orchestration.ServerTasks.OctoThreadClosureAsync`1.Execute(CancellationToken cancellationToken) in ./source/Octopus.Server/Orchestration/ServerTasks/OctoThreadClosureAsync.cs:line 61
                    |     
                    |       Failed: Download package s3BucketName/PackageName v1.0.5 directly from AWS S3 Feed



13:22:07   Error    |         Failed to download package s3bucket/RandomQuotesNexusNuget v1.0.5 from feed: ''
```


### After
Download package on target
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/35265fb7-153b-4c7e-a54b-93d4b2565fab)

Download package on Server
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/7675ac6f-33f5-44e5-8774-04d969322f78)


