### PR TITLE
Add retry support to feed package downloads

### DIFF
--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -26,11 +26,11 @@
     <TargetFrameworks>net462;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);USE_NUGET_V2_LIBS;SUPPORTS_POLLY;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT</DefineConstants>
+    <DefineConstants>$(DefineConstants);USE_NUGET_V2_LIBS;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT</DefineConstants>
     <PlatformTarget>anycpu</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <DefineConstants>$(DefineConstants);USE_NUGET_V3_LIBS;SUPPORTS_POLLY</DefineConstants>
+    <DefineConstants>$(DefineConstants);USE_NUGET_V3_LIBS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462' ">
     <NoWarn>CS8600;CS8601;CS8602;CS8603;CS8604;DE0003;DE0004</NoWarn>

--- a/source/Calamari.Shared/Integration/Packages/Download/ArtifactoryPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/ArtifactoryPackageDownloader.cs
@@ -64,7 +64,9 @@ namespace Calamari.Integration.Packages.Download
                                    version,
                                    feedUri,
                                    GetFeedCredentials(feedUsername, feedPassword),
-                                   cacheDirectory);
+                                   cacheDirectory,
+                                   maxDownloadAttempts,
+                                   downloadAttemptBackoff);
         }
 
         PackagePhysicalFileMetadata? AttemptToGetPackageFromCache(string packageId, IVersion version, string cacheDirectory)
@@ -90,12 +92,13 @@ namespace Calamari.Integration.Packages.Download
             return null;
         }
 
-        public PackagePhysicalFileMetadata DownloadPackage(
-            string packageId,
-            IVersion version,
-            Uri feedUri,
-            ICredentials feedCredentials,
-            string cacheDirectory)
+        public PackagePhysicalFileMetadata DownloadPackage(string packageId,
+                                                           IVersion version,
+                                                           Uri feedUri,
+                                                           ICredentials feedCredentials,
+                                                           string cacheDirectory,
+                                                           int maxDownloadAttempts,
+                                                           TimeSpan downloadAttemptBackoff)
         {
             Log.Info("Downloading package {0} v{1} from feed: '{2}'", packageId, version, feedUri);
             Log.VerboseFormat("Downloaded package will be stored in: '{0}'", cacheDirectory);
@@ -113,22 +116,22 @@ namespace Calamari.Integration.Packages.Download
                 
                 var cachedFileName = PackageName.ToCachedFileName(packageId, version, fileExtension);
                 var downloadPath = Path.Combine(Path.Combine(stagingDir, cachedFileName));
+                
+                var retryStrategy = PackageDownloaderRetryUtils.CreateRetryStrategy<CommandException>(maxDownloadAttempts, downloadAttemptBackoff, log);
+                retryStrategy.Execute(() =>
+                                      {
+                                          using var response = DownloadPackage(downloadUri, feedCredentials);
+                                          if (!response.IsSuccessStatusCode)
+                                          {
+                                              throw new CommandException(
+                                                                         $"Failed to download artifact (Status Code {(int)response.StatusCode}). Reason: {response.ReasonPhrase}");
+                                          }
+                                          
+                                          using var fileStream = fileSystem.OpenFile(downloadPath, FileAccess.Write);
+                                          response.Content.CopyToAsync(fileStream).GetAwaiter().GetResult();
+                                      });
+                
 
-                using (var fileStream = fileSystem.OpenFile(downloadPath, FileAccess.Write))
-                {
-                    using var response = DownloadPackage(downloadUri, feedCredentials);
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        throw new CommandException(
-                                                   $"Failed to download artifact (Status Code {(int)response.StatusCode}). Reason: {response.ReasonPhrase}");
-                    }
-
-#if NET40
-                    response.Content.CopyToAsync(fileStream).Wait();
-#else
-                    response.Content.CopyToAsync(fileStream).GetAwaiter().GetResult();
-#endif
-                }
 
                 var localDownloadName = Path.Combine(cacheDirectory, cachedFileName);
                 fileSystem.MoveFile(downloadPath, localDownloadName);
