### PR TITLE
Support helm values files in secondary git dependencies

### DIFF
--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -72,17 +72,20 @@ namespace Calamari.Deployment
             public static readonly string IgnoreVariableReplacementErrors = "Octopus.Action.Package.IgnoreVariableReplacementErrors";
             public static readonly string RunPackageScripts = "Octopus.Action.Package.RunScripts";
         }
-        
+
         public static class GitResources
-        {                  
-            public static readonly string GitResourceCollection = "Octopus.Action.GitResource";        
-        
-            public static string CommitHash(string name) => $"Octopus.Action.GitResource[{name}].CommitHash";
-            public static string OriginalPath(string name) => $"Octopus.Action.GitResource[{name}].OriginalPath";
-            public static string Extract(string name) => $"Octopus.Action.GitResource[{name}].Extract";
-            public static string ExtractedPath(string name) => $"Octopus.Action.GitResource[{name}].ExtractedPath";
-            public static string FileName(string name) => $"Octopus.Action.GitResource[{name}].PackageFileName";       
-            public static string FilePath(string name) => $"Octopus.Action.GitResource[{name}].PackageFilePath";
+        {
+            public const string GitResourceCollection = "Octopus.Action.GitResource";
+
+            public static string CommitHash(string name) => GetIndexedName(name, "CommitHash");
+            public static string OriginalPath(string name) => GetIndexedName(name, "OriginalPath");
+            public static string Extract(string name) => GetIndexedName(name, "Extract");
+            public static string ExtractedPath(string name) => GetIndexedName(name, "ExtractedPath");
+            public static string FileName(string name) => GetIndexedName(name, "PackageFileName");
+            public static string FilePath(string name) => GetIndexedName(name, "PackageFilePath");
+            public static string RepositoryUrl(string name) => GetIndexedName(name, "RepositoryUrl");
+
+            static string GetIndexedName(string name, string property) => $"Octopus.Action.GitResource[{name}].{property}";
         }
 
         public static class Packages
@@ -162,7 +165,7 @@ namespace Calamari.Deployment
             public static class Aws
             {
                 public static readonly string CloudFormationStackName = "Octopus.Action.Aws.CloudFormationStackName";
-                public static readonly string CloudFormationTemplate =  "Octopus.Action.Aws.CloudFormationTemplate";
+                public static readonly string CloudFormationTemplate = "Octopus.Action.Aws.CloudFormationTemplate";
                 public static readonly string CloudFormationProperties = "Octopus.Action.Aws.CloudFormationProperties";
                 public static readonly string AssumeRoleARN = "Octopus.Action.Aws.AssumedRoleArn";
                 public static readonly string AssumeRoleExternalId = "Octopus.Action.Aws.AssumeRoleExternalId";
@@ -307,7 +310,6 @@ namespace Calamari.Deployment
                     public static readonly string KeystoreAlias = "Java.Certificate.KeystoreAlias";
                 }
 
-
                 public static class WildFly
                 {
                     public static readonly string Feature = "Octopus.Features.WildflyDeployCLI";
@@ -367,10 +369,8 @@ namespace Calamari.Deployment
 
         public static class Certificate
         {
-
             public static readonly string PrivateKeyAccessRules =
                 "Octopus.Action.Certificate.PrivateKeyAccessRules";
-
 
             public static string Name(string variableName)
             {

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/GitRepositoryValuesFileWriterFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/GitRepositoryValuesFileWriterFixture.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.Deployment;
 using Calamari.Kubernetes.Helm;
 using Calamari.Testing.Helpers;
 using FluentAssertions;
@@ -24,7 +25,11 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
         public void SetUp()
         {
             deployment = new RunningDeployment(new CalamariVariables());
+            
             fileSystem = Substitute.For<ICalamariFileSystem>();
+            //we have no invalid names
+            fileSystem.RemoveInvalidFileNameChars(Arg.Any<string>()).Returns(ci => ci.ArgAt<string>(0));
+            
             log = new InMemoryLog();
         }
 
@@ -55,18 +60,18 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
             // Assert
             act.Should().ThrowExactly<CommandException>();
         }
-        
+
         [Test]
         public void FindChartValuesFiles_FilesFoundInFilesystem_ReturnsFullyQualifiedPaths()
         {
             // Arrange
             fileSystem.EnumerateFilesWithGlob(Arg.Any<string>(), Arg.Any<string[]>())
-                .Returns(ci =>
-                         {
-                             return ci.ArgAt<string[]>(1)
-                                      .Select(filename => Path.Combine(ci.ArgAt<string>(0), filename))
-                                      .ToList();
-                         });
+                      .Returns(ci =>
+                               {
+                                   return ci.ArgAt<string[]>(1)
+                                            .Select(filename => Path.Combine(ci.ArgAt<string>(0), filename))
+                                            .ToList();
+                               });
 
             //Act
             var result = GitRepositoryValuesFileWriter.FindChartValuesFiles(deployment, fileSystem, log, "values.yaml\n values.Development.yaml");
@@ -77,6 +82,111 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
                   {
                       Path.Combine(deployment.CurrentDirectory, "values.yaml"),
                       Path.Combine(deployment.CurrentDirectory, "values.Development.yaml")
+                  });
+        }
+
+        [Test]
+        public void FindGitDependencyValueFiles_GitDependencyNameEmpty_ReturnsNullAndLogsVerboseMessage()
+        {
+            // Arrange
+            deployment.Variables.Add(SpecialVariables.GitResources.CommitHash("MyRepo"), "123abc");
+
+            // Act
+            var result = GitRepositoryValuesFileWriter.FindGitDependencyValuesFiles(deployment,
+                                                                                    fileSystem,
+                                                                                    log,
+                                                                                    null,
+                                                                                    "values.yaml");
+
+            // Assert
+            result.Should().BeNull();
+            log.Messages.Should().Contain(msg => msg.Level == InMemoryLog.Level.Verbose && msg.FormattedMessage.Contains("Sourcing secondary values files from primary git dependency is not supported"));
+        }
+
+        [Test]
+        public void FindGitDependencyValueFiles_GitDependencyNameNotInVariables_ReturnsNull()
+        {
+            // Arrange
+            deployment.Variables.Add(SpecialVariables.GitResources.CommitHash("MyRepo"), "123abc");
+
+            // Act
+            var result = GitRepositoryValuesFileWriter.FindGitDependencyValuesFiles(deployment,
+                                                                                    fileSystem,
+                                                                                    log,
+                                                                                    "MyOtherRepo",
+                                                                                    "values.yaml");
+
+            // Assert
+            result.Should().BeNull();
+        }
+
+        [TestCase(null)]
+        [TestCase("\r")]
+        [TestCase("\n")]
+        [TestCase("\r\n")]
+        [TestCase("  \n   ")]
+        public void GitRepositoryValuesFileWriter_InvalidValuesFilePaths_ReturnsNull(string valuesFilePaths)
+        {
+            // Arrange
+            deployment.Variables.Add(SpecialVariables.GitResources.CommitHash("MyRepo"), "123abc");
+
+            // Act
+            var result = GitRepositoryValuesFileWriter.FindGitDependencyValuesFiles(deployment,
+                                                                                    fileSystem,
+                                                                                    log,
+                                                                                    "MyRepo",
+                                                                                    valuesFilePaths);
+            // Assert
+            result.Should().BeNull();
+        }
+
+        [Test]
+        public void GitRepositoryValuesFileWriter_FileNotFoundInFilesystem_ThrowsCommandException()
+        {
+            // Arrange
+            fileSystem.EnumerateFilesWithGlob(Arg.Any<string>(), Arg.Any<string[]>())
+                      .Returns(new List<string>());
+
+            deployment.Variables.Add(SpecialVariables.GitResources.CommitHash("MyRepo"), "123abc");
+
+            //Act
+            Action act = () => GitRepositoryValuesFileWriter.FindGitDependencyValuesFiles(deployment,
+                                                                                          fileSystem,
+                                                                                          log,
+                                                                                          "MyRepo",
+                                                                                          "values.yaml");
+
+            // Assert
+            act.Should().ThrowExactly<CommandException>();
+        }
+
+        [Test]
+        public void FindGitDependencyValuesFiles_FilesFoundInFilesystem_ReturnsFullyQualifiedPaths()
+        {
+            // Arrange
+            fileSystem.EnumerateFilesWithGlob(Arg.Any<string>(), Arg.Any<string[]>())
+                      .Returns(ci =>
+                               {
+                                   return ci.ArgAt<string[]>(1)
+                                            .Select(filename => Path.Combine(ci.ArgAt<string>(0), filename))
+                                            .ToList();
+                               });
+
+            deployment.Variables.Add(SpecialVariables.GitResources.CommitHash("MyRepo"), "123abc");
+
+            //Act
+            var result = GitRepositoryValuesFileWriter.FindGitDependencyValuesFiles(deployment,
+                                                                                    fileSystem,
+                                                                                    log,
+                                                                                    "MyRepo",
+                                                                                    "values.yaml \n values.Development.yaml");
+
+            // Assert
+            result.Should()
+                  .BeEquivalentTo(new List<string>
+                  {
+                      Path.Combine(deployment.CurrentDirectory, "MyRepo", "values.yaml"),
+                      Path.Combine(deployment.CurrentDirectory, "MyRepo", "values.Development.yaml")
                   });
         }
     }

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/GitRepositoryValuesFileWriterFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/GitRepositoryValuesFileWriterFixture.cs
@@ -41,6 +41,7 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
         public void FindChartValuesFiles_InvalidValuesFilePaths_ReturnsNull(string valuesFilePaths)
         {
             // Act
+            deployment.Variables.Add(SpecialVariables.GitResources.CommitHash(string.Empty), "123abc");
             var result = GitRepositoryValuesFileWriter.FindChartValuesFiles(deployment, fileSystem, log, valuesFilePaths);
 
             // Assert
@@ -51,6 +52,7 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
         public void FindChartValuesFiles_FileNotFoundInFilesystem_ThrowsCommandException()
         {
             // Arrange
+            deployment.Variables.Add(SpecialVariables.GitResources.CommitHash(string.Empty), "123abc");
             fileSystem.EnumerateFilesWithGlob(Arg.Any<string>(), Arg.Any<string[]>())
                       .Returns(new List<string>());
 
@@ -65,6 +67,7 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
         public void FindChartValuesFiles_FilesFoundInFilesystem_ReturnsFullyQualifiedPaths()
         {
             // Arrange
+            deployment.Variables.Add(SpecialVariables.GitResources.CommitHash(string.Empty), "123abc");
             fileSystem.EnumerateFilesWithGlob(Arg.Any<string>(), Arg.Any<string[]>())
                       .Returns(ci =>
                                {
@@ -83,24 +86,6 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
                       Path.Combine(deployment.CurrentDirectory, "values.yaml"),
                       Path.Combine(deployment.CurrentDirectory, "values.Development.yaml")
                   });
-        }
-
-        [Test]
-        public void FindGitDependencyValueFiles_GitDependencyNameEmpty_ReturnsNullAndLogsVerboseMessage()
-        {
-            // Arrange
-            deployment.Variables.Add(SpecialVariables.GitResources.CommitHash("MyRepo"), "123abc");
-
-            // Act
-            var result = GitRepositoryValuesFileWriter.FindGitDependencyValuesFiles(deployment,
-                                                                                    fileSystem,
-                                                                                    log,
-                                                                                    null,
-                                                                                    "values.yaml");
-
-            // Assert
-            result.Should().BeNull();
-            log.Messages.Should().Contain(msg => msg.Level == InMemoryLog.Level.Verbose && msg.FormattedMessage.Contains("Sourcing secondary values files from primary git dependency is not supported"));
         }
 
         [Test]

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesCreatorFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesCreatorFixture.cs
@@ -212,7 +212,8 @@ secondary.Development.yaml"
             {
                 [SpecialVariables.Helm.TemplateValuesSources] = templateValuesSourcesJson,
                 [KnownVariables.OriginalPackageDirectoryPath] = RootDir,
-                [ScriptVariables.ScriptSource] = ScriptVariables.ScriptSourceOptions.GitRepository
+                [ScriptVariables.ScriptSource] = ScriptVariables.ScriptSourceOptions.GitRepository,
+                [Deployment.SpecialVariables.GitResources.CommitHash(string.Empty)] = "abc123"
             };
 
             var deployment = new RunningDeployment(variables)

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -302,7 +302,7 @@ namespace Calamari.Kubernetes.Conventions
                     {
                         var relative = file.Substring(Path.Combine(deployment.CurrentDirectory, sanitizedPackageReferenceName).Length);
                         log.Info($"Including values file `{relative}` from package {packageId} v{version}");
-                        files.AddRange(currentFiles);
+                        files.Add(file);
                     }
                 }
             }

--- a/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
@@ -28,6 +28,7 @@ namespace Calamari.Kubernetes.Helm
             var gitDependencyNames = variables.GetIndexes(Deployment.SpecialVariables.GitResources.GitResourceCollection);
             if (!gitDependencyNames.Contains(gitDependencyName))
             {
+                log.Warn($"Failed to find variables for git resource {gitDependencyName}");
                 return null;
             }
 

--- a/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
@@ -73,12 +73,8 @@ namespace Calamari.Kubernetes.Helm
                 return null;
             }
 
