### PR TITLE
Add support for bypassing isolation on dotnet-script - this may lead to unexpected step failures.

### DIFF
--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
@@ -32,11 +32,12 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
             var configurationFile = DotnetScriptBootstrapper.PrepareConfigurationFile(workingDirectory, variables);
             var (bootstrapFile, otherTemporaryFiles) = DotnetScriptBootstrapper.PrepareBootstrapFile(script.File, configurationFile, workingDirectory, variables);
             var arguments = DotnetScriptBootstrapper.FormatCommandArguments(bootstrapFile, script.Parameters);
+            bool.TryParse(variables.Get("Octopus.Action.Script.CSharp.BypassIsolation", "false"), out var bypassDotnetScriptIsolation);
 
             var cli = CreateCommandLineInvocation(executable, arguments, !string.IsNullOrWhiteSpace(localDotnetScriptPath));
             cli.EnvironmentVars = environmentVars;
             cli.WorkingDirectory = workingDirectory;
-            cli.Isolate = true;
+            cli.Isolate = !bypassDotnetScriptIsolation;
 
             yield return new ScriptExecution(cli, otherTemporaryFiles.Concat(new[] { bootstrapFile, configurationFile }));
         }


### PR DESCRIPTION
When dotnet-script executes it checks the Nuget.config file on disk. When multiple dotnet-script actions execute on a single target this can lead to file access locks and step failures. We enabled isolation for the dotnet-script command invocation similar to how python scripts are executed but in some cases customers would like to still run dotnet-script in parallel. This change adds support for a variable `Octopus.Action.Script.CSharp.BypassIsolation`, which when set to true will skip isolation and allow dotnet-script to run in parallel.