### PR TITLE
All test fixtures to use a cancellationToken

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -365,6 +365,8 @@ namespace Calamari.AzureAppService.Tests
         {
             // For some reason we are having issues creating these linux resources on Standard in EastUS
             protected override string DefaultResourceGroupLocation => "westus2";
+            static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+            readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
             protected override async Task ConfigureTestResources(ResourceGroupResource resourceGroup)
             {
@@ -399,7 +401,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                       IsReserved = true
                                                                                   });
 
-                await linuxAppServicePlan.WaitForCompletionAsync(CancellationToken.None);
+                await linuxAppServicePlan.WaitForCompletionAsync(cancellationToken);
 
                 var linuxWebSiteResponse = await resourceGroup.GetWebSites()
                                                               .CreateOrUpdateAsync(WaitUntil.Completed,
@@ -425,7 +427,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                        }
                                                                                    });
 
-                await linuxWebSiteResponse.WaitForCompletionAsync(CancellationToken.None);
+                await linuxWebSiteResponse.WaitForCompletionAsync(cancellationToken);
                 
                 WebSiteResource = linuxWebSiteResponse.Value;
             }

--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -43,6 +43,9 @@ namespace Calamari.AzureAppService.Tests
         private readonly HttpClient client = new HttpClient();
 
         protected virtual string DefaultResourceGroupLocation => "eastus";
+        
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         [OneTimeSetUp]
         public async Task Setup()
@@ -54,10 +57,10 @@ namespace Calamari.AzureAppService.Tests
 
             ResourceGroupName = $"{DateTime.UtcNow:yyyyMMdd}-{Guid.NewGuid():N}";
 
-            ClientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, CancellationToken.None);
-            ClientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, CancellationToken.None);
-            TenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, CancellationToken.None);
-            SubscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None);
+            ClientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken);
+            ClientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken);
+            TenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken);
+            SubscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
             ResourceGroupLocation = Environment.GetEnvironmentVariable("AZURE_NEW_RESOURCE_REGION") ?? DefaultResourceGroupLocation;
 
             var servicePrincipalAccount = new AzureServicePrincipalAccount(SubscriptionId,

--- a/source/Calamari.AzureCloudService.Tests/DeployAzureCloudServiceCommandFixture.cs
+++ b/source/Calamari.AzureCloudService.Tests/DeployAzureCloudServiceCommandFixture.cs
@@ -27,6 +27,8 @@ namespace Calamari.AzureCloudService.Tests
         string subscriptionId;
         string certificate;
         string pathToPackage;
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         [OneTimeSetUp]
         public async Task Setup()
@@ -34,8 +36,8 @@ namespace Calamari.AzureCloudService.Tests
             storageName = $"Test{Guid.NewGuid().ToString("N").Substring(0, 10)}".ToLower();
             // We need to trim because of issue with team city:
             // https://app.shortcut.com/octopusdeploy/story/65471/failing-azurecloudservice-tests-due-to-whitespace-being-added-to-end-of-certificate-env-var
-            certificate = (await ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate, CancellationToken.None)).Trim();
-            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None);
+            certificate = (await ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate, cancellationToken)).Trim();
+            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
             managementCertificate = CreateManagementCertificate(certificate);
             subscriptionCloudCredentials = new CertificateCloudCredentials(subscriptionId, managementCertificate);
             storageClient = new StorageManagementClient(subscriptionCloudCredentials);

--- a/source/Calamari.AzureCloudService.Tests/HealthCheckCommandFixture.cs
+++ b/source/Calamari.AzureCloudService.Tests/HealthCheckCommandFixture.cs
@@ -14,13 +14,15 @@ namespace Calamari.AzureCloudService.Tests
 {
     public class HealthCheckCommandFixture
     {
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
         [Test]
         public async Task CloudService_Is_Found()
         {
-            var subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None);
+            var subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
             // We need to trim because of issue with team city:
             // https://app.shortcut.com/octopusdeploy/story/65471/failing-azurecloudservice-tests-due-to-whitespace-being-added-to-end-of-certificate-env-var
-            var certificate = (await ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate, CancellationToken.None)).Trim();
+            var certificate = (await ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate, cancellationToken)).Trim();
             var serviceName = $"{nameof(HealthCheckCommandFixture)}-{Guid.NewGuid().ToString("N").Substring(0, 12)}";
 
             using var managementCertificate = CreateManagementCertificate(certificate);
