### PR TITLE
Configure AWS CLI when setting up k8s authn

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator.approved.txt
@@ -7,5 +7,5 @@
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
 [Info] Creating kubectl context to https://someHash.gr7.ap-southeast-2.eks.amazonaws.com (namespace calamari-testing) using EKS cluster name my-eks-cluster
 [Verbose] Attempting to authenticate with aws-cli
-[Verbose] "kubectl" config set-credentials octouser --exec-command=aws --exec-arg=eks --exec-arg=get-token --exec-arg=--cluster-name=my-eks-cluster --exec-arg=--region=ap-southeast-2 --exec-api-version=client.authentication.k8s.io/v1beta1 --request-timeout=1m
+[Verbose] "kubectl" config set-credentials octouser --token=<token> --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
@@ -7,7 +7,8 @@
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using EKS cluster name my-eks-cluster
 [Verbose] Attempting to authenticate with aws-cli
-[Verbose] Unable to authenticate to <server> using the aws cli. Failed with error message: Unexpected character encountered while parsing value: P. Path '', line 0, position 0.
+[Verbose] Unable to authenticate to <server> using the aws cli. Failed with error message: Could not parse eks token: '
+Provided region_name '<server>' doesn't match a supported format.'
 [Verbose] Attempting to authenticate with aws-iam-authenticator
 [Verbose] "kubectl" config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1beta1 --exec-arg=token --exec-arg=-i --exec-arg=my-eks-cluster --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/BaseSetupKubectlAuthenticationFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/BaseSetupKubectlAuthenticationFixture.cs
