### PR TITLE
Convert most tests to use nuke

### DIFF
--- a/build/Build.DetermineAffectedTests.cs
+++ b/build/Build.DetermineAffectedTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using JetBrains.Annotations;
+using Nuke.Common;
+using Nuke.Common.CI.TeamCity;
+using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.Git;
+using Serilog;
+
+namespace Calamari.Build;
+
+partial class Build
+{
+    [Parameter(Name = "DefaultGitBranch")] readonly string MainBranchName;
+    
+    [PublicAPI]
+    Target DetermineAffectedTests =>
+        target => target
+            .Executes(() =>
+            {
+                if (GitVersionInfo is null)
+                    throw new ArgumentNullException(nameof(GitVersionInfo));
+                
+                if (GitVersionInfo.BranchName == MainBranchName)
+                {
+                    Log.Information("On default branch, nothing to calculate");
+                    return;
+                }
+
+                GitTasks.Git($"fetch origin {MainBranchName}");
+                var mainCommitSha = GitTasks.Git($"show-ref {MainBranchName} -s").FirstOrDefault().Text;
+                var mergeBase = GitTasks.Git($"merge-base {GitVersionInfo.Sha} {mainCommitSha}").FirstOrDefault();
+
+                if (string.IsNullOrWhiteSpace(mergeBase.Text))
+                {
+                    Log.Warning("No common merge base found. Not publishing an affected.proj artifact");
+                    return;
+                }
+
+                DotNetTasks.DotNetToolRestore();
+                DotNetTasks.DotNet($"affected --from {GitVersionInfo.Sha} --to {mergeBase.Text} --verbose");
+
+                if (File.Exists("affected.proj"))
+                {
+                    TeamCity.Instance.PublishArtifacts("affected.proj");
+                    Log.Information("Published affected.proj artifact");
+                }
+                else
+                {
+                    Log.Warning("Did not publish affected.proj artifact");
+                }
+            });
+}
+

--- a/build/Build.NetCoreTesting.cs
+++ b/build/Build.NetCoreTesting.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using Nuke.Common;
+using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 
 namespace Calamari.Build;
@@ -11,10 +12,19 @@ partial class Build
         target => target
             .Executes(() =>
             {
+                const string testFilter =
+                    "TestCategory != Windows & TestCategory != fsharp & TestCategory != scriptcs & TestCategory != PlatformAgnostic & TestCategory != RunOnceOnWindowsAndLinux";
+
                 DotNetTasks.DotNetTest(settings => settings
                     .SetProjectFile("Binaries/Calamari.Tests.dll")
-                    .SetFilter("TestCategory != Windows & TestCategory != fsharp & TestCategory != scriptcs & TestCategory != PlatformAgnostic & TestCategory != RunOnceOnWindowsAndLinux")
-                    .SetLoggers("trx"));
+                    .SetFilter(testFilter)
+                    .SetLoggers("trx")
+                    .SetProcessExitHandler(
+                        process => process.ExitCode switch
+                        {
+                            0 => null, //successful
+                            1 => null, //some tests failed
+                            _ => throw new ProcessException(process)
+                        }));
             });
 }
-

--- a/build/Build.NetCoreTesting.cs
+++ b/build/Build.NetCoreTesting.cs
@@ -1,0 +1,20 @@
+﻿using JetBrains.Annotations;
+using Nuke.Common;
+using Nuke.Common.Tools.DotNet;
+
+namespace Calamari.Build;
+
+partial class Build
+{
+    [PublicAPI]
+    Target NetCoreTesting =>
+        target => target
+            .Executes(() =>
+            {
+                DotNetTasks.DotNetTest(settings => settings
+                    .SetProjectFile("Binaries/Calamari.Tests.dll")
+                    .SetFilter("TestCategory != Windows & TestCategory != fsharp & TestCategory != scriptcs & TestCategory != PlatformAgnostic & TestCategory != RunOnceOnWindowsAndLinux")
+                    .SetLoggers("trx"));
+            });
+}
+

--- a/build/Build.TestCalamariFlavourProject.cs
+++ b/build/Build.TestCalamariFlavourProject.cs
@@ -34,8 +34,7 @@ partial class Build
             isAffected = true;
         }
 
-        // Force test to ensure master build will work
-        if (isAffected || true)
+        if (isAffected)
         {
             Log.Verbose("{TestProject} tests will be executed", testProject);
 

--- a/build/Build.TestCalamariFlavourProject.cs
+++ b/build/Build.TestCalamariFlavourProject.cs
@@ -40,7 +40,7 @@ partial class Build
                               Log.Verbose("{TestProject} tests will be executed", testProject);
 
                               DotNetTasks.DotNetTest(settings => settings
-                                                                 .SetProjectFile($"{testProject}.dll")
+                                                                 .SetProjectFile($"CalamariTests/{testProject}.dll")
                                                                  .SetFilter(CalamariFlavourTestCaseFilter)
                                                                  .SetLoggers("trx"));
                           }

