### PR TITLE
Make sure all kubectl commands use the command pipeline

### DIFF
--- a/source/Calamari/Kubernetes/Integration/AzureCli.cs
+++ b/source/Calamari/Kubernetes/Integration/AzureCli.cs
@@ -39,11 +39,12 @@ namespace Calamari.Kubernetes.Integration
         {
             SetConfigDirectoryEnvironmentVariable(environmentVars, workingDirectory);
 
-            TryExecuteCommandAndLogOutput(ExecutableLocation,
-                                          "cloud",
-                                          "set",
-                                          "--name",
-                                          azEnvironment);
+            ExecuteCommandAndLogOutput(new CommandLineInvocation(
+                                                                 ExecutableLocation,
+                                                                 "cloud",
+                                                                 "set",
+                                                                 "--name",
+                                                                 azEnvironment));
 
             if (isOidc)
             {
@@ -78,7 +79,12 @@ namespace Calamari.Kubernetes.Integration
             log.Info("Successfully authenticated with the Azure CLI");
         }
 
-        public void ConfigureAksKubeCtlAuthentication(IKubectl kubectlCli, string clusterResourceGroup, string clusterName, string clusterNamespace, string kubeConfigPath, bool adminLogin)
+        public void ConfigureAksKubeCtlAuthentication(IKubectl kubectlCli,
+                                                      string clusterResourceGroup,
+                                                      string clusterName,
+                                                      string clusterNamespace,
+                                                      string kubeConfigPath,
+                                                      bool adminLogin)
         {
             log.Info($"Creating kubectl context to AKS Cluster in resource group {clusterResourceGroup} called {clusterName} (namespace {clusterNamespace})");
 

--- a/source/Calamari/Kubernetes/Integration/CommandLineTool.cs
+++ b/source/Calamari/Kubernetes/Integration/CommandLineTool.cs
@@ -30,6 +30,11 @@ namespace Calamari.Kubernetes.Integration
         protected CommandResult ExecuteCommandAndLogOutput(CommandLineInvocation invocation)
             => ExecuteCommandAndLogOutput(invocation, false);
 
+        /// <summary>
+        /// This is a special case for when the invocation results in an error
+        /// 1) but is to be expected as a valid scenario; and
+        /// 2) we don't want to inform this at an error level when this happens.
+        /// </summary>
         protected CommandResult ExecuteCommandAndLogOutputAsVerbose(CommandLineInvocation invocation)
             => ExecuteCommandAndLogOutput(invocation, true);
 

--- a/source/Calamari/Kubernetes/Integration/Kubectl.cs
+++ b/source/Calamari/Kubernetes/Integration/Kubectl.cs
@@ -16,7 +16,7 @@ namespace Calamari.Kubernetes.Integration
     {
         readonly string customKubectlExecutable;
         private bool isSet;
-        List<string> defaultCommandArgs = new List<string>{ "--request-timeout=1m" };
+        List<string> defaultCommandArgs = new List<string> { "--request-timeout=1m" };
 
         public Kubectl(IVariables variables, ILog log, ICommandLineRunner commandLineRunner)
             : this(variables,
@@ -98,6 +98,18 @@ namespace Calamari.Kubernetes.Integration
             return ExecuteCommandAndLogOutput(commandInvocation);
         }
 
+        /// <summary>
+        /// This is a special case for when the invocation results in an error
+        /// 1) but is to be expected as a valid scenario; and
+        /// 2) we don't want to inform this at an error level when this happens.
+        /// </summary>
+        public CommandResult ExecuteCommandWithVerboseLoggingOnly(params string[] arguments)
+        {
+            var kubectlArguments = arguments.Concat(defaultCommandArgs).ToArray();
+            var commandInvocation = new CommandLineInvocation(ExecutableLocation, kubectlArguments);
+            return ExecuteCommandAndLogOutputAsVerbose(commandInvocation);
+        }
+
         public void ExecuteCommandAndAssertSuccess(params string[] arguments)
         {
             var result = ExecuteCommand(arguments);
@@ -141,6 +153,7 @@ namespace Calamari.Kubernetes.Integration
         void SetEnvironmentVariables(Dictionary<string, string> variables);
         void SetKubectl();
         CommandResult ExecuteCommand(params string[] arguments);
+        CommandResult ExecuteCommandWithVerboseLoggingOnly(params string[] arguments);
         void ExecuteCommandAndAssertSuccess(params string[] arguments);
         CommandResultWithOutput ExecuteCommandAndReturnOutput(params string[] arguments);
         Maybe<SemanticVersion> GetVersion();


### PR DESCRIPTION
The `--request-timeout` flag does not work when running ambient k8s auth. This was being suppressed by `DisableRequestTimeoutArgument`, however the `get namespace` and `create namespace` didn't use the `kubectl` tool, meaning this wasn't respected.

I refactored the code so that these cli calls now go through the kubectl tool, but to make sure feature parity is maintained, I had to add new code to allow for all command line outputs to be logged as verbose (which is why there was the bifurcation in the code).

Shortcut story: [sc-65597]