### PR TITLE
Add Calamari variable to print Kubectl output on parsing error

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Kubernetes.Integration;
 using Calamari.Kubernetes.ResourceStatus;
 using Calamari.Kubernetes.ResourceStatus.Resources;
 using FluentAssertions;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
@@ -43,7 +45,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                 .Build();
 
             var kubectlGet = new MockKubectlGet();
-            var resourceRetriever = new ResourceRetriever(kubectlGet);
+            var resourceRetriever = new ResourceRetriever(kubectlGet, Substitute.For<ILog>());
 
             kubectlGet.SetResource("nginx", nginxDeployment);
             kubectlGet.SetAllResources("ReplicaSet", nginxReplicaSet);
@@ -111,7 +113,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                 .Build();
 
             var kubectlGet = new MockKubectlGet();
-            var resourceRetriever = new ResourceRetriever(kubectlGet);
+            var resourceRetriever = new ResourceRetriever(kubectlGet, Substitute.For<ILog>());
 
             kubectlGet.SetResource("deployment-1", deployment1);
             kubectlGet.SetResource("deployment-2", deployment2);
@@ -180,7 +182,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                 .Build();
 
             var kubectlGet = new MockKubectlGet();
-            var resourceRetriever = new ResourceRetriever(kubectlGet);
+            var resourceRetriever = new ResourceRetriever(kubectlGet, Substitute.For<ILog>());
 
             kubectlGet.SetResource("rs", replicaSet);
             kubectlGet.SetAllResources("Pod", childPod, irrelevantPod);

--- a/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
@@ -140,6 +140,10 @@ namespace Calamari.Kubernetes.Commands.Executors
                 log.Verbose(outputJson);
                 log.Verbose("---------------------------");
             }
+            else
+            {
+                log.Verbose($"To get Octopus to print out the JSON string retrieved from kubectl, set Octopus Variable '{SpecialVariables.PrintVerboseKubectlOutputOnError}' to 'true'");
+            }
             log.Error("This can happen with older versions of kubectl. Please update to a recent version of kubectl.");
             log.Error("See https://github.com/kubernetes/kubernetes/issues/58834 for more details.");
             log.Error("Custom resources will not be saved as output variables.");

--- a/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
@@ -142,7 +142,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             }
             else
             {
-                log.Verbose($"To get Octopus to print out the JSON string retrieved from kubectl, set Octopus Variable '{SpecialVariables.PrintVerboseKubectlOutputOnError}' to 'true'");
+                log.Verbose($"To get Octopus to log out the JSON string retrieved from kubectl, set Octopus Variable '{SpecialVariables.PrintVerboseKubectlOutputOnError}' to 'true'");
             }
             log.Error("This can happen with older versions of kubectl. Please update to a recent version of kubectl.");
             log.Error("See https://github.com/kubernetes/kubernetes/issues/58834 for more details.");

--- a/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
@@ -98,14 +98,14 @@ namespace Calamari.Kubernetes.Commands.Executors
                     log.LogResources(resources);
                 }
 
-                return lastResources.Select(r => r.ToResourceIdentifier());
+                return resources;
             }
             catch
             {
                 LogParsingError(outputJson, deployment.Variables.GetFlag(SpecialVariables.PrintVerboseKubectlOutputOnError));
+
+                throw new KubernetesApplyException();
             }
-            
-            return Enumerable.Empty<ResourceIdentifier>();
         }
 
         void WriteResourcesToOutputVariables(IEnumerable<ResourceIdentifier> resources)
@@ -136,19 +136,17 @@ namespace Calamari.Kubernetes.Commands.Executors
             log.Error($"\"kubectl apply -o json\" returned invalid JSON");
             if (logKubectlOutputOnError)
             {
-                log.Verbose("---------------------------");
-                log.Verbose(outputJson);
-                log.Verbose("---------------------------");
+                log.Error("---------------------------");
+                log.Error(outputJson);
+                log.Error("---------------------------");
             }
             else
             {
-                log.Verbose($"To get Octopus to log out the JSON string retrieved from kubectl, set Octopus Variable '{SpecialVariables.PrintVerboseKubectlOutputOnError}' to 'true'");
+                log.Error($"To get Octopus to log out the JSON string retrieved from kubectl, set Octopus Variable '{SpecialVariables.PrintVerboseKubectlOutputOnError}' to 'true'");
             }
             log.Error("This can happen with older versions of kubectl. Please update to a recent version of kubectl.");
             log.Error("See https://github.com/kubernetes/kubernetes/issues/58834 for more details.");
             log.Error("Custom resources will not be saved as output variables.");
-
-            throw new KubernetesApplyException();
         }
         
         protected class KubernetesApplyException : Exception

--- a/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
@@ -73,7 +73,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             }
         }
 