@@ -150,12 +153,8 @@ namespace Calamari.Integration.Packages.Download
             HttpContent content = new StringContent(contentString, Encoding.UTF8);
 
             var response = Post(new Uri(url, "artifactory/api/search/aql"), content, credentials);
-
-#if NET40
-            var allPackagesRaw = response.Content.ReadAsStringAsync().Result;
-#else
+            
             var allPackagesRaw = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-#endif
 
             var allPackagesJson = JsonConvert.DeserializeObject<JObject>(allPackagesRaw);
             var packagesCollection = allPackagesJson["results"].ToArray();
@@ -336,14 +335,7 @@ namespace Calamari.Integration.Packages.Download
             throw new Exception("Unable to retrieve authentication token required to perform operation.");
         }
 
-        static string? GetContent(HttpResponseMessage response)
-        {
-#if NET40
-            return response.Content.ReadAsStringAsync().Result;
-#else
-            return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-#endif
-        }
+        static string? GetContent(HttpResponseMessage response) => response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
         AuthenticationHeaderValue CreateAuthenticationHeader(NetworkCredential credential)
         {
@@ -351,14 +343,7 @@ namespace Calamari.Integration.Packages.Download
             return new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
         }
 
-        HttpResponseMessage SendRequest(HttpRequestMessage request)
-        {
-#if NET40
-            return client.SendAsync(request).Result;
-#else
-            return client.SendAsync(request).GetAwaiter().GetResult();
-#endif
-        }
+        HttpResponseMessage SendRequest(HttpRequestMessage request) => client.SendAsync(request).GetAwaiter().GetResult();
 
         static ICredentials GetFeedCredentials(string? feedUsername, string? feedPassword)
         {

--- a/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
@@ -37,7 +37,11 @@ namespace Calamari.Integration.Packages.Download
             }
         };
 
-        public DockerImagePackageDownloader(IScriptEngine scriptEngine, ICalamariFileSystem fileSystem, ICommandLineRunner commandLineRunner, IVariables variables, ILog log)
+        public DockerImagePackageDownloader(IScriptEngine scriptEngine,
+                                            ICalamariFileSystem fileSystem,
+                                            ICommandLineRunner commandLineRunner,
+                                            IVariables variables,
+                                            ILog log)
         {
             this.scriptEngine = scriptEngine;
             this.fileSystem = fileSystem;
@@ -60,23 +64,21 @@ namespace Calamari.Integration.Packages.Download
             var fullImageName = GetFullImageName(packageId, version, feedUri);
 
             var feedHost = GetFeedHost(feedUri);
-            
+
             PerformLogin(username, password, feedHost);
 
             const string cachedWorkerToolsShortLink = "https://g.octopushq.com/CachedWorkerToolsImages";
             var imageNotCachedMessage =
-                "The docker image '{0}' may not be cached." +
-                " Please note images that have not been cached may take longer to be acquired than expected." +
-                " Your deployment will begin as soon as all images have been pulled." +
-                $" Please see {cachedWorkerToolsShortLink} for more information on cached worker-tools image versions.";
-            
+                "The docker image '{0}' may not be cached." + " Please note images that have not been cached may take longer to be acquired than expected." + " Your deployment will begin as soon as all images have been pulled." + $" Please see {cachedWorkerToolsShortLink} for more information on cached worker-tools image versions.";
+
             if (!IsImageCached(fullImageName))
             {
                 log.InfoFormat(imageNotCachedMessage, fullImageName);
             }
-            
-            PerformPull(fullImageName);
-            
+
+            var strategy = PackageDownloaderRetryUtils.CreateRetryStrategy<CommandException>(maxDownloadAttempts, downloadAttemptBackoff, log);
+            strategy.Execute(() => PerformPull(fullImageName));
+
             var (hash, size) = GetImageDetails(fullImageName);
             return new PackagePhysicalFileMetadata(new PackageFileNameMetadata(packageId, version, version, ""), string.Empty, hash, size);
         }
