### PR TITLE
Added 'PreventHelmV2Deployments' feature toggle

### DIFF
--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -14,6 +14,6 @@
         AsynchronousAzureZipDeployFeatureToggle,
         FSharpDeprecationFeatureToggle,
         AzureRMDeprecationFeatureToggle,
-        HelmV2SupportEnabledFeatureToggle
+        PreventHelmV2DeploymentsFeatureToggle
     }
 }

--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -13,6 +13,7 @@
         OidcAccountsFeatureToggle,
         AsynchronousAzureZipDeployFeatureToggle,
         FSharpDeprecationFeatureToggle,
-        AzureRMDeprecationFeatureToggle
+        AzureRMDeprecationFeatureToggle,
+        HelmV2SupportEnabledFeatureToggle
     }
 }

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -9,6 +9,7 @@ using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.Scripts;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.FileSystem.GlobExpressions;
 using Calamari.Common.Plumbing.Logging;
@@ -70,7 +71,14 @@ namespace Calamari.Kubernetes.Conventions
 
             if (helmVersion == HelmVersion.V2)
             {
-                log.Warn("This step is currently configured to use Helm V2. Support for Helm V2 will be removed in Octopus Server 2024.3. Please migrate to Helm V3 as soon as possible");
+                if (FeatureToggle.HelmV2SupportEnabledFeatureToggle.IsEnabled(deployment.Variables))
+                {
+                    log.Warn("This step is currently configured to use Helm V2. Support for Helm V2 will be removed in Octopus Server 2024.3. Please migrate to Helm V3 as soon as possible.");
+                }
+                else
+                {
+                    throw new CommandException("Helm V2 is no longer supported. Please migrate to Helm V3.");
+                }
             }
 
             var sb = new StringBuilder();

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -71,7 +71,7 @@ namespace Calamari.Kubernetes.Conventions
 
             if (helmVersion == HelmVersion.V2)
             {
-                if (FeatureToggle.HelmV2SupportEnabledFeatureToggle.IsEnabled(deployment.Variables))
+                if (!FeatureToggle.PreventHelmV2DeploymentsFeatureToggle.IsEnabled(deployment.Variables))
                 {
                     log.Warn("This step is currently configured to use Helm V2. Support for Helm V2 will be removed in Octopus Server 2024.3. Please migrate to Helm V3 as soon as possible.");
                 }

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -71,13 +71,13 @@ namespace Calamari.Kubernetes.Conventions
 
             if (helmVersion == HelmVersion.V2)
             {
-                if (!FeatureToggle.PreventHelmV2DeploymentsFeatureToggle.IsEnabled(deployment.Variables))
+                if (FeatureToggle.PreventHelmV2DeploymentsFeatureToggle.IsEnabled(deployment.Variables))
                 {
-                    log.Warn("This step is currently configured to use Helm V2. Support for Helm V2 will be removed in Octopus Server 2024.3. Please migrate to Helm V3 as soon as possible.");
+                    throw new CommandException("Helm V2 is no longer supported. Please migrate to Helm V3.");
                 }
                 else
                 {
-                    throw new CommandException("Helm V2 is no longer supported. Please migrate to Helm V3.");
+                    log.Warn("This step is currently configured to use Helm V2. Support for Helm V2 will be removed in Octopus Server 2024.3. Please migrate to Helm V3 as soon as possible.");
                 }
             }
 

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -77,7 +77,7 @@ namespace Calamari.Kubernetes.Conventions
                 }
                 else
                 {
-                    log.Warn("This step is currently configured to use Helm V2. Support for Helm V2 will be removed in Octopus Server 2024.3. Please migrate to Helm V3 as soon as possible.");
+                    log.Warn("This step is currently configured to use Helm V2. Support for Helm V2 will be completely removed in Octopus Server 2025.1. Please migrate to Helm V3 as soon as possible.");
                 }
             }
 


### PR DESCRIPTION
We are removing support for Helm V2 in 2024.3. We currently warn users about this, and this PR adds a feature toggle which will disable that support.

The feature toggle is `PreventHelmV2DeploymentsFeatureToggle`.  If the toggle is enabled and a Helm v2 deployment is attempted, Calamari will throw an exception.

**To the reviewer:**
This pairs with the below server PR.  Please take extra time to ensure that I have implemented the toggles the same way around.  I have tested this, but a second set of eyes never hurts.

Related server PR: https://github.com/OctopusDeploy/OctopusDeploy/pull/25041