### PR TITLE
Bypass Kubectl authentication when specified

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
@@ -1,7 +1,7 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
@@ -1,7 +1,7 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
@@ -1,7 +1,7 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
@@ -1,7 +1,7 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=my-special-namespace --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
@@ -1,7 +1,7 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-cluster octocluster --certificate-authority=<certificateAuthorityPath> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
@@ -1,7 +1,7 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipal.approved.txt
@@ -1,7 +1,7 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "az" cloud set --name AzureCloud
 [Verbose] Azure CLI: Authenticating with Service Principal
 [Verbose] "az" login --service-principal --username="azClientId" --password="azPassword" --tenant="azTenantId"

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithAzureServicePrincipalWithAdmin.approved.txt
@@ -1,7 +1,7 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "az" cloud set --name AzureCloud
 [Verbose] Azure CLI: Authenticating with Service Principal
 [Verbose] "az" login --service-principal --username="azClientId" --password="azPassword" --tenant="azTenantId"

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
@@ -1,7 +1,7 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable.approved.txt
@@ -1,3 +1,1 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>\kubectl-octo.yml
 [Error] The custom kubectl location of mykubectl does not exist. See https://g.octopushq.com/KubernetesTarget for more information.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileDoesNotExist.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileDoesNotExist.approved.txt