@@ -49,10 +51,10 @@ namespace Calamari.AzureCloudService.Tests
         [Test]
         public async Task CloudService_Is_Not_Found()
         {
-            var subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None);
+            var subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
             // We need to trim because of issue with team city:
             // https://app.shortcut.com/octopusdeploy/story/65471/failing-azurecloudservice-tests-due-to-whitespace-being-added-to-end-of-certificate-env-var
-            var certificate = (await ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate, CancellationToken.None)).Trim();
+            var certificate = (await ExternalVariables.Get(ExternalVariable.AzureSubscriptionCertificate, cancellationToken)).Trim();
             var serviceName = $"{nameof(HealthCheckCommandFixture)}-{Guid.NewGuid().ToString("N").Substring(0, 12)}";
 
             using var managementCertificate = CreateManagementCertificate(certificate);

--- a/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
@@ -20,22 +20,24 @@ using NUnit.Framework;
 namespace Calamari.AzureResourceGroup.Tests
 {
     [TestFixture]
-    internal class AzureResourceGroupActionHandlerFixture
+    class AzureResourceGroupActionHandlerFixture
     {
-        private string clientId;
-        private string clientSecret;
-        private string tenantId;
-        private string subscriptionId;
-        private IResourceGroup resourceGroup;
-        private IAzure azure;
+        string clientId;
+        string clientSecret;
+        string tenantId;
+        string subscriptionId;
+        IResourceGroup resourceGroup;
+        IAzure azure;
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         [OneTimeSetUp]
         public async Task Setup()
         {
-            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, CancellationToken.None);
-            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, CancellationToken.None);
-            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, CancellationToken.None);
-            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None);
+            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken);
+            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken);
+            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken);
+            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
 
             var resourceGroupName = SdkContext.RandomResourceName(nameof(AzureResourceGroupActionHandlerFixture), 60);
 

--- a/source/Calamari.AzureResourceGroup.Tests/LegacyAzureResourceGroupActionHandlerFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/LegacyAzureResourceGroupActionHandlerFixture.cs
@@ -18,22 +18,24 @@ using NUnit.Framework;
 namespace Calamari.AzureResourceGroup.Tests
 {
     [TestFixture]
-    internal class LegacyAzureResourceGroupActionHandlerFixture
+    class LegacyAzureResourceGroupActionHandlerFixture
     {
-        private string clientId;
-        private string clientSecret;
-        private string tenantId;
-        private string subscriptionId;
-        private IResourceGroup resourceGroup;
-        private IAzure azure;
+        string clientId;
+        string clientSecret;
+        string tenantId;
+        string subscriptionId;
+        IResourceGroup resourceGroup;
+        IAzure azure;
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         [OneTimeSetUp]
         public async Task Setup()
         {
-            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, CancellationToken.None);
-            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, CancellationToken.None);
-            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, CancellationToken.None);
-            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None);
+            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken);
+            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken);
+            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken);
+            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
 
             var resourceGroupName = SdkContext.RandomResourceName(nameof(LegacyAzureResourceGroupActionHandlerFixture), 60);
 

--- a/source/Calamari.AzureScripting.Tests/AzurePowershellCommandFixture.cs
+++ b/source/Calamari.AzureScripting.Tests/AzurePowershellCommandFixture.cs
@@ -27,14 +27,16 @@ namespace Calamari.AzureScripting.Tests
                                                                                              "Powershell\\Azure\\5.3.0",
                                                                                              "Powershell",
                                                                                          });
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         [OneTimeSetUp]
         public async Task Setup()
         {
-            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, CancellationToken.None);
-            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, CancellationToken.None);
-            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, CancellationToken.None);
-            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None);
+            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken);
+            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken);
+            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken);
+            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
         }
 
         [Test]

