### PR TITLE
New Calamari command for the Kubernetes Kustomize step to run as a conventional step (not using step-api)

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperLiveFixtureEks.DeployRawYaml_WithInvalidYaml_OutputShouldIndicateFailure.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperLiveFixtureEks.DeployRawYaml_WithInvalidYaml_OutputShouldIndicateFailure.approved.txt
@@ -1,6 +1,0 @@
-"kubectl apply -o json" returned invalid JSON for Batch #1:
----------------------------
----------------------------
-This can happen with older versions of kubectl. Please update to a recent version of kubectl.
-See https://github.com/kubernetes/kubernetes/issues/58834 for more details.
-Custom resources will not be saved as output variables.

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperLiveFixtureEks.DeployRawYaml_WithMultipleYamlFilesGlobPatterns_YamlFilesAppliedInCorrectBatches.ApplyingBatches.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperLiveFixtureEks.DeployRawYaml_WithMultipleYamlFilesGlobPatterns_YamlFilesAppliedInCorrectBatches.ApplyingBatches.approved.txt
@@ -4,15 +4,9 @@ Matched file: deployments/subfolder/myapp-deployment.yml
 Created Resources:
  - Deployment/nginx-deployment in namespace calamari-testing
  - Deployment/nginx-deployment2 in namespace calamari-testing
-Resource Status Check: 2 new resources have been added:
- - Deployment/nginx-deployment in namespace calamari-testing
- - Deployment/nginx-deployment2 in namespace calamari-testing
 Applying Batch #2 for YAML matching 'services/myapp-service.yml'
 Matched file: services/myapp-service.yml
 Created Resources:
- - Service/nginx-service in namespace calamari-testing
-Resource Status Check: reported 8 updates, 0 removals
-Resource Status Check: 1 new resources have been added:
  - Service/nginx-service in namespace calamari-testing
 Applying Batch #3 for YAML matching 'configmaps/*.yml'
 Matched file: configmaps/myapp-configmap2.yml
@@ -20,7 +14,9 @@ Matched file: configmaps/myapp-configmap1.yml
 Created Resources:
  - ConfigMap/game-demo in namespace calamari-testing
  - ConfigMap/game-demo2 in namespace calamari-testing
-Resource Status Check: reported 10 updates, 0 removals
-Resource Status Check: 2 new resources have been added:
+Resource Status Check: 5 new resources have been added:
+ - Deployment/nginx-deployment in namespace calamari-testing
+ - Deployment/nginx-deployment2 in namespace calamari-testing
+ - Service/nginx-service in namespace calamari-testing
  - ConfigMap/game-demo in namespace calamari-testing
  - ConfigMap/game-demo2 in namespace calamari-testing

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.FeatureToggles;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.ServiceMessages;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes;
+using Calamari.Kubernetes.Commands;
+using Calamari.Kubernetes.Commands.Executors;
+using Calamari.Kubernetes.Integration;
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using Calamari.Testing.Helpers;
+using Calamari.Tests.Fixtures.Integration.FileSystem;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
+{
+    [TestFixture]
+    public class GatherAndApplyRawYamlExecutorTests
+    {
+        readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();
+        InMemoryLog log;
+        ICommandLineRunner commandLineRunner;
+        List<ResourceIdentifier> receivedCallbacks;
+        string tempDirectory;
+
+        string StagingDirectory => Path.Combine(tempDirectory, "staging");
+        string PackageDirectory => Path.Combine(tempDirectory, "staging", KubernetesDeploymentCommandBase.PackageDirectoryName);
+
+        [SetUp]
+        public void Init()
+        {
+            log = new InMemoryLog();
+            receivedCallbacks = new List<ResourceIdentifier>();
+            tempDirectory = fileSystem.CreateTemporaryDirectory();
+            SetupCommandLineRunnerMocks();
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            fileSystem.DeleteDirectory(tempDirectory, FailureOptions.IgnoreFailure);
+        }
+
+        [Test]
+        public async Task NoYamlFileName_DoesNothing()
+        {
+            // Arrange
+            var variables = new CalamariVariables
+            {
+                [KnownVariables.EnabledFeatureToggles] = FeatureToggle.GlobPathsGroupSupportFeatureToggle.ToString()
+            };
+            var runningDeployment = new RunningDeployment(variables);
+            var fileSystem = new TestCalamariPhysicalFileSystem();
+            var executor = CreateExecutor(variables, fileSystem);
+
+            // Act
+            var result = await executor.Execute(runningDeployment, RecordingCallback);
+
+            // Assert
+            result.Should().BeTrue();
+            commandLineRunner.ReceivedCalls().Should().BeEmpty();
+            receivedCallbacks.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task AppliesKubernetesManifestsAndAddsResourceIdentifiers()
+        {
+            // Arrange
+            AddTestFiles();
+            var variables = new CalamariVariables
+            {
+                [KnownVariables.EnabledFeatureToggles] = FeatureToggle.GlobPathsGroupSupportFeatureToggle.ToString(),
+                [KnownVariables.OriginalPackageDirectoryPath] = StagingDirectory,
+                [SpecialVariables.CustomResourceYamlFileName] = "dirA/*\ndirB/*"
+            };
+            var runningDeployment = new RunningDeployment(variables);
+            var executor = CreateExecutor(variables, fileSystem);
+            var expectedYamlGrouping = $"{Path.Combine(StagingDirectory, "grouped", "1")};{Path.Combine(StagingDirectory, "grouped", "2")}";
+
+            // Act
+            var result = await executor.Execute(runningDeployment, RecordingCallback);
+
+            // Assert
+            result.Should().BeTrue();
+            variables.Get(SpecialVariables.GroupedYamlDirectories).Should().Be(expectedYamlGrouping);
+
+            commandLineRunner.ReceivedCalls().Count().Should().Be(4);
+            var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
+            commandLineArgs[0].Should().Contain("apply").And.Contain($"{Path.Combine("grouped", "1")}");
+            commandLineArgs[1].Should().Contain("apply").And.Contain($"{Path.Combine("grouped", "2")}");
+            commandLineArgs[2].Should().Contain("get").And.Contain("basic-deployment");
+            commandLineArgs[3].Should().Contain("get").And.Contain("basic-service");
+
+            receivedCallbacks.Should()
+                             .BeEquivalentTo(new List<ResourceIdentifier>
+                             {
+                                 new ResourceIdentifier("Deployment", "basic-deployment", "dev"), new ResourceIdentifier("Service", "basic-service", "dev")
+                             });
+
+            log.ServiceMessages.Count.Should().Be(2);
+            log.ServiceMessages[0].Name.Should().Be(ServiceMessageNames.SetVariable.Name);
+            log.ServiceMessages[0].Properties.Should().Contain(new KeyValuePair<string, string>("name", "CustomResources(basic-deployment)"));
+            log.ServiceMessages[1].Name.Should().Be(ServiceMessageNames.SetVariable.Name);
+            log.ServiceMessages[1].Properties.Should().Contain(new KeyValuePair<string, string>("name", "CustomResources(basic-service)"));
+        }
+
+        void AddTestFiles()
+        {
+            void CreateTemporaryTestFile(string directory)
+            {
+                if (!Directory.Exists(directory))
+                    Directory.CreateDirectory(directory);
+                var path = Path.Combine(directory, Guid.NewGuid() + ".tmp");
+                using (fileSystem.OpenFile(path, FileMode.OpenOrCreate, FileAccess.Read))
+                {
+                }
+            }
+
+            var dirA = Path.Combine(PackageDirectory, "dirA");
+            var dirB = Path.Combine(PackageDirectory, "dirB");
+            CreateTemporaryTestFile(dirA);
+            CreateTemporaryTestFile(dirB);
+            CreateTemporaryTestFile(dirB);
+        }
+
+        void SetupCommandLineRunnerMocks()
+        {
+            const string deploymentJson = @"{
+                ""kind"": ""Deployment"",
+                ""metadata"": {
+                    ""name"": ""basic-deployment"",
+                    ""namespace"": ""dev""
+                }
+            }";
+
+            const string serviceJson = @"{
+                ""kind"": ""List"",
+                ""items"": [
+                    {
+                        ""kind"": ""Service"",
+                        ""metadata"": {
+                            ""name"": ""basic-service"",
+                            ""namespace"": ""dev""
+                        }
+                    },
+                    {
+                        ""kind"": ""Deployment"",
+                        ""metadata"": {
+                            ""name"": ""basic-deployment"",
+                            ""namespace"": ""dev""
+                        }
+                    },
+                ]
+            }";
+
+            commandLineRunner = Substitute.For<ICommandLineRunner>();
+            commandLineRunner.Execute(Arg.Is<CommandLineInvocation>(invocation => invocation.Arguments.Contains(Path.Combine("grouped", "1"))))
+                             .Returns(info =>
+                                      {
+                                          var invocation = (CommandLineInvocation)info[0];
+                                          invocation.AdditionalInvocationOutputSink?.WriteInfo(deploymentJson);
+                                          return new CommandResult("group 1", 0);
+                                      });
+            commandLineRunner.Execute(Arg.Is<CommandLineInvocation>(invocation => invocation.Arguments.Contains(Path.Combine("grouped", "2"))))
+                             .Returns(info =>
+                                      {
+                                          var invocation = (CommandLineInvocation)info[0];
+                                          invocation.AdditionalInvocationOutputSink?.WriteInfo(serviceJson);
+                                          return new CommandResult("group 2", 0);
+                                      });
+        }
+
+        GatherAndApplyRawYamlExecutor CreateExecutor(IVariables variables, ICalamariFileSystem fs)
+        {
+            var kubectl = new Kubectl(variables, log, commandLineRunner);
+            return new GatherAndApplyRawYamlExecutor(log, fs, kubectl);
+        }
+
+        Task RecordingCallback(ResourceIdentifier[] identifiers)
+        {
+            receivedCallbacks.AddRange(identifiers.ToList());
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
@@ -73,6 +73,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             result.Should().BeTrue();
             commandLineRunner.ReceivedCalls().Should().BeEmpty();
             receivedCallbacks.Should().BeEmpty();
+            log.ServiceMessages.Should().BeEmpty();
         }
 
         [Test]
@@ -140,6 +141,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             result.Should().BeFalse();
             commandLineRunner.ReceivedCalls().Should().NotBeEmpty();
             receivedCallbacks.Should().BeEmpty();
+            log.ServiceMessages.Should().BeEmpty();
         }
         
         void AddTestFiles()
