### PR TITLE
Add Helm OCI Registry support

### DIFF
--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -60,7 +60,7 @@ namespace Calamari.Kubernetes.Commands
         {
               Options.Parse(commandLineArguments);
 
-            if (!File.Exists(pathToPackage))
+            if (variables.Get(ScriptVariables.ScriptSource) != SpecialVariables.Helm.ScriptSource.OciRegistry && !File.Exists(pathToPackage))
                 throw new CommandException("Could not find package file: " + pathToPackage);
 
             var conventions = new List<IConvention>

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -294,6 +294,11 @@ namespace Calamari.Kubernetes.Conventions
 
         string GetChartLocation(RunningDeployment deployment)
         {
+            if (deployment.Variables.Get(ScriptVariables.ScriptSource) == SpecialVariables.Helm.ScriptSource.OciRegistry)
+            {
+                return deployment.Variables.Get(SpecialVariables.Helm.OciRegistry);
+            }
+
             var installDir = deployment.Variables.Get(PackageVariables.Output.InstallationDirectoryPath);
 
             var chartDirectoryVariable = deployment.Variables.Get(SpecialVariables.Helm.ChartDirectory);

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -55,9 +55,9 @@ namespace Calamari.Kubernetes
 
             public static class ScriptSource
             {
-                public const string OciRegistry = nameof(OciRegistry);
-                public const string Package = nameof(Package);
-                public const string GitRepository = nameof(GitRepository);
+                public const string OciRegistry = "OciRegistry";
+                public const string Package = "Package";
+                public const string GitRepository = "GitRepository";
             }
 
             public static class Packages

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -51,6 +51,14 @@ namespace Calamari.Kubernetes
             public const string TillerNamespace = "Octopus.Action.Helm.TillerNamespace";
             public const string TillerTimeout = "Octopus.Action.Helm.TillerTimeout";
             public const string ChartDirectory = "Octopus.Action.Helm.ChartDirectory";
+            public const string OciRegistry = "Octopus.Action.Helm.OciRegistry";
+
+            public static class ScriptSource
+            {
+                public const string OciRegistry = nameof(OciRegistry);
+                public const string Package = nameof(Package);
+                public const string GitRepository = nameof(GitRepository);
+            }
 
             public static class Packages
             {


### PR DESCRIPTION
# Background

I'm using the OCI Registry for the automatic/server driven upgrades of the Kubernetes Agent.

# Results

It's actually pretty easy to add, as we just need to adjust one part of the helm command.