### PR TITLE
Attempted fixes for flaky tests in Calamari

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -5,6 +5,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
@@ -394,6 +395,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                       IsReserved = true
                                                                                   });
 
+                await linuxAppServicePlan.WaitForCompletionAsync(CancellationToken.None);
+
                 var linuxWebSiteResponse = await resourceGroup.GetWebSites()
                                                               .CreateOrUpdateAsync(WaitUntil.Completed,
                                                                                    $"{resourceGroup.Data.Name}-linux",
@@ -416,6 +419,9 @@ namespace Calamari.AzureAppService.Tests
                                                                                            }
                                                                                        }
                                                                                    });
+
+                await linuxWebSiteResponse.WaitForCompletionAsync(CancellationToken.None);
+                
                 WebSiteResource = linuxWebSiteResponse.Value;
             }
 

--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -435,7 +435,7 @@ namespace Calamari.AzureAppService.Tests
                                         .Execute();
 
                 // Assert
-                await DoWithRetries(10,
+                await DoWithRetries(2,
                                     async () =>
                                     {
                                         await AssertContent(WebSiteResource.Data.DefaultHostName,
@@ -465,7 +465,7 @@ namespace Calamari.AzureAppService.Tests
                                         .Execute();
 
                 // Assert
-                await DoWithRetries(10,
+                await DoWithRetries(2,
                                     async () =>
                                     {
                                         await AssertContent(WebSiteResource.Data.DefaultHostName,
@@ -499,7 +499,7 @@ namespace Calamari.AzureAppService.Tests
                                         .Execute();
 
                 // Assert
-                await DoWithRetries(10,
+                await DoWithRetries(2,
                                     async () =>
                                     {
                                         await AssertContent(WebSiteResource.Data.DefaultHostName,

--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -188,7 +188,11 @@ namespace Calamari.AzureAppService.Tests
                                                                                    {
                                                                                        JavaVersion = "1.8",
                                                                                        JavaContainer = "TOMCAT",
-                                                                                       JavaContainerVersion = "9.0"
+                                                                                       JavaContainerVersion = "9.0",
+                                                                                       AppSettings = new List<AppServiceNameValuePair>
+                                                                                       {
+                                                                                           new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" }
+                                                                                       }
                                                                                    }
                                                                                });
 
@@ -341,6 +345,13 @@ namespace Calamari.AzureAppService.Tests
 
                 //set the feature toggle so we get the new code
                 context.Variables.Add(KnownVariables.EnabledFeatureToggles, FeatureToggle.ModernAzureAppServiceSdkFeatureToggle.ToString());
+                
+                var settings = LegacyAppServiceSettingsBehaviorFixture.BuildAppSettingsJson(new[]
+                {
+                    ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
+                });
+                
+                context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;
             }
         }
 
@@ -526,6 +537,13 @@ namespace Calamari.AzureAppService.Tests
 
                 //set the feature toggle so we get the new code
                 context.Variables.Add(KnownVariables.EnabledFeatureToggles, FeatureToggle.ModernAzureAppServiceSdkFeatureToggle.ToString());
+                
+                var settings = LegacyAppServiceSettingsBehaviorFixture.BuildAppSettingsJson(new[]
+                {
+                    ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
+                });
+                
+                context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;
             }
         }
     }

--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -192,7 +192,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                        JavaContainerVersion = "9.0",
                                                                                        AppSettings = new List<AppServiceNameValuePair>
                                                                                        {
-                                                                                           new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" }
+                                                                                           new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "600" }
                                                                                        }
                                                                                    }
                                                                                });

--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -213,8 +213,13 @@ namespace Calamari.AzureAppService.Tests
                                                          context.Variables[PackageVariables.SubstituteInFilesTargets] = "test.jsp";
                                                      })
                                         .Execute();
-
-                await AssertContent(javaSite.Value.Data.DefaultHostName, $"Hello! {greeting}", "test.jsp");
+                
+                await DoWithRetries(3,
+                                    async () =>
+                                    {
+                                        await AssertContent(javaSite.Value.Data.DefaultHostName, $"Hello! {greeting}", "test.jsp");
+                                    },
+                                    secondsBetweenRetries: 10);
             }
 
             [Test]

--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -376,8 +376,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                   {
                                                                                       Sku = new AppServiceSkuDescription
                                                                                       {
-                                                                                          Name = "S1",
-                                                                                          Tier = "Standard"
+                                                                                          Name = "PremiumV3",
+                                                                                          Tier = "P1V3"
                                                                                       },
                                                                                       Kind = "linux",
                                                                                       IsReserved = true

--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -192,7 +192,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                        JavaContainerVersion = "9.0",
                                                                                        AppSettings = new List<AppServiceNameValuePair>
                                                                                        {
-                                                                                           new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "600" }
+                                                                                           new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "600" },
+                                                                                           new AppServiceNameValuePair { Name = "WEBSITE_SCM_ALWAYS_ON_ENABLED", Value = "true" }
                                                                                        }
                                                                                    }
                                                                                });
@@ -355,6 +356,7 @@ namespace Calamari.AzureAppService.Tests
                 var settings = LegacyAppServiceSettingsBehaviorFixture.BuildAppSettingsJson(new[]
                 {
                     ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
+                    ("WEBSITE_SCM_ALWAYS_ON_ENABLED", "true", false)
                 });
                 
                 context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;
@@ -420,7 +422,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                                new AppServiceNameValuePair { Name = "FUNCTIONS_WORKER_RUNTIME", Value = "dotnet" },
                                                                                                new AppServiceNameValuePair { Name = "FUNCTIONS_EXTENSION_VERSION", Value = "~4" },
                                                                                                new AppServiceNameValuePair { Name = "AzureWebJobsStorage", Value = $"DefaultEndpointsProtocol=https;AccountName={storageAccountName};AccountKey={keys.First().Value};EndpointSuffix=core.windows.net" },
-                                                                                               new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" }
+                                                                                               new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" },
+                                                                                               new AppServiceNameValuePair { Name = "WEBSITE_SCM_ALWAYS_ON_ENABLED", Value = "true"}
                                                                                            }
                                                                                        }
                                                                                    });
@@ -552,6 +555,7 @@ namespace Calamari.AzureAppService.Tests
                 var settings = LegacyAppServiceSettingsBehaviorFixture.BuildAppSettingsJson(new[]
                 {
                     ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
+                    ("WEBSITE_SCM_ALWAYS_ON_ENABLED", "true", false)
                 });
                 
                 context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;

--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -376,8 +376,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                   {
                                                                                       Sku = new AppServiceSkuDescription
                                                                                       {
-                                                                                          Name = "PremiumV3",
-                                                                                          Tier = "P1V3"
+                                                                                          Name = "P1V3",
+                                                                                          Tier = "PremiumV3"
                                                                                       },
                                                                                       Kind = "linux",
                                                                                       IsReserved = true
@@ -401,6 +401,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                                new AppServiceNameValuePair { Name = "FUNCTIONS_WORKER_RUNTIME", Value = "dotnet" },
                                                                                                new AppServiceNameValuePair { Name = "FUNCTIONS_EXTENSION_VERSION", Value = "~4" },
                                                                                                new AppServiceNameValuePair { Name = "AzureWebJobsStorage", Value = $"DefaultEndpointsProtocol=https;AccountName={storageAccountName};AccountKey={keys.First().Value};EndpointSuffix=core.windows.net" },
+                                                                                               new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" }
                                                                                            }
                                                                                        }
                                                                                    });

