### PR TITLE
Force E2E test Kubernetes clusters to version 1.28

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/aks.tf
@@ -8,6 +8,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   resource_group_name = azurerm_resource_group.default.name
   location            = "Australia East"
   dns_prefix          = "${random_pet.prefix.id}-k8s"
+  kubernetes_version  = "1.28"
   
   tags = {
     octopus-environment = "Staging"

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/aks.tf
@@ -13,6 +13,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   tags = {
     octopus-environment = "Staging"
     octopus-role = "discovery-role"
+    source       = "calamari-e2e-tests"
   }
 
   default_node_pool {

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.tf
@@ -8,6 +8,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   resource_group_name = azurerm_resource_group.default.name
   location            = "Australia East"
   dns_prefix          = "${random_pet.prefix.id}-k8s"
+  kubernetes_version  = "1.28"
   
   tags = {
     octopus-environment = "Staging"

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.tf
@@ -13,6 +13,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   tags = {
     octopus-environment = "Staging"
     octopus-role = "discovery-role"
+    source       = "calamari-e2e-tests"
   }
 
   default_node_pool {

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/EKS/eks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/EKS/eks.tf
@@ -79,6 +79,7 @@ resource "aws_eks_cluster" "default" {
   tags = {
     octopus-environment = "Staging"
     octopus-role = "discovery-role"
+    source       = "calamari-e2e-tests"
   }
 
   vpc_config {

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/EKS/eks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/EKS/eks.tf
@@ -74,6 +74,7 @@ resource "aws_eks_node_group" "default" {
 resource "aws_eks_cluster" "default" {
   name     = "${random_pet.prefix.id}-eks"
   role_arn = aws_iam_role.cluster.arn
+  version  = "1.28"
 
   tags = {
     octopus-environment = "Staging"

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/GKE/gke.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/GKE/gke.tf
@@ -1,6 +1,7 @@
 # Get latest version
 data "google_container_engine_versions" "main" {
   location = local.region
+  project       = "octopus-api-tester"
 
   # Since this is just a string match, it's recommended that you append a . after minor versions 
   # to ensure that prefixes such as 1.1 don't match versions like 1.12.5-gke.10 accidentally.


### PR DESCRIPTION
Most cloud providers are phasing out 1.27 and earlier (or putting them under different support tiers), so fixing the version at 1.28