### PR TITLE
Adds back the condition to check whether kubelogin is configured when using AKS kube login

### DIFF
--- a/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AzureKubernetesServicesAuth.cs
@@ -56,7 +56,10 @@ namespace Calamari.Kubernetes.Authentication
                 var azureCluster = deploymentVariables.Get(SpecialVariables.AksClusterName);
                 var azureAdmin = deploymentVariables.GetFlag(SpecialVariables.AksAdminLogin);
                 azureCli.ConfigureAksKubeCtlAuthentication(kubectlCli, azureResourceGroup, azureCluster, @namespace, kubeConfig, azureAdmin);
-                kubeLogin.ConfigureAksKubeLogin(kubeConfig);
+                if (kubeLogin.IsConfigured)
+                {
+                    kubeLogin.ConfigureAksKubeLogin(kubeConfig);
+                }
             }
         }
     }


### PR DESCRIPTION
This was accidentally removed as part of the feature toggle removal in #1304