@@ -171,7 +173,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
                 }
             }";
 
-            const string serviceJson = @"{
+            const string serviceAndDeploymentJson = @"{
                 ""kind"": ""List"",
                 ""items"": [
                     {
@@ -201,7 +203,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
                              .Returns(info =>
                                       {
                                           var invocation = (CommandLineInvocation)info[0];
-                                          invocation.AdditionalInvocationOutputSink?.WriteInfo(serviceJson);
+                                          invocation.AdditionalInvocationOutputSink?.WriteInfo(serviceAndDeploymentJson);
                                           return new CommandResult("group 2", 0);
                                       });
         }

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
@@ -100,8 +100,8 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
 
             commandLineRunner.ReceivedCalls().Count().Should().Be(4);
             var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
-            commandLineArgs[0].Should().Contain("apply").And.Contain($"{Path.Combine("grouped", "1")}");
-            commandLineArgs[1].Should().Contain("apply").And.Contain($"{Path.Combine("grouped", "2")}");
+            commandLineArgs[0].Should().Contain("apply -f").And.Contain("--recursive").And.Contain("-o json").And.Contain($"{Path.Combine("grouped", "1")}");
+            commandLineArgs[1].Should().Contain("apply -f").And.Contain("--recursive").And.Contain("-o json").And.Contain($"{Path.Combine("grouped", "2")}");
             commandLineArgs[2].Should().Contain("get").And.Contain("basic-deployment");
             commandLineArgs[3].Should().Contain("get").And.Contain("basic-service");
 
@@ -116,25 +116,6 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             log.ServiceMessages[0].Properties.Should().Contain(new KeyValuePair<string, string>("name", "CustomResources(basic-deployment)"));
             log.ServiceMessages[1].Name.Should().Be(ServiceMessageNames.SetVariable.Name);
             log.ServiceMessages[1].Properties.Should().Contain(new KeyValuePair<string, string>("name", "CustomResources(basic-service)"));
-        }
-
-        void AddTestFiles()
-        {
-            void CreateTemporaryTestFile(string directory)
-            {
-                if (!Directory.Exists(directory))
-                    Directory.CreateDirectory(directory);
-                var path = Path.Combine(directory, Guid.NewGuid() + ".tmp");
-                using (fileSystem.OpenFile(path, FileMode.OpenOrCreate, FileAccess.Read))
-                {
-                }
-            }
-
-            var dirA = Path.Combine(PackageDirectory, "dirA");
-            var dirB = Path.Combine(PackageDirectory, "dirB");
-            CreateTemporaryTestFile(dirA);
-            CreateTemporaryTestFile(dirB);
-            CreateTemporaryTestFile(dirB);
         }
 
         [Test]
