### PR TITLE
Order ScriptProxyFixtureBase tests

### DIFF
--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/ScriptProxyFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/ScriptProxyFixtureBase.cs
@@ -14,14 +14,9 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
         protected const string BadproxyUrl = "http://proxy-initializer-fixture-bad-proxy:1234";
         protected const string ProxyUserName = "some@:/user";
         protected const string ProxyPassword = "some@:/password";
-
-#if NET40
-        const string UrlEncodedProxyUserName = "some%40%3a%2fuser";
-        const string UrlEncodedProxyPassword = "some%40%3a%2fpassword";
-#else
+        
         const string UrlEncodedProxyUserName = "some%40%3A%2Fuser";
         const string UrlEncodedProxyPassword = "some%40%3A%2Fpassword";
-#endif
         
         protected const string proxyHost = "proxy-initializer-fixture-good-proxy";
         protected const int proxyPort = 8888;
@@ -37,7 +32,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
             ResetProxyEnvironmentVariables();
         }
 
-        [Test]
+        [Test, Order(1)]
         public virtual void Initialize_NoSystemProxy_NoProxy()
         {
             var result = RunWith(false, "", 80, "", "");
@@ -45,7 +40,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
             AssertProxyBypassed(result);
         }
 
-        [Test]
+        [Test, Order(2)]
         public virtual void Initialize_NoSystemProxy_UseSystemProxy()
         {
             var result = RunWith(true, "", 80, "", "");
@@ -53,7 +48,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
             AssertNoProxyChanges(result);
         }
 
-        [Test]
+        [Test, Order(3)]
         public virtual void Initialize_NoSystemProxy_UseSystemProxyWithCredentials()
         {
             var result = RunWith(true, "", 80, ProxyUserName, ProxyPassword);
@@ -61,7 +56,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
             AssertNoProxyChanges(result);
         }
 
-        [Test]
+        [Test, Order(4)]
         public virtual void Initialize_NoSystemProxy_CustomProxy()
         {
             var result = RunWith(false, proxyHost, proxyPort, "", "");
@@ -69,7 +64,7 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
             AssertUnauthenticatedProxyUsed(result);
         }
 
-        [Test]
+        [Test, Order(5)]
         public virtual void Initialize_NoSystemProxy_CustomProxyWithCredentials()
         {
             var result = RunWith(false, proxyHost, proxyPort, ProxyUserName, ProxyPassword);


### PR DESCRIPTION
Due to test splitting, we need the no proxy tests to run first so it can pre-acquire packages without running through a non-existant proxy