### PR TITLE
Add option to build for specific targets locally

### DIFF
--- a/build-local.ps1
+++ b/build-local.ps1
@@ -1,3 +1,8 @@
+Param(
+    [string] $Framework,
+    [string] $Runtime
+)
+
 Write-Host "
 ##################################################################################################
 #                                                                                                #
@@ -18,7 +23,7 @@ Write-Host "
 ##################################################################################################
 " -ForegroundColor Cyan
 
-./build.ps1 -BuildVerbosity Minimal -Verbosity Normal -PackInParallel -AppendTimestamp -SetOctopusServerVersion 
+./build.ps1 -BuildVerbosity Minimal -Verbosity Normal -PackInParallel -AppendTimestamp -SetOctopusServerVersion -TargetFramework "$Framework" -TargetRuntime "$Runtime"
 
 Write-Host "
 ########################################################################################

--- a/build-local.sh
+++ b/build-local.sh
@@ -1,5 +1,26 @@
 #!/usr/bin/env bash
 
+auto_accept=""
+target_framework=""
+target_runtime=""
+
+while test $# -gt 0; do
+  case "$1" in
+  -y)
+    auto_accept='yes'
+    ;;
+  --framework)
+    target_framework=$2
+    shift
+    ;;
+  --runtime)
+    target_runtime=$2
+    shift
+    ;;
+  esac
+  shift
+done
+
 Green='\033[32m'
 Yellow='\033[1;33m'
 NoColour='\033[0m' # No Color
@@ -48,15 +69,16 @@ echo -e "$StartMessage"
 
 echo -e "$WarningMessage"
 
-read -p "Are you sure you want to continue? (Y,n): " option
-
-if ! [[ -z "$option" ]] && ! [[ "$option" == 'Y' ]] && ! [[ "$option" == 'y' ]]
-then
-    echo "Build Cancelled."
-    exit 0;
+if [ -z "$auto_accept" ]; then
+  read -p "Are you sure you want to continue? (Y,n): " option
+  
+  if ! [[ -z "$option" ]] && ! [[ "$option" == 'Y' ]] && ! [[ "$option" == 'y' ]]
+  then
+      echo "Build Cancelled."
+      exit 0;
+  fi
 fi
 
-./build.sh -BuildVerbosity Minimal -Verbosity Minimal -PackInParallel -AppendTimestamp -SetOctopusServerVersion
+./build.sh -BuildVerbosity Minimal -Verbosity Minimal -PackInParallel -AppendTimestamp -SetOctopusServerVersion -TargetFramework "$target_framework" -TargetRuntime "$target_runtime"
 
 echo -e "$FinishMessage"
-

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -82,12 +82,12 @@ namespace Calamari.Build
         [Parameter(Name = "signing_certificate_password")] 
         [Secret]
         readonly string SigningCertificatePassword = "Password01!";
+
+        [Parameter]
+        readonly string? TargetFramework;
         
         [Parameter] 
-        readonly string? TargetFramework = "net6.0";
-        
-        [Parameter] 
-        readonly string? TargetRuntime = "linux-x64";
+        readonly string? TargetRuntime;
 
         [Required]
         [GitVersion]


### PR DESCRIPTION
Building via `build-local.sh` is required for some local testing but often takes ~10 minutes per change as it builds every runtime/framework combination, when really we likely only care about the combination that we need to run on our local machines.

I've added two parameters to optionally filter down what we are building. If they are not provided the build runs as it did before and packages everything.

Anecdotally, full builds take approx 10 minutes on my machine, but running `./build-local.sh -y --framework "net6.0" --runtime "linux-x64"` only takes 2-3 minutes.

I've got an [open PR](https://github.com/OctopusDeploy/Calamari/pull/1191) for updating some docs, I'll make an adjustment to include information about this change in that.