### PR TITLE
Add warning message about upcoming F# script deprecation

### DIFF
--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -11,6 +11,7 @@
         GlobPathsGroupSupportFeatureToggle,
         ModernAzureAppServiceSdkFeatureToggle,
         OidcAccountsFeatureToggle,
-        AsynchronousAzureZipDeployFeatureToggle
+        AsynchronousAzureZipDeployFeatureToggle,
+        FSharpDeprecationFeatureToggle
     }
 }

--- a/source/Calamari.Common/Features/Scripting/ScriptEngine.cs
+++ b/source/Calamari.Common/Features/Scripting/ScriptEngine.cs
@@ -9,7 +9,6 @@ using Calamari.Common.Features.Scripting.Python;
 using Calamari.Common.Features.Scripting.ScriptCS;
 using Calamari.Common.Features.Scripting.WindowsPowerShell;
 using Calamari.Common.Features.Scripts;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -108,20 +107,11 @@ namespace Calamari.Common.Features.Scripting
                 case ScriptSyntax.Bash:
                     return new BashScriptExecutor();
                 case ScriptSyntax.FSharp:
-                    LogFSharpDeprecationWarning(variables);
-                    return new FSharpExecutor();
+                    return new FSharpExecutor(log);
                 case ScriptSyntax.Python:
                     return new PythonScriptExecutor();
                 default:
                     throw new NotSupportedException($"{scriptSyntax} script are not supported for execution");
-            }
-        }
-
-        void LogFSharpDeprecationWarning(IVariables variables)
-        {
-            if (FeatureToggle.FSharpDeprecationFeatureToggle.IsEnabled(variables))
-            {
-                log.Warn($"Executing FSharp scripts will soon be deprecated. Please read our deprecation {log.FormatLink("https://octopus.com/blog/2024-deprecated-features#f-sharp", "blog post")} for more details.");
             }
         }
     }

