### PR TITLE
Authenticate the AWS CLI when setting up k8s authn

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
@@ -1,0 +1,336 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Aws.Deployment;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes;
+using Calamari.Kubernetes.Authentication;
+using Calamari.Kubernetes.Integration;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.Authentication
+{
+    public class SetupKubectlAuthenticationAwsFixture
+    {
+        private readonly string workingDirectory = Path.Combine("working", "directory");
+        private const string Namespace = "my-cool-namespace";
+
+        private const string CurrentAwsVersion = "aws-cli/2.14.2";
+        private const string OlderAwsVersion = "aws-cli/1.16.155";
+        private const string InvalidAwsVersion = "aws-cli/not-a-version";
+
+        private const string EksClusterName = "my-cool-eks-cluster-name";
+        private const string AwsRegion = "southwest";
+        private const string AwsClusterUrl = "http://www." + AwsRegion + ".eks.amazonaws.com";
+        private const string InvalidAwsClusterUrl = "http://www." + AwsRegion + "..eks.amazonaws.com";
+
+        private IVariables variables;
+        private ILog log;
+        private ICommandLineRunner commandLineRunner;
+        private IKubectl kubectl;
+        private ICalamariFileSystem fileSystem;
+        private Dictionary<string, string> environmentVars;
+
+        private SetupKubectlAuthenticationFixture.Invocations invocations;
+
+        // TODO: Strip down/commonize
+        [SetUp]
+        public void Setup()
+        {
+            invocations = new SetupKubectlAuthenticationFixture.Invocations();
+            invocations.AddLogMessageFor("which", "kubelogin", "kubelogin");
+            invocations.AddLogMessageFor("where", "kubelogin", "kubelogin");
+            AddLogForAwsVersion(CurrentAwsVersion);
+
+            variables = new CalamariVariables();
+
+            log = Substitute.For<ILog>();
+            commandLineRunner = Substitute.For<ICommandLineRunner>();
+            commandLineRunner.Execute(Arg.Any<CommandLineInvocation>())
+                .Returns(
+                    x =>
+                    {
+                        var invocation = x.Arg<CommandLineInvocation>();
+                        var isSuccess = true;
+                        string logMessage = null;
+                        if (invocation.Executable != "chmod")
+                        {
+                            isSuccess = invocations.TryAdd(invocation.Executable, invocation.Arguments, out logMessage);
+                        }
+                        if (logMessage != null)
+                            invocation.AdditionalInvocationOutputSink?.WriteInfo(logMessage);
+                        return new CommandResult(
+                            invocation.Executable,
+                            isSuccess ? 0 : 1,
+                            workingDirectory: workingDirectory);
+                    });
+            kubectl = Substitute.For<IKubectl>();
+            kubectl.ExecutableLocation.Returns("kubectl");
+            kubectl.TrySetKubectl().Returns(true);
+            kubectl.When(x => x.ExecuteCommandAndAssertSuccess(Arg.Any<string[]>()))
+                .Do(
+                    x =>
+                    {
+                        var args = x.Arg<string[]>();
+                        if (args != null)
+                            invocations.TryAdd("kubectl", string.Join(" ", args), out var _);
+                    });
+            fileSystem = Substitute.For<ICalamariFileSystem>();
+
+            variables.Set(SpecialVariables.ClusterUrl, AwsClusterUrl);
+            variables.Set(SpecialVariables.EksClusterName, EksClusterName);
+            variables.Set(SpecialVariables.Namespace, Namespace);
+
+            environmentVars = new Dictionary<string, string>
+            {
+                { "AWS_ACCESS_KEY_ID", "access_key" },
+                { "AWS_SECRET_ACCESS_KEY", "secret_key" },
+                { "AWS_REGION", "region" }
+            };
+        }
+
+        SetupKubectlAuthentication CreateSut() =>
+            new SetupKubectlAuthentication(
+                variables,
+                log,
+                commandLineRunner,
+                kubectl,
+                fileSystem,
+                environmentVars,
+                workingDirectory);
+
+        [Test]
+        public void AuthenticatesWithAwsCli()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForWhichAws();
+            AddLogForAwsVersion(CurrentAwsVersion);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(AwsCliInvocations());
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    GetAwsTokenInvocation,
+                    SetKubectlCredentialsWithAwsCliInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute(AccountTypes.AmazonWebServicesAccount);
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+        }
+
+        [Test]
+        public void AuthenticatesForInstanceRoleWithAwsCli()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForWhichAws();
+            AddLogForAwsVersion(CurrentAwsVersion);
+            variables.AddFlag(AwsSpecialVariables.Authentication.UseInstanceRole, true);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(AwsCliInvocations());
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    GetAwsTokenInvocation,
+                    SetKubectlCredentialsWithAwsCliInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute(null);
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+        }
+
+        [Test]
+        public void FallsBackToIamAuthenticatorWithoutAwsCli()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForAwsVersion(OlderAwsVersion);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    IamAuthenticatorInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute(AccountTypes.AmazonWebServicesAccount);
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+            log.Received().Verbose("Could not find the aws cli, falling back to the aws-iam-authenticator.");
+        }
+
+        [Test]
+        public void AuthenticatesForInstanceRoleWithIamAuthenticator()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForAwsVersion(OlderAwsVersion);
+            variables.AddFlag(AwsSpecialVariables.Authentication.UseInstanceRole, true);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    IamAuthenticatorInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute(null);
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+            log.Received().Verbose("Could not find the aws cli, falling back to the aws-iam-authenticator.");
+        }
+
+        [Test]
+        public void FallsBackToIamAuthenticatorWithOlderAwsCliVersion()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForWhichAws();
+            AddLogForAwsVersion(OlderAwsVersion);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(AwsCliInvocations());
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    IamAuthenticatorInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute(AccountTypes.AmazonWebServicesAccount);
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+            log.Received()
+                .Verbose(
+                    "aws cli version: 1.16.155 does not support the \"aws eks get-token\" command. Please update to a version later than 1.16.156");
+        }
+
+        [Test]
+        public void FailsWithInvalidAwsCliVersion()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForWhichAws();
+            AddLogForAwsVersion(InvalidAwsVersion);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(AwsCliInvocations());
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    IamAuthenticatorInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute(AccountTypes.AmazonWebServicesAccount);
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+            log.Received()
+                .Verbose(
+                    Arg.Is<string>(
+                        s => s.StartsWith(
+                            $"Unable to authenticate to {AwsClusterUrl} using the aws cli. Failed with error message: 'not-a-version' is not a valid version string")));
+        }
+
+        [Test]
+        public void FallsBackToIamAuthenticatorWithoutRegion()
+        {
+            variables.Set(SpecialVariables.ClusterUrl, InvalidAwsClusterUrl);
+
+            AddLogForAwsEksGetToken();
+            AddLogForWhichAws();
+
+            var expectedInvocations = SetupClusterContextInvocations(InvalidAwsClusterUrl);
+            expectedInvocations.AddRange(AwsCliInvocations());
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    IamAuthenticatorInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute(AccountTypes.AmazonWebServicesAccount);
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+            log.Received().Verbose("The EKS cluster Url specified should contain a valid aws region name");
+        }
+
+        void AddLogForWhichAws()
+        {
+            invocations.AddLogMessageFor("which", "aws", "aws");
+            invocations.AddLogMessageFor("where", "aws.exe", "aws");
+        }
+
+        void AddLogForAwsEksGetToken()
+        {
+            invocations.AddLogMessageFor(
+                "aws",
+                $"eks get-token --cluster-name={EksClusterName} --region={AwsRegion}",
+                $"{{ \"apiVersion\": \"1.2.3\"}}");
+        }
+
+        void AddLogForAwsVersion(string version)
+        {
+            invocations.AddLogMessageFor("aws", "--version", version);
+        }
+
+        List<(string, string)> SetupClusterContextInvocations(string clusterUser)
+        {
+            return new List<(string, string)>
+            {
+                ("kubectl", $"config set-cluster octocluster --server={clusterUser}"),
+                ("kubectl",
+                    $"config set-context octocontext --user=octouser --cluster=octocluster --namespace={Namespace}"),
+                ("kubectl", "config use-context octocontext"),
+            };
+        }
+
+        List<(string, string)> AwsCliInvocations()
+        {
+            return new List<(string, string)>
+            {
+                ("aws", "configure set aws_access_key_id access_key"),
+                ("aws", "configure set aws_secret_access_key secret_key"),
+                ("aws", "configure set aws_default_region region"),
+                ("aws", "configure set aws_session_token"),
+                ("aws", "--version")
+            };
+        }
+
+        (string, string) IamAuthenticatorInvocation =>
+            ("kubectl",
+                $"config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1alpha1 --exec-arg=token --exec-arg=-i --exec-arg={EksClusterName}");
+
+        (string, string ) GetAwsTokenInvocation =>
+            ("aws", "eks get-token --cluster-name=my-cool-eks-cluster-name --region=southwest");
+
+        (string, string) SetKubectlCredentialsWithAwsCliInvocation =>
+            ("kubectl",
+                "config set-credentials octouser --exec-command=aws --exec-arg=eks --exec-arg=get-token --exec-arg=--cluster-name=my-cool-eks-cluster-name --exec-arg=--region=southwest --exec-api-version=1.2.3");
+
+        (string, string) GetNamespaceInvocation =>
+            ("kubectl", $"get namespace {Namespace} --request-timeout=1m");
+
+        private void AssertInvocations(List<(string, string)> expectedInvocations)
+        {
+            invocations.Where(x => x.Executable != "which" && x.Executable != "where")
+                .Should()
+                .BeEquivalentTo(expectedInvocations, opts => opts.WithStrictOrdering());
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationFixture.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using Calamari.Aws.Deployment;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
@@ -48,11 +47,6 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
         private const string GoogleCloudRegion = "my-cool-google-cloud-region";
         private const string GoogleCloudProject = "my-cool-google-cloud-project";
         private const string GkeClusterName = "my-cool-gke-cluster-name";
-
-        private const string EksClusterName = "my-cool-eks-cluster-name";
-        private const string AwsRegion = "southwest";
-        private const string AwsClusterUrl = "http://www." + AwsRegion + ".eks.amazonaws.com";
-        private const string InvalidAwsClusterUrl = "http://www." + AwsRegion + "..eks.amazonaws.com";
 
         private const string CertificateAuthorityPath = "/path/to/certificate.authority";
         private const string PodServiceAccountTokenPath = "/path/to/pod-service-account.token";
@@ -425,109 +419,6 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             log.Received().Error("Either zone or region must be defined");
         }
 