-        protected IEnumerable<ResourceIdentifier> ProcessKubectlCommandOutput(CommandResultWithOutput commandResult, string directory)
+        protected IEnumerable<ResourceIdentifier> ProcessKubectlCommandOutput(RunningDeployment deployment, CommandResultWithOutput commandResult, string directory)
         {
             CheckResultForErrors(commandResult, directory);
             
@@ -102,7 +102,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             }
             catch
             {
-                LogParsingError(outputJson);
+                LogParsingError(outputJson, deployment.Variables.GetFlag(SpecialVariables.PrintVerboseKubectlOutputOnError));
             }
             
             return Enumerable.Empty<ResourceIdentifier>();
@@ -131,12 +131,15 @@ namespace Calamari.Kubernetes.Commands.Executors
             }
         }
         
-        void LogParsingError(string outputJson)
+        void LogParsingError(string outputJson, bool logKubectlOutputOnError)
         {
-            log.Error($"\"kubectl apply -o json\" returned invalid JSON:");
-            log.Error("---------------------------");
-            log.Error(outputJson);
-            log.Error("---------------------------");
+            log.Error($"\"kubectl apply -o json\" returned invalid JSON");
+            if (logKubectlOutputOnError)
+            {
+                log.Verbose("---------------------------");
+                log.Verbose(outputJson);
+                log.Verbose("---------------------------");
+            }
             log.Error("This can happen with older versions of kubectl. Please update to a recent version of kubectl.");
             log.Error("See https://github.com/kubernetes/kubernetes/issues/58834 for more details.");
             log.Error("Custom resources will not be saved as output variables.");

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -50,7 +50,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             var resourcesIdentifiers = new HashSet<ResourceIdentifier>();
             foreach (var directory in directories)
             {
-                var res = ApplyBatchAndReturnResourceIdentifiers(directory).ToArray();
+                var res = ApplyBatchAndReturnResourceIdentifiers(deployment, directory).ToArray();
 
                 if (appliedResourcesCallback != null)
                 {
@@ -100,7 +100,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             return directories;
         }
 
-        IEnumerable<ResourceIdentifier> ApplyBatchAndReturnResourceIdentifiers(GlobDirectory globDirectory)
+        IEnumerable<ResourceIdentifier> ApplyBatchAndReturnResourceIdentifiers(RunningDeployment deployment, GlobDirectory globDirectory)
         {
             var index = globDirectory.Index;
             var directoryWithTrailingSlash = globDirectory.Directory + Path.DirectorySeparatorChar;
@@ -120,7 +120,7 @@ namespace Calamari.Kubernetes.Commands.Executors
 
             var result = kubectl.ExecuteCommandAndReturnOutput("apply", "-f", $@"""{globDirectory.Directory}""", "--recursive", "-o", "json");
 
-            return ProcessKubectlCommandOutput(result, globDirectory.Directory);
+            return ProcessKubectlCommandOutput(deployment, result, globDirectory.Directory);
         }
 
         private class GlobDirectory

--- a/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
@@ -45,7 +45,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             var kustomizationDirectory = Path.Combine(deployment.CurrentDirectory, KubernetesDeploymentCommandBase.PackageDirectoryName, overlayPath);
             var result = kubectl.ExecuteCommandAndReturnOutput("apply", "-k", $@"""{kustomizationDirectory}""", "-o", "json");
 
-            var resourceIdentifiers =  ProcessKubectlCommandOutput(result, kustomizationDirectory).ToArray();
+            return ProcessKubectlCommandOutput(deployment, result, kustomizationDirectory);
             
             if (appliedResourcesCallback != null)
             {

--- a/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
@@ -45,7 +45,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             var kustomizationDirectory = Path.Combine(deployment.CurrentDirectory, KubernetesDeploymentCommandBase.PackageDirectoryName, overlayPath);
             var result = kubectl.ExecuteCommandAndReturnOutput("apply", "-k", $@"""{kustomizationDirectory}""", "-o", "json");
 
-            return ProcessKubectlCommandOutput(deployment, result, kustomizationDirectory);
+            var resourceIdentifiers = ProcessKubectlCommandOutput(deployment, result, kustomizationDirectory).ToArray();
             
             if (appliedResourcesCallback != null)
             {

--- a/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Kubernetes.Integration;
@@ -18,7 +17,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
                 "get", kind, name, "-o json", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
-            }).Output.InfoLogs.Join(Environment.NewLine);
+            }).Output.InfoLogs.Join(string.Empty);
         }
 
         public string AllResources(string kind, string @namespace, IKubectl kubectl)
@@ -26,7 +25,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
                 "get", kind, "-o json", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
-            }).Output.InfoLogs.Join(Environment.NewLine);
+            }).Output.InfoLogs.Join(string.Empty);
         }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Kubernetes.Integration;
@@ -17,7 +18,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
                 "get", kind, name, "-o json", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
-            }).Output.InfoLogs.Join(string.Empty);
+            }).Output.InfoLogs.Join(Environment.NewLine);
         }
 
         public string AllResources(string kind, string @namespace, IKubectl kubectl)
