### PR TITLE
Allow kubectl server side apply

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
@@ -152,7 +152,8 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
                 .And.Contain("-o json")
                 .And.Contain($"{Path.Combine("grouped", "1")}")
                 .And.Contain("--server-side")
-                .And.Contain("--field-manager octopus");
+                .And.Contain("--field-manager octopus")
+                .And.NotContain("--force-conflicts");
             commandLineArgs[1]
                 .Should()
                 .Contain("apply -f")
@@ -160,7 +161,8 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
                 .And.Contain("-o json")
                 .And.Contain($"{Path.Combine("grouped", "2")}")
                 .And.Contain("--server-side")
-                .And.Contain("--field-manager octopus");
+                .And.Contain("--field-manager octopus")
+                .And.NotContain("--force-conflicts");
         }
 
         [Test]

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
@@ -198,7 +198,8 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
                 .And.Contain("-o json")
                 .And.Contain(OverlayPath)
                 .And.Contain("--server-side")
-                .And.Contain("--field-manager octopus");
+                .And.Contain("--field-manager octopus")
+                .And.NotContain("--force-conflicts");
         }
 
         [Test]

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -119,17 +119,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             }
 
             string[] executeArgs = {"apply", "-f", $@"""{globDirectory.Directory}""", "--recursive", "-o", "json"};
-            if (deployment.Variables.GetFlag(SpecialVariables.ServerSideApplyEnabled))
-            {
-                log.Verbose("Server-side apply is enabled. Applying with field manager 'octopus'");
-                
-                executeArgs = executeArgs.Concat(new[] {"--server-side", "--field-manager", "octopus"}).ToArray();
-                if(deployment.Variables.GetFlag(SpecialVariables.ServerSideApplyForceConflicts))
-                {
-                    log.Verbose("Force conflicts is enabled. Field manager 'octopus' will be the sole manager.");
-                    executeArgs = executeArgs.Concat(new[] {"--force-conflicts"}).ToArray();
-                }
-            }
+            executeArgs = executeArgs.AddOptionsForServerSideApply(deployment.Variables, log);
 
             var result = kubectl.ExecuteCommandAndReturnOutput(executeArgs);
 

--- a/source/Calamari/Kubernetes/Commands/Executors/KuberenetesApplyExtensionMethods.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/KuberenetesApplyExtensionMethods.cs
@@ -1,0 +1,29 @@
+#if !NET40
+using System;
+using System.Linq;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Kubernetes.Commands.Executors
+{
+    static class KuberenetesApplyExtensionMethods
+    {
+        public static string[] AddOptionsForServerSideApply(this string[] executeArgs, IVariables variables, ILog log)
+        {
+            if (variables.GetFlag(SpecialVariables.ServerSideApplyEnabled))
+            {
+                log.Verbose("Server-side apply is enabled. Applying with field manager 'octopus'");
+                
+                executeArgs = executeArgs.Concat(new[] {"--server-side", "--field-manager", "octopus"}).ToArray();
+                if(variables.GetFlag(SpecialVariables.ServerSideApplyForceConflicts))
+                {
+                    log.Verbose("Force conflicts is enabled. Field manager 'octopus' will be the sole manager.");
+                    executeArgs = executeArgs.Concat(new[] {"--force-conflicts"}).ToArray();
+                }
+            }
+
+            return executeArgs;
+        }
+    }
+}
+#endif

--- a/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
@@ -44,17 +44,7 @@ namespace Calamari.Kubernetes.Commands.Executors
 
             var kustomizationDirectory = Path.Combine(deployment.CurrentDirectory, KubernetesDeploymentCommandBase.PackageDirectoryName, overlayPath);
             string[] executeArgs = {"apply", "-k", $@"""{kustomizationDirectory}""", "-o", "json"};
-            if (deployment.Variables.GetFlag(SpecialVariables.ServerSideApplyEnabled))
-            {
-                log.Verbose("Server-side apply is enabled. Applying with field manager 'octopus'");
-                
-                executeArgs = executeArgs.Concat(new[] {"--server-side", "--field-manager", "octopus"}).ToArray();
-                if(deployment.Variables.GetFlag(SpecialVariables.ServerSideApplyForceConflicts))
-                {
-                    log.Verbose("Force conflicts is enabled. Field manager 'octopus' will be the sole manager.");
-                    executeArgs = executeArgs.Concat(new[] {"--force-conflicts"}).ToArray();
-                }
-            }
+            executeArgs = executeArgs.AddOptionsForServerSideApply(deployment.Variables, log);
             
             var result = kubectl.ExecuteCommandAndReturnOutput(executeArgs);
             

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -38,6 +38,9 @@ namespace Calamari.Kubernetes
 
         public const string KubernetesResourceStatusServiceMessageName = "k8s-status";
 
+        public const string ServerSideApplyEnabled = "Octopus.Action.Kubernetes.ServerSideApply.Enabled";
+        public const string ServerSideApplyForceConflicts = "Octopus.Action.Kubernetes.ServerSideApply.ForceConflicts";
+        
         public static class Helm
         {
             public const string ReleaseName = "Octopus.Action.Helm.ReleaseName";


### PR DESCRIPTION
# Background
As a part of supporting kubectl server side apply we need to update Calamari to allow it to pass through the required kubectl arguments `--server-side` `--force-conflicts` and `--field-manager`

[SC-51459]

# Results
If the known variables `Octopus.Action.Kubernetes.ServerSideApply.Enabled` and `Octopus.Action.Kubernetes.ServerSideApply.ForceConflicts` are set to `"true"` the `--server-side` `--force-conflicts` and `--field-manager` arguments will be added to the kubectl apply