--- a/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
+++ b/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
@@ -36,6 +36,8 @@ namespace Calamari.AzureWebApp.Tests
         TemporaryDirectory azureConfigPath;
 
         readonly HttpClient client = new HttpClient();
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         [OneTimeSetUp]
         public async Task Setup()
@@ -43,10 +45,10 @@ namespace Calamari.AzureWebApp.Tests
             azureConfigPath = TemporaryDirectory.Create();
             Environment.SetEnvironmentVariable("AZURE_CONFIG_DIR", azureConfigPath.DirectoryPath);
             
-            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, CancellationToken.None);
-            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, CancellationToken.None);
-            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, CancellationToken.None);
-            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None);
+            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken);
+            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken);
+            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken);
+            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
             var resourceGroupName = SdkContext.RandomResourceName(nameof(DeployAzureWebCommandFixture), 60);
 
             var credentials = SdkContext.AzureCredentialsFactory.FromServicePrincipal(clientId, clientSecret, tenantId,

--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -585,6 +585,8 @@ namespace Calamari.Tests.AWS
     {
         protected string region;
         protected string bucketName;
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         public S3Fixture()
         {
@@ -620,8 +622,8 @@ namespace Calamari.Tests.AWS
         protected async Task Validate(Func<AmazonS3Client, Task> execute)
         {
             var credentials = new BasicAWSCredentials(
-                                                      await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, CancellationToken.None),
-                                                      await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, CancellationToken.None));
+                                                      await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, cancellationToken),
+                                                      await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, cancellationToken));
 
             var config = new AmazonS3Config { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.GetBySystemName(region) };
 