--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -108,6 +108,11 @@ namespace Calamari.AzureAppService.Tests
             var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async () =>
                                                                                            {
                                                                                                var r = await client.GetAsync($"https://{hostName}/{rootPath}");
+                                                                                               if (!r.IsSuccessStatusCode)
+                                                                                               {
+                                                                                                   var messageContent = await r.Content.ReadAsStringAsync();
+                                                                                                   TestContext.WriteLine($"Unable to retreive content from https://{hostName}/{rootPath}, failed with: {messageContent}");
+                                                                                               }
                                                                                                r.EnsureSuccessStatusCode();
                                                                                                return r;
                                                                                            });

--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -103,12 +103,12 @@ namespace Calamari.AzureAppService.Tests
 
         protected async Task AssertContent(string hostName, string actualText, string rootPath = null)
         {
-            var response = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
-                                                          {
-                                                              var r = await client.GetAsync($"https://{hostName}/{rootPath}");
-                                                              r.EnsureSuccessStatusCode();
-                                                              return r;
-                                                          });
+            var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async () =>
+                                                                                           {
+                                                                                               var r = await client.GetAsync($"https://{hostName}/{rootPath}");
+                                                                                               r.EnsureSuccessStatusCode();
+                                                                                               return r;
+                                                                                           });
             
             var result = await response.Content.ReadAsStringAsync();
             result.Should().Contain(actualText);
@@ -157,8 +157,8 @@ namespace Calamari.AzureAppService.Tests
             {
                 Sku = new AppServiceSkuDescription
                 {
-                    Name = "S1",
-                    Tier = "Standard"
+                    Name = "PremiumV3",
+                    Tier = "P1V3"
                 }
             };
 

--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -68,6 +68,8 @@ namespace Calamari.AzureAppService.Tests
                                                                     retryOptions.MaxRetries = 5;
                                                                     retryOptions.Mode = RetryMode.Exponential;
                                                                     retryOptions.Delay = TimeSpan.FromSeconds(2);
+                                                                    // AzureAppServiceDeployContainerBehaviorFixture.AzureLinuxContainerSlotDeploy occasional timeout at default 100 seconds
+                                                                    retryOptions.NetworkTimeout = TimeSpan.FromSeconds(200);
                                                                 });
 
             //create the resource group

--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -157,8 +157,8 @@ namespace Calamari.AzureAppService.Tests
             {
                 Sku = new AppServiceSkuDescription
                 {
-                    Name = "PremiumV3",
-                    Tier = "P1V3"
+                    Name = "P1V3",
+                    Tier = "PremiumV3"
                 }
             };
 

--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -105,18 +106,27 @@ namespace Calamari.AzureAppService.Tests
 
         protected async Task AssertContent(string hostName, string actualText, string rootPath = null)
         {
-            var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async () =>
+            var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async context =>
                                                                                            {
-                                                                                               var r = await client.GetAsync($"https://{hostName}/{rootPath}");
+                                                                                               var r = await client.GetAsync($"https://{hostName}z/{rootPath}");
+
+                                                                                               var isFinalRetry = context.TryGetValue("isFinalRetry", out var shouldCheckResponseStatus);
+                                                                                               if (isFinalRetry && shouldCheckResponseStatus is bool)
+                                                                                               {
+                                                                                                   return r;
+                                                                                               }
+
                                                                                                if (!r.IsSuccessStatusCode)
                                                                                                {
                                                                                                    var messageContent = await r.Content.ReadAsStringAsync();
-                                                                                                   TestContext.WriteLine($"Unable to retreive content from https://{hostName}/{rootPath}, failed with: {messageContent}");
+                                                                                                   TestContext.WriteLine($"Unable to retrieve content from https://{hostName}/{rootPath}, failed with: {messageContent}");
                                                                                                }
+
                                                                                                r.EnsureSuccessStatusCode();
                                                                                                return r;
-                                                                                           });
-            
+                                                                                           },
+                                                                                           contextData: new Dictionary<string, object>());
+ 
             var result = await response.Content.ReadAsStringAsync();
             result.Should().Contain(actualText);
         }

--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -109,13 +109,6 @@ namespace Calamari.AzureAppService.Tests
             var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async context =>
                                                                                            {
                                                                                                var r = await client.GetAsync($"https://{hostName}/{rootPath}");
-
-                                                                                               var isFinalRetry = context.TryGetValue("isFinalRetry", out var shouldCheckResponseStatus);
-                                                                                               if (isFinalRetry && shouldCheckResponseStatus is bool)
-                                                                                               {
-                                                                                                   return r;
-                                                                                               }
-
                                                                                                if (!r.IsSuccessStatusCode)
                                                                                                {
                                                                                                    var messageContent = await r.Content.ReadAsStringAsync();

--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -108,7 +108,7 @@ namespace Calamari.AzureAppService.Tests
         {
             var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async context =>
                                                                                            {
-                                                                                               var r = await client.GetAsync($"https://{hostName}z/{rootPath}");
+                                                                                               var r = await client.GetAsync($"https://{hostName}/{rootPath}");
 
                                                                                                var isFinalRetry = context.TryGetValue("isFinalRetry", out var shouldCheckResponseStatus);
                                                                                                if (isFinalRetry && shouldCheckResponseStatus is bool)

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -36,8 +36,8 @@ namespace Calamari.AzureAppService.Tests
                                                                        IsReserved = true,
                                                                        Sku = new AppServiceSkuDescription
                                                                        {
-                                                                           Name = "S1",
-                                                                           Tier = "Standard"
+                                                                           Name = "PremiumV3",
+                                                                           Tier = "P1V3"
                                                                        }
                                                                    },
                                                                    new WebSiteData(resourceGroup.Data.Location)
@@ -103,12 +103,12 @@ namespace Calamari.AzureAppService.Tests
 
         async Task AssertSetupSuccessAsync()
         {
-            var response = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
-                                                                                      {
-                                                                                          var r = await client.GetAsync($@"https://{WebSiteResource.Data.DefaultHostName}");
-                                                                                          r.EnsureSuccessStatusCode();
-                                                                                          return r;
-                                                                                      });
+            var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async () =>
+                                                                                           {
+                                                                                               var r = await client.GetAsync($@"https://{WebSiteResource.Data.DefaultHostName}");
+                                                                                               r.EnsureSuccessStatusCode();
+                                                                                               return r;
+                                                                                           });
             
             var receivedContent = await response.Content.ReadAsStringAsync();
 

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -23,7 +23,7 @@ namespace Calamari.AzureAppService.Tests
     {
         CalamariVariables newVariables;
         readonly HttpClient client = new HttpClient();
-        
+
         // For some reason we are having issues creating these linux resources on Standard in EastUS
         protected override string DefaultResourceGroupLocation => "westus2";
 
@@ -70,9 +70,9 @@ namespace Calamari.AzureAppService.Tests
 
             await new AzureAppServiceContainerDeployBehaviour(new InMemoryLog()).Execute(runningContext);
 
-            var targetSite = new AzureTargetSite(SubscriptionId, 
-                                            ResourceGroupName, 
-                                            WebSiteResource.Data.Name);
+            var targetSite = new AzureTargetSite(SubscriptionId,
+                                                 ResourceGroupName,
+                                                 WebSiteResource.Data.Name);
 
             await AssertDeploySuccessAsync(targetSite);
         }
@@ -93,24 +93,38 @@ namespace Calamari.AzureAppService.Tests
             var runningContext = new RunningDeployment("", newVariables);
 
             await new AzureAppServiceContainerDeployBehaviour(new InMemoryLog()).Execute(runningContext);
-            
-            var targetSite = new AzureTargetSite(SubscriptionId, 
-                                            ResourceGroupName, 
-                                            WebSiteResource.Data.Name,
-                                            slotName);
+
+            var targetSite = new AzureTargetSite(SubscriptionId,
+                                                 ResourceGroupName,
+                                                 WebSiteResource.Data.Name,
+                                                 slotName);
 
             await AssertDeploySuccessAsync(targetSite);
         }
 
         async Task AssertSetupSuccessAsync()
         {
-            var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async () =>
+            var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async context =>
                                                                                            {
                                                                                                var r = await client.GetAsync($@"https://{WebSiteResource.Data.DefaultHostName}");
+
+                                                                                               var isFinalRetry = context.TryGetValue("isFinalRetry", out var shouldCheckResponseStatus);
+                                                                                               if (isFinalRetry && shouldCheckResponseStatus is bool)
+                                                                                               {
+                                                                                                   return r;
+                                                                                               }
+
+                                                                                               if (!r.IsSuccessStatusCode)
+                                                                                               {
+                                                                                                   var messageContent = await r.Content.ReadAsStringAsync();
+                                                                                                   TestContext.WriteLine($"Unable to retrieve content from https://{WebSiteResource.Data.DefaultHostName}, failed with: {messageContent}");
+                                                                                               }
+
                                                                                                r.EnsureSuccessStatusCode();
                                                                                                return r;
-                                                                                           });
-            
+                                                                                           },
+                                                                                           contextData: new Dictionary<string, object>());
+
             var receivedContent = await response.Content.ReadAsStringAsync();
 
             receivedContent.Should().Contain(@"<title>Welcome to Azure Container Instances!</title>");

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -36,8 +36,8 @@ namespace Calamari.AzureAppService.Tests
                                                                        IsReserved = true,
                                                                        Sku = new AppServiceSkuDescription
                                                                        {
-                                                                           Name = "PremiumV3",
-                                                                           Tier = "P1V3"
+                                                                           Name = "P1V3",
+                                                                           Tier = "PremiumV3"
                                                                        }
                                                                    },
                                                                    new WebSiteData(resourceGroup.Data.Location)
