### PR TITLE
Allow passing arguments to dotnet-script (#1295)

### DIFF
--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripts;
@@ -23,7 +24,7 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
         static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-
+        static readonly Regex ScriptParameterArgumentsRegex = new Regex(@"^(?<scriptCommandArgs>.*)\s*--\s(?<scriptArgs>.*)$", RegexOptions.Compiled);
         static DotnetScriptBootstrapper()
         {
             BootstrapScriptTemplate = EmbeddedResource.ReadEmbeddedText(typeof(DotnetScriptBootstrapper).Namespace + ".Bootstrap.csx");
@@ -48,20 +49,30 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
 
         public static string FormatCommandArguments(string bootstrapFile, string? scriptParameters)
         {
-            scriptParameters = RetrieveParameterValues(scriptParameters);
+            var (scriptCommandArguments, scriptArguments) = RetrieveParameterValues(scriptParameters);
             var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword));
             var commandArguments = new StringBuilder();
             commandArguments.Append("-s https://api.nuget.org/v3/index.json ");
-            commandArguments.AppendFormat("\"{0}\" -- {1} \"{2}\"", bootstrapFile, scriptParameters, encryptionKey);
+            if (!string.IsNullOrWhiteSpace(scriptCommandArguments)) commandArguments.Append($"{scriptCommandArguments} ");
+            commandArguments.AppendFormat("\"{0}\" -- {1} \"{2}\"", bootstrapFile, scriptArguments, encryptionKey);
             return commandArguments.ToString();
         }
 
         [return: NotNullIfNotNull("scriptParameters")]
-        static string? RetrieveParameterValues(string? scriptParameters)
+        static (string? scriptCommandArguments, string? scriptArguments) RetrieveParameterValues(string? scriptParameters)
         {
-            return scriptParameters?.Trim()
-                .TrimStart('-')
-                .Trim();
+            var scriptCommandArguments = string.Empty;
+            if (!string.IsNullOrEmpty(scriptParameters))
+            {
+                var scriptParameterParts = ScriptParameterArgumentsRegex.Match(scriptParameters);
+                if (scriptParameterParts.Success)
+                {
+                    scriptCommandArguments = scriptParameterParts.Groups["scriptCommandArgs"].Value;
+                    scriptParameters = scriptParameterParts.Groups["scriptArgs"].Value;
+                }
+            }
+
+            return (scriptCommandArguments.Trim(), scriptParameters?.Trim().TrimStart('-').Trim());
         }
 
         public static (string bootstrapFile, string[] temporaryFiles) PrepareBootstrapFile(string scriptFilePath, string configurationFile, string workingDirectory, IVariables variables)

--- a/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptBootstrapperFixture.cs
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptBootstrapperFixture.cs
@@ -15,7 +15,7 @@ namespace Calamari.Tests.Fixtures.DotnetScript
         [TestCase("--isolated-load-context -- \"Parameter 1\" \"Parameter 2\"", "--isolated-load-context ", "\"Parameter 1\" \"Parameter 2\"")]
         [TestCase("--isolated-load-context -d -- \"Parameter 1\" \"Parameter 2\"", "--isolated-load-context -d ", "\"Parameter 1\" \"Parameter 2\"")]
         [TestCase("--isolated-load-context --verbosity debug -- \"Parameter 1\" \"Parameter 2\"", "--isolated-load-context --verbosity debug ", "\"Parameter 1\" \"Parameter 2\"")]
