### PR TITLE
Isaac/enumerate files

### DIFF
--- a/source/Calamari.Common/Plumbing/FileSystem/FileOperations.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/FileOperations.cs
@@ -253,10 +253,12 @@ namespace Calamari.Common.Plumbing.FileSystem
             SearchOption searchOption,
             string[] searchPatterns)
         {
+            // Note we aren't using Alphaleonis.Win32.Filesystem.Directory.EnumerateFiles which handles long file paths due to performance issues.
+            var parentDirectoryInfo = new DirectoryInfo(parentDirectoryPath);
+
             return searchPatterns.Length == 0
-                ? Alphaleonis.Win32.Filesystem.Directory.EnumerateFiles(parentDirectoryPath, "*", searchOption)
-                : searchPatterns.SelectMany(pattern =>
-                    Alphaleonis.Win32.Filesystem.Directory.EnumerateFiles(parentDirectoryPath, pattern, searchOption));
+                ? parentDirectoryInfo.GetFiles("*", searchOption).Select(fi => fi.FullName)
+                : searchPatterns.SelectMany(pattern => parentDirectoryInfo.GetFiles(pattern, searchOption).Select(fi => fi.FullName));
         }
 
         public IEnumerable<string> GetFiles(string path, string searchPattern)


### PR DESCRIPTION
A couple of customers have run into issues for IIS steps which specifically target netfx when running things like configuration transformation. Customers are deploying packages with ~1650 files and configuration transformation completion has gone from ~2 seconds to ~1 minute. This is causing issues as they deploy across 200+ tenants to a single deployment target and tasks are now blocking on each other taking deployment times from ~2 minutes to ~20. This change isn't ideal in the sense that it removes support for long file paths. As the original change was made to tidy up and bring consistency to this functionality I think this is safe to revert, we likely don't have customer relying on long file paths here. This change is up for discussion and whether it's worth it, so far we have this one confirmed case with a second similar issue raised that may or may not be related. I'm open to feedback on whether reverting this change is the correct thing to do, but this is a significant issue for this customer.

Fixes https://github.com/OctopusDeploy/Issues/issues/8406

Original change - https://github.com/OctopusDeploy/Calamari/pull/1044