@@ -49,7 +49,8 @@ namespace Calamari.AzureAppService.Tests
                                                                            AppSettings = new List<AppServiceNameValuePair>
                                                                            {
                                                                                new AppServiceNameValuePair { Name = "DOCKER_REGISTRY_SERVER_URL", Value = "https://index.docker.io" },
-                                                                               new AppServiceNameValuePair { Name = "WEBSITES_ENABLE_APP_SERVICE_STORAGE", Value = "false" }
+                                                                               new AppServiceNameValuePair { Name = "WEBSITES_ENABLE_APP_SERVICE_STORAGE", Value = "false" },
+                                                                               new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" }
                                                                            }
                                                                        }
                                                                    });

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -108,12 +108,6 @@ namespace Calamari.AzureAppService.Tests
                                                                                            {
                                                                                                var r = await client.GetAsync($@"https://{WebSiteResource.Data.DefaultHostName}");
 
-                                                                                               var isFinalRetry = context.TryGetValue("isFinalRetry", out var shouldCheckResponseStatus);
-                                                                                               if (isFinalRetry && shouldCheckResponseStatus is bool)
-                                                                                               {
-                                                                                                   return r;
-                                                                                               }
-
                                                                                                if (!r.IsSuccessStatusCode)
                                                                                                {
                                                                                                    var messageContent = await r.Content.ReadAsStringAsync();

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
@@ -54,7 +54,15 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                        name: resourceGroup.Name,
                                                                                                                        new Site(resourceGroup.Location)
                                                                                                                        {
-                                                                                                                           ServerFarmId = svcPlan.Id
+                                                                                                                           ServerFarmId = svcPlan.Id,
+                                                                                                                           SiteConfig = new SiteConfig
+                                                                                                                           {
+                                                                                                                               AppSettings = new List<NameValuePair>
+                                                                                                                               {
+                                                                                                                                   // Default is 230
+                                                                                                                                   new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "460")
+                                                                                                                               },
+                                                                                                                           },
                                                                                                                        }
                                                                                                                       ));
             }
@@ -205,11 +213,6 @@ namespace Calamari.AzureAppService.Tests
                 packageinfo.packageVersion = "1.0.0";
                 packageinfo.packageName = "sample";
                 greeting = "java";
-                
-                var settings = LegacyAppServiceSettingsBehaviorFixture.BuildAppSettingsJson(new[]
-                {
-                    ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
-                });
 
                 await CommandTestBuilder.CreateAsync<DeployAzureAppServiceCommand, Program>()
                                         .WithArrange(context =>
@@ -218,7 +221,6 @@ namespace Calamari.AzureAppService.Tests
                                                          AddVariables(context);
                                                          context.Variables["Octopus.Action.Azure.WebAppName"] = javaSite.Name;
                                                          context.Variables[PackageVariables.SubstituteInFilesTargets] = "test.jsp";
-                                                         context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;
                                                      })
                                         .Execute();
 
@@ -312,6 +314,13 @@ namespace Calamari.AzureAppService.Tests
                 context.Variables.Add(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.SubstituteInFiles);
                 context.Variables.Add(PackageVariables.SubstituteInFilesTargets, "index.html");
                 context.Variables.Add(SpecialVariables.Action.Azure.DeploymentType, "ZipDeploy");
+
+                var settings = LegacyAppServiceSettingsBehaviorFixture.BuildAppSettingsJson(new[]
+                {
+                    ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
+                });
+                
+                context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;
             }
         }
 
@@ -455,6 +464,13 @@ namespace Calamari.AzureAppService.Tests
             {
                 AddAzureVariables(context);
                 context.Variables.Add(SpecialVariables.Action.Azure.DeploymentType, "ZipDeploy");
+
+                var settings = LegacyAppServiceSettingsBehaviorFixture.BuildAppSettingsJson(new[]
+                {
+                    ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
+                });
+                
+                context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;
             }
         }
     }

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
@@ -202,7 +202,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                        AppSettings = new List<NameValuePair>
                                                                                                                                        {
                                                                                                                                            // Default is 230
-                                                                                                                                           new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "460")
+                                                                                                                                           new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "600")
                                                                                                                                        },
                                                                                                                                    },
                                                                                                                                }));
@@ -224,7 +224,12 @@ namespace Calamari.AzureAppService.Tests
                                                      })
                                         .Execute();
 
-                await AssertContent(javaSite.DefaultHostName, $"Hello! {greeting}", "test.jsp");
+                await DoWithRetries(3,
+                                    async () =>
+                                    {
+                                        await AssertContent(javaSite.DefaultHostName, $"Hello! {greeting}", "test.jsp");
+                                    },
+                                    secondsBetweenRetries: 10);
             }
 
             [Test]

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
@@ -60,7 +60,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                AppSettings = new List<NameValuePair>
                                                                                                                                {
                                                                                                                                    // Default is 230
-                                                                                                                                   new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "460")
+                                                                                                                                   new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "460"),
+                                                                                                                                   new NameValuePair("WEBSITE_SCM_ALWAYS_ON_ENABLED", "true")
                                                                                                                                },
                                                                                                                            },
                                                                                                                        }