-            var valuesPaths = valuesFilePaths?
-                              .Split('\r', '\n')
-                              .Where(x => !string.IsNullOrWhiteSpace(x))
-                              .Select(x => x.Trim())
-                              .ToList();
-            
+
+            var valuesPaths = HelmValuesFileUtils.SplitValuesFilePaths(valuesFilePaths);
             if (valuesPaths == null || !valuesPaths.Any())
                 return null;
 
@@ -87,6 +83,7 @@ namespace Calamari.Kubernetes.Helm
 
             var sanitizedPackageReferenceName = fileSystem.RemoveInvalidFileNameChars(gitDependencyName);
 
+            var commitHash = variables.Get(Deployment.SpecialVariables.GitResources.CommitHash(gitDependencyName));
             foreach (var valuePath in valuesPaths)
             {
                 var relativePath = Path.Combine(sanitizedPackageReferenceName, valuePath);
@@ -94,13 +91,13 @@ namespace Calamari.Kubernetes.Helm
 
                 if (!currentFiles.Any())
                 {
-                    errors.Add($"Unable to find file `{valuePath}` for git repository {gitDependencyName}");
+                    errors.Add($"Unable to find file `{valuePath}` for git repository {gitDependencyName}, commit {commitHash}");
                 }
 
                 foreach (var file in currentFiles)
                 {
                     var relative = file.Substring(Path.Combine(deployment.CurrentDirectory, sanitizedPackageReferenceName).Length);
-                    log.Info($"Including values file `{relative}` from git repository {gitDependencyName}");
+                    log.Info($"Including values file `{relative}` from git repository {gitDependencyName}, commit {commitHash}");
                     filenames.Add(file);
                 }
             }