--- a/source/Calamari.Common/Features/Scripting/ScriptEngine.cs
+++ b/source/Calamari.Common/Features/Scripting/ScriptEngine.cs
@@ -121,7 +121,7 @@ namespace Calamari.Common.Features.Scripting
         {
             if (FeatureToggle.FSharpDeprecationFeatureToggle.IsEnabled(variables))
             {
-                log.Warn($"Executing FSharp scripts will soon be deprecated. Please read our deprecation {log.FormatLink("https://octopus.com/blog/2024-deprecated-features#f-sharp", "blog post")} for more details");
+                log.Warn($"Executing FSharp scripts will soon be deprecated. Please read our deprecation {log.FormatLink("https://octopus.com/blog/2024-deprecated-features#f-sharp", "blog post")} for more details.");
             }
         }
     }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
@@ -240,7 +240,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         static DockerImagePackageDownloader GetDownloader(ILog log)
         {
             var runner = new CommandLineRunner(log, new CalamariVariables());
-            return new DockerImagePackageDownloader(new ScriptEngine(Enumerable.Empty<IScriptWrapper>()), CalamariPhysicalFileSystem.GetPhysicalFileSystem(), runner, new CalamariVariables(), log);
+            return new DockerImagePackageDownloader(new ScriptEngine(Enumerable.Empty<IScriptWrapper>(), log), CalamariPhysicalFileSystem.GetPhysicalFileSystem(), runner, new CalamariVariables(), log);
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/FSharpExecutorTests.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/FSharpExecutorTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Features.Scripting;
+using Calamari.Common.Features.Scripting.FSharp;
+using Calamari.Common.FeatureToggles;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Integration.Scripting
+{
+    [TestFixture]
+    public class FSharpExecutorTests
+    {
+        static IEnumerable<TestCaseData> FSharpDeprecationFeatureToggleTestData()
+        {
+            yield return new TestCaseData(new KeyValuePair<string, string>(),
+                                          false);
+            yield return new TestCaseData(
+                                          new KeyValuePair<string, string>(KnownVariables.EnabledFeatureToggles, ""),
+                                          false);
+            yield return new TestCaseData(
+                                          new KeyValuePair<string, string>(KnownVariables.EnabledFeatureToggles, FeatureToggle.FSharpDeprecationFeatureToggle.ToString()),
+                                          true);
+        }
+        
+        [Test]
+        [TestCaseSource(nameof(FSharpDeprecationFeatureToggleTestData))]
+        public void LogsFSharpDeprecationWarningWhenToggledOn(KeyValuePair<string, string> variableKvp, bool expected)
+        {
+            // Arrange
+            var log = Substitute.For<ILog>();
+            var script = new Script("fakeScript.fsx");
+            var variables = new CalamariVariables
+                { { variableKvp.Key, variableKvp.Value } };
+            var commandResult = new CommandResult("fakeCommand", 0);
+            var commandLineRunner = Substitute.For<ICommandLineRunner>();
+            commandLineRunner.Execute(Arg.Any<CommandLineInvocation>()).Returns(commandResult);
+
+            var executor = new FSharpExecutor(log);
+
+            // Act
+            executor.Execute(script, variables, commandLineRunner);
+
+            // Assert
+            if (expected)
+            {
+                log.Received(1).Warn(Arg.Is<string>(s => s.StartsWith("Executing FSharp scripts will soon be deprecated")));
+            }
+            else
+            {
+                log.DidNotReceive().Warn(Arg.Any<string>());
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
@@ -1,17 +1,22 @@
+using System;
 using System.Collections.Generic;
+using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.Scripts;
+using Calamari.Common.FeatureToggles;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing.Helpers;
-using Calamari.Tests.Helpers;
-using NUnit.Framework;
 using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures.Integration.Scripting
 {
     [TestFixture]
     public class ScriptEngineFixture
     {
-        private static readonly ScriptSyntax[] ScriptPreferencesNonWindows = new[]
+        static readonly ScriptSyntax[] ScriptPreferencesNonWindows =
         {
             ScriptSyntax.Bash,
             ScriptSyntax.Python,
@@ -20,7 +25,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
             ScriptSyntax.PowerShell
         };
 
-        private static readonly ScriptSyntax[] ScriptPreferencesWindows = new[]
+        static readonly ScriptSyntax[] ScriptPreferencesWindows =
         {
             ScriptSyntax.PowerShell,
             ScriptSyntax.Python,
@@ -29,22 +34,67 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
             ScriptSyntax.Bash
         };
 
+        static IEnumerable<TestCaseData> FSharpDeprecationFeatureToggleTestData()
+        {
+            yield return new TestCaseData(new KeyValuePair<string, string>(),
+                                          false);
+            yield return new TestCaseData(
+                                          new KeyValuePair<string, string>(KnownVariables.EnabledFeatureToggles, ""),
+                                          false);
+            yield return new TestCaseData(
+                                          new KeyValuePair<string, string>(KnownVariables.EnabledFeatureToggles, FeatureToggle.FSharpDeprecationFeatureToggle.ToString()),
+                                          true);
+        }
+
         [Test]
         [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void DeterminesCorrectScriptTypePreferenceOrderWindows()
-            => DeterminesCorrectScriptTypePreferenceOrder(ScriptPreferencesWindows);
+        {
+            DeterminesCorrectScriptTypePreferenceOrder(ScriptPreferencesWindows);
+        }
 
         [Test]
         [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void DeterminesCorrectScriptTypePreferencesOrderNonWindows()
-            => DeterminesCorrectScriptTypePreferenceOrder(ScriptPreferencesNonWindows);
-
-        private void DeterminesCorrectScriptTypePreferenceOrder(IEnumerable<ScriptSyntax> expected)
         {
-            var engine = new ScriptEngine(null);
+            DeterminesCorrectScriptTypePreferenceOrder(ScriptPreferencesNonWindows);
+        }
+
+        void DeterminesCorrectScriptTypePreferenceOrder(IEnumerable<ScriptSyntax> expected)
+        {
+            var engine = new ScriptEngine(new List<IScriptWrapper>(), Substitute.For<ILog>());
             var supportedTypes = engine.GetSupportedTypes();
 
             supportedTypes.Should().Equal(expected);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(FSharpDeprecationFeatureToggleTestData))]
+        public void LogsFSharpDeprecationWarningWhenToggledOn(KeyValuePair<string, string> variableKvp, bool expected)
+        {
+            // Arrange
+            var log = Substitute.For<ILog>();
+            var script = new Script("fakeScript.fsx");
+            var variables = new CalamariVariables
+                { { variableKvp.Key, variableKvp.Value } };
+            var commandResult = new CommandResult("fakeCommand", 0);
+            var commandLineRunner = Substitute.For<ICommandLineRunner>();
+            commandLineRunner.Execute(Arg.Any<CommandLineInvocation>()).Returns(commandResult);
+
+            var engine = new ScriptEngine(new List<IScriptWrapper>(), log);
+
+            // Act
+            engine.Execute(script, variables, commandLineRunner);
+
+            // Assert
+            if (expected)
+            {
+                log.Received(1).Warn(Arg.Is<string>(s => s.StartsWith("Executing FSharp scripts will soon be deprecated")));
+            }
+            else
+            {
+                log.DidNotReceive().Warn(Arg.Any<string>());
+            }
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
-using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.Scripts;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Logging;
-using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing.Helpers;
 using FluentAssertions;
 using NSubstitute;
@@ -34,18 +31,6 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
             ScriptSyntax.Bash
         };
 
-        static IEnumerable<TestCaseData> FSharpDeprecationFeatureToggleTestData()
-        {
-            yield return new TestCaseData(new KeyValuePair<string, string>(),
-                                          false);
-            yield return new TestCaseData(
-                                          new KeyValuePair<string, string>(KnownVariables.EnabledFeatureToggles, ""),
-                                          false);
-            yield return new TestCaseData(
-                                          new KeyValuePair<string, string>(KnownVariables.EnabledFeatureToggles, FeatureToggle.FSharpDeprecationFeatureToggle.ToString()),
-                                          true);
-        }
-
         [Test]
         [Category(TestCategory.CompatibleOS.OnlyWindows)]
         public void DeterminesCorrectScriptTypePreferenceOrderWindows()
@@ -66,35 +51,6 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
             var supportedTypes = engine.GetSupportedTypes();
 
             supportedTypes.Should().Equal(expected);
-        }
-
-        [Test]
-        [TestCaseSource(nameof(FSharpDeprecationFeatureToggleTestData))]
-        public void LogsFSharpDeprecationWarningWhenToggledOn(KeyValuePair<string, string> variableKvp, bool expected)
-        {
-            // Arrange
-            var log = Substitute.For<ILog>();
-            var script = new Script("fakeScript.fsx");
-            var variables = new CalamariVariables
-                { { variableKvp.Key, variableKvp.Value } };
-            var commandResult = new CommandResult("fakeCommand", 0);
-            var commandLineRunner = Substitute.For<ICommandLineRunner>();
-            commandLineRunner.Execute(Arg.Any<CommandLineInvocation>()).Returns(commandResult);
-
-            var engine = new ScriptEngine(new List<IScriptWrapper>(), log);
-
-            // Act
-            engine.Execute(script, variables, commandLineRunner);
-
-            // Assert
-            if (expected)
-            {
-                log.Received(1).Warn(Arg.Is<string>(s => s.StartsWith("Executing FSharp scripts will soon be deprecated")));
-            }
-            else
-            {
-                log.DidNotReceive().Warn(Arg.Any<string>());
-            }
         }
     }
 }

--- a/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
@@ -131,7 +131,7 @@ namespace Calamari.Tests.Java.Fixtures.Deployment
             var commandLineRunner = new CommandLineRunner(log, variables);
             var command = new DeployJavaArchiveCommand(
                 log,
-                new ScriptEngine(Enumerable.Empty<IScriptWrapper>()),
+                new ScriptEngine(Enumerable.Empty<IScriptWrapper>(), log),
                 variables,
                 fileSystem,
                 commandLineRunner,

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -421,7 +421,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 wrappers.Add(new AwsScriptWrapper(log, variables) { VerifyAmazonLogin = () => Task.FromResult(true) });
             }
 
-            var engine = new ScriptEngine(wrappers);
+            var engine = new ScriptEngine(wrappers, log);
             var result = engine.Execute(new Script(scriptName), variables, runner, environmentVariables);
 
             return new CalamariResult(result.ExitCode, new CaptureCommandInvocationOutputSink());


### PR DESCRIPTION
# Background

[sc-66834]

Support for F# scripting is being deprecated in 2024. Warning messages are being added to provide users with some notice before its removal.

# Results
Adds a feature toggled warning message in the task log of F# script executions.
[PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/21945) to add feature toggle

Part of https://github.com/OctopusDeploy/OctopusDeploy/issues/21942

## Before
<img width="1363" alt="Screenshot 2023-12-20 at 3 00 10 pm" src="https://github.com/OctopusDeploy/Calamari/assets/151479559/f9da9b5a-f069-4c37-b3c0-c85928d8fac5">

## After
<img width="1372" alt="Screenshot 2023-12-20 at 3 03 05 pm" src="https://github.com/OctopusDeploy/Calamari/assets/151479559/f65d8b1a-ec84-43d3-a04b-c73528a2a384">