### PR TITLE
Remove journalling for Kubernetes steps

### DIFF
--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -79,17 +79,8 @@ namespace Calamari.Kubernetes.Commands
             var deployment = new RunningDeployment(pathToPackage, variables);
 
             var conventionRunner = new ConventionProcessor(deployment, conventions, log);
-            try
-            {
-                conventionRunner.RunConventions();
-                deploymentJournalWriter.AddJournalEntry(deployment, true, pathToPackage);
-            }
-            catch (Exception)
-            {
-                deploymentJournalWriter.AddJournalEntry(deployment, false, pathToPackage);
-                throw;
-            }
-
+            conventionRunner.RunConventions();
+            
             return 0;
         }
 

--- a/source/Calamari/Kubernetes/Commands/KubernetesDeploymentCommandBase.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesDeploymentCommandBase.cs
@@ -127,18 +127,9 @@ namespace Calamari.Kubernetes.Commands
             var runningDeployment = new RunningDeployment(pathToPackage, variables);
 
             var conventionRunner = new ConventionProcessor(runningDeployment, conventions, log);
-            try
-            {
-                conventionRunner.RunConventions(logExceptions: false);
-                var result = ExecuteCommand(runningDeployment).GetAwaiter().GetResult();
-                deploymentJournalWriter.AddJournalEntry(runningDeployment, result, pathToPackage);
-                return result ? 0 : -1;
-            }
-            catch (Exception)
-            {
-                deploymentJournalWriter.AddJournalEntry(runningDeployment, false, pathToPackage);
-                throw;
-            }
+            conventionRunner.RunConventions(logExceptions: false);
+            var result = ExecuteCommand(runningDeployment).GetAwaiter().GetResult();
+            return result ? 0 : -1;
         }
     }
 }


### PR DESCRIPTION
[sc-70260]

Kubernetes steps don't need to keep a journal, since the journal is intended for long-lived extracted files that are used externally AFTER deployment has completed.