-        public void FormatCommandArgumentsTest([CanBeNull] string scriptParameters, [CanBeNull] string commandArguments, [CanBeNull] string scriptArguments)
+        public void FormatCommandArgumentsTest(string scriptParameters, string commandArguments, string scriptArguments)
         {
             var bootstrapFile = "Bootstrap." + Guid.NewGuid().ToString().Substring(10) + "." + "Script.csx";
             var formattedCommandArgument = DotnetScriptBootstrapper.FormatCommandArguments(bootstrapFile, scriptParameters);

--- a/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptBootstrapperFixture.cs
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptBootstrapperFixture.cs
@@ -1,0 +1,25 @@
+using System;
+using Calamari.Common.Features.Scripting.DotnetScript;
+using FluentAssertions;
+using JetBrains.Annotations;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.DotnetScript
+{
+    [TestFixture]
+    public class DotnetScriptBootstrapperFixture
+    {
+        [TestCase(null, null, null)]
+        [TestCase("-- \"Parameter 1\" \"Parameter 2\"", null, "\"Parameter 1\" \"Parameter 2\"")]
+        [TestCase("\"Parameter 1\" \"Parameter 2\"", null, "\"Parameter 1\" \"Parameter 2\"")]
+        [TestCase("--isolated-load-context -- \"Parameter 1\" \"Parameter 2\"", "--isolated-load-context ", "\"Parameter 1\" \"Parameter 2\"")]
+        [TestCase("--isolated-load-context -d -- \"Parameter 1\" \"Parameter 2\"", "--isolated-load-context -d ", "\"Parameter 1\" \"Parameter 2\"")]
+        [TestCase("--isolated-load-context --verbosity debug -- \"Parameter 1\" \"Parameter 2\"", "--isolated-load-context --verbosity debug ", "\"Parameter 1\" \"Parameter 2\"")]
+        public void FormatCommandArgumentsTest([CanBeNull] string scriptParameters, [CanBeNull] string commandArguments, [CanBeNull] string scriptArguments)
+        {
+            var bootstrapFile = "Bootstrap." + Guid.NewGuid().ToString().Substring(10) + "." + "Script.csx";
+            var formattedCommandArgument = DotnetScriptBootstrapper.FormatCommandArguments(bootstrapFile, scriptParameters);
+            formattedCommandArgument.Should().Contain($"{commandArguments}\"{bootstrapFile}\" -- {scriptArguments}");
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptFixture.cs
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptFixture.cs
@@ -108,5 +108,29 @@ namespace Calamari.Tests.Fixtures.DotnetScript
             output.AssertSuccess();
             output.AssertOutput("Parameters Parameter0Parameter1");
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        [RequiresDotNetCore]
+        public void UsingIsolatedAssemblyLoadContext(bool enableIsolatedLoadContext)
+        {
+            var (output, _) = RunScript("IsolatedLoadContext.csx",
+                                        new Dictionary<string, string>()
+                                        {
+                                            [SpecialVariables.Action.Script.ScriptParameters] = $"{(enableIsolatedLoadContext ? "--isolated-load-context " : "")}-- Parameter0 Parameter1",
+                                            [ScriptVariables.UseDotnetScript] = bool.TrueString
+                                        });
+            if (enableIsolatedLoadContext)
+            {
+                output.AssertSuccess();
+                output.AssertOutput("NuGet.Commands version: 6.10.0.");
+                output.AssertOutput("Parameters Parameter0Parameter1");
+            }
+            else
+            {
+                output.AssertFailure();
+                output.AssertErrorOutput("Could not load file or assembly 'NuGet.Protocol, Version=6.10.0.");
+            }
+        }
     }
 }

--- a/source/Calamari.Tests/Fixtures/DotnetScript/Scripts/IsolatedLoadContext.csx
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/Scripts/IsolatedLoadContext.csx
@@ -1,0 +1,9 @@
+#r "nuget: NuGet.Commands, 6.10.0"
+
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+var version = typeof(INuGetResourceProvider).Assembly.GetName().Version;
+Console.WriteLine("NuGet.Commands version: " + version);
+Console.WriteLine("Parameters " + Env.ScriptArgs[0] + Env.ScriptArgs[1]);


### PR DESCRIPTION
This is a back-port of https://github.com/OctopusDeploy/Calamari/pull/1295 for Octopus Server 2024.1

Relates to https://github.com/OctopusDeploy/Issues/issues/8885

[sc-82730]