### PR TITLE
SPIKE: Fix ambient auth bugs

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -47,6 +47,7 @@
     <ProjectReference Include="..\Calamari.Azure\Calamari.Azure.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="KubernetesClient.Classic" Version="12.1.1" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -64,7 +65,7 @@
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="scriptcs" Version="0.17.1" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
-    <PackageReference Include="YamlDotNet" Version="8.1.2" />
+    <PackageReference Include="YamlDotNet" Version="13.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">

--- a/source/Calamari/Kubernetes/Commands/KubernetesDeploymentCommandBase.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesDeploymentCommandBase.cs
@@ -124,7 +124,7 @@ namespace Calamari.Kubernetes.Commands
 
             conventions.AddRange(CommandSpecificInstallConventions());
 
-            var runningDeployment = new RunningDeployment(pathToPackage, variables);
+            var runningDeployment = new RunningDeployment(pathToPackage, variables, GetEnvironmentVariables());
 
             var conventionRunner = new ConventionProcessor(runningDeployment, conventions, log);
             try
@@ -139,6 +139,12 @@ namespace Calamari.Kubernetes.Commands
                 deploymentJournalWriter.AddJournalEntry(runningDeployment, false, pathToPackage);
                 throw;
             }
+        }
+
+        private static Dictionary<string, string> GetEnvironmentVariables()
+        {
+            var environmentVariables = Environment.GetEnvironmentVariables();
+            return environmentVariables.Keys.Cast<string>().ToDictionary(x => x, x => environmentVariables[x]?.ToString());
         }
     }
 }

--- a/source/Calamari/Kubernetes/Integration/CommandLineTool.cs
+++ b/source/Calamari/Kubernetes/Integration/CommandLineTool.cs
@@ -8,8 +8,8 @@ namespace Calamari.Kubernetes.Integration
     public class CommandLineTool
     {
         protected readonly ILog log;
-        protected string workingDirectory;
-        protected Dictionary<string, string> environmentVars;
+        public string workingDirectory { get; set; }
+        public Dictionary<string, string> environmentVars { get; set; }
 
         readonly ICommandLineRunner commandLineRunner;
 

--- a/source/Calamari/Kubernetes/Integration/Kubectl.cs
+++ b/source/Calamari/Kubernetes/Integration/Kubectl.cs
@@ -124,6 +124,8 @@ namespace Calamari.Kubernetes.Integration
 
     public interface IKubectl
     {
+        string workingDirectory { get; }
+        Dictionary<string, string> environmentVars { get; }
         void SetWorkingDirectory(string directory);
         void SetEnvironmentVariables(Dictionary<string, string> variables);
         bool TrySetKubectl();

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -1,4 +1,5 @@
 #if !NET40
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -165,12 +166,23 @@ namespace Calamari.Kubernetes
             // Use the config object to create a client.
             var client = new k8s.Kubernetes(config);
 
-            var result = client.CoreV1.ReadNamespaceWithHttpMessagesAsync(@namespace).GetAwaiter().GetResult();
-            if (result.Response.IsSuccessStatusCode)
+            try
+            {
+                client.CoreV1.ReadNamespaceAsync(@namespace).GetAwaiter().GetResult();
                 return true;
-
-            return client.CoreV1.CreateNamespaceWithHttpMessagesAsync(new V1Namespace(metadata: new V1ObjectMeta(name: @namespace))).GetAwaiter().GetResult().Response
-                .IsSuccessStatusCode;
+            }
+            catch
+            {
+                try
+                {
+                    client.CoreV1.CreateNamespaceAsync(new V1Namespace(metadata: new V1ObjectMeta(name: @namespace))).GetAwaiter().GetResult();
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
 
             // if (TryExecuteCommandWithVerboseLoggingOnly("get", "namespace", @namespace))
             //     return true;


### PR DESCRIPTION
# Background

This PR adds the ability for Calamari to do ambient auth (eg: if no variables for auth are set, don't fail, just assume that auth is given ambiently)

There are two bugs that have come out of that:
1. https://app.shortcut.com/octopusdeploy/story/65557/when-deploying-to-kubernetes-with-ambient-auth-context-if-no-namespace-is-specified-the-default-will-be-the-namespace-where
2. https://app.shortcut.com/octopusdeploy/story/65597/kubectl-get-create-don-t-seem-to-work-with-ambient-auth

# Results

This PR has random hacks that I used to try and figure out what was going on and why it wasn't working properly. I'll leave comments on bits that might be of interest.