@@ -202,7 +203,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                        AppSettings = new List<NameValuePair>
                                                                                                                                        {
                                                                                                                                            // Default is 230
-                                                                                                                                           new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "600")
+                                                                                                                                           new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "600"),
+                                                                                                                                           new NameValuePair("WEBSITE_SCM_ALWAYS_ON_ENABLED", "true")
                                                                                                                                        },
                                                                                                                                    },
                                                                                                                                }));
@@ -323,6 +325,7 @@ namespace Calamari.AzureAppService.Tests
                 var settings = LegacyAppServiceSettingsBehaviorFixture.BuildAppSettingsJson(new[]
                 {
                     ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
+                    ("WEBSITE_SCM_ALWAYS_ON_ENABLED", "true", false)
                 });
                 
                 context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;
@@ -381,7 +384,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                    new NameValuePair("FUNCTIONS_WORKER_RUNTIME", "dotnet"),
                                                                                                                                    new NameValuePair("FUNCTIONS_EXTENSION_VERSION", "~4"),
                                                                                                                                    new NameValuePair("AzureWebJobsStorage", $"DefaultEndpointsProtocol=https;AccountName={storageAccount.Name};AccountKey={keys.Keys.First().Value};EndpointSuffix=core.windows.net"),
-                                                                                                                                   new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "460")
+                                                                                                                                   new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "460"),
+                                                                                                                                   new NameValuePair("WEBSITE_SCM_ALWAYS_ON_ENABLED", "true")
                                                                                                                                }
                                                                                                                            }
                                                                                                                        }
@@ -473,6 +477,7 @@ namespace Calamari.AzureAppService.Tests
                 var settings = LegacyAppServiceSettingsBehaviorFixture.BuildAppSettingsJson(new[]
                 {
                     ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
+                    ("WEBSITE_SCM_ALWAYS_ON_ENABLED", "true", false)
                 });
                 
                 context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
