### PR TITLE
Update publish profile

### DIFF
--- a/source/Calamari.AzureAppService/PublishingProfile.cs
+++ b/source/Calamari.AzureAppService/PublishingProfile.cs
@@ -61,7 +61,7 @@ namespace Calamari.AzureAppService
             var document = XDocument.Parse(await streamReader.ReadToEndAsync());
 
             var profile = (from el in document.Descendants("publishProfile")
-                where string.Compare(el.Attribute("publishMethod")?.Value, "MSDeploy",
+                where string.Compare(el.Attribute("publishMethod")?.Value, "ZipDeploy",
                     StringComparison.OrdinalIgnoreCase) == 0
                 select new PublishingProfile
                 {


### PR DESCRIPTION
This PR uses the ZipDeploy functionality over MsDeploy. While this may technically be correct, we've depended on MSDeploy and have only seen one occurrence of a possible issue based on a customer's misconfigured MSDeploy that brought up this investigation. This PR is being closed as a result, there are some additional configurations available in the ZipDeploy functionality, however this risks breaking some existing customers deployments to change.