--- a/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
@@ -83,6 +83,7 @@ namespace Calamari.Kubernetes.Helm
 
             var sanitizedPackageReferenceName = fileSystem.RemoveInvalidFileNameChars(gitDependencyName);
 
+            var repositoryUrl = variables.Get(Deployment.SpecialVariables.GitResources.RepositoryUrl(gitDependencyName));
             var commitHash = variables.Get(Deployment.SpecialVariables.GitResources.CommitHash(gitDependencyName));
             foreach (var valuePath in valuesPaths)
             {
@@ -91,13 +92,13 @@ namespace Calamari.Kubernetes.Helm
 
                 if (!currentFiles.Any())
                 {
-                    errors.Add($"Unable to find file `{valuePath}` for git repository {gitDependencyName}, commit {commitHash}");
+                    errors.Add($"Unable to find file `{valuePath}` for git repository {repositoryUrl}, commit {commitHash}");
                 }
 
                 foreach (var file in currentFiles)
                 {
                     var relative = file.Substring(Path.Combine(deployment.CurrentDirectory, sanitizedPackageReferenceName).Length);
-                    log.Info($"Including values file `{relative}` from git repository {gitDependencyName}, commit {commitHash}");
+                    log.Info($"Including values file `{relative}` from git repository {repositoryUrl}, commit {commitHash}");
                     filenames.Add(file);
                 }
             }

