### PR TITLE
Fix web app ResourceManagerPublishProfileProvider GetPublishProperties

### DIFF
--- a/source/Calamari.AzureWebApp/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
+++ b/source/Calamari.AzureWebApp/Integration/Websites/Publishing/ResourceManagerPublishProfileProvider.cs
@@ -55,7 +55,7 @@ namespace Calamari.AzureWebApp.Integration.Websites.Publishing
                 SubscriptionId = account.SubscriptionNumber,
                 BaseUri = baseUri,
             })
-            using (var webSiteClient = new WebSiteManagementClient(new TokenCredentials(token)) { SubscriptionId = account.SubscriptionNumber })
+            using (var webSiteClient = new WebSiteManagementClient(new Uri(account.ResourceManagementEndpointBaseUri), new TokenCredentials(token)) { SubscriptionId = account.SubscriptionNumber })
             {
                 webSiteClient.SetRetryPolicy(new RetryPolicy(new HttpStatusCodeErrorDetectionStrategy(), 3));
                 resourcesClient.HttpClient.DefaultRequestHeaders.Add("Authorization", "Bearer " + token);

--- a/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
+++ b/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
@@ -55,7 +55,11 @@ namespace Calamari.GoogleCloudScripting.Tests
 
                 foreach (var result in results)
                 {
-                    if (result.TimeCreated.HasValue)
+                    // Checking date time less than to fetch gcloud versions earlier than 448.
+                    // 448 requires python 3.8 and up, currently 3.5 is available on Teamcity agents
+                    // This is intended as a temporary workaround
+                    // https://build.octopushq.com/test/-1383742321497021969?currentProjectId=OctopusDeploy_Calamari_CalamariGoogleCloudScriptingTests_NetcoreTesting&expandTestHistoryChartSection=true
+                    if (result.TimeCreated.HasValue && result.TimeCreated.Value < new DateTime(2023, 09, 24));
                     {
                         listOfFilesSortedByCreatedDate.Add(result.TimeCreated.Value, result);
                     }

--- a/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
+++ b/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
@@ -55,25 +55,18 @@ namespace Calamari.GoogleCloudScripting.Tests
 
                 foreach (var result in results)
                 {
-                    // Checking date time less than to fetch gcloud versions earlier than 448.
-                    // 448 requires python 3.8 and up, currently 3.5 is available on Teamcity agents
-                    // This is intended as a temporary workaround
-                    // https://build.octopushq.com/test/-1383742321497021969?currentProjectId=OctopusDeploy_Calamari_CalamariGoogleCloudScriptingTests_NetcoreTesting&expandTestHistoryChartSection=true
-                    if (result.TimeCreated.HasValue && DateTime.Compare(DateTime.Parse(result.TimeCreatedRaw), new DateTime(2023, 09, 24)) < 0);
+                    if (result.TimeCreated.HasValue);
                     {
-                        var tw = Console.Out;
-                        var sw = new StreamWriter(Console.OpenStandardOutput());
-                        sw.AutoFlush = true;
-                        Console.SetOut(sw);
-
-                        Console.WriteLine($"File name: {result.Name}, Time Created: {result.TimeCreated}, Time Created Raw:{result.TimeCreatedRaw}, Converted DateTime: {DateTime.Parse(result.TimeCreatedRaw).ToString()}");
-
-                        Console.SetOut(tw);
                         listOfFilesSortedByCreatedDate.Add(result.TimeCreated.Value, result);
                     }
                 }
-
-                foreach (var file in listOfFilesSortedByCreatedDate.Where(file => file.Value.Name.EndsWith(postfix)))
+                
+                // Checking date time less than to fetch gcloud versions earlier than 448.
+                // 448 requires python 3.8 and up, currently 3.5 is available on Teamcity agents
+                // This is intended as a temporary workaround
+                // https://build.octopushq.com/test/-1383742321497021969?currentProjectId=OctopusDeploy_Calamari_CalamariGoogleCloudScriptingTests_NetcoreTesting&expandTestHistoryChartSection=true
+                var dateBeforeGcloud448 = new DateTime(2023, 09, 20);
+                foreach (var file in listOfFilesSortedByCreatedDate.Where(file => file.Value.Name.EndsWith(postfix) && file.Key.CompareTo(dateBeforeGcloud448) == -1))
                 {
                     return file.Value;
                 }

--- a/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
+++ b/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
@@ -59,9 +59,16 @@ namespace Calamari.GoogleCloudScripting.Tests
                     // 448 requires python 3.8 and up, currently 3.5 is available on Teamcity agents
                     // This is intended as a temporary workaround
                     // https://build.octopushq.com/test/-1383742321497021969?currentProjectId=OctopusDeploy_Calamari_CalamariGoogleCloudScriptingTests_NetcoreTesting&expandTestHistoryChartSection=true
-                    if (result.TimeCreated.HasValue && result.TimeCreated.Value < new DateTime(2023, 09, 24));
+                    if (result.TimeCreated.HasValue && DateTime.Compare(DateTime.Parse(result.TimeCreatedRaw), new DateTime(2023, 09, 24)) < 0);
                     {
-                        Console.WriteLine($"File name: {result.Name}, Time Created: {result.TimeCreated}, Time Created Raw:{result.TimeCreatedRaw}");
+                        var tw = Console.Out;
+                        var sw = new StreamWriter(Console.OpenStandardOutput());
+                        sw.AutoFlush = true;
+                        Console.SetOut(sw);
+
+                        Console.WriteLine($"File name: {result.Name}, Time Created: {result.TimeCreated}, Time Created Raw:{result.TimeCreatedRaw}, Converted DateTime: {DateTime.Parse(result.TimeCreatedRaw).ToString()}");
+
+                        Console.SetOut(tw);
                         listOfFilesSortedByCreatedDate.Add(result.TimeCreated.Value, result);
                     }
                 }

--- a/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
+++ b/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
@@ -61,6 +61,7 @@ namespace Calamari.GoogleCloudScripting.Tests
                     // https://build.octopushq.com/test/-1383742321497021969?currentProjectId=OctopusDeploy_Calamari_CalamariGoogleCloudScriptingTests_NetcoreTesting&expandTestHistoryChartSection=true
                     if (result.TimeCreated.HasValue && result.TimeCreated.Value < new DateTime(2023, 09, 24));
                     {
+                        Console.WriteLine($"File name: {result.Name}, Time Created: {result.TimeCreated}, Time Created Raw:{result.TimeCreatedRaw}");
                         listOfFilesSortedByCreatedDate.Add(result.TimeCreated.Value, result);
                     }
                 }