-        public enum AwsCliFailureModes
-        {
-            None,
-            CliDoesNotInitialise,
-            NoRegion,
-            InvalidVersion,
-            ExceptionWhenGettingVersion
-        }
-
-        [TestCase(true, AwsCliFailureModes.None)]
-        [TestCase(false, AwsCliFailureModes.None)]
-        [TestCase(true, AwsCliFailureModes.CliDoesNotInitialise)]
-        [TestCase(false, AwsCliFailureModes.CliDoesNotInitialise)]
-        [TestCase(false, AwsCliFailureModes.NoRegion)]
-        [TestCase(true, AwsCliFailureModes.InvalidVersion)]
-        [TestCase(true, AwsCliFailureModes.ExceptionWhenGettingVersion)]
-        public void Execute_WithAwsAccountType_ConfiguresAuthenticationCorrectly(bool useInstanceRole, AwsCliFailureModes awsCliFailureMode)
-        {
-            const string apiVersion = "1.2.3";
-            invocations.AddLogMessageFor("aws", $"eks get-token --cluster-name={EksClusterName} --region={AwsRegion}", $"{{ \"apiVersion\": \"{apiVersion}\"}}");
-            if (awsCliFailureMode != AwsCliFailureModes.CliDoesNotInitialise)
-            {
-                invocations.AddLogMessageFor("which", "aws", "aws");
-                invocations.AddLogMessageFor("where", "aws.exe", "aws");
-            }
-
-            switch (awsCliFailureMode)
-            {
-                case AwsCliFailureModes.InvalidVersion:
-                    invocations.AddLogMessageFor("aws", "--version", "aws-cli/1.16.155");
-                    break;
-                case AwsCliFailureModes.ExceptionWhenGettingVersion:
-                    invocations.AddLogMessageFor("aws", "--version", "aws-cli/a3nsf3");
-                    break;
-            }
-
-            string accountType = null;
-            if (useInstanceRole) variables.AddFlag(AwsSpecialVariables.Authentication.UseInstanceRole, true);
-            else accountType = AccountTypes.AmazonWebServicesAccount;
-
-            var clusterUrl = awsCliFailureMode == AwsCliFailureModes.NoRegion ? InvalidAwsClusterUrl : AwsClusterUrl;
-            variables.Set(SpecialVariables.ClusterUrl, clusterUrl);
-            variables.Set(SpecialVariables.EksClusterName, EksClusterName);
-            variables.Set(SpecialVariables.Namespace, Namespace);
-
-            var sut = CreateSut();
-
-            var result = sut.Execute(accountType);
-
-            result.VerifySuccess();
-
-            var expectedInvocations = new List<(string, string)>
-            {
-                ("kubectl", $"config set-cluster octocluster --server={clusterUrl}"),
-                ("kubectl", $"config set-context octocontext --user=octouser --cluster=octocluster --namespace={Namespace}"),
-                ("kubectl", "config use-context octocontext"),
-            };
-
-            if (awsCliFailureMode != AwsCliFailureModes.CliDoesNotInitialise)
-            {
-                expectedInvocations.Add(("aws", "--version"));
-            }
-
-            if (awsCliFailureMode == AwsCliFailureModes.None)
-            {
-                expectedInvocations.AddRange(new []
-                {
-                    ("aws", $"eks get-token --cluster-name={EksClusterName} --region={AwsRegion}"),
-                    ("kubectl", $"config set-credentials octouser --exec-command=aws --exec-arg=eks --exec-arg=get-token --exec-arg=--cluster-name={EksClusterName} --exec-arg=--region={AwsRegion} --exec-api-version={apiVersion}"),
-                });
-            }
-            else
-            {
-                expectedInvocations.Add(("kubectl",
-                    $"config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1alpha1 --exec-arg=token --exec-arg=-i --exec-arg={EksClusterName}"));
-            }
-
-            expectedInvocations.Add(("kubectl", $"get namespace {Namespace} --request-timeout=1m"));
-
-            invocations.Where(x => x.Executable != "which" && x.Executable != "where")
-                .Should().BeEquivalentTo(expectedInvocations, opts => opts.WithStrictOrdering());
-
-            switch (awsCliFailureMode)
-            {
-                case AwsCliFailureModes.CliDoesNotInitialise:
-                    log.Received().Verbose(
-                        "Could not find the aws cli, falling back to the aws-iam-authenticator.");
-                    break;
-                case AwsCliFailureModes.NoRegion:
-                    log.Received().Verbose(
-                        "The EKS cluster Url specified should contain a valid aws region name");
-                    break;
-                case AwsCliFailureModes.InvalidVersion:
-                    log.Received().Verbose(
-                        "aws cli version: 1.16.155 does not support the \"aws eks get-token\" command. Please update to a version later than 1.16.156");
-                    break;
-                case AwsCliFailureModes.ExceptionWhenGettingVersion:
-                    log.Received().Verbose(
-                        Arg.Is<string>(s => s.StartsWith($"Unable to authenticate to {AwsClusterUrl} using the aws cli. Failed with error message: 'a3nsf3' is not a valid version string")));
-                    break;
-            }
-        }
-
         [TestCase(true)]
         [TestCase(false)]
         public void Execute_WithPodServiceAccountAuth_ConfiguresAuthenticationCorrectly(bool skipTlsVerification)