--- a/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
@@ -101,7 +101,7 @@ namespace Calamari.Kubernetes.Helm
                 {
                     var relative = file.Substring(Path.Combine(deployment.CurrentDirectory, sanitizedPackageReferenceName).Length);
                     log.Info($"Including values file `{relative}` from git repository {gitDependencyName}");
-                    filenames.AddRange(currentFiles);
+                    filenames.Add(file);
                 }
             }
 

--- a/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
+++ b/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
@@ -44,13 +44,17 @@ namespace Calamari.Kubernetes.Helm
                             default:
                                 if (scriptSource is null)
                                     throw new ArgumentNullException($"{ScriptVariables.ScriptSource} variable cannot be null");
-                                
+
                                 throw new ArgumentException($"{scriptSource} is not a support Chart values source type");
                         }
 
-                        filenames.AddRange(chartFilenames);
+                        if (chartFilenames != null)
+                        {
+                            filenames.AddRange(chartFilenames);
+                        }
+
                         break;
-                    
+
                     case TemplateValuesSourceType.KeyValues:
                         var keyValuesTvs = json.ToObject<KeyValuesTemplateValuesSource>();
                         var keyValueFilename = KeyValuesValuesFileWriter.WriteToFile(deployment, fileSystem, keyValuesTvs.Value, index);
