### PR TITLE
Better variable replacement error handling

### DIFF
--- a/source/Calamari.Common/Features/ConfigurationVariables/ConfigurationVariablesReplacer.cs
+++ b/source/Calamari.Common/Features/ConfigurationVariables/ConfigurationVariablesReplacer.cs
@@ -48,8 +48,7 @@ namespace Calamari.Common.Features.ConfigurationVariables
             {
                 if (ignoreVariableReplacementErrors)
                 {
-                    log.Warn(ex.Message);
-                    log.Warn(ex.StackTrace);
+                    log.InfoFormat("Ignoring variable replacement error: {0}", ex.Message);
                 }
                 else
                 {

--- a/source/Calamari.Common/Features/ConfigurationVariables/ConfigurationVariablesReplacer.cs
+++ b/source/Calamari.Common/Features/ConfigurationVariables/ConfigurationVariablesReplacer.cs
@@ -49,6 +49,7 @@ namespace Calamari.Common.Features.ConfigurationVariables
                 if (ignoreVariableReplacementErrors)
                 {
                     log.InfoFormat("Ignoring variable replacement error: {0}", ex.Message);
+                    log.VerboseFormat(ex.StackTrace);
                 }
                 else
                 {

--- a/source/Calamari.Common/Features/ConfigurationVariables/ConfigurationVariablesReplacer.cs
+++ b/source/Calamari.Common/Features/ConfigurationVariables/ConfigurationVariablesReplacer.cs
@@ -49,7 +49,7 @@ namespace Calamari.Common.Features.ConfigurationVariables
                 if (ignoreVariableReplacementErrors)
                 {
                     log.InfoFormat("Ignoring variable replacement error: {0}", ex.Message);
-                    log.VerboseFormat(ex.StackTrace);
+                    log.Verbose(ex.StackTrace);
                 }
                 else
                 {


### PR DESCRIPTION
If `IgnoreVariableReplacementErrors` is set we still log a warning of the exception message and its stacktrace. This can cause confusion in some cases. Logging the error as `INFO` and stacktrace as `VERBOSE` provides the same information in a more friendly way.

[sc-67827]