@@ -159,6 +140,25 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             result.Should().BeFalse();
             commandLineRunner.ReceivedCalls().Should().NotBeEmpty();
             receivedCallbacks.Should().BeEmpty();
+        }
+        
+        void AddTestFiles()
+        {
+            void CreateTemporaryTestFile(string directory)
+            {
+                if (!Directory.Exists(directory))
+                    Directory.CreateDirectory(directory);
+                var path = Path.Combine(directory, Guid.NewGuid() + ".tmp");
+                using (fileSystem.OpenFile(path, FileMode.OpenOrCreate, FileAccess.Read))
+                {
+                }
+            }
+
+            var dirA = Path.Combine(PackageDirectory, "dirA");
+            var dirB = Path.Combine(PackageDirectory, "dirB");
+            CreateTemporaryTestFile(dirA);
+            CreateTemporaryTestFile(dirB);
+            CreateTemporaryTestFile(dirB);
         }
 
         void SetupCommandLineRunnerMocks()

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
@@ -208,7 +208,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
                                       });
         }
 
-        GatherAndApplyRawYamlExecutor CreateExecutor(IVariables variables, ICalamariFileSystem fs)
+        IRawYamlKubernetesApplyExecutor CreateExecutor(IVariables variables, ICalamariFileSystem fs)
         {
             var kubectl = new Kubectl(variables, log, commandLineRunner);
             return new GatherAndApplyRawYamlExecutor(log, fs, kubectl);

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
@@ -246,7 +246,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
                 }}
             }}";
 