@@ -661,8 +663,8 @@ namespace Calamari.Tests.AWS
             var variablesFile = Path.GetTempFileName();
 
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
-            variables.Set("AWSAccount.AccessKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, CancellationToken.None));
-            variables.Set("AWSAccount.SecretKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, CancellationToken.None));
+            variables.Set("AWSAccount.AccessKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, cancellationToken));
+            variables.Set("AWSAccount.SecretKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, cancellationToken));
             variables.Set("Octopus.Action.Aws.Region", region);
 
             if (customVariables != null) variables.Merge(customVariables);
@@ -728,8 +730,8 @@ namespace Calamari.Tests.AWS
             var variablesFile = Path.GetTempFileName();
 
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
-            variables.Set("AWSAccount.AccessKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, CancellationToken.None));
-            variables.Set("AWSAccount.SecretKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, CancellationToken.None));
+            variables.Set("AWSAccount.AccessKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, cancellationToken));
+            variables.Set("AWSAccount.SecretKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, cancellationToken));
             variables.Set("Octopus.Action.Aws.Region", region);
 
             if (customVariables != null) variables.Merge(customVariables);

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/ArtifactoryPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/ArtifactoryPackageDownloaderFixture.cs
@@ -25,6 +25,8 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                 Uri feedUri;
                 NetworkCredential feedCredentials;
                 ArtifactoryPackageDownloader downloader;
+                static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+                readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
         
                 public ArtifactoryPackageDownloaderFixture()
                 {
@@ -40,7 +42,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                     fileSystem.EnsureDirectoryExists(cacheDirectory);
 
                     feedUri = new Uri("https://octopusdeploy.jfrog.io");
-                    var sensitiveValue = await ExternalVariables.Get(ExternalVariable.ArtifactoryE2EPassword, CancellationToken.None);
+                    var sensitiveValue = await ExternalVariables.Get(ExternalVariable.ArtifactoryE2EPassword, cancellationToken);
                     feedCredentials = new NetworkCredential("", sensitiveValue.ToString());
         
                     var log = Substitute.For<ILog>();

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
@@ -31,12 +31,14 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         static readonly string DockerHubFeedUri = "https://index.docker.io";
         static readonly string DockerTestUsername = "octopustestaccount";
         static string DockerTestPassword;
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         [OneTimeSetUp]
         public async Task TestFixtureSetUp()
         {
-            FeedPassword = await ExternalVariables.Get(ExternalVariable.HelmPassword, CancellationToken.None);
-            DockerTestPassword = await ExternalVariables.Get(ExternalVariable.DockerReaderPassword, CancellationToken.None);
+            FeedPassword = await ExternalVariables.Get(ExternalVariable.HelmPassword, cancellationToken);
+            DockerTestPassword = await ExternalVariables.Get(ExternalVariable.DockerReaderPassword, cancellationToken);
             Environment.SetEnvironmentVariable("TentacleHome", Home);
         }
 

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/GitHubPackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/GitHubPackageDownloadFixture.cs
@@ -25,11 +25,15 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         static readonly CalamariPhysicalFileSystem fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static string home = Path.GetTempPath();
+        
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
+        
         [OneTimeSetUp]
         public async Task TestFixtureSetUp()
         {
-            FeedUsername = await ExternalVariables.Get(ExternalVariable.GitHubUsername, CancellationToken.None);
-            FeedPassword = await ExternalVariables.Get(ExternalVariable.GitHubPassword, CancellationToken.None);
+            FeedUsername = await ExternalVariables.Get(ExternalVariable.GitHubUsername, cancellationToken);
+            FeedPassword = await ExternalVariables.Get(ExternalVariable.GitHubPassword, cancellationToken);
             Environment.SetEnvironmentVariable("TentacleHome", home);
         }
 

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
@@ -21,11 +21,13 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         static string FeedPassword;
         static string home = Path.GetTempPath();
         HelmChartPackageDownloader downloader;
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
         
         [OneTimeSetUp]
         public async Task TestFixtureSetUp()
         {
-            FeedPassword = await ExternalVariables.Get(ExternalVariable.HelmPassword, CancellationToken.None);
+            FeedPassword = await ExternalVariables.Get(ExternalVariable.HelmPassword, cancellationToken);
             Environment.SetEnvironmentVariable("TentacleHome", home);
         }
 

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/S3PackageDownloaderFixture.cs
@@ -28,6 +28,8 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         static readonly string TentacleHome = TestEnvironment.GetTestPath("Fixtures", "PackageDownload");
         readonly string region;
         readonly string bucketName;
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
         
         public S3PackageDownloaderFixture()
         {
@@ -89,15 +91,15 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                                                                            Key = filename,
                                                                            InputStream = File.OpenRead(Path.Combine(rootDir, filename))
                                                                        },
-                                                                       CancellationToken.None));
+                                                                       cancellationToken));
 
             var downloader = GetDownloader();
             var package = downloader.DownloadPackage(packageId,
                                                      version,
                                                      "s3-feed",
                                                      new Uri("https://please-ignore.com"),
-                                                     await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, CancellationToken.None),
-                                                     await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, CancellationToken.None),
+                                                     await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, cancellationToken),
+                                                     await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, cancellationToken),
                                                      true,
                                                      3,
                                                      TimeSpan.FromSeconds(3));
@@ -109,8 +111,8 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         protected async Task Validate(Func<AmazonS3Client, Task> execute)
         {
             var credentials = new BasicAWSCredentials(
-                                                      await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, CancellationToken.None),
-                                                      await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, CancellationToken.None));
+                                                      await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, cancellationToken),
+                                                      await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, cancellationToken));
 
             var config = new AmazonS3Config {AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.GetBySystemName(region)};
             