@@ -67,16 +71,20 @@ namespace Calamari.Kubernetes.Helm
                                                                                               packageTvs.PackageId,
                                                                                               packageTvs.PackageName);
 
-                        filenames.AddRange(packageFilenames);
+                        if (packageFilenames != null)
+                        {
+                            filenames.AddRange(packageFilenames);
+                        }
+
                         break;
-                    
+
                     case TemplateValuesSourceType.InlineYaml:
                         var inlineYamlTvs = json.ToObject<InlineYamlTemplateValuesSource>();
                         var inlineYamlFilename = InlineYamlValuesFileWriter.WriteToFile(deployment, fileSystem, inlineYamlTvs.Value, index);
 
                         AddIfNotNull(filenames, inlineYamlFilename);
                         break;
-                    
+
                     case TemplateValuesSourceType.GitRepository:
                         var gitRepTvs = json.ToObject<GitRepositoryTemplateValuesSource>();
                         var gitRepositoryFilenames = GitRepositoryValuesFileWriter.FindGitDependencyValuesFiles(deployment,
@@ -84,10 +92,14 @@ namespace Calamari.Kubernetes.Helm
                                                                                                                 log,
                                                                                                                 gitRepTvs.GitDependencyName,
                                                                                                                 gitRepTvs.ValuesFilePaths);