@@ -25,7 +26,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
                 "get", kind, "-o json", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
-            }).Output.InfoLogs.Join(string.Empty);
+            }).Output.InfoLogs.Join(Environment.NewLine);
         }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/Options.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Options.cs
@@ -10,5 +10,7 @@ namespace Calamari.Kubernetes.ResourceStatus
         /// Otherwise Jobs are always treated as being successful once created.
         /// </summary>
         public bool WaitForJobs { get; set; }
+
+        public bool PrintVerboseKubectlOutputOnError { get; set; }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
@@ -82,11 +82,14 @@ namespace Calamari.Kubernetes.ResourceStatus
             {
                 if (options.PrintVerboseKubectlOutputOnError)
                 {
-                    log.Verbose($"Failed to parse JSON: \n----------\n{jsonString}\n----------");
+                    log.Verbose("Failed to parse JSON:");
+                    log.Verbose("---------------------------");
+                    log.Verbose(jsonString);
+                    log.Verbose("---------------------------");
                 }
                 else
                 {
-                    log.Verbose($"Failed to parse JSON, to get Octopus to print out the JSON string retrieved from kubectl, set Octopus Variable '{SpecialVariables.PrintVerboseKubectlOutputOnError}' to 'true'");
+                    log.Verbose($"Failed to parse JSON, to get Octopus to log out the JSON string retrieved from kubectl, set Octopus Variable '{SpecialVariables.PrintVerboseKubectlOutputOnError}' to 'true'");
                 }
                 throw;
             }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
@@ -84,6 +84,10 @@ namespace Calamari.Kubernetes.ResourceStatus
                 {
                     log.Verbose($"Failed to parse JSON: \n----------\n{jsonString}\n----------");
                 }
+                else
+                {
+                    log.Verbose($"Failed to parse JSON, to get Octopus to print out the JSON string retrieved from kubectl, set Octopus Variable '{SpecialVariables.PrintVerboseKubectlOutputOnError}' to 'true'");
+                }
                 throw;
             }
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
@@ -80,18 +80,23 @@ namespace Calamari.Kubernetes.ResourceStatus
             }
             catch (JsonException)
             {
-                if (options.PrintVerboseKubectlOutputOnError)
-                {
-                    log.Verbose("Failed to parse JSON:");
-                    log.Verbose("---------------------------");
-                    log.Verbose(jsonString);
-                    log.Verbose("---------------------------");
-                }
-                else
-                {
-                    log.Verbose($"Failed to parse JSON, to get Octopus to log out the JSON string retrieved from kubectl, set Octopus Variable '{SpecialVariables.PrintVerboseKubectlOutputOnError}' to 'true'");
-                }
+                LogJsonStringError(jsonString, options);
                 throw;
+            }
+        }
+
+        void LogJsonStringError(string jsonString, Options options)
+        {
+            if (options.PrintVerboseKubectlOutputOnError)
+            {
+                log.Error("Failed to parse JSON:");
+                log.Error("---------------------------");
+                log.Error(jsonString);
+                log.Error("---------------------------");
+            }
+            else
+            {
+                log.Error($"Failed to parse JSON, to get Octopus to log out the JSON string retrieved from kubectl, set Octopus Variable '{SpecialVariables.PrintVerboseKubectlOutputOnError}' to 'true'");
             }
         }
     }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
@@ -34,7 +34,7 @@ namespace Calamari.Kubernetes.ResourceStatus
                 ? Timeout.InfiniteTimeSpan
                 : TimeSpan.FromSeconds(timeoutSeconds);
 
-            return runningResourceStatusCheckFactory(timeout, new Options {  WaitForJobs = waitForJobs}, initialResources);
+            return runningResourceStatusCheckFactory(timeout, new Options {  WaitForJobs = waitForJobs, PrintVerboseKubectlOutputOnError = variables.GetFlag(SpecialVariables.PrintVerboseKubectlOutputOnError)}, initialResources);
         }
     }
 }

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -25,6 +25,7 @@ namespace Calamari.Kubernetes
         
         public const string Timeout = "Octopus.Action.Kubernetes.DeploymentTimeout";
         public const string WaitForJobs = "Octopus.Action.Kubernetes.WaitForJobs";
+        public const string PrintVerboseKubectlOutputOnError = "Octopus.Action.Kubernetes.PrintVerboseKubectlOutputOnError";  
         public const string ClientCertificate = "Octopus.Action.Kubernetes.ClientCertificate";
         public const string CertificateAuthorityPath = "Octopus.Action.Kubernetes.CertificateAuthorityPath";
         public const string PodServiceAccountTokenPath = "Octopus.Action.Kubernetes.PodServiceAccountTokenPath";


### PR DESCRIPTION
Adding a variable to Calamari to allow customers to turn on verbose logging of kubectl output in case it fails to parse the yaml.

This will hopefully help us to diagnose this issue: https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1710389143225389