@@ -1,0 +1,123 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes.Integration;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.Authentication
+{
+    public class BaseSetupKubectlAuthenticationFixture
+    {
+        protected readonly string workingDirectory = Path.Combine("working", "directory");
+        protected const string Namespace = "my-cool-namespace";
+
+        protected IVariables variables;
+        protected ILog log;
+        protected ICommandLineRunner commandLineRunner;
+        protected IKubectl kubectl;
+        protected ICalamariFileSystem fileSystem;
+        protected Dictionary<string, string> environmentVars;
+
+        protected Invocations invocations;
+
+        [SetUp]
+        public void BaseSetup()
+        {
+            invocations = new Invocations();
+            invocations.AddLogMessageFor("which", "kubelogin", "kubelogin");
+            invocations.AddLogMessageFor("where", "kubelogin", "kubelogin");
+
+            variables = new CalamariVariables();
+
+            log = Substitute.For<ILog>();
+            commandLineRunner = Substitute.For<ICommandLineRunner>();
+            commandLineRunner.Execute(Arg.Any<CommandLineInvocation>())
+                .Returns(
+                    x =>
+                    {
+                        var invocation = x.Arg<CommandLineInvocation>();
+                        var isSuccess = true;
+                        string logMessage = null;
+                        if (invocation.Executable != "chmod")
+                        {
+                            isSuccess = invocations.TryAdd(invocation.Executable, invocation.Arguments, out logMessage);
+                        }
+                        if (logMessage != null)
+                            invocation.AdditionalInvocationOutputSink?.WriteInfo(logMessage);
+                        return new CommandResult(
+                            invocation.Executable,
+                            isSuccess ? 0 : 1,
+                            workingDirectory: workingDirectory);
+                    });
+
+            kubectl = Substitute.For<IKubectl>();
+            kubectl.ExecutableLocation.Returns("kubectl");
+            kubectl.When(x => x.ExecuteCommandAndAssertSuccess(Arg.Any<string[]>()))
+                .Do(
+                    x =>
+                    {
+                        var args = x.Arg<string[]>();
+                        if (args != null)
+                            invocations.TryAdd("kubectl", string.Join(" ", args), out var _);
+                    });
+            kubectl.ExecuteCommandWithVerboseLoggingOnly(Arg.Any<string[]>())
+                .Returns(
+                    x =>
+                    {
+                        var args = x.Arg<string[]>();
+                        var isSuccess = true;
+
+                        if (args != null)
+                            isSuccess = invocations.TryAdd("kubectl", string.Join(" ", args), out _);
+
+                        return new CommandResult("kubectl", isSuccess ? 0 : 1);
+                    });
+
+            fileSystem = Substitute.For<ICalamariFileSystem>();
+            environmentVars = new Dictionary<string, string>();
+        }
+
+        protected class Invocations : IReadOnlyList<(string Executable, string Arguments)>
+        {
+            private readonly List<(string Executable, string Arguments)> invocations = new List<(string Executable, string Arguments)>();
+            private readonly List<(string Executable, string Arguments)> failFor = new List<(string Executable, string Arguments)>();
+            private readonly Dictionary<(string, string), string> logMessageMap = new Dictionary<(string, string), string>();
+
+            public bool TryAdd(string executable, string arguments, out string logMessage)
+            {
+                invocations.Add((executable, arguments));
+                logMessageMap.TryGetValue((executable, arguments), out logMessage);
+                return !failFor.Contains((executable, arguments));
+            }
+
+            public void FailFor(string executable, string arguments)
+            {
+                failFor.Add((executable, arguments));
+            }
+
+            public void AddLogMessageFor(string executable, string arguments, string logMessage)
+            {
+                logMessageMap[(executable, arguments)] = logMessage;
+            }
+
+            public IEnumerator<(string Executable, string Arguments)> GetEnumerator()
+            {
+                return invocations.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public int Count => invocations.Count;
+
+            public (string Executable, string Arguments) this[int index] => invocations[index];
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
@@ -1,0 +1,334 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Aws.Deployment;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes;
+using Calamari.Kubernetes.Integration;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.Authentication
+{
+    public class SetupKubectlAuthenticationAwsFixture
+    {
+        private readonly string workingDirectory = Path.Combine("working", "directory");
+        private const string Namespace = "my-cool-namespace";
+
+        private const string CurrentAwsVersion = "aws-cli/2.14.2";
+        private const string OlderAwsVersion = "aws-cli/1.16.155";
+        private const string InvalidAwsVersion = "aws-cli/not-a-version";
+
+        private const string EksClusterName = "my-cool-eks-cluster-name";
+        private const string AwsRegion = "southwest";
+        private const string AwsClusterUrl = "http://www." + AwsRegion + ".eks.amazonaws.com";
+        private const string InvalidAwsClusterUrl = "http://www." + AwsRegion + "..eks.amazonaws.com";
+
+        private IVariables variables;
+        private ILog log;
+        private ICommandLineRunner commandLineRunner;
+        private IKubectl kubectl;
+        private ICalamariFileSystem fileSystem;
+        private Dictionary<string, string> environmentVars;
+
+        private SetupKubectlAuthenticationFixture.Invocations invocations;
+
+        // TODO: Strip down/commonize
+        [SetUp]
+        public void Setup()
+        {
+            invocations = new SetupKubectlAuthenticationFixture.Invocations();
+            invocations.AddLogMessageFor("which", "kubelogin", "kubelogin");
+            invocations.AddLogMessageFor("where", "kubelogin", "kubelogin");
+            AddLogForAwsVersion(CurrentAwsVersion);
+
+            variables = new CalamariVariables();
+
+            log = Substitute.For<ILog>();
+            commandLineRunner = Substitute.For<ICommandLineRunner>();
+            commandLineRunner.Execute(Arg.Any<CommandLineInvocation>())
+                .Returns(
+                    x =>
+                    {
+                        var invocation = x.Arg<CommandLineInvocation>();
+                        var isSuccess = true;
+                        string logMessage = null;
+                        if (invocation.Executable != "chmod")
+                        {
+                            isSuccess = invocations.TryAdd(invocation.Executable, invocation.Arguments, out logMessage);
+                        }
+                        if (logMessage != null)
+                            invocation.AdditionalInvocationOutputSink?.WriteInfo(logMessage);
+                        return new CommandResult(
+                            invocation.Executable,
+                            isSuccess ? 0 : 1,
+                            workingDirectory: workingDirectory);
+                    });
+            kubectl = Substitute.For<IKubectl>();
+            kubectl.ExecutableLocation.Returns("kubectl");
+            kubectl.When(x => x.ExecuteCommandAndAssertSuccess(Arg.Any<string[]>()))
+                .Do(
+                    x =>
+                    {
+                        var args = x.Arg<string[]>();
+                        if (args != null)
+                            invocations.TryAdd("kubectl", string.Join(" ", args), out var _);
+                    });
+            fileSystem = Substitute.For<ICalamariFileSystem>();
+
+            variables.Set(SpecialVariables.ClusterUrl, AwsClusterUrl);
+            variables.Set(SpecialVariables.EksClusterName, EksClusterName);
+            variables.Set(SpecialVariables.Namespace, Namespace);
+
+            environmentVars = new Dictionary<string, string>
+            {
+                { "AWS_ACCESS_KEY_ID", "access_key" },
+                { "AWS_SECRET_ACCESS_KEY", "secret_key" },
+                { "AWS_REGION", "region" }
+            };
+        }
+
+        SetupKubectlAuthentication CreateSut() =>
+            new SetupKubectlAuthentication(
+                variables,
+                log,
+                commandLineRunner,
+                kubectl,
+                fileSystem,
+                environmentVars,
+                workingDirectory);
+
+        [Test]
+        public void AuthenticatesWithAwsCli()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForWhichAws();
+            AddLogForAwsVersion(CurrentAwsVersion);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(AwsCliInvocations());
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    GetAwsTokenInvocation,
+                    SetKubectlCredentialsWithAwsCliInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute();
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+        }
+
+        [Test]
+        public void AuthenticatesForInstanceRoleWithAwsCli()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForWhichAws();
+            AddLogForAwsVersion(CurrentAwsVersion);
+            variables.AddFlag(AwsSpecialVariables.Authentication.UseInstanceRole, true);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(AwsCliInvocations());
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    GetAwsTokenInvocation,
+                    SetKubectlCredentialsWithAwsCliInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute();
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+        }
+
+        [Test]
+        public void FallsBackToIamAuthenticatorWithoutAwsCli()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForAwsVersion(OlderAwsVersion);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    IamAuthenticatorInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute();
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+            log.Received().Verbose("Could not find the aws cli, falling back to the aws-iam-authenticator.");
+        }
+
+        [Test]
+        public void AuthenticatesForInstanceRoleWithIamAuthenticator()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForAwsVersion(OlderAwsVersion);
+            variables.AddFlag(AwsSpecialVariables.Authentication.UseInstanceRole, true);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    IamAuthenticatorInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute();
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+            log.Received().Verbose("Could not find the aws cli, falling back to the aws-iam-authenticator.");
+        }
+
+        [Test]
+        public void FallsBackToIamAuthenticatorWithOlderAwsCliVersion()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForWhichAws();
+            AddLogForAwsVersion(OlderAwsVersion);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(AwsCliInvocations());
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    IamAuthenticatorInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute();
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+            log.Received()
+                .Verbose(
+                    "aws cli version: 1.16.155 does not support the \"aws eks get-token\" command. Please update to a version later than 1.16.156");
+        }
+
+        [Test]
+        public void FailsWithInvalidAwsCliVersion()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForWhichAws();
+            AddLogForAwsVersion(InvalidAwsVersion);
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(AwsCliInvocations());
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    IamAuthenticatorInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute();
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+            log.Received()
+                .Verbose(
+                    Arg.Is<string>(
+                        s => s.StartsWith(
+                            $"Unable to authenticate to {AwsClusterUrl} using the aws cli. Failed with error message: 'not-a-version' is not a valid version string")));
+        }
+
+        [Test]
+        public void FallsBackToIamAuthenticatorWithoutRegion()
+        {
+            variables.Set(SpecialVariables.ClusterUrl, InvalidAwsClusterUrl);
+
+            AddLogForAwsEksGetToken();
+            AddLogForWhichAws();
+
+            var expectedInvocations = SetupClusterContextInvocations(InvalidAwsClusterUrl);
+            expectedInvocations.AddRange(AwsCliInvocations());
+            expectedInvocations.AddRange(
+                new List<(string, string)>
+                {
+                    IamAuthenticatorInvocation,
+                    GetNamespaceInvocation
+                });
+
+            var result = CreateSut().Execute();
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+            log.Received().Verbose("The EKS cluster Url specified should contain a valid aws region name");
+        }
+
+        void AddLogForWhichAws()
+        {
+            invocations.AddLogMessageFor("which", "aws", "aws");
+            invocations.AddLogMessageFor("where", "aws.exe", "aws");
+        }
+
+        void AddLogForAwsEksGetToken()
+        {
+            invocations.AddLogMessageFor(
+                "aws",
+                $"eks get-token --cluster-name={EksClusterName} --region={AwsRegion}",
+                $"{{ \"apiVersion\": \"1.2.3\"}}");
+        }
+
+        void AddLogForAwsVersion(string version)
+        {
+            invocations.AddLogMessageFor("aws", "--version", version);
+        }
+
+        List<(string, string)> SetupClusterContextInvocations(string clusterUser)
+        {
+            return new List<(string, string)>
+            {
+                ("kubectl", $"config set-cluster octocluster --server={clusterUser}"),
+                ("kubectl",
+                    $"config set-context octocontext --user=octouser --cluster=octocluster --namespace={Namespace}"),
+                ("kubectl", "config use-context octocontext"),
+            };
+        }
+
+        List<(string, string)> AwsCliInvocations()
+        {
+            return new List<(string, string)>
+            {
+                ("aws", "configure set aws_access_key_id access_key"),
+                ("aws", "configure set aws_secret_access_key secret_key"),
+                ("aws", "configure set aws_default_region region"),
+                ("aws", "configure set aws_session_token"),
+                ("aws", "--version")
+            };
+        }
+
+        (string, string) IamAuthenticatorInvocation =>
+            ("kubectl",
+                $"config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1alpha1 --exec-arg=token --exec-arg=-i --exec-arg={EksClusterName}");
+
+        (string, string ) GetAwsTokenInvocation =>
+            ("aws", "eks get-token --cluster-name=my-cool-eks-cluster-name --region=southwest");
+
+        (string, string) SetKubectlCredentialsWithAwsCliInvocation =>
+            ("kubectl",
+                "config set-credentials octouser --exec-command=aws --exec-arg=eks --exec-arg=get-token --exec-arg=--cluster-name=my-cool-eks-cluster-name --exec-arg=--region=southwest --exec-api-version=1.2.3");
+
+        (string, string) GetNamespaceInvocation =>
+            ("kubectl", $"get namespace {Namespace} --request-timeout=1m");
+
+        private void AssertInvocations(List<(string, string)> expectedInvocations)
+        {
+            invocations.Where(x => x.Executable != "which" && x.Executable != "where")
+                .Should()
+                .BeEquivalentTo(expectedInvocations, opts => opts.WithStrictOrdering());
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -1,0 +1,153 @@
+#if !NET40
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.CloudAccounts;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes.Integration;
+using Octopus.CoreUtilities;
+using Octopus.CoreUtilities.Extensions;
+using Octopus.Versioning.Semver;
+
+namespace Calamari.Kubernetes.Authentication
+{
+    public class AwsCliAuth
+    {
+        readonly AwsCli awsCli;
+        readonly IKubectl kubectl;
+        readonly IVariables deploymentVariables;
+        readonly Dictionary<string, string> environmentVars;
+        readonly ILog log;
+
+        public AwsCliAuth(
+            AwsCli awsCli,
+            IKubectl kubectl,
+            IVariables deploymentVariables,
+            Dictionary<string, string> environmentVars,
+            ILog log)
+        {
+            this.awsCli = awsCli;
+            this.kubectl = kubectl;
+            this.deploymentVariables = deploymentVariables;
+            this.environmentVars = environmentVars;
+            this.log = log;
+        }
+
+        public void Configure(string @namespace, string clusterUrl, string user)
+        {
+            var clusterName = deploymentVariables.Get(SpecialVariables.EksClusterName);
+            log.Info(
+                $"Creating kubectl context to {clusterUrl} (namespace {@namespace}) using EKS cluster name {clusterName}");
+
+            if (TrySetKubeConfigAuthenticationToAwsCli(clusterName, clusterUrl, user))
+                return;
+
+            log.Verbose("Attempting to authenticate with aws-iam-authenticator");
+            SetKubeConfigAuthenticationToAwsIAm(user, clusterName);
+        }
+
+        bool TrySetKubeConfigAuthenticationToAwsCli(string clusterName, string clusterUrl, string user)
+        {
+            if (!awsCli.TrySetAws())
+            {
+                log.Verbose("Could not find the aws cli, falling back to the aws-iam-authenticator.");
+                return false;
+            }
+
+            ConfigureAwsCli();
+
+            try
+            {
+                var awsCliVersion = awsCli.GetAwsCliVersion();
+                var minimumAwsCliVersionForAuth = new SemanticVersion("1.16.156");
+                if (awsCliVersion.CompareTo(minimumAwsCliVersionForAuth) > 0)
+                {
+                    var region = GetEksClusterRegion(clusterUrl);
+                    if (!string.IsNullOrWhiteSpace(region))
+                    {
+                        var apiVersion = awsCli.GetEksClusterApiVersion(clusterName, region);
+                        SetKubeConfigAuthenticationToAwsCli(user, clusterName, region, apiVersion);
+                        return true;
+                    }
+
+                    log.Verbose("The EKS cluster Url specified should contain a valid aws region name");
+                }
+
+                log.Verbose(
+                    $"aws cli version: {awsCliVersion} does not support the \"aws eks get-token\" command. Please update to a version later than 1.16.156");
+            }
+            catch (Exception e)
+            {
+                log.Verbose(
+                    $"Unable to authenticate to {clusterUrl} using the aws cli. Failed with error message: {e.Message}");
+            }
+
+            return false;
+        }
+
+        void SetKubeConfigAuthenticationToAwsIAm(string user, string clusterName)
+        {
+            var kubectlVersion = kubectl.GetVersion();
+            var apiVersion = kubectlVersion.Some() && kubectlVersion.Value > new SemanticVersion("1.23.6")
+                ? "client.authentication.k8s.io/v1beta1"
+                : "client.authentication.k8s.io/v1alpha1";
+
+            kubectl.ExecuteCommandAndAssertSuccess(
+                "config",
+                "set-credentials",
+                user,
+                "--exec-command=aws-iam-authenticator",
+                $"--exec-api-version={apiVersion}",
+                "--exec-arg=token",
+                "--exec-arg=-i",
+                $"--exec-arg={clusterName}");
+        }
+
+        void ConfigureAwsCli()
+        {
+            if (!environmentVars.ContainsKey("AWS_ACCESS_KEY_ID"))
+            {
+                var awsEnvironmentGeneration =
+                    AwsEnvironmentGeneration.Create(log, deploymentVariables).GetAwaiter().GetResult();
+                environmentVars.AddRange(awsEnvironmentGeneration.EnvironmentVars);
+            }
+
+            awsCli.Configure(
+                GetEnvironmentVarOrDefault("AWS_ACCESS_KEY_ID"),
+                GetEnvironmentVarOrDefault("AWS_SECRET_ACCESS_KEY"),
+                GetEnvironmentVarOrDefault("AWS_REGION"),
+                GetEnvironmentVarOrDefault("AWS_SESSION_TOKEN")
+            );
+        }
+
+        string GetEnvironmentVarOrDefault(string key) => environmentVars.TryGetValue(key, out var value) ? value : null;
+
+        string GetEksClusterRegion(string clusterUrl) => clusterUrl.Replace(".eks.amazonaws.com", "").Split('.').Last();
+
+        void SetKubeConfigAuthenticationToAwsCli(string user, string clusterName, string region, string apiVersion)
+        {
+            var oidcJwt = deploymentVariables.Get(AccountVariables.Jwt);
+            var arguments = new List<string>
+            {
+                "config",
+                "set-credentials",
+                user,
+                "--exec-command=aws",
+                "--exec-arg=eks",
+                "--exec-arg=get-token",
+                $"--exec-arg=--cluster-name={clusterName}",
+                $"--exec-arg=--region={region}",
+                $"--exec-api-version={apiVersion}"
+            };
+
+            if (!oidcJwt.IsNullOrEmpty())
+            {
+                arguments.Add($"--token={oidcJwt}");
+            }
+
+            kubectl.ExecuteCommandAndAssertSuccess(arguments.ToArray());
+        }
+    }
+}
+#endif

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -138,7 +138,8 @@ namespace Calamari.Kubernetes.Authentication
                 "--exec-arg=get-token",
                 $"--exec-arg=--cluster-name={clusterName}",
                 $"--exec-arg=--region={region}",
-                $"--exec-api-version={apiVersion}"
+                $"--exec-api-version={apiVersion}",
+                "--exec-env AWS_PROFILE=octopus"
             };
 
             if (!oidcJwt.IsNullOrEmpty())

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -126,6 +126,7 @@ namespace Calamari.Kubernetes.Authentication
 
             var arguments = new List<string> { "config", "set-credentials", user, $"--token={token}" };
 
