### PR TITLE
skip SCM check if resource group name is missing.

### DIFF
--- a/source/Calamari.AzureWebApp/AzureWebAppBehaviour.cs
+++ b/source/Calamari.AzureWebApp/AzureWebAppBehaviour.cs
@@ -63,7 +63,7 @@ namespace Calamari.AzureWebApp
             }
             else
             {
-                log.Warn("No Resource Group Name was provided. Checking 'SCM Basic Auth Publishing Credentials' configuration will be skipped. If authentication fails, ensure 'SCM Basic Auth Publishing Credentials' is enabled on '{targetSite.Site}'-{slotText}. To deploy Web Apps with SCM disabled, please use the 'Deploy an Azure App Service' step.");
+                log.Warn($"No Resource Group Name was provided. Checking 'SCM Basic Auth Publishing Credentials' configuration will be skipped. If authentication fails, ensure 'SCM Basic Auth Publishing Credentials' is enabled on '{targetSite.Site}'-{slotText}. To deploy Web Apps with SCM disabled, please use the 'Deploy an Azure App Service' step.");
             }
 
 

--- a/source/Calamari.AzureWebApp/AzureWebAppBehaviour.cs
+++ b/source/Calamari.AzureWebApp/AzureWebAppBehaviour.cs
@@ -45,11 +45,11 @@ namespace Calamari.AzureWebApp
             var resourceGroupText = string.IsNullOrEmpty(resourceGroupName) ? string.Empty : $" in Resource Group '{resourceGroupName}'";
             var slotText = targetSite.HasSlot ? $", deployment slot '{targetSite.Slot}'" : string.Empty;
             var azureAccount = hasJwt ? (IAzureAccount)new AzureOidcAccount(variables) : new AzureServicePrincipalAccount(variables);
-            var accessToken = await azureAccount.GetAccessTokenAsync();
 
             // We will skip checking if SCM is enabled when a resource group is not provided as it's not possible, and authentication may still be valid
             if (!string.IsNullOrEmpty(resourceGroupName))
             {
+                var accessToken = await azureAccount.GetAccessTokenAsync();
                 var isCurrentScmBasicAuthPublishingEnabled = await AzureWebAppHelper.GetBasicPublishingCredentialsPoliciesAsync(azureAccount.ResourceManagementEndpointBaseUri,
                                                                                                                                 subscriptionId,
                                                                                                                                 resourceGroupName,

--- a/source/Calamari.AzureWebApp/AzureWebAppBehaviour.cs
+++ b/source/Calamari.AzureWebApp/AzureWebAppBehaviour.cs
@@ -46,14 +46,27 @@ namespace Calamari.AzureWebApp
             var slotText = targetSite.HasSlot ? $", deployment slot '{targetSite.Slot}'" : string.Empty;
             var azureAccount = hasJwt ? (IAzureAccount)new AzureOidcAccount(variables) : new AzureServicePrincipalAccount(variables);
             var accessToken = await azureAccount.GetAccessTokenAsync();
-            var isCurrentScmBasicAuthPublishingEnabled = await AzureWebAppHelper.GetBasicPublishingCredentialsPoliciesAsync(azureAccount.ResourceManagementEndpointBaseUri, subscriptionId, resourceGroupName, siteAndSlotName, accessToken);
-            
-            if (!isCurrentScmBasicAuthPublishingEnabled)
+
+            // We will skip checking if SCM is enabled when a resource group is not provided as it's not possible, and authentication may still be valid
+            if (!string.IsNullOrEmpty(resourceGroupName))
             {
-                log.Error($"The 'SCM Basic Auth Publishing Credentials' configuration is disabled on '{targetSite.Site}'-{slotText}. To deploy Web Apps with SCM disabled, please use the 'Deploy an Azure App Service' step.");
-                throw new CommandException($"The 'SCM Basic Auth Publishing Credentials' is disabled on target '{targetSite.Site}'{slotText}");
+                var isCurrentScmBasicAuthPublishingEnabled = await AzureWebAppHelper.GetBasicPublishingCredentialsPoliciesAsync(azureAccount.ResourceManagementEndpointBaseUri,
+                                                                                                                                subscriptionId,
+                                                                                                                                resourceGroupName,
+                                                                                                                                siteAndSlotName,
+                                                                                                                                accessToken);
+                if (!isCurrentScmBasicAuthPublishingEnabled)
+                {
+                    log.Error($"The 'SCM Basic Auth Publishing Credentials' configuration is disabled on '{targetSite.Site}'-{slotText}. To deploy Web Apps with SCM disabled, please use the 'Deploy an Azure App Service' step.");
+                    throw new CommandException($"The 'SCM Basic Auth Publishing Credentials' is disabled on target '{targetSite.Site}'{slotText}");
+                }
             }
-            
+            else
+            {
+                log.Warn("No Resource Group Name was provided. Checking 'SCM Basic Auth Publishing Credentials' configuration will be skipped. If authentication fails, ensure 'SCM Basic Auth Publishing Credentials' is enabled on '{targetSite.Site}'-{slotText}. To deploy Web Apps with SCM disabled, please use the 'Deploy an Azure App Service' step.");
+            }
+
+
             log.Info($"Deploying to Azure WebApp '{targetSite.Site}'{slotText}{resourceGroupText}, using subscription-id '{subscriptionId}'");
             var publishSettings = await GetPublishProfile(variables, azureAccount);
             RemoteCertificateValidationCallback originalServerCertificateValidationCallback = null;


### PR DESCRIPTION
skip SCM check if resource group name is not provided to fix the following issue. https://github.com/OctopusDeploy/Issues/issues/8906