### PR TITLE
Retry temporary file deletion

### DIFF
--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -351,12 +351,19 @@ namespace Calamari.AzureAppService.Behaviors
             Log.Verbose("Finished zip deployment");
         }
 
-        void CleanupUploadFile(string? uploadPath)
+        static void CleanupUploadFile(string? uploadPath)
         {
-            if (File.Exists(uploadPath))
-            {
-                File.Delete(uploadPath!);
-            }
+            Policy.Handle<IOException>()
+                .WaitAndRetry(
+                    5,
+                    i => TimeSpan.FromMilliseconds(200))
+                .Execute(() =>
+                    {
+                        if (File.Exists(uploadPath))
+                        {
+                            File.Delete(uploadPath!);
+                        }
+                    });
         }
     }
 }


### PR DESCRIPTION
A customer has encountered an issue on a dynamic worker deleting the interim file when deploying an Azure App Service. It is difficult to determine what is holding onto the file. I assume it is a transient issue, so hammering it with retries.

```
The process cannot access the file 'C:\Octopus\Tentacle\Files\ABC@S0.0.0-preview.0.9@C648E19E03056448B5851DB873FD5237.zip' because it is being used by another process.
```

Relates to https://github.com/OctopusDeploy/Issues/issues/8727