--- a/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
+++ b/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
@@ -53,20 +53,21 @@ namespace Calamari.GoogleCloudScripting.Tests
                 var results = client.ListObjects("cloud-sdk-release", "google-cloud-sdk-");
                 var listOfFilesSortedByCreatedDate = new SortedList<DateTime, GoogleStorageObject>(Comparer<DateTime>.Create((a, b) => b.CompareTo(a)));
 
-                foreach (var result in results)
-                {
-                    if (result.TimeCreated.HasValue);
-                    {
-                        listOfFilesSortedByCreatedDate.Add(result.TimeCreated.Value, result);
-                    }
-                }
-                
                 // Checking date time less than to fetch gcloud versions earlier than 448.
                 // 448 requires python 3.8 and up, currently 3.5 is available on Teamcity agents
                 // This is intended as a temporary workaround
                 // https://build.octopushq.com/test/-1383742321497021969?currentProjectId=OctopusDeploy_Calamari_CalamariGoogleCloudScriptingTests_NetcoreTesting&expandTestHistoryChartSection=true
                 var dateBeforeGcloud448 = new DateTime(2023, 09, 20);
-                foreach (var file in listOfFilesSortedByCreatedDate.Where(file => file.Value.Name.EndsWith(postfix) && file.Key.CompareTo(dateBeforeGcloud448) == -1))
+
+                foreach (var result in results)
+                {
+                    if (result.TimeCreated.HasValue && result.TimeCreated.Value.CompareTo(dateBeforeGcloud448) == -1)
+                    {
+                        listOfFilesSortedByCreatedDate.Add(result.TimeCreated.Value, result);
+                    }
+                }
+
+                foreach (var file in listOfFilesSortedByCreatedDate.Where(file => file.Value.Name.EndsWith(postfix)))
                 {
                     return file.Value;
                 }


### PR DESCRIPTION
During OIDC work, this creation of `WebSiteManagementClient` mistakenly had the ResourceManaementEndpointBaseUri removed. This is causing failures to find WebApps in cases where the ResourceManagementEndpoint is not the default.

Rolling back change from https://github.com/OctopusDeploy/Calamari/pull/1119/files#diff-4633112ec25a33cf99c65bf5927db785b4db60c20354548b13a35cacc6f772f9R58

[sc-60756]