### PR TITLE
Retrieve k8s resources from kubectl as single line JSON

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -657,6 +657,7 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Kubernetes.ResourceStatusCheck", "True");
             variables.Set("Octopus.Action.KubernetesContainers.DeploymentWait", "NoWait");
             variables.Set("Octopus.Action.Kubernetes.DeploymentTimeout", timeout.ToString());
+            variables.Set("Octopus.Action.Kubernetes.PrintVerboseKubectlOutputOnError", "True");
         }
 
         private static string CreateResourceYamlFile(string directory, string fileName, string content)

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
@@ -4,6 +4,7 @@ using Calamari.Common.Plumbing.Logging;
 using Calamari.Kubernetes.Integration;
 using Calamari.Kubernetes.ResourceStatus;
 using Calamari.Kubernetes.ResourceStatus.Resources;
+using Calamari.Tests.Helpers;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -282,6 +283,6 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
             return this;
         }
 
-        public string Build() => string.Format(template, kind, name, uid, ownerUid);
+        public string Build() => string.Format(template, kind, name, uid, ownerUid).ReplaceLineEndings();
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
@@ -227,18 +227,20 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         }
 
 
-        public ICommandOutput Resource(string kind, string name, string @namespace, IKubectl kubectl)
+        public KubectlGetResult Resource(string kind, string name, string @namespace, IKubectl kubectl)
         {
-            var output = new CaptureCommandOutput();
-            output.WriteInfo(resourceEntries[name]);
-            return output;
+            return new KubectlGetResult(resourceEntries[name], new List<string>
+            {
+                $"{Level.Info}: {resourceEntries[name]}"
+            });
         }
 
-        public ICommandOutput AllResources(string kind, string @namespace, IKubectl kubectl)
+        public KubectlGetResult AllResources(string kind, string @namespace, IKubectl kubectl)
         {
-            var output = new CaptureCommandOutput();
-            output.WriteInfo(resourcesByKind[kind]);
-            return output;
+            return new KubectlGetResult(resourcesByKind[kind], new List<string>
+            {
+                $"{Level.Info}: {resourcesByKind[kind]}"
+            });
         }
     }
 

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
@@ -283,6 +283,6 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
             return this;
         }
 
-        public string Build() => string.Format(template, kind, name, uid, ownerUid).ReplaceLineEndings();
+        public string Build() => string.Format(template, kind, name, uid, ownerUid).ReplaceLineEndings().Replace(Environment.NewLine, string.Empty);
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
@@ -227,14 +227,18 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         }
 
 
-        public string Resource(string kind, string name, string @namespace, IKubectl kubectl)
+        public ICommandOutput Resource(string kind, string name, string @namespace, IKubectl kubectl)
         {
-            return resourceEntries[name];
+            var output = new CaptureCommandOutput();
+            output.WriteInfo(resourceEntries[name]);
+            return output;
         }
 
-        public string AllResources(string kind, string @namespace, IKubectl kubectl)
+        public ICommandOutput AllResources(string kind, string @namespace, IKubectl kubectl)
         {
-            return resourcesByKind[kind];
+            var output = new CaptureCommandOutput();
+            output.WriteInfo(resourcesByKind[kind]);
+            return output;
         }
     }
 

--- a/source/Calamari/Kubernetes/Integration/CaptureCommandOutput.cs
+++ b/source/Calamari/Kubernetes/Integration/CaptureCommandOutput.cs
@@ -14,7 +14,7 @@ namespace Calamari.Kubernetes.Integration
         private readonly List<Message> messages = new List<Message>();
         public Message[] Messages => messages.ToArray();
 
-        public IEnumerable<string> InfoLogs => Messages.Where(m => m.Level == Level.Info).Select(m => m.Text);
+        public IEnumerable<string> InfoLogs => Messages.Where(m => m.Level == Level.Info).Select(m => m.Text).ToArray();
 
         public void WriteInfo(string line)
         {

--- a/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Kubernetes.Integration;
@@ -6,25 +7,47 @@ namespace Calamari.Kubernetes.ResourceStatus
 {
     public interface IKubectlGet
     {
-        ICommandOutput Resource(string kind, string name, string @namespace, IKubectl kubectl);
-        ICommandOutput AllResources(string kind, string @namespace, IKubectl kubectl);
+        KubectlGetResult Resource(string kind, string name, string @namespace, IKubectl kubectl);
+        KubectlGetResult AllResources(string kind, string @namespace, IKubectl kubectl);
     }
 
     public class KubectlGet : IKubectlGet
     {
-        public ICommandOutput Resource(string kind, string name, string @namespace, IKubectl kubectl)
+        public KubectlGetResult Resource(string kind, string name, string @namespace, IKubectl kubectl)
         {
-            return kubectl.ExecuteCommandAndReturnOutput(new[]
-            {
-                "get", kind, name, "-o=jsonpath=\"{@}\"", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}" }).Output;
+            var output = kubectl.ExecuteCommandAndReturnOutput(new[]
+                                {
+                                    "get", kind, name, "-o=jsonpath=\"{@}\"", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
+                                })
+                                .Output;
+
+            return new KubectlGetResult(output.InfoLogs.Join(string.Empty),
+                                        output.Messages.Select(msg => $"{msg.Level}: {msg.Text}").ToList());
         }
 
-        public ICommandOutput AllResources(string kind, string @namespace, IKubectl kubectl)
+        public KubectlGetResult AllResources(string kind, string @namespace, IKubectl kubectl)
         {
-            return kubectl.ExecuteCommandAndReturnOutput(new[]
-            {
-                "get", kind, "-o=jsonpath=\"{@}\"", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
-            }).Output;
+            var output = kubectl.ExecuteCommandAndReturnOutput(new[]
+                                {
+                                    "get", kind, "-o=jsonpath=\"{@}\"", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
+                                })
+                                .Output;
+
+            return new KubectlGetResult(output.InfoLogs.Join(string.Empty),
+                                        output.Messages.Select(msg => $"{msg.Level}: {msg.Text}").ToList());
         }
+    }
+
+    public class KubectlGetResult
+    {
+        public KubectlGetResult(string resourceJson, IList<string> rawOutput)
+        {
+            ResourceJson = resourceJson;
+            RawOutput = rawOutput;
+        }
+
+        public string ResourceJson { get; }
+
+        public IList<string> RawOutput { get; }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
@@ -16,15 +16,14 @@ namespace Calamari.Kubernetes.ResourceStatus
         {
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
-                "get", kind, name, "-o=jsonpath='{@}'", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
-            }).Output;
+                "get", kind, name, "-o=jsonpath=\"{@}\"", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}" }).Output;
         }
 
         public ICommandOutput AllResources(string kind, string @namespace, IKubectl kubectl)
         {
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
-                "get", kind, "-o=jsonpath='{@}'", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
+                "get", kind, "-o=jsonpath=\"{@}\"", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
             }).Output;
         }
     }

