### PR TITLE
Upissue octostache to 3.7.0

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -63,7 +63,7 @@
         <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
         <PackageReference Include="Octopus.Versioning" Version="5.1.155" />
         <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
-        <PackageReference Include="Octostache" Version="3.5.0" />
+        <PackageReference Include="Octostache" Version="3.7.0" />
         <PackageReference Include="SharpCompress" Version="0.24.0" />
         <PackageReference Include="XPath2" Version="1.0.12" />
         <PackageReference Include="YamlDotNet" Version="8.1.2" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Octopus.Versioning" Version="5.1.155" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
-    <PackageReference Include="Octostache" Version="3.5.0" />
+    <PackageReference Include="Octostache" Version="3.7.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="Sprache" Version="2.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />


### PR DESCRIPTION
Octostache 3.7.0 supports using braces to enclose variable names inside of a `calc` block, thus allowing variables to appear on the left-hand-side of a divide and subtract operation