+            log.AddValueToRedact(token, "<token>");
             kubectl.ExecuteCommandAndAssertSuccess(arguments.ToArray());
         }
     }

--- a/source/Calamari/Kubernetes/Integration/AwsCli.cs
+++ b/source/Calamari/Kubernetes/Integration/AwsCli.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Logging;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Octopus.Versioning.Semver;
 
@@ -67,7 +69,15 @@ namespace Calamari.Kubernetes.Integration
             result.Result.VerifySuccess();
 
             var awsEksTokenCommand = string.Join("\n", result.Output.InfoLogs);
-            return JObject.Parse(awsEksTokenCommand).SelectToken("apiVersion")?.ToString();
+
+            try
+            {
+                return JObject.Parse(awsEksTokenCommand).SelectToken("apiVersion")?.ToString();
+            }
+            catch (Exception e)
+            {
+                throw new JsonReaderException($"Could not parse eks token: '{awsEksTokenCommand}'", e);
+            }
         }
 
         CommandResultWithOutput ExecuteAwsCommand(params string[] arguments)

--- a/source/Calamari/Kubernetes/Integration/AwsCli.cs
+++ b/source/Calamari/Kubernetes/Integration/AwsCli.cs
@@ -71,6 +71,9 @@ namespace Calamari.Kubernetes.Integration
         }
 
         CommandResultWithOutput ExecuteAwsCommand(params string[] arguments)
