### PR TITLE
Attempt to clean up the upload file if it was duplicated/renamed during deployment

### DIFF
--- a/source/Calamari.AzureAppService/ArchivePackagProvider/NugetPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/NugetPackageProvider.cs
@@ -25,7 +25,7 @@ namespace Calamari.AzureAppService
         public async Task<FileInfo> ConvertToAzureSupportedFile(FileInfo sourceFile)
         {
             var newFilePath = sourceFile.FullName.Replace(".nupkg", ".zip");
-            await Task.Run(() => File.Move(sourceFile.FullName, newFilePath));
+            await Task.Run(() => File.Copy(sourceFile.FullName, newFilePath));
             return new FileInfo(newFilePath);
         }
     }

--- a/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
+++ b/source/Calamari.GoogleCloudScripting.Tests/GoogleCloudActionHandlerFixture.cs
@@ -53,9 +53,15 @@ namespace Calamari.GoogleCloudScripting.Tests
                 var results = client.ListObjects("cloud-sdk-release", "google-cloud-sdk-");
                 var listOfFilesSortedByCreatedDate = new SortedList<DateTime, GoogleStorageObject>(Comparer<DateTime>.Create((a, b) => b.CompareTo(a)));
 
+                // Checking date time less than to fetch gcloud versions earlier than 448.
+                // 448 requires python 3.8 and up, currently 3.5 is available on Teamcity agents
+                // This is intended as a temporary workaround
+                // https://build.octopushq.com/test/-1383742321497021969?currentProjectId=OctopusDeploy_Calamari_CalamariGoogleCloudScriptingTests_NetcoreTesting&expandTestHistoryChartSection=true
+                var dateBeforeGcloud448 = new DateTime(2023, 09, 20);
+                
                 foreach (var result in results)
                 {
-                    if (result.TimeCreated.HasValue)
+                    if (result.TimeCreated.HasValue && result.TimeCreated.Value.CompareTo(dateBeforeGcloud448) == -1)
                     {
                         listOfFilesSortedByCreatedDate.Add(result.TimeCreated.Value, result);
                     }


### PR DESCRIPTION
[sc-61082]

This is a workaround which probably requires a better solution.

Related to https://github.com/OctopusDeploy/Issues/issues/7382

Related to https://github.com/OctopusDeploy/Calamari/pull/1155