### PR TITLE
Send null instead of empty string when there is no service password

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.WindowsService_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.WindowsService_BeforePostDeploy.ps1
@@ -148,6 +148,9 @@ else
 if ($serviceAccount -eq "_CUSTOM") {
 	# dont use sc.exe to set the username / password, as it may be logged to the windows audit log if process creation event logs are enabled 
 	$wmiService = Get-WmiObject win32_service -filter "name='$($serviceName -replace "'", "\'")'" -computer "."
+	if ($customAccountPassword -eq "") {
+        $customAccountPassword = $null
+    }
 	$result = $wmiService.change($null, $null, $null, $null, $null, $null, $customAccountName, $customAccountPassword, $null, $null, $null)
 	if ($result.ReturnValue -ne "0") {
 		#return codes: https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/change-method-in-class-win32-service#return-value


### PR DESCRIPTION
Relates to https://github.com/OctopusDeploy/Issues/issues/8676