### PR TITLE
Fix KOS not running for Kubernetes Agent scripts

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportWrapperTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportWrapperTests.cs
@@ -323,9 +323,8 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
              statusChecker.CheckedResources.Should().BeEquivalentTo(new ResourceIdentifier("Deployment", "deployment", "default"));
          }
 
-         private static void AddKubernetesStatusCheckVariables(IVariables variables)
+         static void AddKubernetesStatusCheckVariables(IVariables variables)
          {
-             variables.Set(SpecialVariables.ClusterUrl, "https://localhost");
              variables.Set(SpecialVariables.ResourceStatusCheck, "True");
          }
     }

--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -34,13 +34,7 @@ namespace Calamari.Kubernetes
         /// <summary>
         /// One of these fields must be present for a k8s step
         /// </summary>
-        public bool IsEnabled(ScriptSyntax syntax)
-        {
-            var isKubernetesTentacleTarget = string.Equals(variables.Get(MachineVariables.DeploymentTargetType), "KubernetesTentacle", StringComparison.OrdinalIgnoreCase);
-            var hasClusterUrl = !string.IsNullOrEmpty(variables.Get(SpecialVariables.ClusterUrl));
-            var hasClusterName = !string.IsNullOrEmpty(variables.Get(SpecialVariables.AksClusterName)) || !string.IsNullOrEmpty(variables.Get(SpecialVariables.EksClusterName)) || !string.IsNullOrEmpty(variables.Get(SpecialVariables.GkeClusterName));
-            return isKubernetesTentacleTarget || hasClusterUrl || hasClusterName;
-        }
+        public bool IsEnabled(ScriptSyntax syntax) => variables.IsKubernetesScript();
 
         public IScriptWrapper NextWrapper { get; set; }
 
@@ -56,7 +50,11 @@ namespace Calamari.Kubernetes
                 environmentVars = new Dictionary<string, string>();
             }
 
-            var kubectl = new Kubectl(variables, log, commandLineRunner, workingDirectory, environmentVars);
+            var kubectl = new Kubectl(variables,
+                                      log,
+                                      commandLineRunner,
+                                      workingDirectory,
+                                      environmentVars);
             var setupKubectlAuthentication = new SetupKubectlAuthentication(variables,
                                                                             log,
                                                                             commandLineRunner,

--- a/source/Calamari/Kubernetes/KubernetesVariableExtensions.cs
+++ b/source/Calamari/Kubernetes/KubernetesVariableExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Kubernetes
+{
+    public static class KubernetesVariableExtensions
+    {
+        public static bool IsKubernetesScript(this IVariables variables)
+        {
+            //A Kubernetes agent won't have any of the other variable set
+            var isKubernetesAgentTarget = string.Equals(variables.Get(MachineVariables.DeploymentTargetType), "KubernetesTentacle", StringComparison.OrdinalIgnoreCase);
+            
+            var hasClusterUrl = !string.IsNullOrEmpty(variables.Get(SpecialVariables.ClusterUrl));
+            
+            var hasClusterName = !string.IsNullOrEmpty(variables.Get(SpecialVariables.AksClusterName)) ||
+                                 !string.IsNullOrEmpty(variables.Get(SpecialVariables.EksClusterName)) ||
+                                 !string.IsNullOrEmpty(variables.Get(SpecialVariables.GkeClusterName));
+            
+            return isKubernetesAgentTarget || hasClusterUrl || hasClusterName;
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/KubernetesVariableExtensions.cs
+++ b/source/Calamari/Kubernetes/KubernetesVariableExtensions.cs
@@ -7,7 +7,7 @@ namespace Calamari.Kubernetes
     {
         public static bool IsKubernetesScript(this IVariables variables)
         {
-            //A Kubernetes agent won't have any of the other variable set
+            //A Kubernetes agent won't have any of the other variables set
             var isKubernetesAgentTarget = string.Equals(variables.Get(MachineVariables.DeploymentTargetType), "KubernetesTentacle", StringComparison.OrdinalIgnoreCase);
             
             var hasClusterUrl = !string.IsNullOrEmpty(variables.Get(SpecialVariables.ClusterUrl));

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -35,19 +35,18 @@ namespace Calamari.Kubernetes.ResourceStatus
 
         public bool IsEnabled(ScriptSyntax syntax)
         {
-            var resourceStatusEnabled = variables.GetFlag(SpecialVariables.ResourceStatusCheck);
-            var isBlueGreen = variables.Get(SpecialVariables.DeploymentStyle) == "bluegreen";
-            var isWaitDeployment = variables.Get(SpecialVariables.DeploymentWait) == "wait";
-            if (!resourceStatusEnabled || isBlueGreen || isWaitDeployment)
+            var isBlueGreen = string.Equals(variables.Get(SpecialVariables.DeploymentStyle), "bluegreen", StringComparison.OrdinalIgnoreCase);
+            var isWaitDeployment = string.Equals(variables.Get(SpecialVariables.DeploymentWait) , "wait", StringComparison.OrdinalIgnoreCase);
+
+            //A blue/green or deployment wait is already waiting, so we don't run the 
+            if (isBlueGreen || isWaitDeployment)
             {
                 return false;
             }
 
-            var hasClusterUrl = !string.IsNullOrEmpty(variables.Get(SpecialVariables.ClusterUrl));
-            var hasClusterName = !string.IsNullOrEmpty(variables.Get(SpecialVariables.AksClusterName)) ||
-                                 !string.IsNullOrEmpty(variables.Get(SpecialVariables.EksClusterName)) ||
-                                 !string.IsNullOrEmpty(variables.Get(SpecialVariables.GkeClusterName));
-            return hasClusterUrl || hasClusterName;
+            // At this point, we only care about the status of the resource status check
+            // If someone has set this variable manually, then it might blow up, but hey, that's on them
+            return variables.GetFlag(SpecialVariables.ResourceStatusCheck);
         }
 
         public CommandResult ExecuteScript(

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -45,7 +45,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             }
 
             // At this point, we only care about the status of the resource status check
-            // If someone has set this variable manually, then it might blow up, but hey, that's on them
+            // If someone has set this variable manually then it might blow up, but that's not a supported configuration
             return variables.GetFlag(SpecialVariables.ResourceStatusCheck);
         }
 

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -38,7 +38,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             var isBlueGreen = string.Equals(variables.Get(SpecialVariables.DeploymentStyle), "bluegreen", StringComparison.OrdinalIgnoreCase);
             var isWaitDeployment = string.Equals(variables.Get(SpecialVariables.DeploymentWait) , "wait", StringComparison.OrdinalIgnoreCase);
 
-            //A blue/green or deployment wait is already waiting, so we don't run the 
+            //A blue/green or deployment wait is waiting for other things, so we don't run resource status check 
             if (isBlueGreen || isWaitDeployment)
             {
                 return false;


### PR DESCRIPTION
The Kubernetes Object Status  was not correctly running for Deploy Containers  via Kubernetes agent because this step is actually executed as a script. The `ResourceStatusReporterWrapper` was being skipped for Kubernetes agents as there is no cluster url or cluster names.

After a discussion with @zentron, we decided it makes sense to just rely on the `ResourceStatusCheck` variable value (once we pass the blue/green & wait deployment checks

Shortcut story: [sc-78819]