-        KustomizeExecutor CreateExecutor(IVariables variables)
+        IKustomizeKubernetesApplyExecutor CreateExecutor(IVariables variables)
         {
             var kubectl = new Kubectl(variables, log, commandLineRunner);
             return new KustomizeExecutor(log, kubectl);

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
@@ -65,10 +65,11 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             var result = await executor.Execute(runningDeployment, RecordingCallback);
 
             // Assert
-            result.Should().BeTrue();
+            result.Should().BeFalse();
             commandLineRunner.ReceivedCalls().Should().BeEmpty();
             receivedCallbacks.Should().BeEmpty();
             log.ServiceMessages.Should().BeEmpty();
+            log.StandardError[0].Should().Contain("Kustomization directory not specified");
         }
         
         [Test]

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.ServiceMessages;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes;
+using Calamari.Kubernetes.Commands.Executors;
+using Calamari.Kubernetes.Integration;
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using Calamari.Testing.Helpers;
+using Calamari.Tests.Fixtures.Integration.FileSystem;
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.ClearExtensions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
+{
+    [TestFixture]
+    public class KustomizeExecutorTests
+    {
+        const string OverlayPath = "/kustomize-example/overlays/dev/";
+        readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();
+        readonly ICommandLineRunner commandLineRunner = Substitute.For<ICommandLineRunner>();
+
+        InMemoryLog log;
+        List<ResourceIdentifier> receivedCallbacks;
+        string tempDirectory;
+
+        string StagingDirectory => Path.Combine(tempDirectory, "staging");
+
+        [SetUp]
+        public void Init()
+        {
+            log = new InMemoryLog();
+            receivedCallbacks = new List<ResourceIdentifier>();
+            tempDirectory = fileSystem.CreateTemporaryDirectory();
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            fileSystem.DeleteDirectory(tempDirectory, FailureOptions.IgnoreFailure);
+            commandLineRunner.ClearSubstitute();
+        }
+
+        [Test]
+        public async Task NoOverlayPath_DoesNothing()
+        {
+            // Arrange
+            SetupCommandLineRunnerMock();
+            var variables = new CalamariVariables
+            {
+                [KnownVariables.OriginalPackageDirectoryPath] = StagingDirectory
+            };
+            var runningDeployment = new RunningDeployment(variables);
+            var executor = CreateExecutor(variables);
+
+            // Act
+            var result = await executor.Execute(runningDeployment, RecordingCallback);
+
+            // Assert
+            result.Should().BeTrue();
+            commandLineRunner.ReceivedCalls().Should().BeEmpty();
+            receivedCallbacks.Should().BeEmpty();
+            log.ServiceMessages.Should().BeEmpty();
+        }
+        
+        [Test]
+        public async Task InvalidKubectlVersionJson_ReturnsFalseToIndicateFailure()
+        {
+            // Arrange
+            commandLineRunner.Execute(Arg.Is<CommandLineInvocation>(invocation => invocation.Arguments.Contains("version --client")))
+                             .Returns(info =>
+                                      {
+                                          var invocation = (CommandLineInvocation)info[0];
+                                          invocation.AdditionalInvocationOutputSink?.WriteInfo("banana");
+                                          return new CommandResult("kubectl version result", 0);
+                                      });
+            var variables = new CalamariVariables
+            {
+                [KnownVariables.OriginalPackageDirectoryPath] = StagingDirectory,
+                [SpecialVariables.KustomizeOverlayPath] = OverlayPath
+            };
+            var runningDeployment = new RunningDeployment(variables);
+            var executor = CreateExecutor(variables);
+
+            // Act
+            var result = await executor.Execute(runningDeployment, RecordingCallback);
+            
+            // Assert
+            result.Should().BeFalse();
+            commandLineRunner.ReceivedCalls().Count().Should().Be(1);
+            receivedCallbacks.Should().BeEmpty();
+            log.ServiceMessages.Should().BeEmpty();
+            log.StandardError[0].Should().Contain("Could not determine the kubectl version");
+        }
+
+        [Test]
+        [TestCase(0, 0)]
+        [TestCase(0, 24)]
+        [TestCase(1, 23)]
+        public async Task IncompatibleKubectlVersion_ReturnsFalseToIndicateFailure(int major, int minor)
+        {
+            // Arrange
+            commandLineRunner.Execute(Arg.Is<CommandLineInvocation>(invocation => invocation.Arguments.Contains("version --client")))
+                             .Returns(info =>
+                                      {
+                                          var invocation = (CommandLineInvocation)info[0];
+                                          invocation.AdditionalInvocationOutputSink?.WriteInfo(GetVersionJson(major, minor));
+                                          return new CommandResult("kubectl version result", 0);
+                                      });
+            var variables = new CalamariVariables
+            {
+                [KnownVariables.OriginalPackageDirectoryPath] = StagingDirectory,
+                [SpecialVariables.KustomizeOverlayPath] = OverlayPath
+            };
+            var runningDeployment = new RunningDeployment(variables);
+            var executor = CreateExecutor(variables);
+
+            // Act
+            var result = await executor.Execute(runningDeployment, RecordingCallback);
+            
+            // Assert
+            result.Should().BeFalse();
+            commandLineRunner.ReceivedCalls().Count().Should().Be(1);
+            receivedCallbacks.Should().BeEmpty();
+            log.ServiceMessages.Should().BeEmpty();
+            log.StandardError[0].Should().Contain("it needs to be v1.24");
+        }
+
+        [Test]
+        public async Task AppliesKustomizationAndAddsResourceIdentifiers()
+        {
+            // Arrange
+            SetupCommandLineRunnerMock();
+            var variables = new CalamariVariables
+            {
+                [KnownVariables.OriginalPackageDirectoryPath] = StagingDirectory,
+                [SpecialVariables.KustomizeOverlayPath] = OverlayPath
+            };
+            var runningDeployment = new RunningDeployment(variables);
+            var executor = CreateExecutor(variables);
+
+            // Act
+            var result = await executor.Execute(runningDeployment, RecordingCallback);
+
+            // Assert
+            result.Should().BeTrue();
+            commandLineRunner.ReceivedCalls().Count().Should().Be(4);
+            var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
+            commandLineArgs[0].Should().Contain("version").And.Contain("--client").And.Contain("-o json");
+            commandLineArgs[1].Should().Contain("apply -k").And.Contain("-o json").And.Contain(OverlayPath);
+            commandLineArgs[2].Should().Contain("get").And.Contain("basic-service");
+            commandLineArgs[3].Should().Contain("get").And.Contain("basic-deployment");
+            receivedCallbacks.Should()
+                             .BeEquivalentTo(new List<ResourceIdentifier>
+                             {
+                                 new ResourceIdentifier("Deployment", "basic-deployment", "dev"), new ResourceIdentifier("Service", "basic-service", "dev")
+                             });
+            log.ServiceMessages.Count.Should().Be(2);
+            log.ServiceMessages[0].Name.Should().Be(ServiceMessageNames.SetVariable.Name);
+            log.ServiceMessages[0].Properties.Should().Contain(new KeyValuePair<string, string>("name", "CustomResources(basic-service)"));
+            log.ServiceMessages[1].Name.Should().Be(ServiceMessageNames.SetVariable.Name);
+            log.ServiceMessages[1].Properties.Should().Contain(new KeyValuePair<string, string>("name", "CustomResources(basic-deployment)"));
+        }
+        
+        [Test]
+        public async Task CommandLineReturnsNonZeroCode_ReturnsFalseToIndicateFailure()
+        {
+            // Arrange
+            commandLineRunner.Execute(Arg.Any<CommandLineInvocation>()).Returns(new CommandResult("fail whale", 1));
+            var variables = new CalamariVariables
+            {
+                [KnownVariables.OriginalPackageDirectoryPath] = StagingDirectory,
+                [SpecialVariables.KustomizeOverlayPath] = OverlayPath
+            };
+            var runningDeployment = new RunningDeployment(variables);
+            var executor = CreateExecutor(variables);
+            
+            // Act
+            var result = await executor.Execute(runningDeployment, RecordingCallback);
+        
+            // Assert
+            result.Should().BeFalse();
+            commandLineRunner.ReceivedCalls().Should().NotBeEmpty();
+            receivedCallbacks.Should().BeEmpty();
+            log.ServiceMessages.Should().BeEmpty();
+        }
+
+        void SetupCommandLineRunnerMock()
+        {
+            const string resourceJson = @"{
+                ""kind"": ""List"",
+                ""items"": [
+                    {
+                        ""kind"": ""Service"",
+                        ""metadata"": {
+                            ""name"": ""basic-service"",
+                            ""namespace"": ""dev""
+                        }
+                    },
+                    {
+                        ""kind"": ""Deployment"",
+                        ""metadata"": {
+                            ""name"": ""basic-deployment"",
+                            ""namespace"": ""dev""
+                        }
+                    },
+                ]
+            }";
+            
+            
+            commandLineRunner.Execute(Arg.Is<CommandLineInvocation>(invocation => invocation.Arguments.Contains(OverlayPath)))
+                             .Returns(info =>
+                                      {
+                                          var invocation = (CommandLineInvocation)info[0];
+                                          invocation.AdditionalInvocationOutputSink?.WriteInfo(resourceJson);
+                                          return new CommandResult("kustomize result", 0);
+                                      });
+            commandLineRunner.Execute(Arg.Is<CommandLineInvocation>(invocation => invocation.Arguments.Contains("version --client")))
+                             .Returns(info =>
+                                      {
+                                          var invocation = (CommandLineInvocation)info[0];
+                                          invocation.AdditionalInvocationOutputSink?.WriteInfo(GetVersionJson());
+                                          return new CommandResult("kubectl version result", 0);
+                                      });
+        }
+        
+        static string GetVersionJson(int major=1, int minor=28) => $@"{{
+                ""clientVersion"": {{
+                    ""major"": ""{major}"",
+                    ""minor"": ""{minor}"",
+                    ""gitVersion"": ""v{major}.{minor}.4"",
+                    ""gitCommit"": ""bae2c62678db2b5053817bc97181fcc2e8388103"",
+                    ""gitTreeState"": ""clean"",
+                    ""buildDate"": ""2023-11-15T16:48:52Z"",
+                    ""goVersion"": ""go1.20.11"",
+                    ""compiler"": ""gc"",
+                    ""platform"": ""darwin/arm64""
+                }}
+            }}";
+
+        KustomizeExecutor CreateExecutor(IVariables variables)
+        {
+            var kubectl = new Kubectl(variables, log, commandLineRunner);
+            return new KustomizeExecutor(log, kubectl);
+        }
+
+        Task RecordingCallback(ResourceIdentifier[] identifiers)
+        {
+            receivedCallbacks.AddRange(identifiers.ToList());
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/KubernetesApplyRawYamlCommandFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/KubernetesApplyRawYamlCommandFixture.cs
@@ -66,7 +66,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands
                 Substitute.For<IExtractPackage>(),
                 Substitute.For<ISubstituteInFiles>(),
                 Substitute.For<IStructuredConfigVariablesService>(),
-                Substitute.For<IGatherAndApplyRawYamlExecutor>(),
+                Substitute.For<IKubernetesApplyExecutor>(),
                 resourceStatusCheck,
                 kubectl);
         }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -188,49 +188,10 @@ namespace Calamari.Tests.KubernetesFixtures
             var rawLogs = Log.Messages.Select(m => m.FormattedMessage).Where(m => !m.StartsWith("##octopus") && m != string.Empty).ToArray();
 
             var fileName = usePackage ? $"deployments{Path.DirectorySeparatorChar}{DeploymentFileName}" : DeploymentFileName;
