### PR TITLE
Preserve .tar file attributes when extracting

### DIFF
--- a/source/Calamari.Common/Features/Packages/TarPackageExtractor.cs
+++ b/source/Calamari.Common/Features/Packages/TarPackageExtractor.cs
@@ -50,7 +50,7 @@ namespace Calamari.Common.Features.Packages
         {
             var strategy = PackageExtractorUtils.CreateIoExceptionRetryStrategy(log);
 
-            strategy.Execute(() => reader.WriteEntryToDirectory(directory, new PackageExtractionOptions(log)));
+            strategy.Execute(() => reader.WriteEntryToDirectory(directory, new PackageExtractionOptions(log) { PreserveAttributes = true }));
         }
 
         protected virtual Stream GetCompressionStream(Stream stream)


### PR DESCRIPTION
When extracting .tar files, we preserve the file attributes (such as permissions)