### PR TITLE
Pin versions of Terraform and the AzureRM Terraform provider

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -59,11 +59,13 @@ namespace Calamari.Tests.KubernetesFixtures
                                                             var jObject = JObject.Parse(await json.Content.ReadAsStringAsync());
                                                             var downloadBaseUrl = jObject["current_download_url"].Value<string>();
                                                             var version = jObject["current_version"].Value<string>();
-                                                            
+
                                                             //TODO(tmm): AzureRM_provider and/or Terraform were causing flakey tests - this pins the required version of terraform
                                                             var pinnedVersion = "1.7.5";
                                                             downloadBaseUrl = downloadBaseUrl.Replace(version, pinnedVersion);
                                                             version = pinnedVersion;
+
+                                                            log($"Found Terraform version {version} @ {downloadBaseUrl}");
                                                             
                                                             return (version, downloadBaseUrl);
                                                         },
@@ -164,6 +166,7 @@ namespace Calamari.Tests.KubernetesFixtures
                                                              {
                                                                  return GetAwsCliExecutablePath(destinationDirectoryName);
                                                              }
+
                                                              ExecuteCommandAndReturnResult("msiexec",
                                                                                            $"/a {awsInstaller} /qn TARGETDIR={destinationDirectoryName}\\extract",
                                                                                            destinationDirectoryName);

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -59,6 +59,12 @@ namespace Calamari.Tests.KubernetesFixtures
                                                             var jObject = JObject.Parse(await json.Content.ReadAsStringAsync());
                                                             var downloadBaseUrl = jObject["current_download_url"].Value<string>();
                                                             var version = jObject["current_version"].Value<string>();
+                                                            
+                                                            //TODO(tmm): AzureRM_provider and/or Terraform were causing flakey tests - this pins the required version of terraform
+                                                            var pinnedVersion = "1.7.5";
+                                                            downloadBaseUrl = downloadBaseUrl.Replace(version, pinnedVersion);
+                                                            version = pinnedVersion;
+                                                            
                                                             return (version, downloadBaseUrl);
                                                         },
                                                         async (destinationDirectoryName, tuple) =>

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/providers.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.99.0" 
+      version = "3.95.0" 
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/providers.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.99.0" 
+      version = "3.95.0" 
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
A number of flakey tests appeared on the 12-April-2024, which corresponds to when new versions of both the azureRM provider and Terraform itself were released.

This change pins both of these dependencies to versions which were available prior to 12-April.