### PR TITLE
Fix positional Parameter test

### DIFF
--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/Invalid.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/Invalid.ps1
@@ -1,4 +1,4 @@
-﻿Invoke-Expression "$CurrentPath/DatabaseManagement.exe -p Path -s Server -d TestDatabase
+﻿Invoke-Expression "$CurrentPath/DatabaseManagement.exe -PipelineVariable Path -s Server -d TestDatabase
 
-Invoke-Expression "$CurrentPath/DatabaseManagement.exe -p Path -s Server -d TestDatabase
+Invoke-Expression "$CurrentPath/DatabaseManagement.exe -PipelineVariable Path -s Server -d TestDatabase
 


### PR DESCRIPTION
PSCore7.4.0 introduces ambiguity between -p with -ProgressAction -PipelineVariable. This change specifically specifies the PipelineVariable.

[Credit - internal thread](https://octopusdeploy.slack.com/archives/C03SG0LFJHX/p1700690293166349?thread_ts=1700689063.728339&cid=C03SG0LFJHX)