@@ -630,7 +521,7 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             return Convert.ToBase64String(Encoding.ASCII.GetBytes(input));
         }
 
-        class Invocations : IReadOnlyList<(string Executable, string Arguments)>
+        internal class Invocations : IReadOnlyList<(string Executable, string Arguments)>
         {
             private List<(string Executable, string Arguments)> invocations = new List<(string Executable, string Arguments)>();
             private List<(string Executable, string Arguments)> failFor = new List<(string Executable, string Arguments)>();

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.CloudAccounts;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes.Integration;
+using Octopus.CoreUtilities;
+using Octopus.CoreUtilities.Extensions;
+using Octopus.Versioning.Semver;
+
+namespace Calamari.Kubernetes.Authentication
+{
+    public class AwsCliAuth
+    {
+        readonly AwsCli awsCli;
+        readonly IKubectl kubectl;
+        readonly IVariables deploymentVariables;
+        readonly Dictionary<string, string> environmentVars;
+        readonly ILog log;
+
+        public AwsCliAuth(
+            AwsCli awsCli,
+            IKubectl kubectl,
+            IVariables deploymentVariables,
+            Dictionary<string, string> environmentVars,
+            ILog log)
+        {
+            this.awsCli = awsCli;
+            this.kubectl = kubectl;
+            this.deploymentVariables = deploymentVariables;
+            this.environmentVars = environmentVars;
+            this.log = log;
+        }
+
+        public bool TryConfigure(string @namespace, string clusterUrl, string user)
+        {
+            var clusterName = deploymentVariables.Get(SpecialVariables.EksClusterName);
+            log.Info(
+                $"Creating kubectl context to {clusterUrl} (namespace {@namespace}) using EKS cluster name {clusterName}");
+
+            if (TrySetKubeConfigAuthenticationToAwsCli(clusterName, clusterUrl, user))
+                return true;
+
+            log.Verbose("Attempting to authenticate with aws-iam-authenticator");
+            return SetKubeConfigAuthenticationToAwsIAm(user, clusterName);
+        }
+
+        bool TrySetKubeConfigAuthenticationToAwsCli(string clusterName, string clusterUrl, string user)
+        {
+            if (!awsCli.TrySetAws())
+            {
+                log.Verbose("Could not find the aws cli, falling back to the aws-iam-authenticator.");
+                return false;
+            }
+
+            ConfigureAwsCli();
+
+            try
+            {
+                var awsCliVersion = awsCli.GetAwsCliVersion();
+                var minimumAwsCliVersionForAuth = new SemanticVersion("1.16.156");
+                if (awsCliVersion.CompareTo(minimumAwsCliVersionForAuth) > 0)
+                {
+                    var region = GetEksClusterRegion(clusterUrl);
+                    if (!string.IsNullOrWhiteSpace(region))
+                    {
+                        var apiVersion = awsCli.GetEksClusterApiVersion(clusterName, region);
+                        SetKubeConfigAuthenticationToAwsCli(user, clusterName, region, apiVersion);
+                        return true;
+                    }
+
+                    log.Verbose("The EKS cluster Url specified should contain a valid aws region name");
+                }
+
+                log.Verbose(
+                    $"aws cli version: {awsCliVersion} does not support the \"aws eks get-token\" command. Please update to a version later than 1.16.156");
+            }
+            catch (Exception e)
+            {
+                log.Verbose(
+                    $"Unable to authenticate to {clusterUrl} using the aws cli. Failed with error message: {e.Message}");
+            }
+
+            return false;
+        }
+
+        bool SetKubeConfigAuthenticationToAwsIAm(string user, string clusterName)
+        {
+            var kubectlVersion = kubectl.GetVersion();
+            var apiVersion = kubectlVersion.Some() && kubectlVersion.Value > new SemanticVersion("1.23.6")
+                ? "client.authentication.k8s.io/v1beta1"
+                : "client.authentication.k8s.io/v1alpha1";
+
+            kubectl.ExecuteCommandAndAssertSuccess(
+                "config",
+                "set-credentials",
+                user,
+                "--exec-command=aws-iam-authenticator",
+                $"--exec-api-version={apiVersion}",
+                "--exec-arg=token",
+                "--exec-arg=-i",
+                $"--exec-arg={clusterName}");
+
+            return true;
+        }
+
+        void ConfigureAwsCli()
+        {
+            if (!environmentVars.ContainsKey("AWS_ACCESS_KEY_ID"))
+            {
+                var awsEnvironmentGeneration =
+                    AwsEnvironmentGeneration.Create(log, deploymentVariables).GetAwaiter().GetResult();
+                environmentVars.AddRange(awsEnvironmentGeneration.EnvironmentVars);
+            }
+
+            awsCli.Configure(
+                GetEnvironmentVarOrDefault("AWS_ACCESS_KEY_ID"),
+                GetEnvironmentVarOrDefault("AWS_SECRET_ACCESS_KEY"),
+                GetEnvironmentVarOrDefault("AWS_REGION"),
+                GetEnvironmentVarOrDefault("AWS_SESSION_TOKEN")
+            );
+        }
+
+        string GetEnvironmentVarOrDefault(string key) => environmentVars.TryGetValue(key, out var value) ? value : null;
+
+        string GetEksClusterRegion(string clusterUrl) => clusterUrl.Replace(".eks.amazonaws.com", "").Split('.').Last();
+
+        void SetKubeConfigAuthenticationToAwsCli(string user, string clusterName, string region, string apiVersion)
+        {
+            var oidcJwt = deploymentVariables.Get(AccountVariables.Jwt);
+            var arguments = new List<string>
+            {
+                "config",
+                "set-credentials",
+                user,
+                "--exec-command=aws",
+                "--exec-arg=eks",
+                "--exec-arg=get-token",
+                $"--exec-arg=--cluster-name={clusterName}",
+                $"--exec-arg=--region={region}",
+                $"--exec-api-version={apiVersion}"
+            };
+
+            if (!oidcJwt.IsNullOrEmpty())
+            {
+                arguments.Add($"--token={oidcJwt}");
+            }
+
+            kubectl.ExecuteCommandAndAssertSuccess(arguments.ToArray());
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NET40
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Calamari.CloudAccounts;
@@ -151,3 +152,4 @@ namespace Calamari.Kubernetes.Authentication
         }
     }
 }
+#endif

--- a/source/Calamari/Kubernetes/Integration/AwsCli.cs
+++ b/source/Calamari/Kubernetes/Integration/AwsCli.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing;
+using Calamari.Common.Plumbing.Logging;
+using Newtonsoft.Json.Linq;
+using Octopus.Versioning.Semver;
+
+namespace Calamari.Kubernetes.Integration
+{
+    public class AwsCli : CommandLineTool
+    {
+        public AwsCli(
+            ILog log,
+            ICommandLineRunner commandLineRunner,
+            string workingDirectory,
+            Dictionary<string, string> environmentVars)
+            : base(log, commandLineRunner, workingDirectory, environmentVars)
+        {
+        }
+
+        public bool TrySetAws()
+        {
+            log.Verbose("Attempting to authenticate with aws-cli");
+
+            var result = CalamariEnvironment.IsRunningOnWindows
+                ? ExecuteCommandAndReturnOutput("where", "aws.exe")
+                : ExecuteCommandAndReturnOutput("which", "aws");
+
+            var foundExecutable = result.Output.InfoLogs.FirstOrDefault();
+            if (string.IsNullOrEmpty(foundExecutable))
+            {
+                log.Error("Could not find aws. Make sure aws is on the PATH.");
+                return false;
+            }
+
+            ExecutableLocation = foundExecutable.Trim();
+
+            return true;
+        }
+
+        public void Configure(string accessKey, string secretKey, string region, string sessionToken)
+        {
+            ExecuteAwsCommand("configure", "set", "aws_access_key_id", accessKey);
+            ExecuteAwsCommand("configure", "set", "aws_secret_access_key", secretKey);
+            ExecuteAwsCommand("configure", "set", "aws_default_region", region);
+            ExecuteAwsCommand("configure", "set", "aws_session_token", sessionToken);
+        }
+
+        public SemanticVersion GetAwsCliVersion()
+        {
+            var result = ExecuteAwsCommand("--version");
+            result.Result.VerifySuccess();
+
+            var awsCliVersion = result.Output.InfoLogs?.FirstOrDefault()
+                ?.Split()
+                .FirstOrDefault(versions => versions.StartsWith("aws-cli"))
+                ?.Replace("aws-cli/", string.Empty);
+
+            return new SemanticVersion(awsCliVersion);
+        }
+
+        public string GetEksClusterApiVersion(string clusterName, string region)
+        {
+            var result = ExecuteAwsCommand("eks", "get-token", $"--cluster-name={clusterName}", $"--region={region}");
+
+            result.Result.VerifySuccess();
+
+            var awsEksTokenCommand = string.Join("\n", result.Output.InfoLogs);
+            return JObject.Parse(awsEksTokenCommand).SelectToken("apiVersion")?.ToString();
+        }
+
+        CommandResultWithOutput ExecuteAwsCommand(params string[] arguments)
+            => ExecuteCommandAndReturnOutput(ExecutableLocation, arguments);
+    }
+}

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -1,3 +1,4 @@
+#if !NET40
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -120,7 +121,7 @@ namespace Calamari.Kubernetes
                 if (variables.GetFlag(SpecialVariables.SkipTlsVerification))
                 {
                     kubectl.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--insecure-skip-tls-verify=true");
-                } 
+                }
                 else if (variables.IsSet(SpecialVariables.CertificateAuthorityPath))
                 {
                     var serverCertPath = variables.Get(SpecialVariables.CertificateAuthorityPath);
@@ -150,7 +151,7 @@ namespace Calamari.Kubernetes
                     var skipTlsVerification = variables.GetFlag(SpecialVariables.SkipTlsVerification) ? "true" : "false";
                     kubectl.ExecuteCommandAndAssertSuccess("config", "set-cluster", cluster, $"--insecure-skip-tls-verify={skipTlsVerification}");
                 }
