### PR TITLE
Remove Octopus.Diagnostics dependency

### DIFF
--- a/source/Calamari.Testing/Calamari.Testing.csproj
+++ b/source/Calamari.Testing/Calamari.Testing.csproj
@@ -20,7 +20,6 @@
         <PackageReference Include="Assent" Version="1.6.1" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
         <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     </ItemGroup>
 

--- a/source/Calamari.Testing/CalamariInMemoryTaskLog.cs
+++ b/source/Calamari.Testing/CalamariInMemoryTaskLog.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Octopus.Diagnostics;
 
 namespace Calamari.Testing
 {

--- a/source/Calamari.Testing/LogCategory.cs
+++ b/source/Calamari.Testing/LogCategory.cs
@@ -1,0 +1,17 @@
+namespace Calamari.Testing;
+
+public enum LogCategory
+{
+    Trace,
+    Verbose,
+    Info,
+    Planned,
+    Highlight,
+    Abandoned,
+    Wait,
+    Progress,
+    Finished,
+    Warning,
+    Error,
+    Fatal
+}

--- a/source/Calamari.Testing/LogParser/ScriptOutputFilter.cs
+++ b/source/Calamari.Testing/LogParser/ScriptOutputFilter.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Calamari.Common.Plumbing.ServiceMessages;
-using Octopus.Diagnostics;
 
 namespace Calamari.Testing.LogParser
 {


### PR DESCRIPTION
A warning came up in Calamari because Octopus.Diagnostics is built for 4.6.1 and Calamari is built for 4.6.2.

I noticed that we are only using the LogCategory Enum and also that the Octopus.Diagnostics repo has been archived. It looks like the functionality has been brought into Octopus Server. Because of this, I've copied the enum out and removed the dependency.