### PR TITLE
Support kubernetes file system, retrieve storage space information from env vars

### DIFF
--- a/source/Calamari.Common/Plumbing/CalamariEnvironment.cs
+++ b/source/Calamari.Common/Plumbing/CalamariEnvironment.cs
@@ -12,6 +12,9 @@ namespace Calamari.Common.Plumbing
         /// </summary>
         public static readonly bool IsRunningOnMono = Type.GetType("Mono.Runtime") != null;
 
+        public static bool IsRunningOnKubernetes =>
+            Environment.GetEnvironmentVariable(KubernetesEnvironmentVariables.KubernetesAgentNamespace) != null;
+
         /// <summary>
         /// Based on some internal methods used my mono itself
         /// https://github.com/mono/mono/blob/master/mcs/class/corlib/System/Environment.cs

--- a/source/Calamari.Common/Plumbing/CalamariEnvironment.cs
+++ b/source/Calamari.Common/Plumbing/CalamariEnvironment.cs
@@ -13,7 +13,7 @@ namespace Calamari.Common.Plumbing
         public static readonly bool IsRunningOnMono = Type.GetType("Mono.Runtime") != null;
 
         public static bool IsRunningOnKubernetes =>
-            Environment.GetEnvironmentVariable(KubernetesEnvironmentVariables.KubernetesAgentNamespace) != null;
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(KubernetesEnvironmentVariables.KubernetesAgentNamespace));
 
         /// <summary>
         /// Based on some internal methods used my mono itself

--- a/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
@@ -42,6 +42,9 @@ namespace Calamari.Common.Plumbing.FileSystem
 
         public static CalamariPhysicalFileSystem GetPhysicalFileSystem()
         {
+            if (CalamariEnvironment.IsRunningOnKubernetes)
+                return new KubernetesFileSystem();
+
             if (CalamariEnvironment.IsRunningOnNix || CalamariEnvironment.IsRunningOnMac)
                 return new NixCalamariPhysicalFileSystem();
 

--- a/source/Calamari.Common/Plumbing/FileSystem/KubernetesFileSystem.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/KubernetesFileSystem.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Calamari.Common.Plumbing.FileSystem
+{
+    public class KubernetesFileSystem : CalamariPhysicalFileSystem
+    {
+        public override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
+        {
+            if (Environment.GetEnvironmentVariable(KubernetesEnvironmentVariables.KubernetesAgentVolumeFreeBytes) is
+                { } freeSpaceString)
+            {
+                return ulong.TryParse(freeSpaceString, out totalNumberOfFreeBytes);
+            }
+
+            totalNumberOfFreeBytes = 0;
+            return false;
+        }
+
+        public override bool GetDiskTotalSpace(string directoryPath, out ulong totalNumberOfBytes)
+        {
+            if (Environment.GetEnvironmentVariable(KubernetesEnvironmentVariables.KubernetesAgentVolumeTotalBytes) is
+                { } totalSpaceString)
+            {
+                return ulong.TryParse(totalSpaceString, out totalNumberOfBytes);
+            }
+
+            totalNumberOfBytes = 0;
+            return false;
+        }
+    }
+}

--- a/source/Calamari.Common/Plumbing/KubernetesEnvironmentVariables.cs
+++ b/source/Calamari.Common/Plumbing/KubernetesEnvironmentVariables.cs
@@ -3,7 +3,7 @@ namespace Calamari.Common.Plumbing
     public static class KubernetesEnvironmentVariables
     {
         public const string KubernetesAgentNamespace = "OCTOPUS__K8STENTACLE__NAMESPACE";
-        public const string KubernetesAgentVolumeFreeBytes = "OCTOPUS__K8STENTACLE__PERSISTENVOLUMEFREEBYTES";
-        public const string KubernetesAgentVolumeTotalBytes = "OCTOPUS__K8STENTACLE__PERSISTENVOLUMETOTALBYTES";
+        public const string KubernetesAgentVolumeFreeBytes = "OCTOPUS__K8STENTACLE__PERSISTENTVOLUMEFREEBYTES";
+        public const string KubernetesAgentVolumeTotalBytes = "OCTOPUS__K8STENTACLE__PERSISTENTVOLUMETOTALBYTES";
     }
 }

--- a/source/Calamari.Common/Plumbing/KubernetesEnvironmentVariables.cs
+++ b/source/Calamari.Common/Plumbing/KubernetesEnvironmentVariables.cs
@@ -1,0 +1,9 @@
+namespace Calamari.Common.Plumbing
+{
+    public static class KubernetesEnvironmentVariables
+    {
+        public const string KubernetesAgentNamespace = "OCTOPUS__K8STENTACLE__NAMESPACE";
+        public const string KubernetesAgentVolumeFreeBytes = "OCTOPUS__K8STENTACLE__PERSISTENVOLUMEFREEBYTES";
+        public const string KubernetesAgentVolumeTotalBytes = "OCTOPUS__K8STENTACLE__PERSISTENVOLUMETOTALBYTES";
+    }
+}


### PR DESCRIPTION
# Background

The Kubernetes Script Pods use a PV mount to get access to the shared file system managed by the Kubernetes Tentacle. When Calamari is acquiring packages, it checks if it should do package cleanup first.

Currently the Calamari implementation cannot do package retention when in the Kubernetes agent because it is not able to calculate the amount of storage on the PV.

[sc-76306]

# Results

This PR introduces a FileSystem type for Kubernetes. Instead of trying to calculate the storage usage itself, it relies on Tentacle setting the values as environment variables when launching script pods. The PR to add that is here (https://github.com/OctopusDeploy/OctopusTentacle/pull/941).

With this, the package retention code can correctly calculate if it should clean up old packages when storage space is running low.

# Screen shot:

<img width="903" alt="Screenshot 2024-05-22 at 11 18 00" src="https://github.com/OctopusDeploy/Calamari/assets/97430840/4029782f-e6dd-43ff-bc49-859b4c2c48d6">

