### PR TITLE
Correctly set WindowsFxVersion for windows container app services

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -33,6 +33,9 @@ namespace Calamari.AzureAppService.Tests
             CalamariVariables newVariables;
             readonly HttpClient client = new HttpClient();
 
+            // There are capacity issues in eastus
+            protected override string DefaultResourceGroupLocation => "westus2";
+            
             protected override async Task ConfigureTestResources(ResourceGroupResource resourceGroup)
             {
                 var (_, webSite) = await CreateAppServicePlanAndWebApp(resourceGroup,

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -18,6 +18,12 @@ using Octostache;
 
 namespace Calamari.AzureAppService.Tests
 {
+    /// <summary>
+    /// Tests that both windows and linux app services can have container deployments
+    /// </summary>
+    /// <remarks>
+    /// Both test fixtures have the same two tests, but they have different setups, so it's just easier to have separate test fixtures.
+    /// </remarks>
     public class AzureAppServiceDeployContainerBehaviourFixture
     {
         [TestFixture]

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -113,7 +113,7 @@ namespace Calamari.AzureAppService.Tests
 
                 var receivedContent = await response.Content.ReadAsStringAsync();
 
-                receivedContent.Should().Contain(@"<title>Welcome to Azure Container Instances!</title>");
+                receivedContent.Should().Contain(@"<title>Microsoft Azure App Service - Welcome</title>");
                 Assert.IsTrue(response.IsSuccessStatusCode);
             }
 


### PR DESCRIPTION
When deploying a container to an app service, we were incorrectly always setting the `LinuxFxVersion` for all app service operating systems. However, if this is a windows app service, we should be setting the `WindowsFxVersion` property.

We can determine what the app service's OS is by looking at the `kind` property.

Shortcut story: [sc-41798]