### PR TITLE
Update to polly 8.3.1

### DIFF
--- a/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
+++ b/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="Polly" Version="5.6.1" />
+    <PackageReference Include="Polly" Version="8.3.1" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -32,7 +32,7 @@ namespace Calamari.AzureAppService.Behaviors
     internal class AzureAppServiceZipDeployBehaviour : IDeployBehaviour
     {
         static readonly TimeSpan PollingTimeout = TimeSpan.FromMinutes(3);
-        static readonly TimeoutPolicy<HttpResponseMessage> AsyncZipDeployTimeoutPolicy = Policy.TimeoutAsync<HttpResponseMessage>(PollingTimeout, TimeoutStrategy.Optimistic);
+        static readonly AsyncTimeoutPolicy<HttpResponseMessage> AsyncZipDeployTimeoutPolicy = Policy.TimeoutAsync<HttpResponseMessage>(PollingTimeout, TimeoutStrategy.Optimistic);
 
         public AzureAppServiceZipDeployBehaviour(ILog log)
         {
@@ -308,7 +308,7 @@ namespace Calamari.AzureAppService.Behaviors
                                                                                   {
                                                                                       //the outer policy should only retry when the response is a 202
                                                                                       return await RetryPolicies.AsynchronousZipDeploymentOperationPolicy
-                                                                                                                .ExecuteAsync(async ct1 =>
+                                                                                                                .ExecuteAsync(async (_, ct1) =>
                                                                                                                                   //we nest this policy so any transient errors are handled and retried. If it just keeps falling over, then we want it to bail out of the outer operation
                                                                                                                                   await RetryPolicies.TransientHttpErrorsPolicy
                                                                                                                                                      .ExecuteAsync(async ct2 =>

--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Polly" Version="5.6.1" />
+    <PackageReference Include="Polly" Version="8.3.1" />
     <PackageReference Include="SharpCompress" Version="0.28.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />

--- a/source/Calamari.AzureAppService/RetryPolicies.cs
+++ b/source/Calamari.AzureAppService/RetryPolicies.cs
@@ -20,28 +20,28 @@ namespace Calamari.AzureAppService
 
         // Based on the logic in the Polly.Extensions.Http package, but without having to include the package
         // We add a small amount of random jitter to just offset the retries
-        public static RetryPolicy<HttpResponseMessage> TransientHttpErrorsPolicy { get; } = Policy.Handle<HttpRequestException>()
-                                                                                                  .Or<SocketException>()
-                                                                                                  .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.RequestTimeout)
-                                                                                                  .WaitAndRetryAsync(6,
-                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 1000)));
+        public static AsyncRetryPolicy<HttpResponseMessage> TransientHttpErrorsPolicy { get; } = Policy.Handle<HttpRequestException>()
+                                                                                                       .Or<SocketException>()
+                                                                                                       .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.RequestTimeout)
+                                                                                                       .WaitAndRetryAsync(6,
+                                                                                                                          retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 1000)));
 
         // This is specifically for retries in tests, we retry fewer times with a higher base to try avoid hitting rate limiting in Azure.
         // The Jitter offset has been increased to try stagger requests between parallel test runs.
-        public static RetryPolicy<HttpResponseMessage> TestsTransientHttpErrorsPolicy { get; } = Policy.Handle<HttpRequestException>()
-                                                                                                  .Or<SocketException>()
-                                                                                                  .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.RequestTimeout)
-                                                                                                  .WaitAndRetryAsync(4,
-                                                                                                                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(3.5, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 10000)));
+        public static AsyncRetryPolicy<HttpResponseMessage> TestsTransientHttpErrorsPolicy { get; } = Policy.Handle<HttpRequestException>()
+                                                                                                            .Or<SocketException>()
+                                                                                                            .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.RequestTimeout)
+                                                                                                            .WaitAndRetryAsync(4,
+                                                                                                                               retryAttempt => TimeSpan.FromSeconds(Math.Pow(3.5, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 10000)));
 
-        public static RetryPolicy<HttpResponseMessage> AsynchronousZipDeploymentOperationPolicy { get; } = Policy.HandleResult<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Accepted)
-                                                                                                                 .WaitAndRetryForeverAsync((_1, ctx) => TimeSpan.FromSeconds(2),
-                                                                                                                                           (response, timeout, ctx) =>
-                                                                                                                                           {
-                                                                                                                                               if (ctx.TryGetValue(ContextKeys.Log, out var logObj) && logObj is ILog log)
-                                                                                                                                               {
-                                                                                                                                                   log.Verbose($"Zip deployment not completed. Received HTTP {(int)response.Result.StatusCode}. Next attempt in {timeout}.");
-                                                                                                                                               }
-                                                                                                                                           });
+        public static AsyncRetryPolicy<HttpResponseMessage> AsynchronousZipDeploymentOperationPolicy { get; } = Policy.HandleResult<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Accepted)
+                                                                                                                      .WaitAndRetryForeverAsync((_1, ctx) => TimeSpan.FromSeconds(2),
+                                                                                                                                                (response, timeout, ctx) =>
+                                                                                                                                                {
+                                                                                                                                                    if (ctx.TryGetValue(ContextKeys.Log, out var logObj) && logObj is ILog log)
+                                                                                                                                                    {
+                                                                                                                                                        log.Verbose($"Zip deployment not completed. Received HTTP {(int)response.Result.StatusCode}. Next attempt in {timeout}.");
+                                                                                                                                                    }
+                                                                                                                                                });
     }
 }


### PR DESCRIPTION
Currently the azureappservice project is using _quite_ an old version of polly (5.6.1) - this upgrades the dependency to 8.3.1 - which is still supports .netframework 4.6.2.