--- a/build/Build.TestCalamariFlavourProject.cs
+++ b/build/Build.TestCalamariFlavourProject.cs
@@ -2,6 +2,7 @@
 using JetBrains.Annotations;
 using Nuke.Common;
 using Nuke.Common.IO;
+using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using Serilog;
 
@@ -13,43 +14,49 @@ partial class Build
     [Parameter(Name = "VSTest_TestCaseFilter")] readonly string CalamariFlavourTestCaseFilter;
 
     [PublicAPI]
-    Target TestCalamariFlavourProject =>
-        target => target
-            .Executes(async () =>
-                      {
-                          var testProject = $"Calamari.{CalamariFlavourToTest}.Tests";
+    Target TestCalamariFlavourProject => target => target.Executes(async () =>
+    {
+        var testProject = $"Calamari.{CalamariFlavourToTest}.Tests";
 
-                          var affectedProjectFile = RootDirectory / "affected.proj";
-                          bool isAffected;
-                          if (affectedProjectFile.FileExists())
-                          {
-                              Log.Information("Affected projects analysis found; checking to see if {TestProject} is affected", testProject);
-                              var contents = await File.ReadAllTextAsync(affectedProjectFile);
+        var affectedProjectFile = RootDirectory / "affected.proj";
+        bool isAffected;
+        if (affectedProjectFile.FileExists())
+        {
+            Log.Information("Affected projects analysis found; checking to see if {TestProject} is affected",
+                testProject);
+            var contents = await File.ReadAllTextAsync(affectedProjectFile);
 
-                              isAffected = contents.Contains(testProject);
-                          }
-                          else
-                          {
-                              Log.Information("Affected projects analysis not found; assuming {TestProject} *is* affected", testProject);
-                              isAffected = true;
-                          }
+            isAffected = contents.Contains(testProject);
+        }
+        else
+        {
+            Log.Information("Affected projects analysis not found; assuming {TestProject} *is* affected", testProject);
+            isAffected = true;
+        }
 
-                          // Force test to ensure master build will work
-                          if (isAffected || true)
-                          {
-                              Log.Verbose("{TestProject} tests will be executed", testProject);
+        // Force test to ensure master build will work
+        if (isAffected || true)
+        {
+            Log.Verbose("{TestProject} tests will be executed", testProject);
 
-                              DotNetTasks.DotNetTest(settings => settings
-                                                                 .SetProjectFile($"CalamariTests/{testProject}.dll")
-                                                                 .SetFilter(CalamariFlavourTestCaseFilter)
-                                                                 .SetLoggers("trx"));
-                          }
-                          else
-                          {
-                              Log.Information("{TestProject} is not affected, so no tests will be executed", testProject);
-                              Log.Information($"##teamcity[testStarted name='{testProject}-NoTests' captureStandardOutput='false']");
-                              Log.Information($"##teamcity[testFinished name='{testProject}-NoTests' duration='0']");
-                          }
-                      });
+            DotNetTasks.DotNetTest(settings => settings
+                .SetProjectFile($"CalamariTests/{testProject}.dll")
+                .SetFilter(CalamariFlavourTestCaseFilter)
+                .SetLoggers("trx")
+                .SetProcessExitHandler(
+                    process => process.ExitCode switch
+                    {
+                        0 => null, //successful
+                        1 => null, //some tests failed
+                        _ => throw new ProcessException(process)
+                    }));
+        }
+        else
+        {
+            Log.Information("{TestProject} is not affected, so no tests will be executed", testProject);
+            Log.Information(
+                $"##teamcity[testStarted name='{testProject}-NoTests' captureStandardOutput='false']");
+            Log.Information($"##teamcity[testFinished name='{testProject}-NoTests' duration='0']");
+        }
+    });
 }
-

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -18,7 +18,7 @@ partial class Build
     [PublicAPI]
     Target DetermineAffectedTests =>
         target => target
