### PR TITLE
Update Calamari to strip out the v from versions when parsing semvers

### DIFF
--- a/source/Calamari.Common/Features/Packages/PackageName.cs
+++ b/source/Calamari.Common/Features/Packages/PackageName.cs
@@ -113,7 +113,7 @@ namespace Calamari.Common.Features.Packages
             if (!packageIdMatch.Success || !versionMatch.Success || !extensionMatch.Success)
                 return false;
 
-            version = VersionFactory.TryCreateSemanticVersion(versionMatch.Value.SanitiseVersionString(), true);
+            version = VersionFactory.TryCreateSemanticVersion(versionMatch.Value.SanitiseSemVerString(), true);
             if (version == null)
                 return false;
 
@@ -179,7 +179,7 @@ namespace Calamari.Common.Features.Packages
 //                version = metaData.Version;
 //                packageId = metaData.PackageId;
                 var metaData = new LocalNuGetPackage(path!).Metadata;
-                version = SemVerFactory.CreateVersion(metaData.Version.ToString().SanitiseVersionString());
+                version = SemVerFactory.CreateVersion(metaData.Version.ToString().SanitiseSemVerString());
                 packageId = metaData.Id;
             }
 
@@ -244,7 +244,7 @@ namespace Calamari.Common.Features.Packages
             switch (input[0])
             {
                 case 'S':
-                    return VersionFactory.CreateSemanticVersion(Decode(input.Substring(1)).SanitiseVersionString(), true);
+                    return VersionFactory.CreateSemanticVersion(Decode(input.Substring(1)).SanitiseSemVerString(), true);
                 case 'M':
                     return VersionFactory.CreateMavenVersion(Decode(input.Substring(1)));
                 case 'O':

--- a/source/Calamari.Common/Features/Packages/PackageName.cs
+++ b/source/Calamari.Common/Features/Packages/PackageName.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Calamari.Common.Features.Packages.NuGet;
+using Calamari.Common.Plumbing.Extensions;
 using Octopus.Versioning;
 using Octopus.Versioning.Maven;
 using Octopus.Versioning.Octopus;
@@ -112,7 +113,7 @@ namespace Calamari.Common.Features.Packages
             if (!packageIdMatch.Success || !versionMatch.Success || !extensionMatch.Success)
                 return false;
 
-            version = VersionFactory.TryCreateSemanticVersion(versionMatch.Value, true);
+            version = VersionFactory.TryCreateSemanticVersion(versionMatch.Value.SanitiseVersionString(), true);
             if (version == null)
                 return false;
 
@@ -178,7 +179,7 @@ namespace Calamari.Common.Features.Packages
 //                version = metaData.Version;
 //                packageId = metaData.PackageId;
                 var metaData = new LocalNuGetPackage(path!).Metadata;
-                version = SemVerFactory.CreateVersion(metaData.Version.ToString());
+                version = SemVerFactory.CreateVersion(metaData.Version.ToString().SanitiseVersionString());
                 packageId = metaData.Id;
             }
 
@@ -243,7 +244,7 @@ namespace Calamari.Common.Features.Packages
             switch (input[0])
             {
                 case 'S':
-                    return VersionFactory.CreateSemanticVersion(Decode(input.Substring(1)), true);
+                    return VersionFactory.CreateSemanticVersion(Decode(input.Substring(1)).SanitiseVersionString(), true);
                 case 'M':
                     return VersionFactory.CreateMavenVersion(Decode(input.Substring(1)));
                 case 'O':

--- a/source/Calamari.Common/Plumbing/Extensions/StringExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/StringExtensions.cs
@@ -75,5 +75,10 @@ namespace Calamari.Common.Plumbing.Extensions
                                   ?.Key
                    ?? LineEnding.Dos;
         }
+
+        public static string SanitiseVersionString(this string version)
+        {
+            return version.StartsWith("v") ? version.Substring(1) : version;
+        }
     }
 }

--- a/source/Calamari.Common/Plumbing/Extensions/StringExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/StringExtensions.cs
@@ -76,7 +76,16 @@ namespace Calamari.Common.Plumbing.Extensions
                    ?? LineEnding.Dos;
         }
 
-        public static string SanitiseVersionString(this string version)
+        /// <remarks>
+        /// This method is required as we are using an old version of Octopus.Versioning
+        /// and can't update because it's no longer compatible with net framework versions
+        /// less than net461.
+        ///
+        /// We call this method before passing any strings into Version Factories for the
+        /// referenced version of Octopus.Versioning. Once we update to 4.6.2, we can update
+        /// Octopus.Versioning to a min version of 5.1.796 and then remove this extension method.
+        /// </remarks>
+        public static string SanitiseSemVerString(this string version)
         {
             return version.StartsWith("v") ? version.Substring(1) : version;
         }

