### PR TITLE
Fix output variable values for base kubernetes apply

### DIFF
--- a/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
@@ -115,7 +115,7 @@ namespace Calamari.Kubernetes.Commands.Executors
                 try
                 {
                     var result = kubectl.ExecuteCommandAndReturnOutput("get", resource.Kind, resource.Name,
-                                                                       "-o", "json");
+                                                                       "-o", "json", "-n", resource.Namespace);
 
                     log.WriteServiceMessage(new ServiceMessage(ServiceMessageNames.SetVariable.Name, new Dictionary<string, string>
                     {


### PR DESCRIPTION
This command is used to populate the output variable in the deployment process with the JSON output of each resource.

While testing something else, I noticed it wasn't working - turns out we were missing the namespace here.