### PR TITLE
Randomly assign region for Azure WebApp container tests

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -365,7 +365,8 @@ namespace Calamari.AzureAppService.Tests
         public class WhenUsingALinuxAppService : AppServiceIntegrationTest
         {
             // For some reason we are having issues creating these linux resources on Standard in EastUS
-            protected override string DefaultResourceGroupLocation => "westus2";
+            protected override string DefaultResourceGroupLocation => RandomAzureRegion.GetRandomRegionWithExclusions("eastus");
+            
             static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
             readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 

--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -32,7 +32,7 @@ namespace Calamari.AzureAppService.Tests
         protected string SubscriptionId { get; private set; }
         protected string ResourceGroupName { get; private set; }
         protected string ResourceGroupLocation { get; private set; }
-        
+
         protected string greeting = "Calamari";
         protected ArmClient ArmClient { get; private set; }
 
@@ -42,8 +42,8 @@ namespace Calamari.AzureAppService.Tests
 
         private readonly HttpClient client = new HttpClient();
 
-        protected virtual string DefaultResourceGroupLocation => "eastus";
-        
+        protected virtual string DefaultResourceGroupLocation => RandomAzureRegion.GetRandomRegionWithExclusions();
+
         static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
         readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
@@ -62,6 +62,8 @@ namespace Calamari.AzureAppService.Tests
             TenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken);
             SubscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
             ResourceGroupLocation = Environment.GetEnvironmentVariable("AZURE_NEW_RESOURCE_REGION") ?? DefaultResourceGroupLocation;
+
+            TestContext.WriteLine($"Resource group location: {ResourceGroupLocation}");
 
             var servicePrincipalAccount = new AzureServicePrincipalAccount(SubscriptionId,
                                                                            ClientId,
@@ -126,7 +128,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                                return r;
                                                                                            },
                                                                                            contextData: new Dictionary<string, object>());
- 
+
             var result = await response.Content.ReadAsStringAsync();
             result.Should().Contain(actualText);
         }
@@ -194,7 +196,7 @@ namespace Calamari.AzureAppService.Tests
 
             return (servicePlanResponse.Value, webSiteResponse.Value);
         }
-        
+
         protected (string json, IEnumerable<AppSetting> setting) BuildAppSettingsJson(IEnumerable<(string name, string value, bool isSlotSetting)> settings)
         {
             var appSettings = settings.Select(setting => new AppSetting

--- a/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceIntegrationTest.cs
@@ -63,7 +63,7 @@ namespace Calamari.AzureAppService.Tests
             SubscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
             ResourceGroupLocation = Environment.GetEnvironmentVariable("AZURE_NEW_RESOURCE_REGION") ?? DefaultResourceGroupLocation;
 
-            TestContext.WriteLine($"Resource group location: {ResourceGroupLocation}");
+            TestContext.Progress.WriteLine($"Resource group location: {ResourceGroupLocation}");
 
             var servicePrincipalAccount = new AzureServicePrincipalAccount(SubscriptionId,
                                                                            ClientId,

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -34,7 +34,7 @@ namespace Calamari.AzureAppService.Tests
             readonly HttpClient client = new HttpClient();
 
             //We are having capacity issues in EastUS and WestUS2
-            protected override string DefaultResourceGroupLocation => RandomAzureRegion.GetRandomRegion("eastus", "westus2");
+            protected override string DefaultResourceGroupLocation => RandomAzureRegion.GetRandomRegionWithExclusions("eastus", "westus2");
             
             protected override async Task ConfigureTestResources(ResourceGroupResource resourceGroup)
             {
@@ -177,7 +177,7 @@ namespace Calamari.AzureAppService.Tests
             readonly HttpClient client = new HttpClient();
 
             // For some reason we are having issues creating these linux resources on Standard in EastUS
-            protected override string DefaultResourceGroupLocation => RandomAzureRegion.GetRandomRegion("eastus");
+            protected override string DefaultResourceGroupLocation => RandomAzureRegion.GetRandomRegionWithExclusions("eastus");
 
             protected override async Task ConfigureTestResources(ResourceGroupResource resourceGroup)
             {

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -33,8 +33,8 @@ namespace Calamari.AzureAppService.Tests
             CalamariVariables newVariables;
             readonly HttpClient client = new HttpClient();
 
-            // There are capacity issues in eastus
-            protected override string DefaultResourceGroupLocation => "westus2";
+            //We are having capacity issues in EastUS and WestUS2
+            protected override string DefaultResourceGroupLocation => RandomAzureRegion.GetRandomRegion("eastus", "westus2");
             
             protected override async Task ConfigureTestResources(ResourceGroupResource resourceGroup)
             {
@@ -177,7 +177,7 @@ namespace Calamari.AzureAppService.Tests
             readonly HttpClient client = new HttpClient();
 
             // For some reason we are having issues creating these linux resources on Standard in EastUS
-            protected override string DefaultResourceGroupLocation => "westus2";
+            protected override string DefaultResourceGroupLocation => RandomAzureRegion.GetRandomRegion("eastus");
 
             protected override async Task ConfigureTestResources(ResourceGroupResource resourceGroup)
             {

--- a/source/Calamari.AzureAppService.Tests/RandomAzureRegion.cs
+++ b/source/Calamari.AzureAppService.Tests/RandomAzureRegion.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace Calamari.AzureAppService.Tests
+{
+    public static class RandomAzureRegion
+    {
+        static Random random = new Random();
+
+        static string[] regions = new[]
+        {
+            "southeastasia",
+            "centralus",
+            "eastus",
+            "eastus2",
+            "westus",
+            "westus2",
+            "westus3",
+            "australiaeast"
+        };
+
+        public static string GetRandomRegion(params string[] excludedRegions)
+        {
+            var possibleRegions = regions.Except(excludedRegions).ToArray();
+
+            return possibleRegions[random.Next(0, regions.Length)];
+        }
+    }
+}

--- a/source/Calamari.AzureAppService.Tests/RandomAzureRegion.cs
+++ b/source/Calamari.AzureAppService.Tests/RandomAzureRegion.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using JetBrains.Annotations;
 
 namespace Calamari.AzureAppService.Tests
 {
@@ -20,11 +19,11 @@ namespace Calamari.AzureAppService.Tests
             "australiaeast"
         };
 
-        public static string GetRandomRegion(params string[] excludedRegions)
+        public static string GetRandomRegionWithExclusions(params string[] excludedRegions)
         {
             var possibleRegions = regions.Except(excludedRegions).ToArray();
 
-            return possibleRegions[random.Next(0, regions.Length)];
+            return possibleRegions[random.Next(0, possibleRegions.Length)];
         }
     }
 }

--- a/source/Calamari.AzureAppService.Tests/RandomAzureRegion.cs
+++ b/source/Calamari.AzureAppService.Tests/RandomAzureRegion.cs
@@ -15,7 +15,6 @@ namespace Calamari.AzureAppService.Tests
             "eastus2",
             "westus",
             "westus2",
-            "westus3",
             "australiaeast"
         };
 


### PR DESCRIPTION
We've been getting random failures when performing the windows container web app tests. This PR just randomises against a large list of regions to avoid capacity issues.

Shortcut story: [sc-80825]