@@ -105,12 +107,13 @@ namespace Calamari.Integration.Packages.Download
 
         void PerformLogin(string? username, string? password, string feed)
         {
-            var result = ExecuteScript("DockerLogin", new Dictionary<string, string?>
-            {
-                ["DockerUsername"] = username,
-                ["DockerPassword"] = password,
-                ["FeedUri"] = feed
-            });
+            var result = ExecuteScript("DockerLogin",
+                                       new Dictionary<string, string?>
+                                       {
+                                           ["DockerUsername"] = username,
+                                           ["DockerPassword"] = password,
+                                           ["FeedUri"] = feed
+                                       });
             if (result == null)
                 throw new CommandException("Null result attempting to log in Docker registry");
             if (result.ExitCode != 0)
@@ -133,10 +136,11 @@ namespace Calamari.Integration.Packages.Download
 
         void PerformPull(string fullImageName)
         {
-            var result = ExecuteScript("DockerPull", new Dictionary<string, string?>
-            {
-                ["Image"] = fullImageName
-            });
+            var result = ExecuteScript("DockerPull",
+                                       new Dictionary<string, string?>
+                                       {
+                                           ["Image"] = fullImageName
+                                       });
             if (result == null)
                 throw new CommandException("Null result attempting to pull Docker image");
             if (result.ExitCode != 0)
@@ -153,16 +157,20 @@ namespace Calamari.Integration.Packages.Download
                 {
                     clone[keyValuePair.Key] = keyValuePair.Value;
                 }
+
                 return scriptEngine.Execute(new Script(file), clone, commandLineRunner, environmentVariables);
             }
         }
-        
+
         (string hash, long size) GetImageDetails(string fullImageName)
         {
             var details = "";
             var result2 = SilentProcessRunner.ExecuteCommand("docker",
-                "inspect --format=\"{{.Id}} {{.Size}}\" " + fullImageName,
-                ".", environmentVariables, (stdout) => { details = stdout; }, log.Error);
+                                                             "inspect --format=\"{{.Id}} {{.Size}}\" " + fullImageName,
+                                                             ".",
+                                                             environmentVariables,
+                                                             (stdout) => { details = stdout; },
+                                                             log.Error);
             if (result2.ExitCode != 0)
             {
                 throw new CommandException("Unable to determine acquired docker image hash");
@@ -179,7 +187,6 @@ namespace Calamari.Integration.Packages.Download
                 log.Verbose($"Unable to parse image size. ({parts[0]})");
             }
 
-
             return (hash, size);
         }
 
@@ -188,12 +195,12 @@ namespace Calamari.Integration.Packages.Download
             var output = "";
             var result = SilentProcessRunner.ExecuteCommand("docker",
                                                             "image ls --format=\"{{.ID}}\" --no-trunc",
-                                                            ".", 
-                                                            environmentVariables, 
+                                                            ".",
+                                                            environmentVariables,
                                                             (stdout) => { output += stdout + " "; },
                                                             (error) => { });
-            return result.ExitCode == 0 
-                ? output.Split(' ').Select(digest => digest.Trim()) 
+            return result.ExitCode == 0
+                ? output.Split(' ').Select(digest => digest.Trim())
                 : null;
         }
 
@@ -202,8 +209,8 @@ namespace Calamari.Integration.Packages.Download
             var output = "";
             var result = SilentProcessRunner.ExecuteCommand("docker",
                                                             $"manifest inspect --verbose {fullImageName}",
-                                                            ".", 
-                                                            environmentVariables, 
+                                                            ".",
+                                                            environmentVariables,
                                                             (stdout) => { output += stdout; },
                                                             (error) => { });
 
@@ -247,7 +254,7 @@ namespace Calamari.Integration.Packages.Download
             }
 
             var scriptFile = Path.Combine(".", $"Octopus.{contextFile}");
-            var contextScript = new AssemblyEmbeddedResources().GetEmbeddedResourceText(Assembly.GetExecutingAssembly(), $"{typeof (DockerImagePackageDownloader).Namespace}.Scripts.{contextFile}");
+            var contextScript = new AssemblyEmbeddedResources().GetEmbeddedResourceText(Assembly.GetExecutingAssembly(), $"{typeof(DockerImagePackageDownloader).Namespace}.Scripts.{contextFile}");
             fileSystem.OverwriteFile(scriptFile, contextScript);
             return scriptFile;
         }

