### PR TITLE
Robe/k8s cert refactor

### DIFF
--- a/source/Calamari.Shared/Integration/Certificates/PrivateKeyAccessRule.cs
+++ b/source/Calamari.Shared/Integration/Certificates/PrivateKeyAccessRule.cs
@@ -5,7 +5,6 @@ using System.Security.AccessControl;
 using System.Security.Principal;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using Octostache;
 
 namespace Calamari.Integration.Certificates
 {

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
@@ -3,9 +3,9 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
+[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using a Token
 [Verbose] "kubectl" config set-credentials octouser --token=<token> --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldApplyChmodInBash.approved.txt
@@ -3,7 +3,6 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using a Token

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
@@ -3,7 +3,7 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
+[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Error] Account Type not valid is currently not valid for kubectl contexts

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldFailWhenAccountTypeNotValid.approved.txt
@@ -3,7 +3,6 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
 [Error] Account Type not valid is currently not valid for kubectl contexts

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
@@ -3,9 +3,9 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
+[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using a Token
 [Verbose] "kubectl" config set-credentials octouser --token=<token> --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldOutputKubeConfig.approved.txt
@@ -3,7 +3,6 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using a Token

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
@@ -3,9 +3,9 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
+[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=my-special-namespace --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace my-special-namespace) using a Token
 [Verbose] "kubectl" config set-credentials octouser --token=<token> --request-timeout=1m
 [Verbose] "kubectl" get namespace my-special-namespace --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionShouldUseGivenNamespace.approved.txt
@@ -3,7 +3,6 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=my-special-namespace --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace my-special-namespace) using a Token

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
@@ -3,9 +3,9 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
+[Verbose] "kubectl" config set-cluster octocluster --certificate-authority=<certificateAuthorityPath> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --certificate-authority=<certificateAuthorityPath> --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using a Pod Service Account Token
 [Verbose] "kubectl" config set-credentials octouser --token=<token> --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithServerCert.approved.txt
@@ -3,9 +3,9 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --certificate-authority=<certificateAuthorityPath> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
+[Verbose] "kubectl" config set-cluster octocluster --certificate-authority=<certificateAuthorityPath> --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using a Pod Service Account Token
 [Verbose] "kubectl" config set-credentials octouser --token=<token> --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
@@ -3,7 +3,6 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using a Pod Service Account Token

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
@@ -3,9 +3,9 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
+[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using a Pod Service Account Token
 [Verbose] "kubectl" config set-credentials octouser --token=<token> --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionUsingPodServiceAccount_WithoutServerCert.approved.txt
@@ -3,9 +3,9 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
+[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using a Pod Service Account Token
 [Verbose] "kubectl" config set-credentials octouser --token=<token> --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
@@ -3,9 +3,9 @@
 [Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
 [Verbose] Found kubectl and successfully verified it can be executed.
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
+[Verbose] "kubectl" config set clusters.octocluster.certificate-authority-data <data> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
-[Verbose] "kubectl" config set clusters.octocluster.certificate-authority-data <data> --request-timeout=1m
 [Verbose] Encoding client cert key
 [Verbose] Encoding client cert pem
 [Info] ##octopus[setVariable name="bXljbGllbnRjZXJ0LlByaXZhdGVLZXlQZW1CYXNlNjQ=" value="WkdGMFlRPT0=" sensitive="VHJ1ZQ=="]

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithClientAndCertificateAuthority.approved.txt
@@ -5,10 +5,10 @@
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
+[Verbose] "kubectl" config set clusters.octocluster.certificate-authority-data <data> --request-timeout=1m
 [Verbose] Encoding client cert key
 [Verbose] Encoding client cert pem
 [Info] ##octopus[setVariable name="bXljbGllbnRjZXJ0LlByaXZhdGVLZXlQZW1CYXNlNjQ=" value="WkdGMFlRPT0=" sensitive="VHJ1ZQ=="]
 [Verbose] "kubectl" config set users.octouser.client-certificate-data <data> --request-timeout=1m
 [Verbose] "kubectl" config set users.octouser.client-key-data <data> --request-timeout=1m
-[Verbose] "kubectl" config set clusters.octocluster.certificate-authority-data <data> --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileExists.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithCustomKubectlExecutable_FileExists.approved.txt
@@ -5,7 +5,6 @@
 [Verbose] "<customkubectl>" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "<customkubectl>" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "<customkubectl>" config use-context octocontext --request-timeout=1m
-[Verbose] "<customkubectl>" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using a Token
 [Verbose] "<customkubectl>" config set-credentials octouser --token=<token> --request-timeout=1m
 [Verbose] "<customkubectl>" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
@@ -4,7 +4,6 @@
 [Verbose] "kubectl" config set-cluster octocluster --server=https://someHash.gr7.ap-southeast-2.eks.amazonaws.com --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Info] Creating kubectl context to https://someHash.gr7.ap-southeast-2.eks.amazonaws.com (namespace calamari-testing) using EKS cluster name my-eks-cluster
 [Verbose] Attempting to authenticate with aws-cli
 [Verbose] "kubectl" config set-credentials octouser --exec-command=aws --exec-arg=eks --exec-arg=get-token --exec-arg=--cluster-name=my-eks-cluster --exec-arg=--region=ap-southeast-2 --exec-api-version=client.authentication.k8s.io/v1beta1 --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
@@ -4,7 +4,6 @@
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using EKS cluster name my-eks-cluster
 [Verbose] Attempting to authenticate with aws-cli
 [Verbose] Unable to authenticate to <server> using the aws cli. Failed with error message: Unexpected character encountered while parsing value: P. Path '', line 0, position 0.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithUsernamePassword.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithUsernamePassword.approved.txt
@@ -5,6 +5,5 @@
 [Verbose] "kubectl" config set-cluster octocluster --server=<server> --request-timeout=1m
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
-[Verbose] "kubectl" config set-cluster octocluster --insecure-skip-tls-verify=true --request-timeout=1m
 [Verbose] "kubectl" config set-credentials octouser --username=myusername --password=<password> --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationFixture.cs
@@ -238,7 +238,6 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             var expected = new[]
             {
                 ("kubectl", $"config set-cluster octocluster --server={ClusterUrl}"),
-                ("kubectl", "config set-cluster octocluster --insecure-skip-tls-verify=false"),
                 ("kubectl", $"config set-context octocontext --user=octouser --cluster=octocluster --namespace={Namespace}"),
                 ("kubectl", "config use-context octocontext"),
                 ("kubectl", $"config set-credentials octouser --token={token}"),

--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationFixture.cs
@@ -480,7 +480,6 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             var expectedInvocations = new List<(string, string)>
             {
                 ("kubectl", $"config set-cluster octocluster --server={clusterUrl}"),
-                ("kubectl", "config set-cluster octocluster --insecure-skip-tls-verify=false"),
                 ("kubectl", $"config set-context octocontext --user=octouser --cluster=octocluster --namespace={Namespace}"),
                 ("kubectl", "config use-context octocontext"),
             };

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -376,7 +376,6 @@ namespace Calamari.Tests.KubernetesFixtures
         void SetTestClusterVariables()
         {
             variables.Set(SpecialVariables.ClusterUrl, ServerUrl);
-            variables.Set(SpecialVariables.SkipTlsVerification, "true");
             variables.Set(SpecialVariables.Namespace, "calamari-testing");
         }
 

--- a/source/Calamari/Kubernetes/Authentication/GoogleKubernetesEngineAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/GoogleKubernetesEngineAuth.cs
@@ -31,7 +31,7 @@ namespace Calamari.Kubernetes.Authentication
             this.log = log;
         }
 
-        public bool TryConfigure(bool useVmServiceAccount, string @namespace)
+        public bool TryConfigure(string @namespace)
         {
             if (!gcloudCli.TrySetGcloud())
                 return false;
@@ -52,6 +52,7 @@ namespace Calamari.Kubernetes.Authentication
             var project = deploymentVariables.Get("Octopus.Action.GoogleCloud.Project") ?? string.Empty;
             var region = deploymentVariables.Get("Octopus.Action.GoogleCloud.Region") ?? string.Empty;
             var zone = deploymentVariables.Get("Octopus.Action.GoogleCloud.Zone") ?? string.Empty;
+            var useVmServiceAccount = deploymentVariables.GetFlag("Octopus.Action.GoogleCloud.UseVMServiceAccount");
             gcloudCli.ConfigureGcloudAccount(project, region, zone, jsonKey, useVmServiceAccount, impersonationEmails);
 
             WarnCustomersAboutAuthToolingRequirements();

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -334,35 +334,6 @@ namespace Calamari.Kubernetes
             kubectl.ExecuteCommandAndAssertSuccess("config", "set-credentials", user, "--exec-command=aws-iam-authenticator", $"--exec-api-version={apiVersion}", "--exec-arg=token", "--exec-arg=-i", $"--exec-arg={clusterName}");
         }
 
-        void SetupContextUsingPodServiceAccount(string @namespace,
-            string cluster,
-            string clusterUrl,
-            string serverCert,
-            string skipTlsVerification,
-            string serverCertPath,
-            string context,
-            string user,
-            string podServiceAccountToken)
-        {
-            kubectl.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--server={clusterUrl}");
-
-            if (string.IsNullOrEmpty(serverCert))
-            {
-                kubectl.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--insecure-skip-tls-verify={skipTlsVerification}");
-            }
-            else
-            {
-                kubectl.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--certificate-authority={serverCertPath}");
-            }
-
-            kubectl.ExecuteCommandAndAssertSuccess("config", "set-context", context, $"--user={user}", $"--cluster={cluster}", $"--namespace={@namespace}");
-            kubectl.ExecuteCommandAndAssertSuccess("config", "use-context", context);
-
-            log.Info($"Creating kubectl context to {clusterUrl} (namespace {@namespace}) using a Pod Service Account Token");
-            log.AddValueToRedact(podServiceAccountToken, "<token>");
-            kubectl.ExecuteCommandAndAssertSuccess("config", "set-credentials", user, $"--token={podServiceAccountToken}");
-        }
-
         bool TrySetAws()
         {
             aws = CalamariEnvironment.IsRunningOnWindows

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -75,7 +75,7 @@ namespace Calamari.Kubernetes
             if (!CreateNamespace(@namespace))
             {
                 log.Verbose("Could not create namespace. Continuing on, as it may not be working directly with the target.");
-            };
+            }
 
             var outputKubeConfig = variables.GetFlag(SpecialVariables.OutputKubeConfig);
             if (outputKubeConfig)
@@ -123,7 +123,8 @@ namespace Calamari.Kubernetes
                 if (variables.GetFlag(SpecialVariables.SkipTlsVerification))
                 {
                     kubectl.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--insecure-skip-tls-verify=true");
-                } else if (variables.IsSet(SpecialVariables.CertificateAuthorityPath))
+                } 
+                else if (variables.IsSet(SpecialVariables.CertificateAuthorityPath))
                 {
                     var serverCertPath = variables.Get(SpecialVariables.CertificateAuthorityPath);
                     if (!fileSystem.FileExists(serverCertPath))
@@ -147,7 +148,7 @@ namespace Calamari.Kubernetes
                     log.AddValueToRedact(authorityData, "<data>");
                     kubectl.ExecuteCommandAndAssertSuccess("config", "set", $"clusters.{cluster}.certificate-authority-data", authorityData);
                 }
-                else
+                else if(variables.IsSet(SpecialVariables.SkipTlsVerification))
                 {
                     var skipTlsVerification = variables.GetFlag(SpecialVariables.SkipTlsVerification) ? "true" : "false";
                     kubectl.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--insecure-skip-tls-verify={skipTlsVerification}");

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -158,12 +158,10 @@ namespace Calamari.Kubernetes
                     kubectl.ExecuteCommandAndAssertSuccess("config", "set-credentials", user, $"--token={podServiceAccountToken}");
                 } else
                 {
-                    
-                    var certificateAuthority = variables.Get("Octopus.Action.Kubernetes.CertificateAuthority");
-                    var serverCertPem = variables.Get($"{certificateAuthority}.CertificatePem");
-
-                    if (!string.IsNullOrEmpty(certificateAuthority))
+                    if (variables.IsSet("Octopus.Action.Kubernetes.CertificateAuthority"))
                     {
+                        var certificateAuthority = variables.Get("Octopus.Action.Kubernetes.CertificateAuthority");
+                        var serverCertPem = variables.Get($"{certificateAuthority}.CertificatePem");
                         if (string.IsNullOrEmpty(serverCertPem))
                         {
                             log.Error("Kubernetes server certificate does not include the certificate data");

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -86,7 +86,7 @@ namespace Calamari.Kubernetes
         {
             var clientCert = variables.Get("Octopus.Action.Kubernetes.ClientCertificate");
             var eksUseInstanceRole = variables.GetFlag("Octopus.Action.AwsAccount.UseInstanceRole");
-            var useVmServiceAccount = variables.GetFlag("Octopus.Action.GoogleCloud.UseVMServiceAccount");
+            
 
             if (accountType == "AzureServicePrincipal" ||  accountType == "AzureOidc")
             {
@@ -97,13 +97,13 @@ namespace Calamari.Kubernetes
                 if (!azureAuth.TryConfigure(@namespace, kubeConfig))
                     return false;
             }
-            else if (accountType == "GoogleCloudAccount" || useVmServiceAccount)
+            else if (accountType == "GoogleCloudAccount")
             {
                 var gcloudCli = new GCloud(log, commandLineRunner, workingDirectory, environmentVars);
                 var gkeGcloudAuthPlugin = new GkeGcloudAuthPlugin(log, commandLineRunner, workingDirectory, environmentVars);
                 var gcloudAuth = new GoogleKubernetesEngineAuth(gcloudCli, gkeGcloudAuthPlugin, kubectl, variables, log);
 
-                if (!gcloudAuth.TryConfigure(useVmServiceAccount, @namespace))
+                if (!gcloudAuth.TryConfigure(@namespace))
                     return false;
             }
             else

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -85,8 +85,6 @@ namespace Calamari.Kubernetes
         bool TrySetupContext(string kubeConfig, string @namespace, string accountType)
         {
             var clientCert = variables.Get("Octopus.Action.Kubernetes.ClientCertificate");
-            var eksUseInstanceRole = variables.GetFlag("Octopus.Action.AwsAccount.UseInstanceRole");
-            
 
             if (accountType == "AzureServicePrincipal" ||  accountType == "AzureOidc")
             {
@@ -195,7 +193,7 @@ namespace Calamari.Kubernetes
                     } else if(accountType == "UsernamePassword")
                     {
                         SetupContextForUsernamePassword(user);
-                    } else if (accountType == "AmazonWebServicesAccount" || eksUseInstanceRole)
+                    } else if (accountType == "AmazonWebServicesAccount" || variables.GetFlag("Octopus.Action.AwsAccount.UseInstanceRole"))
                     {
                         SetupContextForAmazonServiceAccount(@namespace, clusterUrl, user);
                     }

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -84,13 +84,11 @@ namespace Calamari.Kubernetes
 
         bool TrySetupContext(string kubeConfig, string @namespace, string accountType)
         {
-            var clusterUrl = variables.Get(SpecialVariables.ClusterUrl);
             var clientCert = variables.Get("Octopus.Action.Kubernetes.ClientCertificate");
             var eksUseInstanceRole = variables.GetFlag("Octopus.Action.AwsAccount.UseInstanceRole");
             var podServiceAccountTokenPath = variables.Get("Octopus.Action.Kubernetes.PodServiceAccountTokenPath");
             var serverCertPath = variables.Get("Octopus.Action.Kubernetes.CertificateAuthorityPath");
             var isUsingPodServiceAccount = false;
-            var skipTlsVerification = variables.GetFlag(SpecialVariables.SkipTlsVerification) ? "true" : "false";
             var useVmServiceAccount = variables.GetFlag("Octopus.Action.GoogleCloud.UseVMServiceAccount");
 
 
@@ -158,6 +156,9 @@ namespace Calamari.Kubernetes
             }
             else
             {
+                var clusterUrl = variables.Get(SpecialVariables.ClusterUrl);
+                var skipTlsVerification = variables.GetFlag(SpecialVariables.SkipTlsVerification) ? "true" : "false";
+                
                 if (string.IsNullOrEmpty(clusterUrl))
                 {
                     log.Error("Kubernetes cluster URL is missing");

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -84,7 +84,7 @@ namespace Calamari.Kubernetes
 
         bool TrySetupContext(string kubeConfig, string @namespace, string accountType)
         {
-            var clientCert = variables.Get("Octopus.Action.Kubernetes.ClientCertificate");
+            
 
             if (accountType == "AzureServicePrincipal" ||  accountType == "AzureOidc")
             {
@@ -158,8 +158,7 @@ namespace Calamari.Kubernetes
                     kubectl.ExecuteCommandAndAssertSuccess("config", "set-credentials", user, $"--token={podServiceAccountToken}");
                 } else
                 {
-                    var clientCertPem = variables.Get($"{clientCert}.CertificatePem");
-                    var clientCertKey = variables.Get($"{clientCert}.PrivateKeyPem");
+                    
                     var certificateAuthority = variables.Get("Octopus.Action.Kubernetes.CertificateAuthority");
                     var serverCertPem = variables.Get($"{certificateAuthority}.CertificatePem");
 
@@ -199,6 +198,10 @@ namespace Calamari.Kubernetes
                     }
                     else if ( variables.IsSet("Octopus.Action.Kubernetes.ClientCertificate"))
                     {
+                        var clientCert = variables.Get("Octopus.Action.Kubernetes.ClientCertificate");
+                        var clientCertPem = variables.Get($"{clientCert}.CertificatePem");
+                        var clientCertKey = variables.Get($"{clientCert}.PrivateKeyPem");
+                        
                         if (string.IsNullOrEmpty(clientCertPem))
                         {
                             log.Error("Kubernetes client certificate does not include the certificate data");


### PR DESCRIPTION
## Background
Ultimately the different auth mechanisms setup in `source/Calamari/Kubernetes/SetupKubectlAuthentication.cs` are mutually exclusive and depend on the authentication type set on the target in server
![image](https://github.com/OctopusDeploy/Calamari/assets/1830666/8d7f1470-122f-4235-8e67-dfb51614d3d6)

Unfortunately, for whatever reason we dont send back the authentication type as a variable on its own and so some of this code does checks on other properties that _would_ have been set. 

The code as it was written was a disorganised mess of multiple conditional checks which is unecessary when the different code flows are mutually exclusive.


## How to review this
I deliberately went through and made each change in its own self-contained commit to help the reviewer better undersand each refactor change that took place to illustrate the (relatively) non-changing refactor steps that took place. 

The only things really that would change is that in some cases the order of the `kubectl config set-context` commands have changed order, and some simpler assumptions can be made that, for example we wont be setting both Google Auth and Client Cert etc.