--- a/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
@@ -157,10 +157,7 @@ namespace Calamari.Integration.Packages.Download
             if (input == null)
                 return null;
 
-            if (input[0].Equals('v') || input[0].Equals('V'))
-                input = input.Substring(1);
-
-            return VersionFactory.TryCreateVersion(input, VersionFormat.Semver);
+            return VersionFactory.TryCreateVersion(input.SanitiseVersionString(), VersionFormat.Semver);
         }
 
         PackagePhysicalFileMetadata DownloadFile(string uri,

--- a/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
@@ -157,7 +157,7 @@ namespace Calamari.Integration.Packages.Download
             if (input == null)
                 return null;
 
-            return VersionFactory.TryCreateVersion(input.SanitiseVersionString(), VersionFormat.Semver);
+            return VersionFactory.TryCreateVersion(input.SanitiseSemVerString(), VersionFormat.Semver);
         }
 
         PackagePhysicalFileMetadata DownloadFile(string uri,

--- a/source/Calamari.Shared/Integration/Packages/Download/Helm/HelmIndexYamlReader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/Helm/HelmIndexYamlReader.cs
@@ -56,7 +56,7 @@ namespace Calamari.Integration.Packages.Download.Helm
                 if (value == null)
                     return null;
 
-                var version = SemVerFactory.TryCreateVersion(value.SanitiseVersionString());
+                var version = SemVerFactory.TryCreateVersion(value.SanitiseSemVerString());
                 if (version == null)
                     return null;
 

--- a/source/Calamari.Shared/Integration/Packages/Download/Helm/HelmIndexYamlReader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/Helm/HelmIndexYamlReader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Calamari.Common.Plumbing.Extensions;
 using Octopus.Versioning;
 using Octopus.Versioning.Semver;
 using YamlDotNet.RepresentationModel;
@@ -55,7 +56,7 @@ namespace Calamari.Integration.Packages.Download.Helm
                 if (value == null)
                     return null;
 
-                var version = SemVerFactory.TryCreateVersion(value);
+                var version = SemVerFactory.TryCreateVersion(value.SanitiseVersionString());
                 if (version == null)
                     return null;
 

--- a/source/Calamari.Shared/Integration/Packages/NuGet/NuGetFileSystemDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NuGetFileSystemDownloader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Calamari.Common.Features.Packages.NuGet;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Octopus.Versioning;
 
@@ -23,7 +24,7 @@ namespace Calamari.Integration.Packages.NuGet
             var package = (from path in GetPackageLookupPaths(packageId, version, feedUri)
                 let pkg = new LocalNuGetPackage(path)
                 where pkg.Metadata.Id.Equals(packageId, StringComparison.OrdinalIgnoreCase) &&
-                      VersionFactory.CreateSemanticVersion(pkg.Metadata.Version.ToString()).Equals(version)
+                      VersionFactory.CreateSemanticVersion(pkg.Metadata.Version.ToString().SanitiseVersionString()).Equals(version)
                 select path
                ).FirstOrDefault();
 
@@ -78,7 +79,7 @@ namespace Calamari.Integration.Packages.NuGet
             // When matching by pattern, we will always have a version token. Packages without versions would be matched early on by the version-less path resolver
             // when doing an exact match.
             return name.Length > packageId.Length &&
-                   (VersionFactory.TryCreateSemanticVersion(name.Substring(packageId.Length + 1))?.Equals(version) ?? false);
+                   (VersionFactory.TryCreateSemanticVersion(name.Substring(packageId.Length + 1).SanitiseVersionString())?.Equals(version) ?? false);
         }
 
         static IEnumerable<string> GetPackageFiles(Uri feedUri, string filter)

--- a/source/Calamari.Shared/Integration/Packages/NuGet/NuGetFileSystemDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NuGetFileSystemDownloader.cs
@@ -24,7 +24,7 @@ namespace Calamari.Integration.Packages.NuGet
             var package = (from path in GetPackageLookupPaths(packageId, version, feedUri)
                 let pkg = new LocalNuGetPackage(path)
                 where pkg.Metadata.Id.Equals(packageId, StringComparison.OrdinalIgnoreCase) &&
-                      VersionFactory.CreateSemanticVersion(pkg.Metadata.Version.ToString().SanitiseVersionString()).Equals(version)
+                      VersionFactory.CreateSemanticVersion(pkg.Metadata.Version.ToString().SanitiseSemVerString()).Equals(version)
                 select path
                ).FirstOrDefault();
 
