### PR TITLE
Isaac/iis multiplecerts

### DIFF
--- a/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
+++ b/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.38.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="Polly" Version="5.6.1" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />

--- a/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
+++ b/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.38.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
     <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Assent" Version="1.6.1" />
     <PackageReference Include="Polly" Version="5.4.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/Calamari/Deployment/Features/IisWebSiteAfterPostDeployFeature.cs
+++ b/source/Calamari/Deployment/Features/IisWebSiteAfterPostDeployFeature.cs
@@ -41,11 +41,13 @@ namespace Calamari.Deployment.Features
 
                 var thumbprint = variables.Get($"{certificateVariable}.{CertificateVariables.Properties.Thumbprint}");
                 var privateKeyAccess = CreatePrivateKeyAccessForApplicationPoolAccount(variables);
+ 
+                var storeName = IisWebSiteBeforeDeployFeature.FindCertificateInLocalMachineStore(thumbprint);
 
-                // The store-name variable was set by IisWebSiteBeforePostDeploy
-                var storeName = variables.Get(SpecialVariables.Action.IisWebSite.Output.CertificateStoreName);
-                WindowsX509CertificateStore.AddPrivateKeyAccessRules(thumbprint, StoreLocation.LocalMachine, storeName,
-                    new List<PrivateKeyAccessRule> {privateKeyAccess});
+                WindowsX509CertificateStore.AddPrivateKeyAccessRules(thumbprint,
+                                                                     StoreLocation.LocalMachine,
+                                                                     storeName,
+                                                                     new List<PrivateKeyAccessRule> { privateKeyAccess });
             }
         }
 
@@ -54,18 +56,18 @@ namespace Calamari.Deployment.Features
             var applicationPoolIdentityTypeValue = variables.Get(SpecialVariables.Action.IisWebSite.ApplicationPoolIdentityType);
 
             ApplicationPoolIdentityType appPoolIdentityType;
-            if(!Enum.TryParse(applicationPoolIdentityTypeValue, out appPoolIdentityType))
+            if (!Enum.TryParse(applicationPoolIdentityTypeValue, out appPoolIdentityType))
             {
                 throw new CommandException($"Unexpected value for '{SpecialVariables.Action.IisWebSite.ApplicationPoolIdentityType}': '{applicationPoolIdentityTypeValue}'");
             }
 
             return new PrivateKeyAccessRule(
-                GetIdentityForApplicationPoolIdentity(appPoolIdentityType, variables),
-                PrivateKeyAccess.FullControl);
+                                            GetIdentityForApplicationPoolIdentity(appPoolIdentityType, variables),
+                                            PrivateKeyAccess.FullControl);
         }
 
         static IdentityReference GetIdentityForApplicationPoolIdentity(ApplicationPoolIdentityType applicationPoolIdentityType,
-            IVariables variables)
+                                                                       IVariables variables)
         {
             switch (applicationPoolIdentityType)
             {
@@ -97,6 +99,5 @@ namespace Calamari.Deployment.Features
             return Regex.Replace(username, "\\.\\\\(.*)", "$1", RegexOptions.None);
         }
 #endif
-
     }
 }

--- a/source/Calamari/Deployment/Features/IisWebSiteBeforeDeployFeature.cs
+++ b/source/Calamari/Deployment/Features/IisWebSiteBeforeDeployFeature.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Deployment;
@@ -57,10 +58,15 @@ namespace Calamari.Deployment.Features
                 storeName = AddCertificateToLocalMachineStore(variables, certificateVariable);
             }
 
-            Log.SetOutputVariable(SpecialVariables.Action.IisWebSite.Output.CertificateStoreName, storeName, variables);
+            var storeNamesVariable = variables.Get(SpecialVariables.Action.IisWebSite.Output.CertificateStoreName, "") ?? "";
+            if (storeNamesVariable.Split(',').Contains(storeName))
+                return;
+
+            storeNamesVariable = string.Join(",", storeNamesVariable, storeName);
+            Log.SetOutputVariable(SpecialVariables.Action.IisWebSite.Output.CertificateStoreName, storeNamesVariable, variables);
         }
 
-        static string FindCertificateInLocalMachineStore(string thumbprint)
+        public static string FindCertificateInLocalMachineStore(string thumbprint)
         {
             foreach (var storeName in WindowsX509CertificateStore.GetStoreNames(StoreLocation.LocalMachine))
             {


### PR DESCRIPTION
Adding support for multiple certificate stores in IIS. This change assumes the certificate store output variable is not depended on by customers

Fixes https://github.com/OctopusDeploy/Issues/issues/5096

## Before

## After
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/9099b7f4-45c8-4e85-9b98-bc8bdee26fd4)
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/2948b03d-0ce4-4182-8025-fd4072fb2658)

**Note: I have not been able to get certificates that are not in the `MY` store to show in the IIS web binding UI. The test output does receive the details **
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/56108660-fb7f-4f60-9083-dc0093be5ed1)
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/6b5c9423-7800-498c-a0a4-4151922833b4)

![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/5bd94cfe-ce25-4214-9e56-cf052e3d2298)

**Test using Octopus provided certs, note still has the issue with the second Cert not showing in the SSL Certificate field**
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/1405905d-bada-45c1-ba0d-492856b8cfbc)
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/4cb4165a-6fe2-400b-ba17-76ada8113339)
![image](https://github.com/OctopusDeploy/Calamari/assets/101079287/0481c664-b713-425e-87af-245edd541cd6)