-            var initialErrorMessage =
+            var parsingErrorLog =
                 $"error: error parsing {fileName}: error converting YAML to JSON: yaml: line 7: could not find expected ':'";
             rawLogs.Should()
-                   .ContainSingle(l => l == initialErrorMessage);
-            var index = Array.IndexOf(rawLogs, initialErrorMessage);
-            var logsToCompare = new List<string>(rawLogs);
-            // We'll check the rest of the logs after the one above
-            // as they should be the same for all cases (except those
-            // filtered out or adjusted below).
-            logsToCompare.RemoveRange(0, index+1);
-            logsToCompare = logsToCompare.Select(l =>
-                                         {
-                                             // This log line is slightly different in the new command because
-                                             // we apply the yaml in batches (even if there is only one file).
-                                             return l.Replace("\"kubectl apply -o json\" returned invalid JSON:",
-                                                 "\"kubectl apply -o json\" returned invalid JSON for Batch #1:");
-                                         })
-                                         .Select(l =>
-                                         {
-                                             // There was actually no clean-up process for custom resources
-                                             // so the log line produced by the deployment script doesn't
-                                             // make sense. The new command does not have that part of the
-                                             // log line.
-                                             return l.Replace(
-                                                 "Custom resources will not be saved as output variables, and will not be automatically cleaned up.",
-                                                 "Custom resources will not be saved as output variables.");
-                                         })
-                                         .Where(l =>
-                                         {
-                                             // These log lines are in the old deployment script but the script
-                                             // doesn't actually do the things that the logs describe and so they
-                                             // aren't in the new command.
-                                             return l != "The previous custom resources were not removed." &&
-                                                 l != "The deployment process failed. The resources created by this step will be passed to \"kubectl describe\" and logged below.";
-                                         })
-                                         .Where(l =>
-                                             {
-                                               // These logs are printed after an error is caught but only for the new command
-                                               return l != "Adding journal entry:" && !l.StartsWith("<Deployment Id=");
-                                             })
-                                         .ToList();
-
-            this.Assent(string.Join('\n', logsToCompare), configuration: AssentConfiguration.Default);
+                   .ContainSingle(l => l == parsingErrorLog);
         }
 
         [Test]
@@ -287,7 +248,7 @@ namespace Calamari.Tests.KubernetesFixtures
             // to when the last k8s resource is created and compare them in an assent test.
             var startIndex = Array.FindIndex(rawLogs, l => l.StartsWith("Applying Batch #1"));
             var endIndex =
-                Array.FindLastIndex(rawLogs, l => l == "Resource Status Check: 2 new resources have been added:") + 2;
+                Array.FindLastIndex(rawLogs, l => l == "Resource Status Check: 5 new resources have been added:") + 5;
             var assentLogs = rawLogs.Skip(startIndex)
                                     .Take(endIndex + 1 - startIndex)
                                     .Where(l => !l.StartsWith("##octopus")).ToArray();

--- a/source/Calamari/Commands/KubernetesAuthenticationCommand.cs
+++ b/source/Calamari/Commands/KubernetesAuthenticationCommand.cs
@@ -1,4 +1,5 @@
 #if !NET40
+using System;
 using System.Collections.Generic;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
