### PR TITLE
Fix Azure Cloud Service tests which are using the Azure_OctopusAPITester_Certificate env var

### DIFF
--- a/source/Calamari.AzureCloudService.Tests/DeployAzureCloudServiceCommandFixture.cs
+++ b/source/Calamari.AzureCloudService.Tests/DeployAzureCloudServiceCommandFixture.cs
@@ -31,6 +31,8 @@ namespace Calamari.AzureCloudService.Tests
         public async Task Setup()
         {
             storageName = $"Test{Guid.NewGuid().ToString("N").Substring(0, 10)}".ToLower();
+            // We need to trim because of issue with team city:
+            // https://app.shortcut.com/octopusdeploy/story/65471/failing-azurecloudservice-tests-due-to-whitespace-being-added-to-end-of-certificate-env-var
             certificate = ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate).Trim();
             subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
             managementCertificate = CreateManagementCertificate(certificate);

--- a/source/Calamari.AzureCloudService.Tests/DeployAzureCloudServiceCommandFixture.cs
+++ b/source/Calamari.AzureCloudService.Tests/DeployAzureCloudServiceCommandFixture.cs
@@ -31,7 +31,7 @@ namespace Calamari.AzureCloudService.Tests
         public async Task Setup()
         {
             storageName = $"Test{Guid.NewGuid().ToString("N").Substring(0, 10)}".ToLower();
-            certificate = ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate);
+            certificate = ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate).Trim();
             subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
             managementCertificate = CreateManagementCertificate(certificate);
             subscriptionCloudCredentials = new CertificateCloudCredentials(subscriptionId, managementCertificate);

--- a/source/Calamari.AzureCloudService.Tests/HealthCheckCommandFixture.cs
+++ b/source/Calamari.AzureCloudService.Tests/HealthCheckCommandFixture.cs
@@ -17,7 +17,7 @@ namespace Calamari.AzureCloudService.Tests
         public async Task CloudService_Is_Found()
         {
             var subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
-            var certificate = ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate);
+            var certificate = ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate).Trim();
             var serviceName = $"{nameof(HealthCheckCommandFixture)}-{Guid.NewGuid().ToString("N").Substring(0, 12)}";
 
             using var managementCertificate = CreateManagementCertificate(certificate);
@@ -47,7 +47,7 @@ namespace Calamari.AzureCloudService.Tests
         public Task CloudService_Is_Not_Found()
         {
             var subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
-            var certificate = ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate);
+            var certificate = ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate).Trim();
             var serviceName = $"{nameof(HealthCheckCommandFixture)}-{Guid.NewGuid().ToString("N").Substring(0, 12)}";
 
             using var managementCertificate = CreateManagementCertificate(certificate);

--- a/source/Calamari.AzureCloudService.Tests/HealthCheckCommandFixture.cs
+++ b/source/Calamari.AzureCloudService.Tests/HealthCheckCommandFixture.cs
@@ -17,6 +17,8 @@ namespace Calamari.AzureCloudService.Tests
         public async Task CloudService_Is_Found()
         {
             var subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
+            // We need to trim because of issue with team city:
+            // https://app.shortcut.com/octopusdeploy/story/65471/failing-azurecloudservice-tests-due-to-whitespace-being-added-to-end-of-certificate-env-var
             var certificate = ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate).Trim();
             var serviceName = $"{nameof(HealthCheckCommandFixture)}-{Guid.NewGuid().ToString("N").Substring(0, 12)}";
 
@@ -47,6 +49,8 @@ namespace Calamari.AzureCloudService.Tests
         public Task CloudService_Is_Not_Found()
         {
             var subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
+            // We need to trim because of issue with team city:
+            // https://app.shortcut.com/octopusdeploy/story/65471/failing-azurecloudservice-tests-due-to-whitespace-being-added-to-end-of-certificate-env-var
             var certificate = ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate).Trim();
             var serviceName = $"{nameof(HealthCheckCommandFixture)}-{Guid.NewGuid().ToString("N").Substring(0, 12)}";
 


### PR DESCRIPTION
# Background

Slack thread: https://octopusdeploy.slack.com/archives/C03SG0LFJHX/p1700708276730729

# Results

Turns out team city is adding a trailing space on the env var which makes it fail to parse as a base64 string.

Adding a trim should solve this issue to remove the trailing space.

[sc-65471]