### PR TITLE
Pin AzureRM terraform provider version in tests

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/providers.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.78.0" 
+      version = "3.99.0" 
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/providers.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.78.0" 
+      version = "3.99.0" 
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
We were getting failing tests for some reason due to a change in the AzureRM terraform provider. I have pinned this at the last known good version