### PR TITLE
Bump Globfish

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -58,7 +58,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Globfish" Version="1.0.3" />
+        <PackageReference Include="Globfish" Version="1.0.4" />
         <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
         <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
         <PackageReference Include="Octopus.Versioning" Version="5.1.155" />


### PR DESCRIPTION
Bumping Globfish to fix issue with directories ending in `.`. 

It also improves the performance by short-circuiting the algorithm when possible.

See https://github.com/OctopusDeploy/Globfish/pull/10 for details.