--- a/source/Calamari.Tests/Fixtures/PackageDownload/NuGetFeedSupportFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/NuGetFeedSupportFixture.cs
@@ -30,14 +30,16 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         static string ArtifactoryNuGetV3FeedUrl;
         
         static readonly string TentacleHome = TestEnvironment.GetTestPath("Fixtures", "PackageDownload");
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         [OneTimeSetUp]
         public async Task OneTimeSetup()
         {
-            FeedzNuGetV2FeedUrl = await ExternalVariables.Get(ExternalVariable.FeedzNuGetV2FeedUrl, CancellationToken.None);
-            FeedzNuGetV3FeedUrl = await ExternalVariables.Get(ExternalVariable.FeedzNuGetV3FeedUrl, CancellationToken.None);
-            ArtifactoryNuGetV2FeedUrl = await ExternalVariables.Get(ExternalVariable.ArtifactoryNuGetV2FeedUrl, CancellationToken.None);
-            ArtifactoryNuGetV3FeedUrl = await ExternalVariables.Get(ExternalVariable.ArtifactoryNuGetV3FeedUrl, CancellationToken.None);
+            FeedzNuGetV2FeedUrl = await ExternalVariables.Get(ExternalVariable.FeedzNuGetV2FeedUrl, cancellationToken);
+            FeedzNuGetV3FeedUrl = await ExternalVariables.Get(ExternalVariable.FeedzNuGetV3FeedUrl, cancellationToken);
+            ArtifactoryNuGetV2FeedUrl = await ExternalVariables.Get(ExternalVariable.ArtifactoryNuGetV2FeedUrl, cancellationToken);
+            ArtifactoryNuGetV3FeedUrl = await ExternalVariables.Get(ExternalVariable.ArtifactoryNuGetV3FeedUrl, cancellationToken);
         }
         
         [SetUp]

--- a/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
+++ b/source/Calamari.Tests/Fixtures/PackageDownload/PackageDownloadFixture.cs
@@ -48,13 +48,16 @@ namespace Calamari.Tests.Fixtures.PackageDownload
         static readonly SampleFeedPackage MavenSnapshotPublicFeed = new SampleFeedPackage("#") { Id = "feeds-maven", Version = VersionFactory.CreateMavenVersion("24.0-SNAPSHOT"), PackageId = "com.google.guava:guava" };
         static readonly string ExpectedMavenSnapshotPackageHash = "425932eacd1450c4c4c32b9ed8a1d9b397f20082";
         static readonly long ExpectedMavenSnapshotPackageSize = 2621686;
+        
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         [OneTimeSetUp]
         public async Task OneTimeSetup()
         {
-            AuthFeedUri = await ExternalVariables.Get(ExternalVariable.MyGetFeedUrl, CancellationToken.None);
-            AuthFeedUsername = await ExternalVariables.Get(ExternalVariable.MyGetFeedUsername, CancellationToken.None);
-            AuthFeedPassword = await ExternalVariables.Get(ExternalVariable.MyGetFeedPassword, CancellationToken.None);
+            AuthFeedUri = await ExternalVariables.Get(ExternalVariable.MyGetFeedUrl, cancellationToken);
+            AuthFeedUsername = await ExternalVariables.Get(ExternalVariable.MyGetFeedUsername, cancellationToken);
+            AuthFeedPassword = await ExternalVariables.Get(ExternalVariable.MyGetFeedPassword, cancellationToken);
         } 
         
         [SetUp]

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -46,12 +46,15 @@ namespace Calamari.Tests.KubernetesFixtures
 
         HelmVersion? helmVersion;
         TemporaryDirectory explicitVersionTempDirectory;