--- a/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
@@ -65,7 +65,8 @@ namespace Calamari.Integration.Packages.Download
 
             var feedHost = GetFeedHost(feedUri);
 
-            PerformLogin(username, password, feedHost);
+            var strategy = PackageDownloaderRetryUtils.CreateRetryStrategy<CommandException>(maxDownloadAttempts, downloadAttemptBackoff, log);
+            strategy.Execute(() => PerformLogin(username, password, feedHost));
 
             const string cachedWorkerToolsShortLink = "https://g.octopushq.com/CachedWorkerToolsImages";
             var imageNotCachedMessage =
@@ -76,7 +77,6 @@ namespace Calamari.Integration.Packages.Download
                 log.InfoFormat(imageNotCachedMessage, fullImageName);
             }
 
-            var strategy = PackageDownloaderRetryUtils.CreateRetryStrategy<CommandException>(maxDownloadAttempts, downloadAttemptBackoff, log);
             strategy.Execute(() => PerformPull(fullImageName));
 
             var (hash, size) = GetImageDetails(fullImageName);

--- a/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/HelmChartPackageDownloader.cs
@@ -59,7 +59,8 @@ namespace Calamari.Integration.Packages.Download
 
             var feedCredentials = GetFeedCredentials(feedUsername, feedPassword);
 
-            var package = GetChartDetails(feedUri, feedCredentials, packageId, CancellationToken.None);
+            var strategy = PackageDownloaderRetryUtils.CreateRetryStrategy<Exception>(maxDownloadAttempts, downloadAttemptBackoff, log);
+            var package = strategy.Execute(() => GetChartDetails(feedUri, feedCredentials, packageId, CancellationToken.None));
 
             if (string.IsNullOrEmpty(package.PackageId))
             {

--- a/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderRetryUtils.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderRetryUtils.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Calamari.Common.Plumbing.Logging;
+using Polly;
+using Polly.Retry;
+
+namespace Calamari.Integration.Packages.Download
+{
+    public static class PackageDownloaderRetryUtils
+    {
+        public static ResiliencePipeline CreateRetryStrategy<T>(int maxAttempts, TimeSpan failureBackoff, ILog log) where T : Exception
+        {
+            return new ResiliencePipelineBuilder()
+                   .AddRetry(new RetryStrategyOptions
+                   {
+                       ShouldHandle = new PredicateBuilder().Handle<T>(),
+                       MaxRetryAttempts = maxAttempts,
+                       Delay = failureBackoff,
+                       BackoffType = DelayBackoffType.Linear,
+                       OnRetry = args =>
+                                 {
+                                     log.Verbose($"Waiting {args.RetryDelay.TotalSeconds}s before attempting the download from the external feed again.");
+                                     return default;
+                                 }
+                   })
+                   .Build();
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
@@ -59,10 +59,10 @@ namespace Calamari.Integration.Packages.Download
                     downloader = new GitHubPackageDownloader(log, fileSystem);
                     break;
                 case FeedType.Helm:
-                    downloader = new HelmChartPackageDownloader(fileSystem);
+                    downloader = new HelmChartPackageDownloader(fileSystem, log);
                     break;
                 case FeedType.OciRegistry:
-                    downloader = new OciPackageDownloader(fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner));
+                    downloader = new OciPackageDownloader(fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner), log);
                     break;
                 case FeedType.Docker:
                 case FeedType.AwsElasticContainerRegistry:

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/ArtifactoryPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/ArtifactoryPackageDownloaderFixture.cs
@@ -71,7 +71,9 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                                                                  version,
                                                                  feedUri,
                                                                  feedCredentials,
-                                                                 cacheDirectory);
+                                                                 cacheDirectory, 
+                                                                 5, 
+                                                                 TimeSpan.FromSeconds(1));
 
             packagePhysicalFile.PackageId.Should().Be("com/octopus/TestWebApp2/TestWebApp2");
             packagePhysicalFile.Version.ToString().Should().Be("1.0.0");