-            => ExecuteCommandAndReturnOutput(ExecutableLocation, arguments);
+        {
+            var args = arguments.Concat(new[] { "--profile octopus" }).ToArray();
+            return ExecuteCommandAndReturnOutput(ExecutableLocation, args);
+        }
     }
 }

--- a/source/Calamari/Kubernetes/Integration/AwsCli.cs
+++ b/source/Calamari/Kubernetes/Integration/AwsCli.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing;
+using Calamari.Common.Plumbing.Logging;
+using Newtonsoft.Json.Linq;
+using Octopus.Versioning.Semver;
+
+namespace Calamari.Kubernetes.Integration
+{
+    public class AwsCli : CommandLineTool
+    {
+        public AwsCli(
+            ILog log,
+            ICommandLineRunner commandLineRunner,
+            string workingDirectory,
+            Dictionary<string, string> environmentVars)
+            : base(log, commandLineRunner, workingDirectory, environmentVars)
+        {
+        }
+
+        public bool TrySetAws()
+        {
+            log.Verbose("Attempting to authenticate with aws-cli");
+
+            var result = CalamariEnvironment.IsRunningOnWindows
+                ? ExecuteCommandAndReturnOutput("where", "aws.exe")
+                : ExecuteCommandAndReturnOutput("which", "aws");
+
+            var foundExecutable = result.Output.InfoLogs.FirstOrDefault();
+            if (string.IsNullOrEmpty(foundExecutable))
+            {
+                log.Error("Could not find aws. Make sure aws is on the PATH.");
+                return false;
+            }
+
+            ExecutableLocation = foundExecutable.Trim();
+
+            return true;
+        }
+
+        public void Configure(string accessKey, string secretKey, string region, string sessionToken)
+        {
+            ExecuteAwsCommand("configure", "set", "aws_access_key_id", accessKey);
+            ExecuteAwsCommand("configure", "set", "aws_secret_access_key", secretKey);
+            ExecuteAwsCommand("configure", "set", "aws_default_region", region);
+            ExecuteAwsCommand("configure", "set", "aws_session_token", sessionToken);
+        }
+
+        public SemanticVersion GetAwsCliVersion()
+        {
+            var result = ExecuteAwsCommand("--version");
+            result.Result.VerifySuccess();
+
+            var awsCliVersion = result.Output.InfoLogs?.FirstOrDefault()
+                ?.Split()
+                .FirstOrDefault(versions => versions.StartsWith("aws-cli"))
+                ?.Replace("aws-cli/", string.Empty);
+
+            return new SemanticVersion(awsCliVersion);
+        }
+
+        public string GetEksClusterApiVersion(string clusterName, string region)
+        {
+            var result = ExecuteAwsCommand("eks", "get-token", $"--cluster-name={clusterName}", $"--region={region}");
+
+            result.Result.VerifySuccess();
+
+            var awsEksTokenCommand = string.Join("\n", result.Output.InfoLogs);
+            return JObject.Parse(awsEksTokenCommand).SelectToken("apiVersion")?.ToString();
+        }
+
+        CommandResultWithOutput ExecuteAwsCommand(params string[] arguments)
+            => ExecuteCommandAndReturnOutput(ExecutableLocation, arguments);
+    }
+}

