### PR TITLE
Attempt to clean up the upload file if it was duplicated/renamed during deployment

### DIFF
--- a/source/Calamari.AzureAppService/ArchivePackagProvider/NugetPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/NugetPackageProvider.cs
@@ -25,7 +25,7 @@ namespace Calamari.AzureAppService
         public async Task<FileInfo> ConvertToAzureSupportedFile(FileInfo sourceFile)
         {
             var newFilePath = sourceFile.FullName.Replace(".nupkg", ".zip");
-            await Task.Run(() => File.Move(sourceFile.FullName, newFilePath));
+            await Task.Run(() => File.Copy(sourceFile.FullName, newFilePath));
             return new FileInfo(newFilePath);
         }
     }


### PR DESCRIPTION
[sc-61082]

This is a workaround which probably requires a better solution.

Related to https://github.com/OctopusDeploy/Issues/issues/7382