-            .Produces(RootDirectory / "affected.proj")
+            .Produces("affected.proj")
             .Executes(async () =>
             {
                 if (GitVersionInfo.BranchName == MainBranchName)

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -1,0 +1,51 @@
+﻿using System.IO;
+using JetBrains.Annotations;
+using Nuke.Common;
+using Nuke.Common.IO;
+using Nuke.Common.Tools.DotNet;
+using Serilog;
+
+namespace Calamari.Build;
+
+partial class Build
+{
+    [Parameter(Name = "CalamariFlavour")] readonly string CalamariFlavourToTest;
+    [Parameter(Name = "VSTest_TestCaseFilter")] readonly string CalamariFlavourTestCaseFilter;
+
+    [PublicAPI]
+    Target TestCalamariFlavourProject =>
+        _ => _
+            .Executes(async () =>
+                      {
+                          var testProject = $"Calamari.{CalamariFlavourToTest}.Tests";
+
+                          var affectedProjectFile = RootDirectory / "affected.proj";
+                          bool isAffected;
+                          if (affectedProjectFile.FileExists())
+                          {
+                              Log.Information("Affected projects analysis found; checking to see if {TestProject} is affected", testProject);
+                              var contents = await File.ReadAllTextAsync(affectedProjectFile);
+
+                              isAffected = contents.Contains(testProject);
+                          }
+                          else
+                          {
+                              Log.Information("Affected projects analysis not found; assuming {TestProject} *is* affected", testProject);
+                              isAffected = true;
+                          }
+
+                          if (isAffected)
+                          {
+                              Log.Verbose("{TestProject} tests will be executed", testProject);
+
+                              DotNetTasks.DotNetTest(settings => settings
+                                                                 .SetProjectFile($"{testProject}.dll")
+                                                                 .SetFilter(CalamariFlavourTestCaseFilter)
+                                                                 .SetLoggers("trx"));
+                          }
+                          else
+                          {
+                              Log.Information("{TestProject} is not affected, so no tests will be executed", testProject);
+                          }
+                      });
+}

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using JetBrains.Annotations;
 using Nuke.Common;
+using Nuke.Common.CI.TeamCity;
 using Nuke.Common.IO;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.Git;
@@ -18,7 +19,6 @@ partial class Build
     [PublicAPI]
     Target DetermineAffectedTests =>
         target => target
-            .Produces("affected.proj")
             .Executes(async () =>
             {
                 if (GitVersionInfo.BranchName == MainBranchName)
@@ -42,6 +42,7 @@ partial class Build
 
                 if (File.Exists("affected.proj"))
                 {
+                    TeamCity.Instance.PublishArtifacts("affected.proj");
                     Log.Information("Published affected.proj artifact");
                 }
                 else

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -100,7 +100,7 @@ partial class Build
             .Executes(() =>
             {
                 DotNetTasks.DotNetTest(settings => settings
-                    .SetProjectFile(BuildDirectory / "Calamari.Tests.dll")
+                    .SetProjectFile("Binaries/Calamari.Tests.dll")
                     .SetFilter("TestCategory != Windows & TestCategory != fsharp & TestCategory != scriptcs & TestCategory != PlatformAgnostic & TestCategory != RunOnceOnWindowsAndLinux")
                     .SetLoggers("trx"));
             });

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -43,11 +43,11 @@ partial class Build
 
                 if (File.Exists("affected.proj"))
                 {
-                    Log.Information("Found affected projects. Publishing them in affected.proj artifact");
+                    Log.Information("Published affected.proj artifact");
                 }
                 else
                 {
-                    Log.Information("No tests were affected. Not publishing an affected.proj artifact.");
+                    Log.Warning("Did not publish affected.proj artifact");
                 }
             });
 

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -5,7 +5,6 @@ using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.Git;
-using Nuke.Common.Tools.GitVersion;
 using Serilog;
 
 namespace Calamari.Build;
@@ -85,6 +84,8 @@ partial class Build
                           else
                           {
                               Log.Information("{TestProject} is not affected, so no tests will be executed", testProject);
+                              Log.Information($"##teamcity[testStarted name='{testProject}-NoTests' captureStandardOutput='false']");
+                              Log.Information($"##teamcity[testFinished name='{testProject}-NoTests' duration='0']");
                           }
                       });
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -89,7 +89,6 @@ namespace Calamari.Build
         [Parameter]
         readonly string? TargetRuntime;
 
-        [Required]
         [GitVersion]
         readonly GitVersion? GitVersionInfo;
 

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -27,7 +27,7 @@
 
     <ItemGroup>
       <PackageDownload Include="AzureSignTool" Version="[3.0.0]" />
-      <PackageDownload Include="GitVersion.Tool" Version="[5.9.0]" />
+      <PackageDownload Include="GitVersion.Tool" Version="[5.12.0]" />
     </ItemGroup>
 
     <ItemGroup>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -22,7 +22,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Nuke.Common" Version="6.3.0" />
+        <PackageReference Include="Nuke.Common" Version="7.0.6" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The tests in Calamari currently run as scripts in TeamCity that sometimes exit the whole step with code 1 on failure, preventing us from muting flakey tests within TeamCity itself.

This PR converts most of the tests (there are some mono and nunit tests I've left untouched in the interest of time) to use nuke, which fixes the immediate issue and is closer aligned to the rest of the company.

[Example of a (hopefully) successful run with non-affected tests skipped](https://build.octopushq.com/buildConfiguration/OctopusDeploy_CalamariNetCore_PublishNugetPackagesToMyGet/10565000?buildTab=dependencies&type=snapshot&mode=timeline&range=1702508901000-1702515352000)
[Example of a (hopefully) successful run with no tests skipped](https://build.octopushq.com/buildConfiguration/OctopusDeploy_CalamariNetCore_PublishNugetPackagesToMyGet/10566511?buildTab=dependencies&type=snapshot&mode=timeline)
These are both still running at the time of writing, I'll update this if they aren't successful.

Once merged, there is a manual set of steps to remove the old build steps in TeamCity and enable the new ones for all branches