@@ -38,7 +38,7 @@ namespace Calamari.AzureAppService.Tests
 
             protected override async Task ConfigureTestResources(ResourceGroup resourceGroup)
             {
-                var svcPlan = await RetryPolicy.ExecuteAsync(async () => await webMgmtClient.AppServicePlans.BeginCreateOrUpdateAsync(
+                var svcPlan = await RetryPolicy.ExecuteAsync(async () => await webMgmtClient.AppServicePlans.CreateOrUpdateAsync(
                                                                                                                                       resourceGroupName: resourceGroup.Name,
                                                                                                                                       name: resourceGroup.Name,
                                                                                                                                       new AppServicePlan(resourceGroup.Location)
@@ -49,7 +49,7 @@ namespace Calamari.AzureAppService.Tests
 
                 servicePlanId = svcPlan.Id;
 
-                site = await RetryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.BeginCreateOrUpdateAsync(
+                site = await RetryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.CreateOrUpdateAsync(
                                                                                                                        resourceGroupName: resourceGroup.Name,
                                                                                                                        name: resourceGroup.Name,
                                                                                                                        new Site(resourceGroup.Location)
@@ -100,7 +100,7 @@ namespace Calamari.AzureAppService.Tests
 
                 (string packagePath, string packageName, string packageVersion) packageinfo;
 
-                var slotTask = RetryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.BeginCreateOrUpdateSlotAsync(resourceGroupName,
+                var slotTask = RetryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.CreateOrUpdateSlotAsync(resourceGroupName,
                                                                                                                              resourceGroupName,
                                                                                                                              site,
                                                                                                                              slotName));
@@ -181,7 +181,7 @@ namespace Calamari.AzureAppService.Tests
             {
                 // Need to spin up a specific app service with Tomcat installed
                 // Need java installed on the test runner (MJH 2022-05-06: is this actually true? I don't see why we'd need java on the test runner)
-                var javaSite = await RetryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.BeginCreateOrUpdateAsync(resourceGroupName,
+                var javaSite = await RetryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.CreateOrUpdateAsync(resourceGroupName,
                                                                                                                                $"{resourceGroupName}-java",
                                                                                                                                new Site(site.Location)
                                                                                                                                {
@@ -329,7 +329,7 @@ namespace Calamari.AzureAppService.Tests
 
                 var keys = await storageClient.StorageAccounts.ListKeysAsync(resourceGroupName, storageAccountName);
 
-                var linuxSvcPlan = await RetryPolicy.ExecuteAsync(async () => await webMgmtClient.AppServicePlans.BeginCreateOrUpdateAsync(resourceGroupName,
+                var linuxSvcPlan = await RetryPolicy.ExecuteAsync(async () => await webMgmtClient.AppServicePlans.CreateOrUpdateAsync(resourceGroupName,
                                                                                                                                            $"{resourceGroupName}-linux-asp",
                                                                                                                                            new AppServicePlan(resourceGroupLocation)
                                                                                                                                            {
@@ -339,7 +339,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                            }
                                                                                                                                           ));
 
-                site = await RetryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.BeginCreateOrUpdateAsync(resourceGroupName,
+                site = await RetryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.CreateOrUpdateAsync(resourceGroupName,
                                                                                                                        $"{resourceGroupName}-linux",
                                                                                                                        new Site(resourceGroupLocation)
                                                                                                                        {

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
@@ -399,7 +399,7 @@ namespace Calamari.AzureAppService.Tests
                                         .Execute();
 
                 // Assert
-                await DoWithRetries(10,
+                await DoWithRetries(2,
                                     async () =>
                                     {
                                         await AssertContent(site.DefaultHostName,
@@ -429,7 +429,7 @@ namespace Calamari.AzureAppService.Tests
                                         .Execute();
 
                 // Assert
-                await DoWithRetries(10,
+                await DoWithRetries(2,
                                     async () =>
                                     {
                                         await AssertContent(site.DefaultHostName,

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
@@ -190,8 +190,13 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                    {
                                                                                                                                        JavaVersion = "1.8",
                                                                                                                                        JavaContainer = "TOMCAT",
-                                                                                                                                       JavaContainerVersion = "9.0"
-                                                                                                                                   }
+                                                                                                                                       JavaContainerVersion = "9.0",
+                                                                                                                                       AppSettings = new List<NameValuePair>
+                                                                                                                                       {
+                                                                                                                                           // Default is 230
+                                                                                                                                           new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "460")
+                                                                                                                                       },
+                                                                                                                                   },
                                                                                                                                }));
 
                 (string packagePath, string packageName, string packageVersion) packageinfo;
@@ -200,6 +205,11 @@ namespace Calamari.AzureAppService.Tests
                 packageinfo.packageVersion = "1.0.0";
                 packageinfo.packageName = "sample";
                 greeting = "java";
+                
+                var settings = LegacyAppServiceSettingsBehaviorFixture.BuildAppSettingsJson(new[]
+                {
+                    ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
+                });
 
                 await CommandTestBuilder.CreateAsync<DeployAzureAppServiceCommand, Program>()
                                         .WithArrange(context =>
@@ -208,6 +218,7 @@ namespace Calamari.AzureAppService.Tests
                                                          AddVariables(context);
                                                          context.Variables["Octopus.Action.Azure.WebAppName"] = javaSite.Name;
                                                          context.Variables[PackageVariables.SubstituteInFilesTargets] = "test.jsp";
+                                                         context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;
                                                      })
                                         .Execute();
 

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
@@ -366,7 +366,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                {
                                                                                                                                    new NameValuePair("FUNCTIONS_WORKER_RUNTIME", "dotnet"),
                                                                                                                                    new NameValuePair("FUNCTIONS_EXTENSION_VERSION", "~4"),
-                                                                                                                                   new NameValuePair("AzureWebJobsStorage", $"DefaultEndpointsProtocol=https;AccountName={storageAccount.Name};AccountKey={keys.Keys.First().Value};EndpointSuffix=core.windows.net")
+                                                                                                                                   new NameValuePair("AzureWebJobsStorage", $"DefaultEndpointsProtocol=https;AccountName={storageAccount.Name};AccountKey={keys.Keys.First().Value};EndpointSuffix=core.windows.net"),
+                                                                                                                                   new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "460")
                                                                                                                                }
                                                                                                                            }
                                                                                                                        }

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceBehaviorFixture.cs
@@ -43,7 +43,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                       name: resourceGroup.Name,
                                                                                                                                       new AppServicePlan(resourceGroup.Location)
                                                                                                                                       {
-                                                                                                                                          Sku = new SkuDescription("S1", "Standard")
+                                                                                                                                          Sku = new SkuDescription("P1V3", "PremiumV3")
                                                                                                                                       }
                                                                                                                                      ));
 
@@ -344,7 +344,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                            $"{resourceGroupName}-linux-asp",
                                                                                                                                            new AppServicePlan(resourceGroupLocation)
                                                                                                                                            {
-                                                                                                                                               Sku = new SkuDescription("S1", "Standard"),
+                                                                                                                                               Sku = new SkuDescription("P1V3", "PremiumV3"),
                                                                                                                                                Kind = "linux",
                                                                                                                                                Reserved = true
                                                                                                                                            }

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
@@ -104,13 +104,6 @@ namespace Calamari.AzureAppService.Tests
             var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async context =>
                                                                                            {
                                                                                                var r = await client.GetAsync($"https://{hostName}/{rootPath}");
-
-                                                                                               var isFinalRetry = context.TryGetValue("isFinalRetry", out var shouldCheckResponseStatus);
-                                                                                               if (isFinalRetry && shouldCheckResponseStatus is bool)
-                                                                                               {
-                                                                                                   return r;
-                                                                                               }
-
                                                                                                if (!r.IsSuccessStatusCode)
                                                                                                {
                                                                                                    var messageContent = await r.Content.ReadAsStringAsync();

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
@@ -103,12 +103,12 @@ namespace Calamari.AzureAppService.Tests
 
         protected async Task AssertContent(string hostName, string actualText, string rootPath = null)
         {
-            var response = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
-                                                                                      {
-                                                                                          var r = await client.GetAsync($"https://{hostName}/{rootPath}");
-                                                                                          r.EnsureSuccessStatusCode();
-                                                                                          return r;
-                                                                                      });
+            var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async () =>
+                                                                                           {
+                                                                                               var r = await client.GetAsync($"https://{hostName}/{rootPath}");
+                                                                                               r.EnsureSuccessStatusCode();
+                                                                                               return r;
+                                                                                           });
 
             var result = await response.Content.ReadAsStringAsync();
             result.Should().Contain(actualText);

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
@@ -105,8 +105,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                                var r = await client.GetAsync($"https://{hostName}/{rootPath}");
                                                                                                if (!r.IsSuccessStatusCode)
                                                                                                {
-                                                                                                   var messageContent = r.Content.ReadAsStringAsync();
-                                                                                                   TestContext.WriteLine($"Unable to retreive content from https://${hostName}/${rootPath}, failed with: {messageContent}");
+                                                                                                   var messageContent = await r.Content.ReadAsStringAsync();
+                                                                                                   TestContext.WriteLine($"Unable to retreive content from https://{hostName}/{rootPath}, failed with: {messageContent}");
                                                                                                }
                                                                                                r.EnsureSuccessStatusCode();
                                                                                                return r;

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceIntegrationTest.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Azure.Identity;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
-using Calamari.AzureAppService;
 using Calamari.AzureAppService.Azure;
 using Calamari.CloudAccounts;
 using Calamari.Testing;
@@ -14,8 +13,6 @@ using Microsoft.Azure.Management.WebSites;
 using Microsoft.Azure.Management.WebSites.Models;
 using Microsoft.Rest;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
-using Polly;
 using Polly.Retry;
 using AccountVariables = Calamari.AzureAppService.Azure.AccountVariables;
 
@@ -106,6 +103,11 @@ namespace Calamari.AzureAppService.Tests
             var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async () =>
                                                                                            {
                                                                                                var r = await client.GetAsync($"https://{hostName}/{rootPath}");
+                                                                                               if (!r.IsSuccessStatusCode)
+                                                                                               {
+                                                                                                   var messageContent = r.Content.ReadAsStringAsync();
+                                                                                                   TestContext.WriteLine($"Unable to retreive content from https://${hostName}/${rootPath}, failed with: {messageContent}");
+                                                                                               }
                                                                                                r.EnsureSuccessStatusCode();
                                                                                                return r;
                                                                                            });

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceSettingsBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceSettingsBehaviourFixture.cs
@@ -83,11 +83,11 @@ namespace Calamari.AzureAppService.Tests
                 HttpClient = { BaseAddress = new Uri(DefaultVariables.ResourceManagementEndpoint) },
             };
 
-            var svcPlan = await retryPolicy.ExecuteAsync(async () => await webMgmtClient.AppServicePlans.BeginCreateOrUpdateAsync(resourceGroup.Name,
+            var svcPlan = await retryPolicy.ExecuteAsync(async () => await webMgmtClient.AppServicePlans.CreateOrUpdateAsync(resourceGroup.Name,
                                                                                                                                   resourceGroup.Name,
                                                                                                                                   new AppServicePlan(resourceGroup.Location)));
 
-            site = await retryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.BeginCreateOrUpdateAsync(resourceGroup.Name,
+            site = await retryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.CreateOrUpdateAsync(resourceGroup.Name,
                                                                                                                    resourceGroup.Name,
                                                                                                                    new Site(resourceGroup.Location) { ServerFarmId = svcPlan.Id }));
 
@@ -186,7 +186,7 @@ namespace Calamari.AzureAppService.Tests
             var slotName = "stage";
             this.slotName = slotName;
 
-            await retryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.BeginCreateOrUpdateSlotAsync(resourceGroupName,
+            await retryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.CreateOrUpdateSlotAsync(resourceGroupName,
                                                                                                                 resourceGroupName,
                                                                                                                 site,
                                                                                                                 slotName));

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceSettingsBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAppServiceSettingsBehaviourFixture.cs
@@ -237,7 +237,7 @@ namespace Calamari.AzureAppService.Tests
             vars.Add("Octopus.Action.Azure.WebAppName", webappName);
         }
 
-        private (string json, IEnumerable<AppSetting> setting) BuildAppSettingsJson(IEnumerable<(string name, string value, bool isSlotSetting)> settings)
+        public static (string json, IEnumerable<AppSetting> setting) BuildAppSettingsJson(IEnumerable<(string name, string value, bool isSlotSetting)> settings)
         {
             var appSettings = settings.Select(setting => new AppSetting
                                                   { Name = setting.name, Value = setting.value, SlotSetting = setting.isSlotSetting });

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAzureAppServiceDeployContainerBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAzureAppServiceDeployContainerBehaviorFixture.cs
@@ -167,13 +167,6 @@ namespace Calamari.AzureAppService.Tests
             var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async context =>
                                                                                            {
                                                                                                var r = await client.GetAsync($@"https://{site.DefaultHostName}");
-
-                                                                                               var isFinalRetry = context.TryGetValue("isFinalRetry", out var shouldCheckResponseStatus);
-                                                                                               if (isFinalRetry && shouldCheckResponseStatus is bool)
-                                                                                               {
-                                                                                                   return r;
-                                                                                               }
-
                                                                                                if (!r.IsSuccessStatusCode)
                                                                                                {
                                                                                                    var messageContent = await r.Content.ReadAsStringAsync();

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAzureAppServiceDeployContainerBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAzureAppServiceDeployContainerBehaviorFixture.cs
@@ -85,8 +85,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                       Reserved = true,
                                                                                                                                       Sku = new SkuDescription
                                                                                                                                       {
-                                                                                                                                          Name = "PremiumV3",
-                                                                                                                                          Tier = "P1V3"
+                                                                                                                                          Name = "P1V3",
+                                                                                                                                          Tier = "PremiumV3"
                                                                                                                                       }
                                                                                                                                   }));
 
@@ -101,7 +101,9 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                            AppSettings = new List<NameValuePair>
                                                                                                                            {
                                                                                                                                new NameValuePair("DOCKER_REGISTRY_SERVER_URL", "https://index.docker.io"),
-                                                                                                                               new NameValuePair("WEBSITES_ENABLE_APP_SERVICE_STORAGE", "false")
+                                                                                                                               new NameValuePair("WEBSITES_ENABLE_APP_SERVICE_STORAGE", "false"),
+                                                                                                                               // Default is 230
+                                                                                                                               new NameValuePair("WEBSITES_CONTAINER_START_TIME_LIMIT", "460")
                                                                                                                            },
                                                                                                                            AlwaysOn = true
                                                                                                                        }

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAzureAppServiceDeployContainerBehaviorFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAzureAppServiceDeployContainerBehaviorFixture.cs
@@ -77,7 +77,7 @@ namespace Calamari.AzureAppService.Tests
                 HttpClient = { BaseAddress = new Uri(DefaultVariables.ResourceManagementEndpoint) },
             };
 
-            var svcPlan = await retryPolicy.ExecuteAsync(async () => await webMgmtClient.AppServicePlans.BeginCreateOrUpdateAsync(resourceGroup.Name,
+            var svcPlan = await retryPolicy.ExecuteAsync(async () => await webMgmtClient.AppServicePlans.CreateOrUpdateAsync(resourceGroup.Name,
                                                                                                                                   resourceGroup.Name,
                                                                                                                                   new AppServicePlan(resourceGroup.Location)
                                                                                                                                   {
@@ -85,12 +85,12 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                       Reserved = true,
                                                                                                                                       Sku = new SkuDescription
                                                                                                                                       {
-                                                                                                                                          Name = "S1",
-                                                                                                                                          Tier = "Standard"
+                                                                                                                                          Name = "PremiumV3",
+                                                                                                                                          Tier = "P1V3"
                                                                                                                                       }
                                                                                                                                   }));
 
-            site = await retryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.BeginCreateOrUpdateAsync(resourceGroup.Name,
+            site = await retryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.CreateOrUpdateAsync(resourceGroup.Name,
                                                                                                                    resourceGroup.Name,
                                                                                                                    new Site(resourceGroup.Location)
                                                                                                                    {
@@ -147,7 +147,7 @@ namespace Calamari.AzureAppService.Tests
             newVariables = new CalamariVariables();
             AddVariables(newVariables);
             newVariables.Add("Octopus.Action.Azure.DeploymentSlot", slotName);
-            await retryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.BeginCreateOrUpdateSlotAsync(resourceGroupName,
+            await retryPolicy.ExecuteAsync(async () => await webMgmtClient.WebApps.CreateOrUpdateSlotAsync(resourceGroupName,
                                                                                                                 webappName,
                                                                                                                 site,
                                                                                                                 slotName));
@@ -162,12 +162,12 @@ namespace Calamari.AzureAppService.Tests
 
         async Task AssertSetupSuccessAsync()
         {
-            var response = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
-                                                                                      {
-                                                                                          var r = await client.GetAsync($@"https://{site.DefaultHostName}");
-                                                                                          r.EnsureSuccessStatusCode();
-                                                                                          return r;
-                                                                                      });
+            var response = await RetryPolicies.TestsTransientHttpErrorsPolicy.ExecuteAsync(async () =>
+                                                                                           {
+                                                                                               var r = await client.GetAsync($@"https://{site.DefaultHostName}");
+                                                                                               r.EnsureSuccessStatusCode();
+                                                                                               return r;
+                                                                                           });
             
             var receivedContent = await response.Content.ReadAsStringAsync();
 

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyAzureWebAppHealthCheckActionHandlerFixtures.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyAzureWebAppHealthCheckActionHandlerFixtures.cs
@@ -127,7 +127,7 @@ namespace Calamari.AzureAppService.Tests
                                                 .Define(SdkContext.RandomResourceName(nameof(LegacyAzureWebAppHealthCheckActionHandlerFixtures), 60))
                                                 .WithRegion(resourceGroup.Region)
                                                 .WithExistingResourceGroup(resourceGroup)
-                                                .WithPricingTier(PricingTier.BasicB1)
+                                                .WithPricingTier(PricingTier.PremiumP1v3)
                                                 .WithOperatingSystem(OperatingSystem.Windows)
                                                 .CreateAsync();
 

--- a/source/Calamari.AzureAppService.Tests/Legacy/LegacyTargetDiscoveryBehaviourIntegrationTestFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/Legacy/LegacyTargetDiscoveryBehaviourIntegrationTestFixture.cs
@@ -83,7 +83,7 @@ namespace Calamari.AzureAppService.Tests
 
             svcPlan = await retryPolicy.ExecuteAsync(async () => await webMgmtClient.AppServicePlans.CreateOrUpdateAsync(resourceGroup.Name,
                                                                                                                          resourceGroup.Name,
-                                                                                                                         new AppServicePlan(resourceGroup.Location) { Sku = new SkuDescription("S1", "Standard") }
+                                                                                                                         new AppServicePlan(resourceGroup.Location) { Sku = new SkuDescription("P1V3", "PremiumV3") }
                                                                                                                         ));
         }
 

--- a/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
@@ -41,8 +41,8 @@ namespace Calamari.AzureAppService.Tests
                                                                    {
                                                                        Sku = new AppServiceSkuDescription
                                                                        {
-                                                                           Name = "PremiumV3",
-                                                                           Tier = "P1V3"
+                                                                           Name = "P1V3",
+                                                                           Tier = "PremiumV3"
                                                                        }
                                                                    });
 

--- a/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
@@ -41,8 +41,8 @@ namespace Calamari.AzureAppService.Tests
                                                                    {
                                                                        Sku = new AppServiceSkuDescription
                                                                        {
-                                                                           Name = "S1",
-                                                                           Tier = "Standard"
+                                                                           Name = "PremiumV3",
+                                                                           Tier = "P1V3"
                                                                        }
                                                                    });
 

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -276,7 +276,7 @@ namespace Calamari.AzureAppService.Behaviors
             var authenticationHeader = new AuthenticationHeaderValue("Basic", publishingProfile.GetBasicAuthCredentials());
 
             //we add some retry just in case the web app's Kudu/SCM is not running just yet
-            var uploadResponse = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async context =>
+            var uploadResponse = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
                                                                                             {
                                                                                                 //we have to create a new request message each time
                                                                                                 var uploadRequest = new HttpRequestMessage(HttpMethod.Post, zipUploadUrl)
@@ -294,8 +294,7 @@ namespace Calamari.AzureAppService.Behaviors
                                                                                                 var r = await httpClient.SendAsync(uploadRequest);
                                                                                                 r.EnsureSuccessStatusCode();
                                                                                                 return r;
-                                                                                            },
-                                                                                            contextData: new Dictionary<string, object>());
+                                                                                            });
 
             if (!uploadResponse.IsSuccessStatusCode)
                 throw new Exception($"Zip upload to {zipUploadUrl} failed with HTTP Status {(int)uploadResponse.StatusCode} '{uploadResponse.ReasonPhrase}'.");

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -292,12 +292,7 @@ namespace Calamari.AzureAppService.Behaviors
                                                                                                 };
 
                                                                                                 var r = await httpClient.SendAsync(uploadRequest);
-                                                                                                var isFinalRetry = context.TryGetValue("isFinalRetry", out var shouldCheckResponseStatus);
-                                                                                                if (isFinalRetry && shouldCheckResponseStatus is bool)
-                                                                                                {
-                                                                                                    r.EnsureSuccessStatusCode();
-                                                                                                }
-
+                                                                                                r.EnsureSuccessStatusCode();
                                                                                                 return r;
                                                                                             },
                                                                                             contextData: new Dictionary<string, object>());

--- a/source/Calamari.AzureAppService/RetryPolicies.cs
+++ b/source/Calamari.AzureAppService/RetryPolicies.cs
@@ -24,14 +24,7 @@ namespace Calamari.AzureAppService
                                                                                                   .Or<SocketException>()
                                                                                                   .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.RequestTimeout)
                                                                                                   .WaitAndRetryAsync(5,
-                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2.15, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 1000)),
-                                                                                                                     onRetry: (response, delay, retryCount, context) =>
-                                                                                                                              {
-                                                                                                                                  if (retryCount == 5)
-                                                                                                                                  {
-                                                                                                                                      context["isFinalRetry"] = true;
-                                                                                                                                  }
-                                                                                                                              });
+                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2.15, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 1000)));
 
         // This is specifically for retries in tests, we retry fewer times with a higher base to try avoid hitting rate limiting in Azure.
         // The Jitter offset has been increased to try stagger requests between parallel test runs.
@@ -39,14 +32,7 @@ namespace Calamari.AzureAppService
                                                                                                   .Or<SocketException>()
                                                                                                   .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.RequestTimeout)
                                                                                                   .WaitAndRetryAsync(4,
-                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(3.5, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 10000)),
-                                                                                                                          onRetry: (response, delay, retryCount, context) =>
-                                                                                                                                   {
-                                                                                                                                       if (retryCount == 5)
-                                                                                                                                       {
-                                                                                                                                           context["isFinalRetry"] = true;
-                                                                                                                                       }
-                                                                                                                                   });
+                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(3.5, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 10000)));
 
         public static RetryPolicy<HttpResponseMessage> AsynchronousZipDeploymentOperationPolicy { get; } = Policy.HandleResult<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Accepted)
                                                                                                                  .WaitAndRetryForeverAsync((_1, ctx) => TimeSpan.FromSeconds(2),

--- a/source/Calamari.AzureAppService/RetryPolicies.cs
+++ b/source/Calamari.AzureAppService/RetryPolicies.cs
@@ -23,8 +23,8 @@ namespace Calamari.AzureAppService
         public static RetryPolicy<HttpResponseMessage> TransientHttpErrorsPolicy { get; } = Policy.Handle<HttpRequestException>()
                                                                                                   .Or<SocketException>()
                                                                                                   .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.RequestTimeout)
