### PR TITLE
Fix Async deploy file lock

### DIFF
--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -130,17 +130,17 @@ namespace Calamari.AzureAppService.Behaviors
             bool uploadFileNeedsCleaning = false;
             try
             {
+                FileInfo? uploadFile;
                 if (substitutionFeatures.Any(featureName => context.Variables.IsFeatureEnabled(featureName)))
                 {
-                    uploadPath = (await packageProvider.PackageArchive(context.StagingDirectory, context.CurrentDirectory)).FullName;
-                    uploadFileNeedsCleaning = true;
+                    uploadFile = (await packageProvider.PackageArchive(context.StagingDirectory, context.CurrentDirectory));
                 }
                 else
                 {
-                    var uploadFile = await packageProvider.ConvertToAzureSupportedFile(packageFileInfo);
-                    uploadPath = uploadFile.FullName;
-                    uploadFileNeedsCleaning = packageFileInfo.Extension != uploadFile.Extension;
+                    uploadFile = await packageProvider.ConvertToAzureSupportedFile(packageFileInfo);
                 }
+                uploadPath = uploadFile.FullName;
+                uploadFileNeedsCleaning = packageFileInfo.Extension != uploadFile.Extension;
 
                 if (uploadPath == null)
                 {

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -229,6 +229,10 @@ namespace Calamari.AzureAppService.Behaviors
             //we add some retry just in case the web app's Kudu/SCM is not running just yet
             var response = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
                                                                                       {
+                                                                                          using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                                                                                          using var streamContent = new StreamContent(fileStream);
+                                                                                          streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                                                                                          
                                                                                           //we have to create a new request message each time
                                                                                           var request = new HttpRequestMessage(HttpMethod.Post, zipUploadUrl)
                                                                                           {
@@ -236,10 +240,7 @@ namespace Calamari.AzureAppService.Behaviors
                                                                                               {
                                                                                                   Authorization = new AuthenticationHeaderValue("Basic", publishingProfile.GetBasicAuthCredentials())
                                                                                               },
-                                                                                              Content = new StreamContent(new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                                                                                              {
-                                                                                                  Headers = { ContentType = new MediaTypeHeaderValue("application/octet-stream") }
-                                                                                              }
+                                                                                              Content = streamContent
                                                                                           };
 
                                                                                           var r = await httpClient.SendAsync(request);

--- a/source/Calamari.AzureAppService/RetryPolicies.cs
+++ b/source/Calamari.AzureAppService/RetryPolicies.cs
@@ -35,7 +35,7 @@ namespace Calamari.AzureAppService
                                                                                                                                retryAttempt => TimeSpan.FromSeconds(Math.Pow(3.5, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 10000)));
 
         public static AsyncRetryPolicy<HttpResponseMessage> AsynchronousZipDeploymentOperationPolicy { get; } = Policy.HandleResult<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Accepted)
-                                                                                                                      .WaitAndRetryForeverAsync((_1, ctx) => TimeSpan.FromSeconds(2),
+                                                                                                                      .WaitAndRetryForeverAsync((_1, ctx) => TimeSpan.FromSeconds(4),
                                                                                                                                                 (response, timeout, ctx) =>
                                                                                                                                                 {
                                                                                                                                                     if (ctx.TryGetValue(ContextKeys.Log, out var logObj) && logObj is ILog log)


### PR DESCRIPTION
The Async zip deploy functionality clashed with a change made to [cleanup uploaded files](https://github.com/OctopusDeploy/Calamari/pull/1161/files). This change leaves in place the delete re-try, although that's likely redundant now it may help in other scenarios. This change also extends the file clean-up to the code path where any of the following variables are used.
`
KnownVariables.Features.ConfigurationTransforms,
KnownVariables.Features.StructuredConfigurationVariables,
KnownVariables.Features.SubstituteInFiles
`