### PR TITLE
Allow passing arguments to dotnet-script

### DIFF
--- a/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptBootstrapperFixture.cs
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptBootstrapperFixture.cs
@@ -1,7 +1,25 @@
+using System;
+using Calamari.Common.Features.Scripting.DotnetScript;
+using FluentAssertions;
+using JetBrains.Annotations;
+using NUnit.Framework;
+
 namespace Calamari.Tests.Fixtures.DotnetScript
 {
+    [TestFixture]
     public class DotnetScriptBootstrapperFixture
     {
-        
+        [TestCase(null, null, null)]
+        [TestCase("-- \"Parameter 1\" \"Parameter 2\"", null, "\"Parameter 1\" \"Parameter 2\"")]
+        [TestCase("\"Parameter 1\" \"Parameter 2\"", null, "\"Parameter 1\" \"Parameter 2\"")]
+        [TestCase("--isolated-load-context -- \"Parameter 1\" \"Parameter 2\"", "--isolated-load-context ", "\"Parameter 1\" \"Parameter 2\"")]
+        [TestCase("--isolated-load-context -d -- \"Parameter 1\" \"Parameter 2\"", "--isolated-load-context -d ", "\"Parameter 1\" \"Parameter 2\"")]
+        [TestCase("--isolated-load-context --verbosity debug -- \"Parameter 1\" \"Parameter 2\"", "--isolated-load-context --verbosity debug ", "\"Parameter 1\" \"Parameter 2\"")]
+        public void FormatCommandArgumentsTest([CanBeNull] string scriptParameters, [CanBeNull] string commandArguments, [CanBeNull] string scriptArguments)
+        {
+            var bootstrapFile = "Bootstrap." + Guid.NewGuid().ToString().Substring(10) + "." + "Script.csx";
+            var formattedCommandArgument = DotnetScriptBootstrapper.FormatCommandArguments(bootstrapFile, scriptParameters);
+            formattedCommandArgument.Should().Contain($"{commandArguments}\"{bootstrapFile}\" -- {scriptArguments}");
+        }
     }
 }

--- a/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptBootstrapperFixture.cs
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptBootstrapperFixture.cs
@@ -1,0 +1,7 @@
+namespace Calamari.Tests.Fixtures.DotnetScript
+{
+    public class DotnetScriptBootstrapperFixture
+    {
+        
+    }
+}

--- a/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptFixture.cs
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptFixture.cs
@@ -108,5 +108,29 @@ namespace Calamari.Tests.Fixtures.DotnetScript
             output.AssertSuccess();
             output.AssertOutput("Parameters Parameter0Parameter1");
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        [RequiresDotNetCore]
+        public void UsingIsolatedAssemblyLoadContext(bool enableIsolatedLoadContext)
+        {
+            var (output, _) = RunScript("IsolatedLoadContext.csx",
+                                        new Dictionary<string, string>()
+                                        {
+                                            [SpecialVariables.Action.Script.ScriptParameters] = $"{(enableIsolatedLoadContext ? "--isolated-load-context " : "")}-- Parameter0 Parameter1",
+                                            [ScriptVariables.UseDotnetScript] = bool.TrueString
+                                        });
+            if (enableIsolatedLoadContext)
+            {
+                output.AssertSuccess();
+                output.AssertOutput("NuGet.Commands version: 6.10.0.");
+                output.AssertOutput("Parameters Parameter0Parameter1");
+            }
+            else
+            {
+                output.AssertFailure();
+                output.AssertErrorOutput("Could not load file or assembly 'NuGet.Protocol, Version=6.10.0.");
+            }
+        }
     }
 }

--- a/source/Calamari.Tests/Fixtures/DotnetScript/Scripts/IsolatedLoadContext.csx
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/Scripts/IsolatedLoadContext.csx
@@ -1,0 +1,9 @@
+#r "nuget: NuGet.Commands, 6.10.0"
+
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+var version = typeof(INuGetResourceProvider).Assembly.GetName().Version;
+Console.WriteLine("NuGet.Commands version: " + version);
+Console.WriteLine("Parameters " + Env.ScriptArgs[0] + Env.ScriptArgs[1]);


### PR DESCRIPTION
At the moment we don't support passing arguments to the `dotnet-script` executable. This means that a customer that needs to load dependencies in their scripts that are different from those that are used by `dotnet-script` are out-of-luck as they are unable to instruct `dotnet-script` to use isolated assembly load context.

This PR extends our parsing of script arguments passed as part of the deployment process so that arguments that should be passed to `dotnet-script` can be specified and we will pass those through.

Relates to https://github.com/OctopusDeploy/Issues/issues/8885

[sc-82730]