### PR TITLE
Isaac/az app service async fix

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -357,6 +357,7 @@ namespace Calamari.AzureAppService.Tests
                 });
                 
                 context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;
+                context.Variables[SpecialVariables.Action.Azure.AsyncZipDeploymentTimeout] =  "3";
             }
         }
 

--- a/source/Calamari.AzureAppService/Azure/SpecialVariables.cs
+++ b/source/Calamari.AzureAppService/Azure/SpecialVariables.cs
@@ -19,6 +19,7 @@ namespace Calamari.AzureAppService.Azure
                 public static readonly string WebAppSlot = "Octopus.Action.Azure.DeploymentSlot";
                 public static readonly string AppSettings = "Octopus.Action.Azure.AppSettings";
                 public static readonly string ConnectionStrings = "Octopus.Action.Azure.ConnectionStrings";
+                public static readonly string AsyncZipDeploymentTimeout = "Octopus.Action.Azure.AsyncZipDeploymentTimeout";
             }
 
             public static class Package

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -130,17 +130,17 @@ namespace Calamari.AzureAppService.Behaviors
             bool uploadFileNeedsCleaning = false;
             try
             {
+                FileInfo? uploadFile;
                 if (substitutionFeatures.Any(featureName => context.Variables.IsFeatureEnabled(featureName)))
                 {
-                    uploadPath = (await packageProvider.PackageArchive(context.StagingDirectory, context.CurrentDirectory)).FullName;
-                    uploadFileNeedsCleaning = true;
+                    uploadFile = (await packageProvider.PackageArchive(context.StagingDirectory, context.CurrentDirectory));
                 }
                 else
                 {
-                    var uploadFile = await packageProvider.ConvertToAzureSupportedFile(packageFileInfo);
-                    uploadPath = uploadFile.FullName;
-                    uploadFileNeedsCleaning = packageFileInfo.Extension != uploadFile.Extension;
+                    uploadFile = await packageProvider.ConvertToAzureSupportedFile(packageFileInfo);
                 }
+                uploadPath = uploadFile.FullName;
+                uploadFileNeedsCleaning = packageFileInfo.Extension != uploadFile.Extension;
 
                 if (uploadPath == null)
                 {

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -229,7 +229,7 @@ namespace Calamari.AzureAppService.Behaviors
             //we add some retry just in case the web app's Kudu/SCM is not running just yet
             var response = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
                                                                                       {
-                                                                                          using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                                                                                          await using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
                                                                                           using var streamContent = new StreamContent(fileStream);
                                                                                           streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
                                                                                           
@@ -281,7 +281,7 @@ namespace Calamari.AzureAppService.Behaviors
             var uploadResponse = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
                                                                                             {
                                                                                                 //we have to create a new request message each time
-                                                                                                using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                                                                                                await using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
                                                                                                 using var streamContent = new StreamContent(fileStream);
                                                                                                 streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
 

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -31,9 +31,6 @@ namespace Calamari.AzureAppService.Behaviors
 {
     internal class AzureAppServiceZipDeployBehaviour : IDeployBehaviour
     {
-        static readonly TimeSpan PollingTimeout = TimeSpan.FromMinutes(3);
-        static readonly AsyncTimeoutPolicy<HttpResponseMessage> AsyncZipDeployTimeoutPolicy = Policy.TimeoutAsync<HttpResponseMessage>(PollingTimeout, TimeoutStrategy.Optimistic);
-
         public AzureAppServiceZipDeployBehaviour(ILog log)
         {
             Log = log;
@@ -54,6 +51,11 @@ namespace Calamari.AzureAppService.Behaviors
             Log.Verbose($"Using Azure Subscription '{account.SubscriptionNumber}'");
             Log.Verbose($"Using Azure ServicePrincipal AppId/ClientId '{account.ClientId}'");
             Log.Verbose($"Using Azure Cloud '{account.AzureEnvironment}'");
+
+            var pollingTimeoutVariableValue = variables.Get(SpecialVariables.Action.Azure.AsyncZipDeploymentTimeout, "5");
+            int.TryParse(pollingTimeoutVariableValue, out var pollingTimeoutValue);
+            var pollingTimeout = TimeSpan.FromMinutes(pollingTimeoutValue);
+            var asyncZipDeployTimeoutPolicy = Policy.TimeoutAsync<HttpResponseMessage>(pollingTimeout, TimeoutStrategy.Optimistic);
 
             string? resourceGroupName = variables.Get(SpecialVariables.Action.Azure.ResourceGroupName);
             if (resourceGroupName == null)
@@ -163,7 +165,7 @@ namespace Calamari.AzureAppService.Behaviors
 
                 if (packageProvider.SupportsAsynchronousDeployment && FeatureToggle.AsynchronousAzureZipDeployFeatureToggle.IsEnabled(context.Variables))
                 {
-                    await UploadZipAndPollAsync(publishingProfile, uploadPath, targetSite.ScmSiteAndSlot, packageProvider);
+                    await UploadZipAndPollAsync(publishingProfile, uploadPath, targetSite.ScmSiteAndSlot, packageProvider, pollingTimeout, asyncZipDeployTimeoutPolicy);
                 }
                 else
                 {
@@ -229,7 +231,11 @@ namespace Calamari.AzureAppService.Behaviors
             //we add some retry just in case the web app's Kudu/SCM is not running just yet
             var response = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
                                                                                       {
+#if NETFRAMEWORK
+                                                                                          using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+#else
                                                                                           await using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+#endif
                                                                                           using var streamContent = new StreamContent(fileStream);
                                                                                           streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
                                                                                           
@@ -257,7 +263,9 @@ namespace Calamari.AzureAppService.Behaviors
         private async Task UploadZipAndPollAsync(PublishingProfile publishingProfile,
                                                  string uploadZipPath,
                                                  string targetSite,
-                                                 IPackageProvider packageProvider)
+                                                 IPackageProvider packageProvider,
+                                                 TimeSpan pollingTimeout,
+                                                 AsyncTimeoutPolicy<HttpResponseMessage> asyncZipDeployTimeoutPolicy)
         {
             Log.Verbose($"Path to upload: {uploadZipPath}");
             Log.Verbose($"Target Site: {targetSite}");
@@ -281,7 +289,11 @@ namespace Calamari.AzureAppService.Behaviors
             var uploadResponse = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
                                                                                             {
                                                                                                 //we have to create a new request message each time
+#if NETFRAMEWORK
+                                                                                                using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+#else
                                                                                                 await using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+#endif
                                                                                                 using var streamContent = new StreamContent(fileStream);
                                                                                                 streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
 
@@ -306,7 +318,7 @@ namespace Calamari.AzureAppService.Behaviors
             var location = uploadResponse.Headers.Location;
 
             //wrap the entire thing in a Polly Timeout policy which uses the cancellation token to raise the timout
-            var result = await AsyncZipDeployTimeoutPolicy.ExecuteAndCaptureAsync(async timeoutCancellationToken =>
+            var result = await asyncZipDeployTimeoutPolicy.ExecuteAndCaptureAsync(async timeoutCancellationToken =>
                                                                                   {
                                                                                       //the outer policy should only retry when the response is a 202
                                                                                       return await RetryPolicies.AsynchronousZipDeploymentOperationPolicy
@@ -342,7 +354,7 @@ namespace Calamari.AzureAppService.Behaviors
             {
                 throw result.FinalException switch
                       {
-                          OperationCanceledException oce => new Exception($"Zip deployment failed to complete after {PollingTimeout}.", oce),
+                          OperationCanceledException oce => new Exception($"Zip deployment failed to complete after {pollingTimeout}.", oce),
                           _ => new Exception($"Zip deployment failed to complete.", result.FinalException)
                       };
             }

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -229,6 +229,10 @@ namespace Calamari.AzureAppService.Behaviors
             //we add some retry just in case the web app's Kudu/SCM is not running just yet
             var response = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
                                                                                       {
+                                                                                          using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                                                                                          using var streamContent = new StreamContent(fileStream);
+                                                                                          streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                                                                                          
                                                                                           //we have to create a new request message each time
                                                                                           var request = new HttpRequestMessage(HttpMethod.Post, zipUploadUrl)
                                                                                           {
@@ -236,10 +240,7 @@ namespace Calamari.AzureAppService.Behaviors
                                                                                               {
                                                                                                   Authorization = new AuthenticationHeaderValue("Basic", publishingProfile.GetBasicAuthCredentials())
                                                                                               },
-                                                                                              Content = new StreamContent(new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                                                                                              {
-                                                                                                  Headers = { ContentType = new MediaTypeHeaderValue("application/octet-stream") }
-                                                                                              }
+                                                                                              Content = streamContent
                                                                                           };
 
                                                                                           var r = await httpClient.SendAsync(request);

--- a/source/Calamari.AzureAppService/RetryPolicies.cs
+++ b/source/Calamari.AzureAppService/RetryPolicies.cs
@@ -35,7 +35,7 @@ namespace Calamari.AzureAppService
                                                                                                                                retryAttempt => TimeSpan.FromSeconds(Math.Pow(3.5, retryAttempt)) + TimeSpan.FromMilliseconds(Jitterer.Next(0, 10000)));
 
         public static AsyncRetryPolicy<HttpResponseMessage> AsynchronousZipDeploymentOperationPolicy { get; } = Policy.HandleResult<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Accepted)
-                                                                                                                      .WaitAndRetryForeverAsync((_1, ctx) => TimeSpan.FromSeconds(2),
+                                                                                                                      .WaitAndRetryForeverAsync((_1, ctx) => TimeSpan.FromSeconds(4),
                                                                                                                                                 (response, timeout, ctx) =>
                                                                                                                                                 {
                                                                                                                                                     if (ctx.TryGetValue(ContextKeys.Log, out var logObj) && logObj is ILog log)


### PR DESCRIPTION
Add an await to new FileStream calls, this wasn't causing issues but may have been the underlying cause for an issue raised in [requests](https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1716992796961289) (Internal).

Bumped in Hotfix tags 
* https://github.com/OctopusDeploy/Calamari/compare/27.0.10-hotfix.4...27.0.10-hotfix.5?expand=1
* https://github.com/OctopusDeploy/Calamari/compare/27.1.16-hotfix.1...27.1.16-hotfix.2?expand=1