--- a/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
@@ -6,26 +6,26 @@ namespace Calamari.Kubernetes.ResourceStatus
 {
     public interface IKubectlGet
     {
-        string Resource(string kind, string name, string @namespace, IKubectl kubectl);
-        string AllResources(string kind, string @namespace, IKubectl kubectl);
+        ICommandOutput Resource(string kind, string name, string @namespace, IKubectl kubectl);
+        ICommandOutput AllResources(string kind, string @namespace, IKubectl kubectl);
     }
 
     public class KubectlGet : IKubectlGet
     {
-        public string Resource(string kind, string name, string @namespace, IKubectl kubectl)
+        public ICommandOutput Resource(string kind, string name, string @namespace, IKubectl kubectl)
         {
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
                 "get", kind, name, "-o=jsonpath='{@}'", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
-            }).Output.InfoLogs.Join(string.Empty);
+            }).Output;
         }
 
-        public string AllResources(string kind, string @namespace, IKubectl kubectl)
+        public ICommandOutput AllResources(string kind, string @namespace, IKubectl kubectl)
         {
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
                 "get", kind, "-o=jsonpath='{@}'", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
-            }).Output.InfoLogs.Join(string.Empty);
+            }).Output;
         }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
@@ -16,7 +16,7 @@ namespace Calamari.Kubernetes.ResourceStatus
         {
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
-                "get", kind, name, "-o json", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
+                "get", kind, name, "-o=jsonpath='{@}'", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
             }).Output.InfoLogs.Join(string.Empty);
         }
 
@@ -24,7 +24,7 @@ namespace Calamari.Kubernetes.ResourceStatus
         {
             return kubectl.ExecuteCommandAndReturnOutput(new[]
             {
-                "get", kind, "-o json", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
+                "get", kind, "-o=jsonpath='{@}'", string.IsNullOrEmpty(@namespace) ? "" : $"-n {@namespace}"
             }).Output.InfoLogs.Join(string.Empty);
         }
     }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Kubernetes.Integration;
 using Calamari.Kubernetes.ResourceStatus.Resources;
@@ -50,7 +51,8 @@ namespace Calamari.Kubernetes.ResourceStatus
         private Resource GetResource(ResourceIdentifier resourceIdentifier, IKubectl kubectl, Options options)
         {
             var result = kubectlGet.Resource(resourceIdentifier.Kind, resourceIdentifier.Name, resourceIdentifier.Namespace, kubectl);
-            return result.IsNullOrEmpty() ? null : TryParse(ResourceFactory.FromJson, result, options);
+            
+            return result.InfoLogs.IsNullOrEmpty() ? null : TryParse(ResourceFactory.FromJson, result, options);
         }
 
         private IEnumerable<Resource> GetChildrenResources(Resource parentResource, IKubectl kubectl, Options options)
@@ -72,26 +74,35 @@ namespace Calamari.Kubernetes.ResourceStatus
                             }).ToList();
         }
 
-        T TryParse<T>(Func<string, Options, T> function, string jsonString, Options options)
+        T TryParse<T>(Func<string, Options, T> function, ICommandOutput commandOutput, Options options)
         {
+            var jsonString = commandOutput.InfoLogs.Join(string.Empty);
             try
             {
+                
                 return function(jsonString, options);
             }
             catch (JsonException)
             {
-                LogJsonStringError(jsonString, options);
+                LogJsonStringError(jsonString, commandOutput, options);
                 throw;
             }
         }
 
-        void LogJsonStringError(string jsonString, Options options)
+        void LogJsonStringError(string jsonString, ICommandOutput commandOutput, Options options)
         {
             if (options.PrintVerboseKubectlOutputOnError)
             {
                 log.Error("Failed to parse JSON:");
                 log.Error("---------------------------");
                 log.Error(jsonString);
+                log.Error("---------------------------");
+                log.Error("Full command output:");
+                log.Error("---------------------------");
+                foreach (var msg in commandOutput.Messages)
+                {
+                    log.Error($"{msg.Level}: {msg.Text}");
+                }
                 log.Error("---------------------------");
             }
             else


### PR DESCRIPTION
We've had reports from customers that they sometimes receive JSON parse errors when Kubernetes Object Status is running.

After receiving some logs, it looks like we are getting truncated JSON back from the kubectl command.

By default, the `kubectl get X -o json` returns formatted, multi-line JSON.

By changing to `-o=jsonpath="{@}"`, we force it to output the entire object as _unformatted_ json, meaning by capturing one line, we should capture the entire json string

I also changed it so the debug output will now show _all_ the command output, not just the info/json string

Shortcut story: [sc-83213]