@@ -90,7 +92,9 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                                                                  version,
                                                                  feedUri,
                                                                  feedCredentials,
-                                                                 cacheDirectory);
+                                                                 cacheDirectory, 
+                                                                 5, 
+                                                                 TimeSpan.FromSeconds(1));
 
             // The packageId for nupkgs uses the id from the nuspec file.
             packagePhysicalFile.PackageId.Should().Be("Octopus.Client");
@@ -110,7 +114,9 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                                                                  version,
                                                                  feedUri,
                                                                  feedCredentials,
-                                                                 cacheDirectory);
+                                                                 cacheDirectory, 
+                                                                 5, 
+                                                                 TimeSpan.FromSeconds(1));
 
             packagePhysicalFile.PackageId.Should().Be("octopus/Acme.Web/Acme.Web");
             packagePhysicalFile.Version.ToString().Should().Be("3.2.5");

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
@@ -116,15 +116,16 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
                 new Uri(AuthFeedUri),
                 FeedUsername, "SuperDooper",
                 true, 
-                3,
-                TimeSpan.FromSeconds(1)));
+                //we don't want to perform too many of these otherwise jfrog / artifactory gets sad at us
+                2,
+                TimeSpan.FromSeconds(5)));
             
             StringAssert.Contains("Unable to log in Docker registry", exception.Message);
             memoryLog.Messages
                      .Where(msg => msg.Level == InMemoryLog.Level.Verbose)
                      .Where(msg => msg.FormattedMessage.Contains("before attempting the download from the external feed again"))
                      .Should()
-                     .HaveCount(3);
+                     .HaveCount(2);
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/HelmChartPackageDownloaderFixture.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Integration.Packages.Download;
 using Calamari.Testing;
+using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
 using FluentAssertions;
 using NUnit.Framework;
@@ -40,7 +41,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [SetUp]
         public void Setup()
         {
-            downloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem());
+            downloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new InMemoryLog());
         }
         
         [Test]
@@ -56,7 +57,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         public void PackageWithInvalidUrl_Throws()
         {
             var badUrl = new Uri($"https://octopusdeploy.jfrog.io/gobbelygook/{Guid.NewGuid().ToString("N")}");
-            var badEndpointDownloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem());
+            var badEndpointDownloader = new HelmChartPackageDownloader(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), new InMemoryLog());
             Action action = () => badEndpointDownloader.DownloadPackage("something", new SemanticVersion("99.9.7"), "gobbely", new Uri(badUrl, "something.99.9.7"), FeedUsername, FeedPassword, true, 1, TimeSpan.FromSeconds(3));
             action.Should().Throw<Exception>().And.Message.Should().Contain("Unable to read Helm index file").And.Contain("404");
         }

--- a/source/Calamari/Commands/DownloadPackageCommand.cs
+++ b/source/Calamari/Commands/DownloadPackageCommand.cs
@@ -174,8 +174,7 @@ namespace Calamari.Commands
             if (parsedMaxDownloadAttempts <= 0)
                 throw new CommandException("The requested number of download attempts should be more than zero");
 
-            int parsedAttemptBackoffSeconds;
-            if (!int.TryParse(attemptBackoffSeconds, out parsedAttemptBackoffSeconds))
+            if (!int.TryParse(attemptBackoffSeconds, out var parsedAttemptBackoffSeconds))
                 throw new CommandException($"Retry requested download attempt retry backoff '{attemptBackoffSeconds}' is not a valid integer number of seconds");
 
             if (parsedAttemptBackoffSeconds < 0)


### PR DESCRIPTION
A number of package feeds were not performing retries as part of the download process. This uses the Polly ResilientPipelines to add retry support to:

- ArtifactoryPackageDownloader
- DockerImagePackageDownloader
- HelmChartPackageDownloader
- OciPackageDownloader

Shortcut story: [sc-79732]