@@ -10,6 +11,7 @@ using Calamari.Kubernetes.Integration;
 
 namespace Calamari.Commands
 {
+    [Obsolete("This command is used exclusively by the Kustomize step package. It should be removed together with \"KustomizeStepMigrationFeatureToggle\" once the step migration has settled.")]
     [Command("authenticate-to-kubernetes")]
     public class KubernetesAuthenticationCommand: Command<KubernetesAuthenticationCommandInput>
     {

--- a/source/Calamari/Commands/KubernetesObjectStatusReporterCommand.cs
+++ b/source/Calamari/Commands/KubernetesObjectStatusReporterCommand.cs
@@ -12,6 +12,7 @@ using Calamari.Kubernetes.ResourceStatus;
 
 namespace Calamari.Commands
 {
+    [Obsolete("This command is used exclusively by the Kustomize step package. It should be removed together with \"KustomizeStepMigrationFeatureToggle\" once the step migration has settled.")]
     [Command("kubernetes-object-status")]
     public class KubernetesObjectStatusReporterCommand : Command<KubernetesObjectStatusReporterCommandInput>
     {

--- a/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
@@ -1,0 +1,168 @@
+#if !NET40
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Extensions;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.ServiceMessages;
+using Calamari.Kubernetes.Integration;
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using Newtonsoft.Json.Linq;
+
+namespace Calamari.Kubernetes.Commands.Executors
+{
+    abstract class BaseKubernetesApplyExecutor : IKubernetesApplyExecutor
+    {
+        readonly ILog log;
+        readonly Kubectl kubectl;
+
+        protected BaseKubernetesApplyExecutor(ILog log, Kubectl kubectl)
+        {
+            this.log = log;
+            this.kubectl = kubectl;
+        }
+     
+        public async Task<bool> Execute(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback)
+        {
+            try
+            {
+                var resourceIdentifiers = ApplyAndGetResourceIdentifiers(deployment).ToArray();
+                if (appliedResourcesCallback != null)
+                {
+                    await appliedResourcesCallback(resourceIdentifiers);
+                }
+                WriteResourcesToOutputVariables(resourceIdentifiers);
+                return true;
+            }
+            catch (KubernetesApplyException)
+            {
+                return false;
+            }
+            catch (Exception e)
+            {
+                log.Error($"Deployment Failed due to exception: {e.Message}");
+                return false;
+            }
+        }
+        
+        protected abstract IEnumerable<ResourceIdentifier> ApplyAndGetResourceIdentifiers(RunningDeployment deployment);
+
+        protected IEnumerable<ResourceIdentifier> ProcessKubectlCommandOutput(CommandResultWithOutput commandResult, string directory)
+        {
+            var directoryWithTrailingSlash = directory + Path.DirectorySeparatorChar;
+
+            foreach (var message in commandResult.Output.Messages)
+            {
+                switch (message.Level)
+                {
+                    case Level.Info:
+                        //No need to log as it's the output json from above.
+                        break;
+                    case Level.Error:
+                        //Files in the error are shown with the full path in their batch directory,
+                        //so we'll remove that for the user.
+                        log.Error(message.Text.Replace($"{directoryWithTrailingSlash}", ""));
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+            
+            if (commandResult.Result.ExitCode != 0)
+            {
+                throw new KubernetesApplyException();
+            }
+            
+            // If it did not error, the output should be valid json.
+            var outputJson = commandResult.Output.InfoLogs.Join(Environment.NewLine);
+            try
+            {
+                var token = JToken.Parse(outputJson);
+
+                List<Resource> lastResources;
+                if (token["kind"]?.ToString() != "List" ||
+                    (lastResources = token["items"]?.ToObject<List<Resource>>()) == null)
+                {
+                    lastResources = new List<Resource> { token.ToObject<Resource>() };
+                }
+
+                var resources = lastResources.Select(r => r.ToResourceIdentifier()).ToList();
+
+                if (resources.Any())
+                {
+                    log.Verbose("Created Resources:");
+                    log.LogResources(resources);
+                }
+
+                return lastResources.Select(r => r.ToResourceIdentifier());
+            }
+            catch
+            {
+                LogParsingError(outputJson);
+            }
+            
+            return Enumerable.Empty<ResourceIdentifier>();
+        }
+
+        void WriteResourcesToOutputVariables(IEnumerable<ResourceIdentifier> resources)
+        {
+            foreach (var resource in resources)
+            {
+                try
+                {
+                    var result = kubectl.ExecuteCommandAndReturnOutput("get", resource.Kind, resource.Name,
+                                                                       "-o", "json");
+
+                    log.WriteServiceMessage(new ServiceMessage(ServiceMessageNames.SetVariable.Name, new Dictionary<string, string>
+                    {
+                        {ServiceMessageNames.SetVariable.NameAttribute, $"CustomResources({resource.Name})"},
+                        {ServiceMessageNames.SetVariable.ValueAttribute, result.Output.InfoLogs.Join("\n")}
+                    }));
+                }
+                catch
+                {
+                    log.Warn(
+                             $"Could not save json for resource to output variable for '{resource.Kind}/{resource.Name}'");
+                }
+            }
+        }
+        
+        void LogParsingError(string outputJson)
+        {
+            log.Error($"\"kubectl apply -o json\" returned invalid JSON:");
+            log.Error("---------------------------");
+            log.Error(outputJson);
+            log.Error("---------------------------");
+            log.Error("This can happen with older versions of kubectl. Please update to a recent version of kubectl.");
+            log.Error("See https://github.com/kubernetes/kubernetes/issues/58834 for more details.");
+            log.Error("Custom resources will not be saved as output variables.");
+
+            throw new KubernetesApplyException();
+        }
+        
+        protected class KubernetesApplyException : Exception
+        {
+        }
+
+        class ResourceMetadata
+        {
+            public string Namespace { get; set; }
+            public string Name { get; set; }
+        }
+
+        class Resource
+        {
+            public string Kind { get; set; }
+            public ResourceMetadata Metadata { get; set; }
+
+            public ResourceIdentifier ToResourceIdentifier()
+            {
+                return new ResourceIdentifier(Kind, Metadata.Name, Metadata.Namespace);
+            }
+        }
+    }
+}
+#endif

--- a/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
@@ -49,8 +49,8 @@ namespace Calamari.Kubernetes.Commands.Executors
         }
         
         protected abstract IEnumerable<ResourceIdentifier> ApplyAndGetResourceIdentifiers(RunningDeployment deployment);
-
-        protected IEnumerable<ResourceIdentifier> ProcessKubectlCommandOutput(CommandResultWithOutput commandResult, string directory)
+        
+        protected void CheckResultForErrors(CommandResultWithOutput commandResult, string directory)
         {
             var directoryWithTrailingSlash = directory + Path.DirectorySeparatorChar;
 
@@ -75,6 +75,11 @@ namespace Calamari.Kubernetes.Commands.Executors
             {
                 throw new KubernetesApplyException();
             }
+        }
+
+        protected IEnumerable<ResourceIdentifier> ProcessKubectlCommandOutput(CommandResultWithOutput commandResult, string directory)
+        {
+            CheckResultForErrors(commandResult, directory);
             
             // If it did not error, the output should be valid json.
             var outputJson = commandResult.Output.InfoLogs.Join(Environment.NewLine);

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -14,7 +14,11 @@ using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Kubernetes.Commands.Executors
 {
-    class GatherAndApplyRawYamlExecutor : BaseKubernetesApplyExecutor
+    public interface IRawYamlKubernetesApplyExecutor : IKubernetesApplyExecutor
+    {
+    }
+    
+    class GatherAndApplyRawYamlExecutor : BaseKubernetesApplyExecutor, IRawYamlKubernetesApplyExecutor
     {
         const string GroupedDirectoryName = "grouped";
 

--- a/source/Calamari/Kubernetes/Commands/Executors/IKubernetesApplyExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/IKubernetesApplyExecutor.cs
@@ -1,0 +1,14 @@
+#if !NET40
+using System;
+using System.Threading.Tasks;
+using Calamari.Common.Commands;
+using Calamari.Kubernetes.ResourceStatus.Resources;
+
+namespace Calamari.Kubernetes.Commands.Executors
+{
+    public interface IKubernetesApplyExecutor
+    {
+        Task<bool> Execute(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback = null);
+    }
+}
+#endif

--- a/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
@@ -1,0 +1,23 @@
+#if !NET40
+using System;
+using System.Collections.Generic;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Kubernetes.Integration;
+using Calamari.Kubernetes.ResourceStatus.Resources;
+
+namespace Calamari.Kubernetes.Commands.Executors
+{
+    class KustomizeExecutor : BaseKubernetesApplyExecutor
+    {
+        public KustomizeExecutor(ILog log, Kubectl kubectl) : base(log, kubectl)
+        {
+        }
+
+        protected override IEnumerable<ResourceIdentifier> ApplyAndGetResourceIdentifiers(RunningDeployment deployment)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+#endif

--- a/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
@@ -36,8 +36,7 @@ namespace Calamari.Kubernetes.Commands.Executors
 
             if (overlayPath == null)
             {
-                log.Warn("Kustomization directory not specified");
-                return Enumerable.Empty<ResourceIdentifier>();
+                throw new KubectlException("Kustomization directory not specified");
             }
 
             ValidateKubectlVersion(deployment.CurrentDirectory);

--- a/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
@@ -12,7 +12,11 @@ using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.Commands.Executors
 {
-    class KustomizeExecutor : BaseKubernetesApplyExecutor
+    public interface IKustomizeKubernetesApplyExecutor : IKubernetesApplyExecutor
+    {
+    }
+    
+    class KustomizeExecutor : BaseKubernetesApplyExecutor, IKustomizeKubernetesApplyExecutor
     {
         const int MinimumKubectlVersionMajor = 1;
         const int MinimumKubectlVersionMinor = 24;

--- a/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
@@ -1,22 +1,87 @@
 #if !NET40
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Kubernetes.Integration;
 using Calamari.Kubernetes.ResourceStatus.Resources;
+using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.Commands.Executors
 {
     class KustomizeExecutor : BaseKubernetesApplyExecutor
     {
+        const int MinimumKubectlVersionMajor = 1;
+        const int MinimumKubectlVersionMinor = 24;
+        readonly ILog log;
+        readonly Kubectl kubectl;
+
         public KustomizeExecutor(ILog log, Kubectl kubectl) : base(log, kubectl)
         {
+            this.log = log;
+            this.kubectl = kubectl;
         }
 
         protected override IEnumerable<ResourceIdentifier> ApplyAndGetResourceIdentifiers(RunningDeployment deployment)
         {
-            throw new NotImplementedException();
+            var variables = deployment.Variables;
+            var overlayPath = variables.Get(SpecialVariables.KustomizeOverlayPath);
+
+            if (overlayPath == null)
+            {
+                log.Warn("Kustomization directory not specified");
+                return Enumerable.Empty<ResourceIdentifier>();
+            }
+
+            ValidateKubectlVersion(deployment.CurrentDirectory);
+
+            var kustomizationDirectory = Path.Combine(deployment.CurrentDirectory, KubernetesDeploymentCommandBase.PackageDirectoryName, overlayPath);
+            var result = kubectl.ExecuteCommandAndReturnOutput("apply", "-k", $@"""{kustomizationDirectory}""", "-o", "json");
+
+            return ProcessKubectlCommandOutput(result, kustomizationDirectory);
+        }
+
+        void ValidateKubectlVersion(string currentDirectory)
+        {
+            var commandResult = kubectl.ExecuteCommandAndReturnOutput("version", "--client", "-o", "json");
+            CheckResultForErrors(commandResult, currentDirectory);
+            var outputJson = commandResult.Output.InfoLogs.Join(Environment.NewLine);
+
+            if (!TryParseVersion(outputJson, out var major, out var minor))
+                throw new KubectlException("Could not determine the kubectl version.");
+
+            if (major < MinimumKubectlVersionMajor || minor < MinimumKubectlVersionMinor)
+                throw new KubectlException($"kubectl is on version v{major}.{minor}, it needs to be v{MinimumKubectlVersionMajor}.{MinimumKubectlVersionMinor} or higher to run Kustomize.");
+        }
+
+        bool TryParseVersion(string kubectlClientVersionJson, out int major, out int minor)
+        {
+            try
+            {
+                var outer = JToken.Parse(kubectlClientVersionJson);
+                major = GetVersion(outer, "clientVersion.major");
+                minor = GetVersion(outer, "clientVersion.minor");
+                return true;
+            }
+            catch
+            {
+                major = -1;
+                minor = -1;
+                return false;
+            }
+        }
+
+        static int GetVersion(JToken root, string jsonPathToVersion)
+        {
+            var clientVersionToken = root.SelectToken($"{jsonPathToVersion}");
+
+            if (clientVersionToken != null && int.TryParse(clientVersionToken.ToString(), out var version))
+                return version;
+
+            return -1;
         }
     }
 }

--- a/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
@@ -31,7 +31,7 @@ namespace Calamari.Kubernetes.Commands
             IExtractPackage extractPackage,
             ISubstituteInFiles substituteInFiles,
             IStructuredConfigVariablesService structuredConfigVariablesService,
-            IKubernetesApplyExecutor kubernetesApplyExecutor,
+            IRawYamlKubernetesApplyExecutor kubernetesApplyExecutor,
             IResourceStatusReportExecutor statusReporter,
             Kubectl kubectl)
             : base(log, deploymentJournalWriter, variables, fileSystem, extractPackage,

--- a/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
@@ -21,7 +21,7 @@ namespace Calamari.Kubernetes.Commands
 
         private readonly IVariables variables;
         private readonly IResourceStatusReportExecutor statusReporter;
-        private readonly IGatherAndApplyRawYamlExecutor gatherAndApplyRawYamlExecutor;
+        private readonly IKubernetesApplyExecutor kubernetesApplyExecutor;
 
         public KubernetesApplyRawYamlCommand(
             ILog log,
@@ -31,7 +31,7 @@ namespace Calamari.Kubernetes.Commands
             IExtractPackage extractPackage,
             ISubstituteInFiles substituteInFiles,
             IStructuredConfigVariablesService structuredConfigVariablesService,
-            IGatherAndApplyRawYamlExecutor gatherAndApplyRawYamlExecutor,
+            IKubernetesApplyExecutor kubernetesApplyExecutor,
             IResourceStatusReportExecutor statusReporter,
             Kubectl kubectl)
             : base(log, deploymentJournalWriter, variables, fileSystem, extractPackage,
@@ -39,14 +39,14 @@ namespace Calamari.Kubernetes.Commands
         {
             this.variables = variables;
             this.statusReporter = statusReporter;
-            this.gatherAndApplyRawYamlExecutor = gatherAndApplyRawYamlExecutor;
+            this.kubernetesApplyExecutor = kubernetesApplyExecutor;
         }
 
         protected override async Task<bool> ExecuteCommand(RunningDeployment runningDeployment)
         {
             if (!variables.GetFlag(SpecialVariables.ResourceStatusCheck))
             {
-                return await gatherAndApplyRawYamlExecutor.Execute(runningDeployment);
+                return await kubernetesApplyExecutor.Execute(runningDeployment);
             }
 
             var timeoutSeconds = variables.GetInt32(SpecialVariables.Timeout) ?? 0;
@@ -54,7 +54,7 @@ namespace Calamari.Kubernetes.Commands
             
             var statusCheck = statusReporter.Start(timeoutSeconds, waitForJobs);
 
-            return await gatherAndApplyRawYamlExecutor.Execute(runningDeployment, statusCheck.AddResources) &&
+            return await kubernetesApplyExecutor.Execute(runningDeployment, statusCheck.AddResources) &&
                 await statusCheck.WaitForCompletionOrTimeout();
         }
     }

--- a/source/Calamari/Kubernetes/Commands/KubernetesKustomizeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesKustomizeCommand.cs
@@ -1,5 +1,6 @@
 #if !NET40
 using System;
+using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.StructuredVariables;
@@ -8,7 +9,9 @@ using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes.Commands.Executors;
 using Calamari.Kubernetes.Integration;
+using Calamari.Kubernetes.ResourceStatus;
 
 namespace Calamari.Kubernetes.Commands
 {
@@ -16,21 +19,47 @@ namespace Calamari.Kubernetes.Commands
     public class KubernetesKustomizeCommand : KubernetesDeploymentCommandBase
     {
         public const string Name = "kubernetes-kustomize";
+        readonly IVariables variables;
+        readonly IKubernetesApplyExecutor kubernetesApplyExecutor;
+        readonly IResourceStatusReportExecutor statusReporter;
 
         public KubernetesKustomizeCommand(
-            ILog log, 
-            IDeploymentJournalWriter deploymentJournalWriter, 
-            IVariables variables, 
+            ILog log,
+            IDeploymentJournalWriter deploymentJournalWriter,
+            IVariables variables,
             ICalamariFileSystem fileSystem,
             IExtractPackage extractPackage,
             ISubstituteInFiles substituteInFiles,
             IStructuredConfigVariablesService structuredConfigVariablesService,
-            Kubectl kubectl) : base(log, deploymentJournalWriter, variables, fileSystem,
+            IKustomizeKubernetesApplyExecutor kubernetesApplyExecutor,
+            IResourceStatusReportExecutor statusReporter,
+            Kubectl kubectl) : base(log,
+                                    deploymentJournalWriter,
+                                    variables,
+                                    fileSystem,
                                     extractPackage,
                                     substituteInFiles,
                                     structuredConfigVariablesService,
                                     kubectl)
         {
+            this.variables = variables;
+            this.kubernetesApplyExecutor = kubernetesApplyExecutor;
+            this.statusReporter = statusReporter;
+        }
+
+        protected override async Task<bool> ExecuteCommand(RunningDeployment runningDeployment)
+        {
+            if (!variables.GetFlag(SpecialVariables.ResourceStatusCheck))
+            {
+                return await kubernetesApplyExecutor.Execute(runningDeployment);
+            }
+
+            var timeoutSeconds = variables.GetInt32(SpecialVariables.Timeout) ?? 0;
+            var waitForJobs = variables.GetFlag(SpecialVariables.WaitForJobs);
+
+            var statusCheck = statusReporter.Start(timeoutSeconds, waitForJobs);
+
+            return await kubernetesApplyExecutor.Execute(runningDeployment, statusCheck.AddResources) && await statusCheck.WaitForCompletionOrTimeout();
         }
     }
 }

--- a/source/Calamari/Kubernetes/Commands/KubernetesKustomizeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesKustomizeCommand.cs
@@ -1,0 +1,37 @@
+#if !NET40
+using System;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Packages;
+using Calamari.Common.Features.StructuredVariables;
+using Calamari.Common.Features.Substitutions;
+using Calamari.Common.Plumbing.Deployment.Journal;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes.Integration;
+
+namespace Calamari.Kubernetes.Commands
+{
+    [Command(Name, Description = "Apply Kubernetes manifests with Kustomize")]
+    public class KubernetesKustomizeCommand : KubernetesDeploymentCommandBase
+    {
+        public const string Name = "kubernetes-kustomize";
+
+        public KubernetesKustomizeCommand(
+            ILog log, 
+            IDeploymentJournalWriter deploymentJournalWriter, 
+            IVariables variables, 
+            ICalamariFileSystem fileSystem,
+            IExtractPackage extractPackage,
+            ISubstituteInFiles substituteInFiles,
+            IStructuredConfigVariablesService structuredConfigVariablesService,
+            Kubectl kubectl) : base(log, deploymentJournalWriter, variables, fileSystem,
+                                    extractPackage,
+                                    substituteInFiles,
+                                    structuredConfigVariablesService,
+                                    kubectl)
+        {
+        }
+    }
+}
+#endif

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -21,6 +21,8 @@ namespace Calamari.Kubernetes
         public const string DeploymentWait = "Octopus.Action.KubernetesContainers.DeploymentWait";
         public const string CustomResourceYamlFileName = "Octopus.Action.KubernetesContainers.CustomResourceYamlFileName";
         public const string GroupedYamlDirectories = "Octopus.Action.KubernetesContainers.YamlDirectories";
+        public const string KustomizeOverlayPath = "Octopus.Action.Kubernetes.Kustomize.OverlayPath";
+        
         public const string Timeout = "Octopus.Action.Kubernetes.DeploymentTimeout";
         public const string WaitForJobs = "Octopus.Action.Kubernetes.WaitForJobs";
         public const string ClientCertificate = "Octopus.Action.Kubernetes.ClientCertificate";

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -75,7 +75,7 @@ namespace Calamari
             builder.RegisterType<ResourceStatusCheckTask>().AsSelf();
             builder.RegisterType<ResourceUpdateReporter>().As<IResourceUpdateReporter>().SingleInstance();
             builder.RegisterType<ResourceStatusReportExecutor>().As<IResourceStatusReportExecutor>();
-            builder.RegisterType<GatherAndApplyRawYamlExecutor>().As<IGatherAndApplyRawYamlExecutor>();
+            builder.RegisterType<GatherAndApplyRawYamlExecutor>().As<IKubernetesApplyExecutor>();
             builder.RegisterType<Timer>().As<ITimer>();
 #endif
             builder.RegisterType<Kubectl>().AsSelf().As<IKubectl>().InstancePerLifetimeScope();

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -75,7 +75,8 @@ namespace Calamari
             builder.RegisterType<ResourceStatusCheckTask>().AsSelf();
             builder.RegisterType<ResourceUpdateReporter>().As<IResourceUpdateReporter>().SingleInstance();
             builder.RegisterType<ResourceStatusReportExecutor>().As<IResourceStatusReportExecutor>();
-            builder.RegisterType<GatherAndApplyRawYamlExecutor>().As<IKubernetesApplyExecutor>();
+            builder.RegisterType<GatherAndApplyRawYamlExecutor>().As<IRawYamlKubernetesApplyExecutor>();
+            builder.RegisterType<KustomizeExecutor>().As<IKustomizeKubernetesApplyExecutor>();
             builder.RegisterType<Timer>().As<ITimer>();
 #endif
             builder.RegisterType<Kubectl>().AsSelf().As<IKubectl>().InstancePerLifetimeScope();


### PR DESCRIPTION
# Background

We are migrating the Kustomize action from the step api to a conventional step - more details can be found in this [doc](https://docs.google.com/document/d/1s_b-I-1Tlcu3HmZMyfgORW5tALHPeFLys6T6RymfBAI/edit#heading=h.zdkbl0q6yra6)

[sc-68738]

# Related PRs
[Add action handler in Server](https://github.com/OctopusDeploy/OctopusDeploy/pull/22498)
[UI changes](https://github.com/OctopusDeploy/OctopusDeploy/pull/22446)