-                                                                                                  .WaitAndRetryAsync(5,
-                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2.15, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 1000)));
+                                                                                                  .WaitAndRetryAsync(6,
+                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 1000)));
 
         // This is specifically for retries in tests, we retry fewer times with a higher base to try avoid hitting rate limiting in Azure.
         // The Jitter offset has been increased to try stagger requests between parallel test runs.

--- a/source/Calamari.AzureAppService/RetryPolicies.cs
+++ b/source/Calamari.AzureAppService/RetryPolicies.cs
@@ -32,7 +32,7 @@ namespace Calamari.AzureAppService
                                                                                                   .Or<SocketException>()
                                                                                                   .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.RequestTimeout)
                                                                                                   .WaitAndRetryAsync(4,
-                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(3, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 10000)));
+                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(3.5, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 10000)));
         
         public static RetryPolicy<HttpResponseMessage> AsynchronousZipDeploymentOperationPolicy { get; } = Policy.HandleResult<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Accepted)
                                                                                                                  .WaitAndRetryForeverAsync((_1,ctx) => TimeSpan.FromSeconds(2),

--- a/source/Calamari.AzureAppService/RetryPolicies.cs
+++ b/source/Calamari.AzureAppService/RetryPolicies.cs
@@ -24,7 +24,14 @@ namespace Calamari.AzureAppService
                                                                                                   .Or<SocketException>()
                                                                                                   .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.RequestTimeout)
                                                                                                   .WaitAndRetryAsync(5,
-                                                                                                        retryAttempt => TimeSpan.FromSeconds(Math.Pow(2.15, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 1000)));
+                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2.15, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 1000)),
+                                                                                                                     onRetry: (response, delay, retryCount, context) =>
+                                                                                                                              {
+                                                                                                                                  if (retryCount == 5)
+                                                                                                                                  {
+                                                                                                                                      context["isFinalRetry"] = true;
+                                                                                                                                  }
+                                                                                                                              });
 
         // This is specifically for retries in tests, we retry fewer times with a higher base to try avoid hitting rate limiting in Azure.
         // The Jitter offset has been increased to try stagger requests between parallel test runs.