-                        
-                        filenames.AddRange(gitRepositoryFilenames);
+
+                        if (gitRepositoryFilenames != null)
+                        {
+                            filenames.AddRange(gitRepositoryFilenames);
+                        }
+
                         break;
-                    
+
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
@@ -149,7 +161,7 @@ namespace Calamari.Kubernetes.Helm
                 Type = TemplateValuesSourceType.Package;
             }
         }
-        
+
         internal class GitRepositoryTemplateValuesSource : TemplateValuesSource
         {
             public string GitDependencyName { get; set; }

--- a/source/Calamari/Kubernetes/Helm/HelmValuesFileUtils.cs
+++ b/source/Calamari/Kubernetes/Helm/HelmValuesFileUtils.cs
@@ -1,4 +1,7 @@
-﻿namespace Calamari.Kubernetes.Helm
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Calamari.Kubernetes.Helm
 {
     public static class HelmValuesFileUtils
     {
@@ -7,6 +10,15 @@
             return index != null
                 ? $"{prefix}-{index}.yaml"
                 : $"{prefix}.yaml";
+        }
+
+        public static IList<string> SplitValuesFilePaths(string valuesFilePaths)
+        {
+            return valuesFilePaths?
+                              .Split('\r', '\n')
+                              .Where(x => !string.IsNullOrWhiteSpace(x))
+                              .Select(x => x.Trim())
+                              .ToList();
         }
     }
 }

--- a/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
@@ -31,6 +31,7 @@ namespace Calamari.Kubernetes.Helm
             var packageNames = variables.GetIndexes(PackageVariables.PackageCollection);
             if (!packageNames.Contains(packageName))
             {
+                log.Warn($"Failed to find variables for package {packageName}");
                 return null;
             }
 

--- a/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
@@ -44,12 +44,7 @@ namespace Calamari.Kubernetes.Helm
                 }
             }
             
-            var valuesPaths = valuesFilePaths?
-                              .Split('\r', '\n')
-                              .Where(x => !string.IsNullOrWhiteSpace(x))
-                              .Select(x => x.Trim())
-                              .ToList();
-            
+            var valuesPaths = HelmValuesFileUtils.SplitValuesFilePaths(valuesFilePaths);
             if (valuesPaths == null || !valuesPaths.Any())
                 return null;
 

--- a/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
@@ -83,7 +83,7 @@ namespace Calamari.Kubernetes.Helm
                 {
                     var relative = file.Substring(Path.Combine(deployment.CurrentDirectory, sanitizedPackageReferenceName).Length);
                     log.Info($"Including values file `{relative}` from package {pathedPackedName} v{version}");
-                    filenames.AddRange(currentFiles);
+                    filenames.Add(file);
                 }
             }
 

--- a/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
@@ -53,12 +53,12 @@ namespace Calamari.Kubernetes.Helm
 
             var sanitizedPackageReferenceName = PackageName.ExtractPackageNameFromPathedPackageId(fileSystem.RemoveInvalidFileNameChars(packageName));
             
-
+            var version = variables.Get(PackageVariables.IndexedPackageVersion(packageName));
+            
+            //we get the package id here
+            var pathedPackedName = PackageName.ExtractPackageNameFromPathedPackageId(variables.Get(PackageVariables.IndexedPackageId(packageName)));
             foreach (var valuePath in valuesPaths)
             {
-                //we get the package id here
-                var pathedPackedName = PackageName.ExtractPackageNameFromPathedPackageId(variables.Get(PackageVariables.IndexedPackageId(packageName)));
-                var version = variables.Get(PackageVariables.IndexedPackageVersion(packageName));
                 var relativePath = Path.Combine(sanitizedPackageReferenceName, valuePath);
                 var currentFiles = fileSystem.EnumerateFilesWithGlob(deployment.CurrentDirectory, relativePath).ToList();
 


### PR DESCRIPTION
Helm template values are going to support sourcing files from secondary git packages. This PR adds this support\

Shortcut story: [sc-66467]