### PR TITLE
Include tags in AWS CloudFormation changeset template

### DIFF
--- a/source/Calamari.Aws/Integration/CloudFormation/Templates/CloudFormationS3Template.cs
+++ b/source/Calamari.Aws/Integration/CloudFormation/Templates/CloudFormationS3Template.cs
@@ -155,7 +155,8 @@ namespace Calamari.Aws.Integration.CloudFormation.Templates
                 ChangeSetName = variables[AwsSpecialVariables.CloudFormation.Changesets.Name],
                 ChangeSetType = await GetStackStatus() == StackStatus.DoesNotExist ? ChangeSetType.CREATE : ChangeSetType.UPDATE,
                 Capabilities = capabilities,
-                RoleARN = roleArn
+                RoleARN = roleArn,
+                Tags = tags
             };
         }
     }

--- a/source/Calamari.Aws/Integration/CloudFormation/Templates/CloudFormationTemplate.cs
+++ b/source/Calamari.Aws/Integration/CloudFormation/Templates/CloudFormationTemplate.cs
@@ -116,7 +116,8 @@ namespace Calamari.Aws.Integration.CloudFormation.Templates
                 ChangeSetName = variables[AwsSpecialVariables.CloudFormation.Changesets.Name],
                 ChangeSetType = await GetStackStatus() == StackStatus.DoesNotExist ? ChangeSetType.CREATE : ChangeSetType.UPDATE,
                 Capabilities = capabilities,
-                RoleARN = roleArn
+                RoleARN = roleArn,
+                Tags = tags
             };
         }
     }

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Amazon.CloudFormation;
@@ -108,6 +109,17 @@ namespace Calamari.Tests.AWS.CloudFormation
                 stackStatus.Should().Be(shouldExist ? Aws.Deployment.Conventions.StackStatus.Completed : Aws.Deployment.Conventions.StackStatus.DoesNotExist);
             });
         }
+
+        public async Task ValidateStackTags(string stackName, IEnumerable<KeyValuePair<string, string>> expectedTags)
+        {
+            await ValidateCloudFormation(async (client) =>
+            {
+                Func<IAmazonCloudFormation> clientFactory = () => client;
+                var stack = await clientFactory.DescribeStackAsync(new StackArn(stackName));
+                stack.Tags.Should().BeEquivalentTo(expectedTags);
+            });
+        }
+        
         async Task ValidateCloudFormation(Func<AmazonCloudFormationClient, Task> execute)
         {
             var credentials = new BasicAWSCredentials(ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey),


### PR DESCRIPTION
# Background
[sc-64624]

When using the 'Deploy an AWS CloudFormation template' step template with Change Sets, any tags specified in the template are not applied to the created resources/stack.

The cause was due to the tags not being included in the mapper that creates the AWS CreateChangeSetRequest object.

Credit to [kshatalov](https://github.com/kshatalov) for reporting and finding the fix.

# Result
Part of https://github.com/OctopusDeploy/Issues/issues/8157