--- a/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
+++ b/source/Calamari/Kubernetes/SetupKubectlAuthentication.cs
@@ -1,8 +1,9 @@
+#if !NET40
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
+using Calamari.Aws.Deployment;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.FileSystem;
@@ -11,10 +12,6 @@ using Calamari.Common.Plumbing.Proxies;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.Authentication;
 using Calamari.Kubernetes.Integration;
-using Newtonsoft.Json.Linq;
-using Octopus.CoreUtilities;
-using Octopus.CoreUtilities.Extensions;
-using Octopus.Versioning.Semver;
 
 namespace Calamari.Kubernetes
 {
@@ -27,7 +24,6 @@ namespace Calamari.Kubernetes
         readonly ICalamariFileSystem fileSystem;
         readonly Dictionary<string, string> environmentVars;
         readonly string workingDirectory;
-        string aws;
 
         public SetupKubectlAuthentication(IVariables variables,
                                           ILog log,
@@ -126,9 +122,9 @@ namespace Calamari.Kubernetes
                 {
                     SetupContextForUsernamePassword(user);
                 }
-                else if (accountType == AccountTypes.AmazonWebServicesAccount || variables.GetFlag("Octopus.Action.AwsAccount.UseInstanceRole") || accountType == AccountTypes.AmazonWebServicesOidcAccount)
+                else if (accountType == AccountTypes.AmazonWebServicesAccount || variables.GetFlag(AwsSpecialVariables.Authentication.UseInstanceRole) || accountType == AccountTypes.AmazonWebServicesOidcAccount)
                 {
-                    SetupContextForAmazonServiceAccount(@namespace, clusterUrl, user);
+                    SetupAwsContext(@namespace, clusterUrl, user);
                 }
                 else if (variables.IsSet(SpecialVariables.ClientCertificate))
                 {
@@ -317,133 +313,12 @@ namespace Calamari.Kubernetes
                                                    $"--password={password}");
         }
 
-        void SetupContextForAmazonServiceAccount(string @namespace, string clusterUrl, string user)
+        void SetupAwsContext(string @namespace, string clusterUrl, string user)
         {
-            var clusterName = variables.Get(SpecialVariables.EksClusterName);
-            log.Info($"Creating kubectl context to {clusterUrl} (namespace {@namespace}) using EKS cluster name {clusterName}");
+            var awsCli = new AwsCli(log, commandLineRunner, workingDirectory, environmentVars);
+            var awsAuth = new AwsCliAuth(awsCli, kubectl, variables, environmentVars, log);
 
-            if (TrySetKubeConfigAuthenticationToAwsCli(clusterName, clusterUrl, user))
-            {
-                return;
-            }
-
-            log.Verbose("Attempting to authenticate with aws-iam-authenticator");
-            SetKubeConfigAuthenticationToAwsIAm(user, clusterName);
-        }
-
-        bool TrySetKubeConfigAuthenticationToAwsCli(string clusterName, string clusterUrl, string user)
-        {
-            log.Verbose("Attempting to authenticate with aws-cli");
-            if (!TrySetAws())
-            {
-                log.Verbose("Could not find the aws cli, falling back to the aws-iam-authenticator.");
-                return false;
-            }
-
-            try
-            {
-                var awsCliVersion = GetAwsCliVersion();
-                var minimumAwsCliVersionForAuth = new SemanticVersion("1.16.156");
-                if (awsCliVersion.CompareTo(minimumAwsCliVersionForAuth) > 0)
-                {
-                    var region = GetEksClusterRegion(clusterUrl);
-                    if (!string.IsNullOrWhiteSpace(region))
-                    {
-                        var apiVersion = GetEksClusterApiVersion(clusterName, region);
-                        SetKubeConfigAuthenticationToAwsCli(user, clusterName, region, apiVersion);
-                        return true;
-                    }
-
-                    log.Verbose("The EKS cluster Url specified should contain a valid aws region name");
-                }
-
-                log.Verbose($"aws cli version: {awsCliVersion} does not support the \"aws eks get-token\" command. Please update to a version later than 1.16.156");
-            }
-            catch (Exception e)
-            {
-                log.Verbose($"Unable to authenticate to {clusterUrl} using the aws cli. Failed with error message: {e.Message}");
-            }
-
-            return false;
-        }
-
-        string GetEksClusterRegion(string clusterUrl) => clusterUrl.Replace(".eks.amazonaws.com", "").Split('.').Last();
-
-        SemanticVersion GetAwsCliVersion()
-        {
-            var awsCliCommandRes = ExecuteCommandAndReturnOutput(aws, "--version").FirstOrDefault();
-            var awsCliVersionString = awsCliCommandRes.Split()
-                                                      .FirstOrDefault(versions => versions.StartsWith("aws-cli"))
-                                                      .Replace("aws-cli/", string.Empty);
-            return new SemanticVersion(awsCliVersionString);
-        }
-
-        string GetEksClusterApiVersion(string clusterName, string region)
-        {
-            var logLines = ExecuteCommandAndReturnOutput(aws,
-                                                         "eks",
-                                                         "get-token",
-                                                         $"--cluster-name={clusterName}",
-                                                         $"--region={region}");
-            var awsEksTokenCommand = string.Join("\n", logLines);
-            return JObject.Parse(awsEksTokenCommand).SelectToken("apiVersion").ToString();
-        }
-
-        void SetKubeConfigAuthenticationToAwsCli(string user, string clusterName, string region, string apiVersion)
-        {
-            var oidcJwt = variables.Get("Octopus.OpenIdConnect.Jwt");
-            var arguments = new List<string>
-            {
-                "config",
-                "set-credentials",
-                user,
-                "--exec-command=aws",
-                "--exec-arg=eks",
-                "--exec-arg=get-token",
-                $"--exec-arg=--cluster-name={clusterName}",
-                $"--exec-arg=--region={region}",
-                $"--exec-api-version={apiVersion}"
-            };
-
-            if (!oidcJwt.IsNullOrEmpty())
-            {
-                arguments.Add($"--token={oidcJwt}");
-            }
-
-            kubectl.ExecuteCommandAndAssertSuccess(arguments.ToArray());
-        }
-
-        void SetKubeConfigAuthenticationToAwsIAm(string user, string clusterName)
-        {
-            var kubectlVersion = kubectl.GetVersion();
-            var apiVersion = kubectlVersion.Some() && kubectlVersion.Value > new SemanticVersion("1.23.6")
-                ? "client.authentication.k8s.io/v1beta1"
-                : "client.authentication.k8s.io/v1alpha1";
-
-            kubectl.ExecuteCommandAndAssertSuccess("config",
-                                                   "set-credentials",
-                                                   user,
-                                                   "--exec-command=aws-iam-authenticator",
-                                                   $"--exec-api-version={apiVersion}",
-                                                   "--exec-arg=token",
-                                                   "--exec-arg=-i",
-                                                   $"--exec-arg={clusterName}");
-        }
-
-        bool TrySetAws()
-        {
-            aws = CalamariEnvironment.IsRunningOnWindows
-                ? ExecuteCommandAndReturnOutput("where", "aws.exe").FirstOrDefault()
-                : ExecuteCommandAndReturnOutput("which", "aws").FirstOrDefault();
-
-            if (string.IsNullOrEmpty(aws))
-            {
-                return false;
-            }
-
-            aws = aws.Trim();
-
-            return true;
+            awsAuth.Configure(@namespace, clusterUrl, user);
         }
 
         void CreateNamespace(string @namespace)
@@ -517,24 +392,6 @@ namespace Calamari.Kubernetes
 
             return result;
         }
