### PR TITLE
Set source branches to release for releases

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,6 +4,7 @@ branches:
     mode: ContinuousDelivery
     is-release-branch: false
     tag: hotfix
+    source-branches: [ 'release' ]
     increment: None
 ignore:
   sha: [
@@ -11,6 +12,5 @@ ignore:
     50f946ec8b017e7f9e0114436d7a8aa8208dcaa0,
     4e7b8753fa3ec1934c718dc94cc88973a92d2dcf,
     e5be8e676416b3229bd2c9d24df59632d4e7ca67,
-    cebffd5ef63e89bca956fd30b829ed4cfa574a0f,
-    9d2248eccc964be58c480d92647b26ae1e2eeeff
+    cebffd5ef63e89bca956fd30b829ed4cfa574a0f
     ]


### PR DESCRIPTION
We're having issues with GitVersion selecting non release branches & creating incorrect build versions for tags. This change adds the source-branches restriction of releases on release builds. 

https://gitversion.net/docs/reference/configuration
> source-branches
Because Git commits only refer to parent commits (not branches) GitVersion sometimes cannot tell which branch the current branch was branched from.

The approach here would be to:
* Create a PR targeting your release version, in this case, 27.0.10.
* Merge.
~~Create a hotfix tag off of that release branch.~~ TBD whether this is required.
* Trigger the build in TeamCity against the release branch. (Subsequent builds against the same release branch should auto increment the hotfix version)