### PR TITLE
Keep journal entries when retention fails to delete a deployment

### DIFF
--- a/source/Calamari/Deployment/Retention/RetentionPolicy.cs
+++ b/source/Calamari/Deployment/Retention/RetentionPolicy.cs
@@ -67,7 +67,7 @@ namespace Calamari.Deployment.Retention
             RemovedFailedPackageDownloads();
         }
 
-        ReadOnlyCollection<string> RemoveDeployments(List<JournalEntry> deploymentsToDelete, List<JournalEntry> preservedEntries)
+        string[] RemoveDeployments(List<JournalEntry> deploymentsToDelete, List<JournalEntry> preservedEntries)
         {
             var deploymentsDeleted = new List<string>();
             foreach (var deployment in deploymentsToDelete)
@@ -85,7 +85,7 @@ namespace Calamari.Deployment.Retention
                 }
             }
 
-            return deploymentsDeleted.AsReadOnly();
+            return deploymentsDeleted.ToArray();
         }
 
         void DeleteExtractionDestination(JournalEntry deployment, List<JournalEntry> preservedEntries)

--- a/source/Calamari/Deployment/Retention/RetentionPolicy.cs
+++ b/source/Calamari/Deployment/Retention/RetentionPolicy.cs
@@ -88,7 +88,7 @@ namespace Calamari.Deployment.Retention
             }
             catch (Exception ex)
             {
-                Log.VerboseFormat("Could not delete directory '{0}' because some files could not be deleted: {1}",
+                Log.WarnFormat("Could not delete directory '{0}' because some files could not be deleted: {1}",
                     deployment.ExtractedTo, ex.Message);
             }
         }

--- a/source/Calamari/Deployment/Retention/RetentionPolicy.cs
+++ b/source/Calamari/Deployment/Retention/RetentionPolicy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Calamari.Common.Features.Deployment.Journal;
@@ -61,15 +61,31 @@ namespace Calamari.Deployment.Retention
                 Log.Info("Did not find any deployments to clean up");
             }
 
-            foreach (var deployment in deploymentsToDelete)
-            {
-                DeleteExtractionDestination(deployment, preservedEntries);
-
-                // Deleting packages is now handled by package retention
-            }
-            deploymentJournal.RemoveJournalEntries(deploymentsToDelete.Select(x => x.Id));
+            var entriesRemoved = RemoveDeployments(deploymentsToDelete, preservedEntries);
+            deploymentJournal.RemoveJournalEntries(entriesRemoved);
 
             RemovedFailedPackageDownloads();
+        }
+
+        ReadOnlyCollection<string> RemoveDeployments(List<JournalEntry> deploymentsToDelete, List<JournalEntry> preservedEntries)
+        {
+            var deploymentsDeleted = new List<string>();
+            foreach (var deployment in deploymentsToDelete)
+            {
+                try
+                {
+                    DeleteExtractionDestination(deployment, preservedEntries);
+                    deploymentsDeleted.Add(deployment.Id);
+                }
+                catch (Exception ex)
+                {
+                    Log.VerboseFormat("Could not delete directory '{0}' because some files could not be deleted: {1}",
+                                   deployment.ExtractedTo,
+                                   ex.Message);
+                }
+            }
+
+            return deploymentsDeleted.AsReadOnly();
         }
 
         void DeleteExtractionDestination(JournalEntry deployment, List<JournalEntry> preservedEntries)
@@ -82,15 +98,7 @@ namespace Calamari.Deployment.Retention
             Log.Info($"Removing directory '{deployment.ExtractedTo}'");
             fileSystem.PurgeDirectory(deployment.ExtractedTo, FailureOptions.IgnoreFailure);
 
-            try
-            {
-                fileSystem.DeleteDirectory(deployment.ExtractedTo);
-            }
-            catch (Exception ex)
-            {
-                Log.WarnFormat("Could not delete directory '{0}' because some files could not be deleted: {1}",
-                    deployment.ExtractedTo, ex.Message);
-            }
+            fileSystem.DeleteDirectory(deployment.ExtractedTo);
         }
 
         static Func<JournalEntry, bool> SuccessfulCountGreaterThanPolicyCountOrDeployedUnsuccessfully(int successfulDeploymentsToKeep, List<JournalEntry> preservedEntries)


### PR DESCRIPTION
Deployment retention can fail to clean up the deployment files. When this happens, it currently swallows exceptions and removes the journal entry from the journal. As a result, deployment files can persist forever.

Instead, this PR proposes to leave the journal entry intact. The subsequent time retention runs, another attempt to clean up the files will occur. Deployment files _should_ be cleaned up more consistently with this approach.

There is the potential that the files will never be cleaned up, and the deployment journal will expand, leading to the journal becoming a performance concern. The reports we have had where files are not cleaned up generally involve files that are being locked because the previous deployment is still running. I assume it is generally the last deployment that fails and will eventually be cleaned up by the next deployment, so journal explosion is a low risk.