-
-        IEnumerable<string> ExecuteCommandAndReturnOutput(string exe, params string[] arguments)
-        {
-            var captureCommandOutput = new CaptureCommandOutput();
-            var invocation = new CommandLineInvocation(exe, arguments)
-            {
-                EnvironmentVars = environmentVars,
-                WorkingDirectory = workingDirectory,
-                OutputAsVerbose = false,
-                OutputToLog = false,
-                AdditionalInvocationOutputSink = captureCommandOutput
-            };
-
-            var result = commandLineRunner.Execute(invocation);
-
-            return result.ExitCode == 0
-                ? captureCommandOutput.InfoLogs.ToArray()
-                : Enumerable.Empty<string>();
-        }
     }
 }
+#endif


### PR DESCRIPTION
## Issue

When running the kustomize step (or any step package step) against an AWS target we did not set up the authentication for the AWS CLI.

Other AWS step package steps got around this by authenticating within the steps execution, but that's not an option for this step that targets one of many k8s cloud providers.
Other k8s steps that do work against AWS don't use the step package framework, so they can share the same env var context.

[sc-64525]

Replaces https://github.com/OctopusDeploy/Calamari/pull/1198 after re-applying changes over main. 

## Solution

I've added a check to see if the env is configured and set the AWS CLI up correctly. ~~I've used the profile option provided by the AWS CLI to separate any credentials we set from what may be used manually (eg. if someone ssh'd in and configured it) and any other steps that may be similarly misconfigured in the future (this would have resulted in the wrong credentials being used).~~

Due to the step package framework not sharing the env var context, I've changed the kubeconfig authn mechanism to be a plain token instead of calling the AWS command. This means it can be cleaned up along with the rest of the workspace at the end of the deployment. The kubeconfig contents does get logged in the verbose logs, but the token is redacted automatically from the logs.
This token is valid for 15 minutes based on my testing, I believe this should be fine as it is generated once per step - so there should not be such a large delay between grabbing the token and before starting any processing.

As part of this I did a bit of basic refactoring, essentially pulling the AWS specific bits out of `SetupKubectlAuthentication.cs` into specific classes like the Azure and Google cloud auth is.