### PR TITLE
Add Kubernetes resources to monitor as soon as the each batch of yaml is applied

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperLiveFixtureEks.DeployRawYaml_WithMultipleYamlFilesGlobPatterns_YamlFilesAppliedInCorrectBatches.ApplyingBatches.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperLiveFixtureEks.DeployRawYaml_WithMultipleYamlFilesGlobPatterns_YamlFilesAppliedInCorrectBatches.ApplyingBatches.approved.txt
@@ -4,9 +4,15 @@ Matched file: deployments/subfolder/myapp-deployment.yml
 Created Resources:
  - Deployment/nginx-deployment in namespace calamari-testing
  - Deployment/nginx-deployment2 in namespace calamari-testing
+Resource Status Check: 2 new resources have been added:
+ - Deployment/nginx-deployment in namespace calamari-testing
+ - Deployment/nginx-deployment2 in namespace calamari-testing
 Applying Batch #2 for YAML matching 'services/myapp-service.yml'
 Matched file: services/myapp-service.yml
 Created Resources:
+ - Service/nginx-service in namespace calamari-testing
+Resource Status Check: reported 8 updates, 0 removals
+Resource Status Check: 1 new resources have been added:
  - Service/nginx-service in namespace calamari-testing
 Applying Batch #3 for YAML matching 'configmaps/*.yml'
 Matched file: configmaps/myapp-configmap2.yml
@@ -14,9 +20,7 @@ Matched file: configmaps/myapp-configmap1.yml
 Created Resources:
  - ConfigMap/game-demo in namespace calamari-testing
  - ConfigMap/game-demo2 in namespace calamari-testing
-Resource Status Check: 5 new resources have been added:
- - Deployment/nginx-deployment in namespace calamari-testing
- - Deployment/nginx-deployment2 in namespace calamari-testing
- - Service/nginx-service in namespace calamari-testing
+Resource Status Check: reported 10 updates, 0 removals
+Resource Status Check: 2 new resources have been added:
  - ConfigMap/game-demo in namespace calamari-testing
  - ConfigMap/game-demo2 in namespace calamari-testing

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
@@ -60,7 +60,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             var variables = new CalamariVariables
             {
                 [KnownVariables.EnabledFeatureToggles] = FeatureToggle.GlobPathsGroupSupportFeatureToggle.ToString(),
-                [KnownVariables.OriginalPackageDirectoryPath] = StagingDirectory,
+                [KnownVariables.OriginalPackageDirectoryPath] = StagingDirectory
             };
             var runningDeployment = new RunningDeployment(variables);
             var fileSystem = new TestCalamariPhysicalFileSystem();
@@ -109,7 +109,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             receivedCallbacks.Should()
                              .BeEquivalentTo(new List<ResourceIdentifier>
                              {
-                                 new ResourceIdentifier("Deployment", "basic-deployment", "dev"), new ResourceIdentifier("Service", "basic-service", "dev")
+                                 new ResourceIdentifier("Deployment", "basic-deployment", "dev"), new ResourceIdentifier("Service", "basic-service", "dev"), new ResourceIdentifier("Deployment", "basic-deployment", "dev")
                              });
 
             log.ServiceMessages.Count.Should().Be(2);
@@ -133,7 +133,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             };
             var runningDeployment = new RunningDeployment(variables);
             var executor = CreateExecutor(variables, fileSystem);
-            
+
             // Act
             var result = await executor.Execute(runningDeployment, RecordingCallback);
 
@@ -143,7 +143,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             receivedCallbacks.Should().BeEmpty();
             log.ServiceMessages.Should().BeEmpty();
         }