@@ -1,3 +1,1 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Error] The custom kubectl location of mykubectl does not exist. See https://g.octopushq.com/KubernetesTarget for more information.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileExists.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileExists.approved.txt
@@ -1,7 +1,7 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "<customkubectl>" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "<customkubectl>" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "<customkubectl>" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "<customkubectl>" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
@@ -1,6 +1,6 @@
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" config set-cluster octocluster --server=https://someHash.gr7.ap-southeast-2.eks.amazonaws.com --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
@@ -1,6 +1,6 @@
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenBothZoneAndRegionAreProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenBothZoneAndRegionAreProvided.approved.txt
@@ -1,6 +1,6 @@
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] Authenticating to gcloud with key file
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"
 [Verbose] Successfully authenticated with gcloud

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenRegionIsProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenRegionIsProvided.approved.txt
@@ -1,6 +1,6 @@
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] Authenticating to gcloud with key file
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"
 [Verbose] Successfully authenticated with gcloud

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenZoneIsProvided.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithGoogleCloudAccount_WhenZoneIsProvided.approved.txt
@@ -1,6 +1,6 @@
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] Authenticating to gcloud with key file
 [Verbose] "gcloud" auth activate-service-account --key-file="<path>gcpJsonKey.json"
 [Verbose] Successfully authenticated with gcloud

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithUsernamePassword.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithUsernamePassword.approved.txt
@@ -1,7 +1,7 @@
-[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
-[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/SetupKubectlAuthenticationFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/SetupKubectlAuthenticationFixture.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Proxies;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes;
+using Calamari.Kubernetes.Integration;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures
+{
+    [TestFixture]
+    public class SetupKubectlAuthenticationFixture
+    {
+        private IVariables variables;
+        private ILog log;
+        private ICommandLineRunner commandLineRunner;
+        private IKubectl kubectl;
+        private Dictionary<string, string> environmentVariables;
+        private string workingDirectory;
+
+        [SetUp]
+        public void Setup()
+        {
+            variables = new CalamariVariables();
+            log = Substitute.For<ILog>();
+            commandLineRunner = Substitute.For<ICommandLineRunner>();
+            kubectl = Substitute.For<IKubectl>();
+            kubectl.TrySetKubectl().Returns(true);
+            environmentVariables = new Dictionary<string, string>();
+            workingDirectory = "/working/directory";
+        }
+
+        public SetupKubectlAuthentication CreateSut() => new TestableSetupKubectlAuthentication(variables, log, commandLineRunner, kubectl, environmentVariables, workingDirectory);
+
+        [Test]
+        public void Execute_SkipsAuthentication_WhenDeploymentTargetIsKubernetesTentacle()
+        {
+            var sut = CreateSut();
+            variables.Add(MachineVariables.DeploymentTargetType, SetupKubectlAuthentication.KubernetesTentacleTargetTypeId);
+
+            var result = sut.Execute(null);
+
+            kubectl.Received().TrySetKubectl();
+            result.VerifySuccess();
+            log.Received().Info(SetupKubectlAuthentication.SkippingAuthenticationMessage);
+            environmentVariables.Should().NotContainKey("KUBECONFIG");
+        }
+
+        [TestCase("Kubernetes")]
+        [TestCase("TentaclePassive")]
+        [TestCase("TentacleActive")]
+        [TestCase("RandomOtherThing")]
+        public void Execute_DoesAuthentication_WhenDeploymentTargetIsNotKubernetesTentacle(string targetTypeId)
+        {
+            var sut = CreateSut();
+            variables.Add(MachineVariables.DeploymentTargetType, targetTypeId);
+
+            Action act = () => sut.Execute(null);
+
+            act.Should().Throw<Exception>(because: "no authentication variables are setup so we expect this to fail.");
+        }
+
+        public class TestableSetupKubectlAuthentication : SetupKubectlAuthentication
+        {
+            public TestableSetupKubectlAuthentication(IVariables variables, ILog log, ICommandLineRunner commandLineRunner, IKubectl kubectl, Dictionary<string, string> environmentVars, string workingDirectory) : base(variables, log, commandLineRunner, kubectl, environmentVars, workingDirectory)
+            {
+            }
+
+            public IEnumerable<EnvironmentVariable> ProxyEnvironmentVariables { get; set; }
+
+            protected override IEnumerable<EnvironmentVariable> GenerateProxyEnvironmentVariables()
+            {
+                return ProxyEnvironmentVariables ?? Enumerable.Empty<EnvironmentVariable>();
+            }
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
@@ -13,7 +13,7 @@ namespace Calamari.Kubernetes.Authentication
     public class AzureKubernetesServicesAuth
     {
         readonly AzureCli azureCli;
-        readonly Kubectl kubectlCli;
+        readonly IKubectl kubectlCli;
         readonly KubeLogin kubeLogin;
         readonly IVariables deploymentVariables;
 
@@ -24,7 +24,7 @@ namespace Calamari.Kubernetes.Authentication
         /// <param name="kubectlCli"></param>
         /// <param name="KubeLogin"></param>
         /// <param name="deploymentVariables"></param>
-        public AzureKubernetesServicesAuth(AzureCli azureCli, Kubectl kubectlCli, KubeLogin kubeloginCli, IVariables deploymentVariables)
+        public AzureKubernetesServicesAuth(AzureCli azureCli, IKubectl kubectlCli, KubeLogin kubeloginCli, IVariables deploymentVariables)
         {
             this.azureCli = azureCli;
             this.kubectlCli = kubectlCli;

--- a/source/Calamari/Kubernetes/Authentication/GoogleKubernetesEngineAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/GoogleKubernetesEngineAuth.cs
@@ -11,7 +11,7 @@ namespace Calamari.Kubernetes.Authentication
     {
         readonly GCloud gcloudCli;
         readonly GkeGcloudAuthPlugin authPluginCli;
-        readonly Kubectl kubectlCli;
+        readonly IKubectl kubectlCli;
         readonly IVariables deploymentVariables;
         readonly ILog log;
 
@@ -22,7 +22,7 @@ namespace Calamari.Kubernetes.Authentication
         /// <param name="authPluginCli"></param>
         /// <param name="kubectlCli"></param>
         /// <param name="deploymentVariables"></param>
-        public GoogleKubernetesEngineAuth(GCloud gcloudCli,GkeGcloudAuthPlugin authPluginCli, Kubectl kubectlCli, IVariables deploymentVariables, ILog log)
+        public GoogleKubernetesEngineAuth(GCloud gcloudCli,GkeGcloudAuthPlugin authPluginCli, IKubectl kubectlCli, IVariables deploymentVariables, ILog log)
         {
             this.gcloudCli = gcloudCli;
             this.authPluginCli = authPluginCli;

--- a/source/Calamari/Kubernetes/Integration/AzureCli.cs
+++ b/source/Calamari/Kubernetes/Integration/AzureCli.cs
@@ -80,7 +80,7 @@ namespace Calamari.Kubernetes.Integration
             log.Info("Successfully authenticated with the Azure CLI");
         }
 
-        public void ConfigureAksKubeCtlAuthentication(Kubectl kubectlCli, string clusterResourceGroup, string clusterName, string clusterNamespace, string kubeConfigPath, bool adminLogin)
+        public void ConfigureAksKubeCtlAuthentication(IKubectl kubectlCli, string clusterResourceGroup, string clusterName, string clusterNamespace, string kubeConfigPath, bool adminLogin)
         {
             log.Info($"Creating kubectl context to AKS Cluster in resource group {clusterResourceGroup} called {clusterName} (namespace {clusterNamespace})");
 

--- a/source/Calamari/Kubernetes/Integration/GCloud.cs
+++ b/source/Calamari/Kubernetes/Integration/GCloud.cs
@@ -78,7 +78,7 @@ namespace Calamari.Kubernetes.Integration
                 environmentVars.Add("CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT", impersonationEmails);
         }
 
-        public void ConfigureGkeKubeCtlAuthentication(Kubectl kubectlCli,
+        public void ConfigureGkeKubeCtlAuthentication(IKubectl kubectlCli,
                                                       string gkeClusterName,
                                                       string region,
                                                       string zone,

--- a/source/Calamari/Kubernetes/Integration/Kubectl.cs
+++ b/source/Calamari/Kubernetes/Integration/Kubectl.cs
@@ -124,8 +124,20 @@ namespace Calamari.Kubernetes.Integration
 
     public interface IKubectl
     {
+        string ExecutableLocation { get; }
+
         bool TrySetKubectl();
 
+        void SetWorkingDirectory(string directory);
+
+        void SetEnvironmentVariables(Dictionary<string, string> variables);
+
+        CommandResult ExecuteCommand(params string[] arguments);
+
+        void ExecuteCommandAndAssertSuccess(params string[] arguments);
+
         CommandResultWithOutput ExecuteCommandAndReturnOutput(params string[] arguments);
+
+        Maybe<SemanticVersion> GetVersion();
     }
 }

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -18,6 +18,8 @@ namespace Calamari.Kubernetes
 {
     public class SetupKubectlAuthentication
     {
+        private const string KubernetesTentacleTargetTypeId = "KubernetesTentacle";
+
         readonly IVariables variables;
         readonly ILog log;
         readonly ICommandLineRunner commandLineRunner;
@@ -57,8 +59,7 @@ namespace Calamari.Kubernetes
             }
 
             //if we are running inside a kubernetes cluster, then we can rely on using the service account inside the pod for authentication
-            if (variables.Get("Octopus.Target.Kubernetes.UseServiceAccountAuth") == bool.TrueString ||
-                Environment.GetEnvironmentVariable("OCTOPUS__TARGET__KUBERNETES__USESERVICEACCOUNTAUTH") == bool.TrueString)
+            if (variables.Get("Octopus.Machine.DeploymentTargetType") == KubernetesTentacleTargetTypeId)
             {
                 log.Info("Running inside Kubernetes cluster, using pod service account for authentication");
                 return new CommandResult(string.Empty, 0);

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -52,13 +52,14 @@ namespace Calamari.Kubernetes
                 environmentVars[proxyVariable.Key] = proxyVariable.Value;
             }
 
-            //make sure Kubectl exists and can be run
+            // Make sure Kubectl exists and can be run
             if (!kubectl.TrySetKubectl())
             {
                 return errorResult;
             }
 
-            //if we are running inside a kubernetes cluster, then we can rely on using the service account inside the pod for authentication
+            // If we are running on a Kubernetes Tentacle Target,
+            // then we can rely on using the service account inside the pod for authentication.
             if (variables.Get("Octopus.Machine.DeploymentTargetType") == KubernetesTentacleTargetTypeId)
             {
                 log.Info("Running inside Kubernetes cluster, using pod service account for authentication");


### PR DESCRIPTION
# Background

For the Kubernetes Agent project, we need a way to disable Kubernetes authentication when we are running on a `KubernetesTentacle`.

This works because `kubectl` uses the container service account if no other authentication is provided. I have tested this locally and it works.

# Results

We are simply checking the Deployment Target Type Id to see what value it has. If it's set to the new target `KubernetesTentacle`, we skip auth as it will fail. All other target types will attempt to authenticate.

We've added a few unit test to ensure this check is working correctly.

Shortcut story: [sc-59583]