@@ -32,10 +39,17 @@ namespace Calamari.AzureAppService
                                                                                                   .Or<SocketException>()
                                                                                                   .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.RequestTimeout)
                                                                                                   .WaitAndRetryAsync(4,
-                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(3.5, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 10000)));
-        
+                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(3.5, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 10000)),
+                                                                                                                          onRetry: (response, delay, retryCount, context) =>
+                                                                                                                                   {
+                                                                                                                                       if (retryCount == 5)
+                                                                                                                                       {
+                                                                                                                                           context["isFinalRetry"] = true;
+                                                                                                                                       }
+                                                                                                                                   });
+
         public static RetryPolicy<HttpResponseMessage> AsynchronousZipDeploymentOperationPolicy { get; } = Policy.HandleResult<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Accepted)
-                                                                                                                 .WaitAndRetryForeverAsync((_1,ctx) => TimeSpan.FromSeconds(2),
+                                                                                                                 .WaitAndRetryForeverAsync((_1, ctx) => TimeSpan.FromSeconds(2),
                                                                                                                                            (response, timeout, ctx) =>
                                                                                                                                            {
                                                                                                                                                if (ctx.TryGetValue(ContextKeys.Log, out var logObj) && logObj is ILog log)

--- a/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
+++ b/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
@@ -66,7 +66,7 @@ namespace Calamari.AzureWebApp.Tests
                 .Define(SdkContext.RandomResourceName(nameof(DeployAzureWebCommandFixture), 60))
                 .WithRegion(resourceGroup.Region)
                 .WithExistingResourceGroup(resourceGroup)
-                .WithPricingTier(PricingTier.StandardS1)
+                .WithPricingTier(PricingTier.PremiumP1v3)
                 .WithOperatingSystem(OperatingSystem.Windows)
                 .CreateAsync();
         }

--- a/source/Calamari.AzureWebApp/Util/AzureRetryTracker.cs
+++ b/source/Calamari.AzureWebApp/Util/AzureRetryTracker.cs
@@ -8,11 +8,11 @@ namespace Calamari.AzureWebApp.Util
         /// <summary>
         /// For azure operations, try again after 1s then 2s, 4s etc...
         /// </summary>
-        static readonly LimitedExponentialRetryInterval RetryIntervalForAzureOperations = new LimitedExponentialRetryInterval(1000, 30000, 2);
+        static readonly LimitedExponentialRetryInterval RetryIntervalForAzureOperations = new LimitedExponentialRetryInterval(2000, 30000, 2);
 
         public static RetryTracker GetDefaultRetryTracker()
         {
-            return new RetryTracker(maxRetries: 3,
+            return new RetryTracker(maxRetries: 4,
                 timeLimit: TimeSpan.MaxValue,
                 retryInterval: RetryIntervalForAzureOperations);
         }

--- a/source/Calamari.AzureWebApp/Util/AzureRetryTracker.cs
+++ b/source/Calamari.AzureWebApp/Util/AzureRetryTracker.cs
@@ -8,7 +8,7 @@ namespace Calamari.AzureWebApp.Util
         /// <summary>
         /// For azure operations, try again after 1s then 2s, 4s etc...
         /// </summary>
-        static readonly LimitedExponentialRetryInterval RetryIntervalForAzureOperations = new LimitedExponentialRetryInterval(2000, 30000, 2);
+        static readonly LimitedExponentialRetryInterval RetryIntervalForAzureOperations = new LimitedExponentialRetryInterval(5000, 30000, 2);
 
         public static RetryTracker GetDefaultRetryTracker()
         {

--- a/source/Calamari.Terraform.Tests/CommandsFixture.cs
+++ b/source/Calamari.Terraform.Tests/CommandsFixture.cs
@@ -492,6 +492,7 @@ namespace Calamari.Terraform.Tests
             fileData.Should().Be("Hello World from Google Cloud");
 
             await ExecuteAndReturnResult(destroyCommand, PopulateVariables, temporaryFolder.DirectoryPath);
+            await Task.Delay(TimeSpan.FromSeconds(10));
             using (var client = new HttpClient())
             {
                 var response = await client.GetAsync($"{requestUri}&bust_cache").ConfigureAwait(false);

--- a/source/Calamari.Terraform.Tests/CommandsFixture.cs
+++ b/source/Calamari.Terraform.Tests/CommandsFixture.cs
@@ -482,6 +482,8 @@ namespace Calamari.Terraform.Tests
 
             string fileData;
 
+            // This intermittently throws a 401, requiring authorization. These buckets are public by default and the client has no authorization so this looks to be a race case in the bucket configuration.
+            await Task.Delay(TimeSpan.FromSeconds(5));
             using (var client = new HttpClient())
             {
                 fileData = await client.GetStringAsync(requestUri).ConfigureAwait(false);

--- a/source/Calamari.Testing/Helpers/EventuallyStrategy.cs
+++ b/source/Calamari.Testing/Helpers/EventuallyStrategy.cs
@@ -116,8 +116,7 @@ namespace Calamari.Testing.Helpers
         void LogPermanentFailure(Exception exception)
         {
             var elapsed = stopwatch.Elapsed;
-            logger.ErrorFormat(
-                $"Eventual assertion failed after {elapsed} {elapsed.TotalMilliseconds} with message {exception.Message}. {exception}");
+            logger.ErrorFormat("Eventual assertion failed after {0} {1} with message {2}. {3}", elapsed, elapsed.TotalMilliseconds, exception.Message, exception);
         }
 
         public record struct Timing(TimeSpan MinDelay, TimeSpan MaxDelay, Backoff Backoff)

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -154,6 +154,10 @@ namespace Calamari.Tests.KubernetesFixtures
 
                                                          if (CalamariEnvironment.IsRunningOnWindows)
                                                          {
+                                                             if (Directory.Exists($"{destinationDirectoryName}\\extract"))
+                                                             {
+                                                                 return GetAwsCliExecutablePath(destinationDirectoryName);
+                                                             }
                                                              ExecuteCommandAndReturnResult("msiexec",
                                                                                            $"/a {awsInstaller} /qn TARGETDIR={destinationDirectoryName}\\extract",
                                                                                            destinationDirectoryName);
@@ -515,7 +519,7 @@ namespace Calamari.Tests.KubernetesFixtures
             log($"Downloading {toolName} cli...");
             Directory.CreateDirectory(destinationDirectoryName);
 
-            var retry = new RetryTracker(3, TimeSpan.MaxValue, new LimitedExponentialRetryInterval(1000, 30000, 2));
+            var retry = new RetryTracker(4, TimeSpan.MaxValue, new LimitedExponentialRetryInterval(3000, 30000, 2));
             while (retry.Try())
             {
                 try

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -271,8 +271,8 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Aws.Region", "eks_region");
             variables.Set($"{account}.AccessKey", "eksAccessKey");
             variables.Set($"{account}.SecretKey", "eksSecretKey");
-            var wrapper = CreateWrapper();
-            TestScriptInReadOnlyMode(wrapper).AssertSuccess();
+            //var wrapper = CreateWrapper();
+            //TestScriptInReadOnlyMode(wrapper).AssertSuccess();
         }
 
         [Test]

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -271,8 +271,8 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Aws.Region", "eks_region");
             variables.Set($"{account}.AccessKey", "eksAccessKey");
             variables.Set($"{account}.SecretKey", "eksSecretKey");
-            //var wrapper = CreateWrapper();
-            //TestScriptInReadOnlyMode(wrapper).AssertSuccess();
+            var wrapper = CreateWrapper();
+            TestScriptInReadOnlyMode(wrapper).AssertSuccess();
         }
 
         [Test]


### PR DESCRIPTION
This PR introduces a number of changes to tests with the aim of reducing flakiness in the builds. While I've tested these and they appear to reduce the flakiness, a lot of the failures in the pipeline seems to come from concurrent runs and external dependencies. This is hard to get a proper feel for on a single PR, this change set is intended as a temporary attempt to improve the pipeline, if we don't see any benefits these changes can be reverted.

* Increase base of TransientHttpErrorsPolicy from 2 -> 2.15. This takes the maximum retry time from 32 seconds to 45 **(Note this change is in the actual step behaviour).** 
* Add a TestTransientHttpErrorsPolicy with 4 retries, and a base of 3, with a Jitterer offset of up to 10 seconds. **(This Increases back off and reduces number of requests trying to minimize 429s)**
* Move from BeginCreate to Create, this means the resource should be available by the time subsequent processes are run. **This should mean resources are ready by the time deployments are running against them, reducing the number of failed calls and retries (reduce 429s)**
* Change app service plans from P1 -> V3. We usually have 50 + of these hanging around, with 14 day deletion times, If this removes the flakiness and we can remove the 14 day retention this should save $ here. It also appears that failed runs aren't deleting their resource groups, this is surprising as clean-ups are in the base class `OneTimeTearDown` method which should always run. Successful runs seem to tear down these resources, so there may be savings by nature of reducing flakiness.
* Set `WEBSITES_CONTAINER_START_TIME_LIMIT` variable on app settings. [This is based on the java app service tests spin up time](https://stackoverflow.com/questions/51103897/increase-startup-timeout-for-azure-webapp-for-containers).


> <html>
<body>
<!--StartFragment-->
WEBSITES_CONTAINER_START_TIME_LIMIT | Amount of time in seconds to wait for the container to complete start-up before restarting the container. Default is 230. You can increase it up to the maximum of 1800.
-- | --


<!--EndFragment-->
</body>
</html>
https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet