### PR TITLE
Include tests for file enumeration in Calamari file system

### DIFF
--- a/source/Calamari.Common/Plumbing/FileSystem/FileOperations.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/FileOperations.cs
@@ -138,7 +138,7 @@ namespace Calamari.Common.Plumbing.FileSystem
             return searchPatterns.Length == 0
                 ? Directory.EnumerateFiles(parentDirectoryPath, "*", searchOption)
                 : searchPatterns.SelectMany(pattern =>
-                    Directory.EnumerateFiles(parentDirectoryPath, pattern, searchOption));
+                    Directory.EnumerateFiles(parentDirectoryPath, pattern, searchOption)).Distinct();
         }
 
         public IEnumerable<string> GetFiles(string path, string searchPattern)
@@ -258,7 +258,7 @@ namespace Calamari.Common.Plumbing.FileSystem
 
             return searchPatterns.Length == 0
                 ? parentDirectoryInfo.GetFiles("*", searchOption).Select(fi => fi.FullName)
-                : searchPatterns.SelectMany(pattern => parentDirectoryInfo.GetFiles(pattern, searchOption).Select(fi => fi.FullName));
+                : searchPatterns.SelectMany(pattern => parentDirectoryInfo.GetFiles(pattern, searchOption).Select(fi => fi.FullName)).Distinct();
         }
 
         public IEnumerable<string> GetFiles(string path, string searchPattern)

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Assent" Version="1.6.1" />
     <PackageReference Include="Polly" Version="5.4.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSystemFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSystemFixture.cs
@@ -246,13 +246,14 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         }
 
         [Test]
-        [TestCase(@"*.txt", new [] {"r.txt"}, 1)]
-        [TestCase(@"*.config", new [] {"root.config"}, 1)]
-        [TestCase(@"Config/*.config", new [] {"c.config"}, 1)]
-        [TestCase(@"Config/Feature1/*.config", new [] {"f1-a.config", "f1-b.config", "f1-c.config"}, 3)]
-        [TestCase(@"Config/Feature2/*.config", new [] {"f2.config"}, 1)]
-        [TestCase(@"Config/Feature2/Feature2-SubFolder/*.config", new[] {"f2-sub.config"}, 1)]
-        public void EnumerateFiles(string pattern, string[] expectedFilesMatchName, int expectedQty)
+        [TestCase(new[] { @"*.txt" }, new [] {"r.txt"}, 1)]
+        [TestCase(new[] { @"*.config" }, new [] {"root.config"}, 1)]
+        [TestCase(new[] { @"*.config", @"*.txt", @"*" }, new [] {"root.config", "r.txt"}, 2)]
+        [TestCase(new[] { @"Config/*.config"}, new [] {"c.config"}, 1)]
+        [TestCase(new[] { @"Config/Feature1/*.config"}, new [] {"f1-a.config", "f1-b.config", "f1-c.config"}, 3)]
+        [TestCase(new[] { @"Config/Feature2/*.config"}, new [] {"f2.config"}, 1)]
+        [TestCase(new[] { @"Config/Feature2/Feature2-SubFolder/*.config"}, new[] {"f2-sub.config"}, 1)]
+        public void EnumerateFiles(string[] pattern, string[] expectedFilesMatchName, int expectedQty)
         {
             var content = "file-content" + Environment.NewLine;
 
@@ -292,13 +293,14 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         }
 
         [Test]
-        [TestCase(@"*.txt", new [] {"r.txt", "f1.txt", "f2.txt", "f2-sub.txt"}, 4)]
-        [TestCase(@"*.config", new [] { "root.config", "c.config", "f1-a.config", "f1-b.config", "f1-c.config", "f2.config", "f2-sub.config"}, 7)]
-        [TestCase(@"Config/*.config",  new [] { "c.config", "f1-a.config", "f1-b.config", "f1-c.config", "f2.config", "f2-sub.config"}, 6)]
-        [TestCase(@"Config/Feature1/*.config",new[] {"f1-a.config", "f1-b.config", "f1-c.config"}, 3)]
-        [TestCase(@"Config/Feature2/*.config", new[] {"f2.config", "f2-sub.config"}, 2)]
-        [TestCase(@"Config/Feature2/Feature2-SubFolder/*.config",new[] {"f2-sub.config"}, 1)]
-        public void EnumerateFilesRecursively(string pattern, string[] expectedFilesMatchNameWithRecursion, int expectedQty)
+        [TestCase(new [] { @"*.txt" }, new [] {"r.txt", "f1.txt", "f2.txt", "f2-sub.txt"}, 4)]
+        [TestCase(new [] { @"*.config" }, new [] { "root.config", "c.config", "f1-a.config", "f1-b.config", "f1-c.config", "f2.config", "f2-sub.config"}, 7)]
+        [TestCase(new [] { @"*.config" , "*.txt", "*" }, new [] { "r.txt", "f1.txt", "f2.txt", "f2-sub.txt", "root.config", "c.config", "f1-a.config", "f1-b.config", "f1-c.config", "f2.config", "f2-sub.config"}, 11)]
+        [TestCase(new [] { @"Config/*.config" }, new [] { "c.config", "f1-a.config", "f1-b.config", "f1-c.config", "f2.config", "f2-sub.config"}, 6)]
+        [TestCase(new [] { @"Config/Feature1/*.config" }, new[] {"f1-a.config", "f1-b.config", "f1-c.config"}, 3)]
+        [TestCase(new [] { @"Config/Feature2/*.config" }, new[] {"f2.config", "f2-sub.config"}, 2)]
+        [TestCase(new [] { @"Config/Feature2/Feature2-SubFolder/*.config" },new[] {"f2-sub.config"}, 1)]
+        public void EnumerateFilesRecursively(string[] patterns, string[] expectedFilesMatchNameWithRecursion, int expectedQty)
         {
             var content = "file-content" + Environment.NewLine;
 
@@ -326,16 +328,16 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             writeFile(configPath, Path.Combine("Feature2", "Feature2-SubFolder"), "f2-sub.config");
             writeFile(configPath, Path.Combine("Feature2", "Feature2-SubFolder"), "f2-sub.txt");
 
-            var resultWithRecursion = fileSystem.EnumerateFilesRecursively(rootPath, pattern).ToList();
+            var resultWithRecursion = fileSystem.EnumerateFilesRecursively(rootPath, patterns).ToList();
 
             resultWithRecursion.Should()
                                .HaveCount(expectedQty,
-                                          $"{pattern} should have found {expectedQty}, but found {resultWithRecursion.Count}");
+                                          $"{patterns} should have found {expectedQty}, but found {resultWithRecursion.Count}");
             
             foreach (var expectedFileName in expectedFilesMatchNameWithRecursion)
             {
                 resultWithRecursion.Should()
-                                   .Contain(r => Path.GetFileName(r) == expectedFileName, $"{pattern} should have found {expectedFileName}, but didn't");
+                                   .Contain(r => Path.GetFileName(r) == expectedFileName, $"{patterns} should have found {expectedFileName}, but didn't");
             }
         }
 

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSystemFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSystemFixture.cs
@@ -218,6 +218,127 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             results.Should().HaveCount(1);
         }
 
+        [TestCase(@"*")]
+        [TestCase(@"**")]
+        [TestCase(@"Dir/*")]
+        [TestCase(@"Dir/**")]
+        public void EnumerateFilesShouldNotReturnDirectories(string pattern)
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, "Dir"));
+            Directory.CreateDirectory(Path.Combine(rootPath, "Dir", "Sub"));
+            File.WriteAllText(Path.Combine(rootPath, "Dir", "File"), "");
+            File.WriteAllText(Path.Combine(rootPath, "Dir", "Sub", "File"), "");
+
+            var results = fileSystem.EnumerateFiles(rootPath, pattern).ToArray();
+
+            if (results.Length > 0)
+                results.Should().OnlyContain(f => f.EndsWith("File"));
+        }
+
+        [Test]
+        public void EnumerateFilesWithShouldNotReturnTheSameFileTwice()
+        {
+            File.WriteAllText(Path.Combine(rootPath, "File"), "");
+
+            var results = fileSystem.EnumerateFiles(rootPath, "*", "**").ToList();
+
+            results.Should().HaveCount(1);
+        }
+
+        [Test]
+        [TestCase(@"*.txt", new [] {"r.txt"}, 1)]
+        [TestCase(@"*.config", new [] {"root.config"}, 1)]
+        [TestCase(@"Config/*.config", new [] {"c.config"}, 1)]
+        [TestCase(@"Config/Feature1/*.config", new [] {"f1-a.config", "f1-b.config", "f1-c.config"}, 3)]
+        [TestCase(@"Config/Feature2/*.config", new [] {"f2.config"}, 1)]
+        [TestCase(@"Config/Feature2/Feature2-SubFolder/*.config", new[] {"f2-sub.config"}, 1)]
+        public void EnumerateFiles(string pattern, string[] expectedFilesMatchName, int expectedQty)
+        {
+            var content = "file-content" + Environment.NewLine;
+
+            var configPath = Path.Combine(rootPath, "Config");
+
+            Directory.CreateDirectory(configPath);
+            Directory.CreateDirectory(Path.Combine(configPath, "Feature1"));
+            Directory.CreateDirectory(Path.Combine(configPath, "Feature2"));
+            Directory.CreateDirectory(Path.Combine(configPath, "Feature2", "Feature2-SubFolder"));
+
+            Action<string, string, string> writeFile = (p1, p2, p3) =>
+                fileSystem.OverwriteFile(p3 == null ? Path.Combine(p1, p2) : Path.Combine(p1, p2, p3), content);
+
+            // NOTE: create all the files in *every case*, and TestCases help supply the assert expectations
+            writeFile(rootPath, "root.config", null);
+            writeFile(rootPath, "r.txt", null);
+            writeFile(configPath, "c.config", null);
+
+            writeFile(configPath, "Feature1", "f1.txt");
+            writeFile(configPath, "Feature1", "f1-a.config");
+            writeFile(configPath, "Feature1", "f1-b.config");
+            writeFile(configPath, "Feature1", "f1-c.config");
+            writeFile(configPath, "Feature2", "f2.config");
+            writeFile(configPath, "Feature1", "f2.txt");
+            writeFile(configPath, Path.Combine("Feature2", "Feature2-SubFolder"), "f2-sub.config");
+            writeFile(configPath, Path.Combine("Feature2", "Feature2-SubFolder"), "f2-sub.txt");
+
+            var resultWithoutRecursion = fileSystem.EnumerateFiles(rootPath, pattern).ToList();
+
+            resultWithoutRecursion.Should()
+                                  .HaveCount(expectedQty, $"{pattern} should have found {expectedQty}, but found {resultWithoutRecursion.Count}");
+            foreach (var expectedFileName in expectedFilesMatchName)
+            {
+                resultWithoutRecursion.Should()
+                                      .Contain(r => Path.GetFileName(r) == expectedFileName, $"{pattern} should have found {expectedFileName}, but didn't");
+            }
+        }
+
+        [Test]
+        [TestCase(@"*.txt", new [] {"r.txt", "f1.txt", "f2.txt", "f2-sub.txt"}, 4)]
+        [TestCase(@"*.config", new [] { "root.config", "c.config", "f1-a.config", "f1-b.config", "f1-c.config", "f2.config", "f2-sub.config"}, 7)]
+        [TestCase(@"Config/*.config",  new [] { "c.config", "f1-a.config", "f1-b.config", "f1-c.config", "f2.config", "f2-sub.config"}, 6)]
+        [TestCase(@"Config/Feature1/*.config",new[] {"f1-a.config", "f1-b.config", "f1-c.config"}, 3)]
+        [TestCase(@"Config/Feature2/*.config", new[] {"f2.config", "f2-sub.config"}, 2)]
+        [TestCase(@"Config/Feature2/Feature2-SubFolder/*.config",new[] {"f2-sub.config"}, 1)]
+        public void EnumerateFilesRecursively(string pattern, string[] expectedFilesMatchNameWithRecursion, int expectedQty)
+        {
+            var content = "file-content" + Environment.NewLine;
+
+            var configPath = Path.Combine(rootPath, "Config");
+
+            Directory.CreateDirectory(configPath);
+            Directory.CreateDirectory(Path.Combine(configPath, "Feature1"));
+            Directory.CreateDirectory(Path.Combine(configPath, "Feature2"));
+            Directory.CreateDirectory(Path.Combine(configPath, "Feature2", "Feature2-SubFolder"));
+
+            Action<string, string, string> writeFile = (p1, p2, p3) =>
+                fileSystem.OverwriteFile(p3 == null ? Path.Combine(p1, p2) : Path.Combine(p1, p2, p3), content);
+
+            // NOTE: create all the files in *every case*, and TestCases help supply the assert expectations
+            writeFile(rootPath, "root.config", null);
+            writeFile(rootPath, "r.txt", null);
+            writeFile(configPath, "c.config", null);
+
+            writeFile(configPath, "Feature1", "f1.txt");
+            writeFile(configPath, "Feature1", "f1-a.config");
+            writeFile(configPath, "Feature1", "f1-b.config");
+            writeFile(configPath, "Feature1", "f1-c.config");
+            writeFile(configPath, "Feature2", "f2.config");
+            writeFile(configPath, "Feature1", "f2.txt");
+            writeFile(configPath, Path.Combine("Feature2", "Feature2-SubFolder"), "f2-sub.config");
+            writeFile(configPath, Path.Combine("Feature2", "Feature2-SubFolder"), "f2-sub.txt");
+
+            var resultWithRecursion = fileSystem.EnumerateFilesRecursively(rootPath, pattern).ToList();
+
+            resultWithRecursion.Should()
+                               .HaveCount(expectedQty,
+                                          $"{pattern} should have found {expectedQty}, but found {resultWithRecursion.Count}");
+            
+            foreach (var expectedFileName in expectedFilesMatchNameWithRecursion)
+            {
+                resultWithRecursion.Should()
+                                   .Contain(r => Path.GetFileName(r) == expectedFileName, $"{pattern} should have found {expectedFileName}, but didn't");
+            }
+        }
+
 
         [TestCase(@"[Configuration]", @"[Configuration]\\*.txt")]
         [TestCase(@"Configuration]", @"Configuration]\\*.txt")]

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSystemFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/CalamariPhysicalFileSystemFixture.cs
@@ -7,6 +7,7 @@ using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.FileSystem.GlobExpressions;
 using Calamari.Testing.Helpers;
+using Calamari.Testing.Requirements;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -292,7 +293,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             }
         }
 
-        [Test]
+        [Test, RequiresNonMono]
         [TestCase(new [] { @"*.txt" }, new [] {"r.txt", "f1.txt", "f2.txt", "f2-sub.txt"}, 4)]
         [TestCase(new [] { @"*.config" }, new [] { "root.config", "c.config", "f1-a.config", "f1-b.config", "f1-c.config", "f2.config", "f2-sub.config"}, 7)]
         [TestCase(new [] { @"*.config" , "*.txt", "*" }, new [] { "r.txt", "f1.txt", "f2.txt", "f2-sub.txt", "root.config", "c.config", "f1-a.config", "f1-b.config", "f1-c.config", "f2.config", "f2-sub.config"}, 11)]


### PR DESCRIPTION
Adds tests to the Calamari.Physicalfilesystem file enumeration methods. This was changed back to the original functionality in https://github.com/OctopusDeploy/Calamari/pull/1164 and there's no explicit test coverage of this functionality. This PR adds some basic test coverage and makes sure that files returned by multiple search patterns are unique.

Test adapter bump is required for running these locally for net461 - see https://github.com/OctopusDeploy/Halibut/pull/223