+        
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         [OneTimeSetUp]
         public async Task OneTimeSetUp()
         {
-            ServerUrl = await ExternalVariables.Get(ExternalVariable.KubernetesClusterUrl, CancellationToken.None);
-            ClusterToken = await ExternalVariables.Get(ExternalVariable.KubernetesClusterToken, CancellationToken.None);
+            ServerUrl = await ExternalVariables.Get(ExternalVariable.KubernetesClusterUrl, cancellationToken);
+            ClusterToken = await ExternalVariables.Get(ExternalVariable.KubernetesClusterToken, cancellationToken);
             
             if (ExplicitExeVersion != null)
             {

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixture.cs
@@ -20,6 +20,8 @@ namespace Calamari.Tests.KubernetesFixtures
     {
         protected const string KubeCtlExecutableVariableName = "Octopus.Action.Kubernetes.CustomKubectlExecutable";
         protected const string KubeConfigFileName = "kubeconfig.tpl";
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
         
         InstallTools installTools;
 
@@ -118,7 +120,7 @@ namespace Calamari.Tests.KubernetesFixtures
         async Task<string> RunTerraformInternal(string terraformWorkingFolder, Dictionary<string, string> env, bool printOut, params string[] args)
         {
             var stdOut = new StringBuilder();
-            var environmentVars = await GetEnvironmentVars(CancellationToken.None);
+            var environmentVars = await GetEnvironmentVars(cancellationToken);
             environmentVars["TF_IN_AUTOMATION"] = bool.TrueString;
             environmentVars.AddRange(env);
 

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -31,6 +31,9 @@ namespace Calamari.Tests.KubernetesFixtures
         string azurermResourceGroup;
         string aksPodServiceAccountToken;
         string azureSubscriptionId;
+        
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         protected override string KubernetesCloudProvider => "AKS";
 
@@ -106,10 +109,10 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Kubernetes.AksClusterResourceGroup", azurermResourceGroup);
             variables.Set(SpecialVariables.AksClusterName, aksClusterName);
             variables.Set("Octopus.Action.Kubernetes.AksAdminLogin", Boolean.FalseString);
-            variables.Set("Octopus.Action.Azure.SubscriptionId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None));
-            variables.Set("Octopus.Action.Azure.TenantId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, CancellationToken.None));
-            variables.Set("Octopus.Action.Azure.Password", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, CancellationToken.None));
-            variables.Set("Octopus.Action.Azure.ClientId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, CancellationToken.None));
+            variables.Set("Octopus.Action.Azure.SubscriptionId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken));
+            variables.Set("Octopus.Action.Azure.TenantId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken));
+            variables.Set("Octopus.Action.Azure.Password", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken));
+            variables.Set("Octopus.Action.Azure.ClientId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken));
             if (runAsScript)
             {
                 DeployWithKubectlTestScriptAndVerifyResult();
@@ -174,10 +177,10 @@ namespace Calamari.Tests.KubernetesFixtures
                 setHealthCheckContainer ? new FeedImage("MyImage:with-tag", "Feeds-123") : null);
 
             var account = new AzureServicePrincipalAccount(
-                                                           await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None),
-                                                           await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, CancellationToken.None),
-                                                           await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, CancellationToken.None),
-                                                           await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, CancellationToken.None),
+                                                           await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken),
+                                                           await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken),
+                                                           await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken),
+                                                           await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken),
                                                            null,
                                                            null,
                                                            null);

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAksLocalAccessDisabled.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAksLocalAccessDisabled.cs
@@ -24,6 +24,9 @@ namespace Calamari.Tests.KubernetesFixtures
         string aksClusterName;
         string azurermResourceGroup;
         string azureSubscriptionId;
+        
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         protected override string KubernetesCloudProvider => "AKS-local-access-disabled";
 
@@ -67,10 +70,10 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Kubernetes.AksClusterResourceGroup", azurermResourceGroup);
             variables.Set(Kubernetes.SpecialVariables.AksClusterName, aksClusterName);
             variables.Set("Octopus.Action.Kubernetes.AksAdminLogin", Boolean.FalseString);
-            variables.Set("Octopus.Action.Azure.SubscriptionId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None));
-            variables.Set("Octopus.Action.Azure.TenantId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, CancellationToken.None));
-            variables.Set("Octopus.Action.Azure.Password", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, CancellationToken.None));
-            variables.Set("Octopus.Action.Azure.ClientId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, CancellationToken.None));
+            variables.Set("Octopus.Action.Azure.SubscriptionId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken));
+            variables.Set("Octopus.Action.Azure.TenantId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken));
+            variables.Set("Octopus.Action.Azure.Password", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken));
+            variables.Set("Octopus.Action.Azure.ClientId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken));
             if (runAsScript)
             {
                 DeployWithKubectlTestScriptAndVerifyResult();
@@ -95,10 +98,10 @@ namespace Calamari.Tests.KubernetesFixtures
                 setHealthCheckContainer ? new FeedImage("MyImage:with-tag", "Feeds-123") : null);
 
             var account = new AzureServicePrincipalAccount(
-                await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, CancellationToken.None),
-                await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, CancellationToken.None),
-                await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, CancellationToken.None),
-                await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, CancellationToken.None),
+                await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken),
+                await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken),
+                await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken),
+                await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken),
                 null,
                 null,
                 null);

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureGke.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureGke.cs
@@ -22,6 +22,9 @@ namespace Calamari.Tests.KubernetesFixtures
         string gkeClusterCaCertificate;
         string gkeClusterEndpoint;
         string gkeClusterName;