-                
+
                 kubectl.ExecuteCommandAndAssertSuccess("config", "set-context", context, $"--user={user}", $"--cluster={cluster}", $"--namespace={@namespace}");
                 kubectl.ExecuteCommandAndAssertSuccess("config", "use-context", context);
 
@@ -365,3 +366,4 @@ namespace Calamari.Kubernetes
         }
     }
 }
+#endif


### PR DESCRIPTION
## Issue

When running the kustomize step (or any step package step) against an AWS target we did not set up the authentication for the AWS CLI.

Other AWS step package steps got around this by authenticating within the steps execution, but that's not an option for this step that targets one of many k8s cloud providers.
Other k8s steps that do work against AWS don't use the step package framework, so they can share the same env var context.

[sc-64525]

## Solution

I've added a check to see if the env is configured and set aws up correctly.

As part of this I did a bit of basic refactoring, essentially pulling the AWS specific bits out of `SetupKubectlAuthentication.cs` into specific classes like the Azure and Google cloud auth is.

## Concerns

The only bit I'm concerned about here is how setting up the AWS authentication this way (using `aws configure`) just leaves those credentials on the worker. The two issues with that are:
1. Security of leaving creds lying around.
2. Crossed wires (eg. if another step isn't setting AWS credentials correctly, it will default to use these previously configured credentials)

The reason for using `aws configure` and saving those creds to a profile file was that environment variables are not shared across different sections of a step package. In this case we would set them in a `preInstruction` script and then they aren't accessible from the main script.

## Alternatives

I explored changing the location of the AWS credential file for the duration of this step, but that of course relies on environment variables which I can't persist over the life of the step.

I also explored using profiles to minimise the risk but it seems that running `aws eks get-token` doesn't support the `--profile` option when running within kubectl