@@ -79,7 +79,7 @@ namespace Calamari.Integration.Packages.NuGet
             // When matching by pattern, we will always have a version token. Packages without versions would be matched early on by the version-less path resolver
             // when doing an exact match.
             return name.Length > packageId.Length &&
-                   (VersionFactory.TryCreateSemanticVersion(name.Substring(packageId.Length + 1).SanitiseVersionString())?.Equals(version) ?? false);
+                   (VersionFactory.TryCreateSemanticVersion(name.Substring(packageId.Length + 1).SanitiseSemVerString())?.Equals(version) ?? false);
         }
 
         static IEnumerable<string> GetPackageFiles(Uri feedUri, string filter)

--- a/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3Downloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3Downloader.cs
@@ -11,6 +11,7 @@ using System.Net;
 using System.Net.Http;
 using System.Web;
 using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Deployment;
 using Newtonsoft.Json;
@@ -287,7 +288,7 @@ namespace Calamari.Integration.Packages.NuGet
             if (json.TryGetValue("version", out versionToken) &&
                 versionToken.Type == JTokenType.String)
             {
-                var version = VersionFactory.TryCreateSemanticVersion((string)versionToken);
+                var version = VersionFactory.TryCreateSemanticVersion(((string)versionToken).SanitiseVersionString());
                 if (version != null && version.Major == 3)
                 {
                     return true;

--- a/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3Downloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3Downloader.cs
@@ -288,7 +288,7 @@ namespace Calamari.Integration.Packages.NuGet
             if (json.TryGetValue("version", out versionToken) &&
                 versionToken.Type == JTokenType.String)
             {
-                var version = VersionFactory.TryCreateSemanticVersion(((string)versionToken).SanitiseVersionString());
+                var version = VersionFactory.TryCreateSemanticVersion(((string)versionToken).SanitiseSemVerString());
                 if (version != null && version.Major == 3)
                 {
                     return true;

--- a/source/Calamari/Commands/DownloadPackageCommand.cs
+++ b/source/Calamari/Commands/DownloadPackageCommand.cs
@@ -6,6 +6,7 @@ using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.Plumbing;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -152,7 +153,7 @@ namespace Calamari.Commands
                 Guard.NotNullOrWhiteSpace(feedUri, "No feed URI was specified. Please pass --feedUri https://url/to/nuget/feed");
             }
 
-            version = VersionFactory.TryCreateVersion(packageVersion, versionFormat);
+            version = VersionFactory.TryCreateVersion(versionFormat == VersionFormat.Semver ? packageVersion.SanitiseVersionString() : this.packageVersion, versionFormat);
             if (version == null)
             {
                 throw new CommandException($"Package version '{packageVersion}' specified is not a valid {versionFormat.ToString()} version string");

--- a/source/Calamari/Commands/DownloadPackageCommand.cs
+++ b/source/Calamari/Commands/DownloadPackageCommand.cs
@@ -153,7 +153,7 @@ namespace Calamari.Commands
                 Guard.NotNullOrWhiteSpace(feedUri, "No feed URI was specified. Please pass --feedUri https://url/to/nuget/feed");
             }
 
-            version = VersionFactory.TryCreateVersion(versionFormat == VersionFormat.Semver ? packageVersion.SanitiseVersionString() : this.packageVersion, versionFormat);
+            version = VersionFactory.TryCreateVersion(versionFormat == VersionFormat.Semver ? packageVersion.SanitiseSemVerString() : this.packageVersion, versionFormat);
             if (version == null)
             {
                 throw new CommandException($"Package version '{packageVersion}' specified is not a valid {versionFormat.ToString()} version string");

--- a/source/Calamari/Commands/DownloadPackageCommand.cs
+++ b/source/Calamari/Commands/DownloadPackageCommand.cs
@@ -153,7 +153,7 @@ namespace Calamari.Commands
                 Guard.NotNullOrWhiteSpace(feedUri, "No feed URI was specified. Please pass --feedUri https://url/to/nuget/feed");
             }
 
-            version = VersionFactory.TryCreateVersion(versionFormat == VersionFormat.Semver ? packageVersion.SanitiseSemVerString() : this.packageVersion, versionFormat);
+            version = VersionFactory.TryCreateVersion(versionFormat == VersionFormat.Semver ? packageVersion.SanitiseSemVerString() : packageVersion, versionFormat);
             if (version == null)
             {
                 throw new CommandException($"Package version '{packageVersion}' specified is not a valid {versionFormat.ToString()} version string");

--- a/source/Calamari/Commands/FindPackageCommand.cs
+++ b/source/Calamari/Commands/FindPackageCommand.cs
@@ -50,7 +50,7 @@ namespace Calamari.Commands
             Guard.NotNullOrWhiteSpace(rawPackageVersion, "No package version was specified. Please pass --packageVersion 1.0.0.0");
             Guard.NotNullOrWhiteSpace(packageHash, "No package hash was specified. Please pass --packageHash YourPackageHash");
 
-            var version = VersionFactory.TryCreateVersion(versionFormat == VersionFormat.Semver ? rawPackageVersion.SanitiseVersionString() : rawPackageVersion, versionFormat);
+            var version = VersionFactory.TryCreateVersion(versionFormat == VersionFormat.Semver ? rawPackageVersion.SanitiseSemVerString() : rawPackageVersion, versionFormat);
             if (version == null)
                 throw new CommandException($"Package version '{rawPackageVersion}' is not a valid {versionFormat} version string. Please pass --packageVersionFormat with a different version type.");
 

--- a/source/Calamari/Commands/FindPackageCommand.cs
+++ b/source/Calamari/Commands/FindPackageCommand.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Calamari.Commands.Support;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Integration.FileSystem;
 using Octopus.Versioning;
@@ -49,7 +50,7 @@ namespace Calamari.Commands
             Guard.NotNullOrWhiteSpace(rawPackageVersion, "No package version was specified. Please pass --packageVersion 1.0.0.0");
             Guard.NotNullOrWhiteSpace(packageHash, "No package hash was specified. Please pass --packageHash YourPackageHash");
 
-            var version = VersionFactory.TryCreateVersion(rawPackageVersion, versionFormat);
+            var version = VersionFactory.TryCreateVersion(versionFormat == VersionFormat.Semver ? rawPackageVersion.SanitiseVersionString() : rawPackageVersion, versionFormat);
             if (version == null)
                 throw new CommandException($"Package version '{rawPackageVersion}' is not a valid {versionFormat} version string. Please pass --packageVersionFormat with a different version type.");
 

--- a/source/Calamari/Commands/RegisterPackageUseCommand.cs
+++ b/source/Calamari/Commands/RegisterPackageUseCommand.cs
@@ -2,6 +2,7 @@
 using Calamari.Commands.Support;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Deployment.PackageRetention;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Octopus.Versioning;
@@ -46,7 +47,7 @@ namespace Calamari.Commands
             try
             {
                 Options.Parse(commandLineArguments);
-                packageVersion = VersionFactory.TryCreateVersion(rawVersionString, versionFormat);
+                packageVersion = VersionFactory.TryCreateVersion(versionFormat == VersionFormat.Semver ? rawVersionString.SanitiseVersionString() : rawVersionString, versionFormat);
                 RegisterPackageUse();
             }
             catch (Exception ex)

--- a/source/Calamari/Commands/RegisterPackageUseCommand.cs
+++ b/source/Calamari/Commands/RegisterPackageUseCommand.cs
@@ -47,7 +47,7 @@ namespace Calamari.Commands
             try
             {
                 Options.Parse(commandLineArguments);
-                packageVersion = VersionFactory.TryCreateVersion(versionFormat == VersionFormat.Semver ? rawVersionString.SanitiseVersionString() : rawVersionString, versionFormat);
+                packageVersion = VersionFactory.TryCreateVersion(versionFormat == VersionFormat.Semver ? rawVersionString.SanitiseSemVerString() : rawVersionString, versionFormat);
                 RegisterPackageUse();
             }
             catch (Exception ex)


### PR DESCRIPTION
# Background

Part of [sc-64777]

I've fixed the issue with parsing semver versions starting with a 'v' eg: `"v1.2.3"` in `Octopus.Versioning`. Unfortunately Octopus can't be updated to the newer version of Octopus.Versioning as it doesn't support net framework versions lower than net461. Once we update Calamari to net462, we can update Calamari to use the new version of `Versioning`.

# Result

This is a pretty crude workaround where we just remove the 'v' from the front of any version before passing them into any create methods in the Octopus.Versioning package. We only do this for semvers.