-        
+
         void AddTestFiles()
         {
             void CreateTemporaryTestFile(string directory)

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -248,7 +248,7 @@ namespace Calamari.Tests.KubernetesFixtures
             // to when the last k8s resource is created and compare them in an assent test.
             var startIndex = Array.FindIndex(rawLogs, l => l.StartsWith("Applying Batch #1"));
             var endIndex =
-                Array.FindLastIndex(rawLogs, l => l == "Resource Status Check: 5 new resources have been added:") + 5;
+                Array.FindLastIndex(rawLogs, l => l == "Resource Status Check: 2 new resources have been added:") + 2;
             var assentLogs = rawLogs.Skip(startIndex)
                                     .Take(endIndex + 1 - startIndex)
                                     .Where(l => !l.StartsWith("##octopus")).ToArray();

--- a/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
@@ -25,15 +25,11 @@ namespace Calamari.Kubernetes.Commands.Executors
             this.kubectl = kubectl;
         }
      
-        public async Task<bool> Execute(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback)
+        public async Task<bool> Execute(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback = null)
         {
             try
             {
-                var resourceIdentifiers = ApplyAndGetResourceIdentifiers(deployment).ToArray();
-                if (appliedResourcesCallback != null)
-                {
-                    await appliedResourcesCallback(resourceIdentifiers);
-                }
+                var resourceIdentifiers = await ApplyAndGetResourceIdentifiers(deployment, appliedResourcesCallback);
                 WriteResourcesToOutputVariables(resourceIdentifiers);
                 return true;
             }
@@ -48,7 +44,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             }
         }
         
-        protected abstract IEnumerable<ResourceIdentifier> ApplyAndGetResourceIdentifiers(RunningDeployment deployment);
+        protected abstract Task<IEnumerable<ResourceIdentifier>> ApplyAndGetResourceIdentifiers(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback = null);
         
         protected void CheckResultForErrors(CommandResultWithOutput commandResult, string directory)
         {

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -50,11 +50,11 @@ namespace Calamari.Kubernetes.Commands.Executors
             var resourcesIdentifiers = new HashSet<ResourceIdentifier>();
             foreach (var directory in directories)
             {
-                var res = ApplyBatchAndReturnResourceIdentifiers(directory).ToList();
+                var res = ApplyBatchAndReturnResourceIdentifiers(directory).ToArray();
 
                 if (appliedResourcesCallback != null)
                 {
-                    await appliedResourcesCallback(res.ToArray());
+                    await appliedResourcesCallback(res);
                 }
                 
                 resourcesIdentifiers.UnionWith(res);

--- a/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
@@ -29,7 +30,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             this.kubectl = kubectl;
         }
 
-        protected override IEnumerable<ResourceIdentifier> ApplyAndGetResourceIdentifiers(RunningDeployment deployment)
+        protected override async Task<IEnumerable<ResourceIdentifier>> ApplyAndGetResourceIdentifiers(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback = null)
         {
             var variables = deployment.Variables;
             var overlayPath = variables.Get(SpecialVariables.KustomizeOverlayPath);
@@ -44,7 +45,14 @@ namespace Calamari.Kubernetes.Commands.Executors
             var kustomizationDirectory = Path.Combine(deployment.CurrentDirectory, KubernetesDeploymentCommandBase.PackageDirectoryName, overlayPath);
             var result = kubectl.ExecuteCommandAndReturnOutput("apply", "-k", $@"""{kustomizationDirectory}""", "-o", "json");
 
-            return ProcessKubectlCommandOutput(result, kustomizationDirectory);
+            var resourceIdentifiers =  ProcessKubectlCommandOutput(result, kustomizationDirectory).ToArray();
+            
+            if (appliedResourcesCallback != null)
+            {
+                await appliedResourcesCallback(resourceIdentifiers);
+            }
+
+            return resourceIdentifiers;
         }
 
         void ValidateKubectlVersion(string currentDirectory)


### PR DESCRIPTION
## Background
This PR puts back the improvement that was originally added to improve the response time of the KOS feature when there are many and/or large batches of YAML that need to be applied. Instead of waiting for all batches to complete before starting the monitoring, the callback is called after every batch operation in the case of `GatherAndApplyRawYamlExecutor` such that it starts getting object statuses sooner.