### PR TITLE
Isolate dotnet-script execution

### DIFF
--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
@@ -36,6 +36,7 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
             var cli = CreateCommandLineInvocation(executable, arguments, !string.IsNullOrWhiteSpace(localDotnetScriptPath));
             cli.EnvironmentVars = environmentVars;
             cli.WorkingDirectory = workingDirectory;
+            cli.Isolate = true;
 
             yield return new ScriptExecution(cli, otherTemporaryFiles.Concat(new[] { bootstrapFile, configurationFile }));
         }


### PR DESCRIPTION
Isolate dotnet-script execution. Nuget restores happen in parallel, when accessing Nuget.Targets this causes file lock issues and failures. Python is the only other scripting language that defaults to this Isolation being set to true. This setting only prevents concurrent execution on the same target across other CommandLineInvocations that use this setting. I'm assuming there's minimal usage of Python and C# scripts running concurrently on the same target.

Fixes https://github.com/OctopusDeploy/OctopusDeploy/issues/23062