+        
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         protected override string KubernetesCloudProvider => "GKE";
 
@@ -84,7 +87,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(SpecialVariables.GkeClusterName, gkeClusterName);
             var account = "gke_account";
             variables.Set("Octopus.Action.GoogleCloudAccount.Variable", account);
-            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, CancellationToken.None);
+            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, cancellationToken);
             variables.Set($"{account}.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonKey)));
             variables.Set("Octopus.Action.GoogleCloud.Project", gkeProject);
             variables.Set("Octopus.Action.GoogleCloud.Zone", gkeLocation);
@@ -106,7 +109,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(SpecialVariables.GkeUseClusterInternalIp, bool.TrueString);
             var account = "gke_account";
             variables.Set("Octopus.Action.GoogleCloudAccount.Variable", account);
-            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, CancellationToken.None);
+            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, cancellationToken);
             variables.Set($"{account}.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonKey)));
             variables.Set("Octopus.Action.GoogleCloud.Project", gkeProject);
             variables.Set("Octopus.Action.GoogleCloud.Zone", gkeLocation);

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesRunsScriptFixture.cs
@@ -37,6 +37,9 @@ namespace Calamari.Tests.KubernetesFixtures
         InMemoryLog log;
         InstallTools installTools;
         Dictionary<string, string> environmentVariables;
+        
+        static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
         [SetUp]
         public void Setup()
@@ -278,7 +281,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(SpecialVariables.GkeClusterName, "gke-cluster-name");
             var account = "gke_account";
             variables.Set("Octopus.Action.GoogleCloudAccount.Variable", account);
-            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, CancellationToken.None);
+            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, cancellationToken);
             variables.Set($"{account}.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonKey)));
             variables.Set("Octopus.Action.GoogleCloud.Project", "gke-project");
             variables.Set("Octopus.Action.GoogleCloud.Zone", "gke-zone");
@@ -297,7 +300,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(SpecialVariables.GkeClusterName, "gke-cluster-name");
             var account = "gke_account";
             variables.Set("Octopus.Action.GoogleCloudAccount.Variable", account);
-            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, CancellationToken.None);
+            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, cancellationToken);
             variables.Set($"{account}.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonKey)));
             variables.Set("Octopus.Action.GoogleCloud.Project", "gke-project");
             variables.Set("Octopus.Action.GoogleCloud.Region", "gke-region");
@@ -316,7 +319,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(SpecialVariables.GkeClusterName, "gke-cluster-name");
             var account = "gke_account";
             variables.Set("Octopus.Action.GoogleCloudAccount.Variable", account);
-            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, CancellationToken.None);
+            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, cancellationToken);
             variables.Set($"{account}.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonKey)));
             variables.Set("Octopus.Action.GoogleCloud.Project", "gke-project");
             variables.Set("Octopus.Action.GoogleCloud.Region", "gke-region");
@@ -334,7 +337,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(SpecialVariables.GkeClusterName, "gke-cluster-name");
             var account = "gke_account";
             variables.Set("Octopus.Action.GoogleCloudAccount.Variable", account);
-            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, CancellationToken.None);
+            var jsonKey = await ExternalVariables.Get(ExternalVariable.GoogleCloudJsonKeyfile, cancellationToken);
             variables.Set($"{account}.JsonKey", Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonKey)));
             variables.Set("Octopus.Action.GoogleCloud.Project", "gke-project");
             var wrapper = CreateWrapper();


### PR DESCRIPTION
This makes no changes to the functionality of production code, nor tests.

However all references to CancellationToken.None in tests have been replaced with a class-level cancellationtoken.