### PR TITLE
Make sure target directory exists when extracting using Jar tool

### DIFF
--- a/source/Calamari.AzureAppService/ArchivePackagProvider/WarPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/WarPackageProvider.cs
@@ -5,6 +5,7 @@ using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Packages.Java;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing.Extensions;
+using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 
@@ -12,13 +13,15 @@ namespace Calamari.AzureAppService
 {
     public class WarPackageProvider : IPackageProvider
     {
+        readonly ICalamariFileSystem fileSystem;
         public bool SupportsAsynchronousDeployment => false;
         private ILog Log { get; }
         private IVariables Variables { get; }
         private RunningDeployment Deployment { get; }
 
-        public WarPackageProvider(ILog log, IVariables variables, RunningDeployment deployment)
+        public WarPackageProvider(ILog log, ICalamariFileSystem fileSystem, IVariables variables, RunningDeployment deployment)
         {
+            this.fileSystem = fileSystem;
             Log = log;
             Variables = variables;
             Deployment = deployment;
@@ -29,7 +32,7 @@ namespace Calamari.AzureAppService
         public async Task<FileInfo> PackageArchive(string sourceDirectory, string targetDirectory)
         {
             var cmdLineRunner = new CommandLineRunner(Log, Variables);
-            var jarTool = new JarTool(cmdLineRunner, Log, Variables);
+            var jarTool = new JarTool(cmdLineRunner, Log, fileSystem, Variables);
 
             var packageMetadata = PackageName.FromFile(Deployment.PackageFilePath);
 

--- a/source/Calamari.AzureAppService/Behaviors/AppDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AppDeployBehaviour.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Calamari.AzureAppService.Azure;
 using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
 
@@ -14,11 +15,11 @@ namespace Calamari.AzureAppService.Behaviors
 
         ILog Log { get; }
 
-        public AppDeployBehaviour(ILog log)
+        public AppDeployBehaviour(ILog log, ICalamariFileSystem fileSystem)
         {
             Log = log;
             containerBehaviour = new AzureAppServiceContainerDeployBehaviour(log);
-            zipDeployBehaviour = new AzureAppServiceZipDeployBehaviour(log);
+            zipDeployBehaviour = new AzureAppServiceZipDeployBehaviour(log, fileSystem);
         }
 
         public bool IsEnabled(RunningDeployment context) => true;

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -19,6 +19,7 @@ using Calamari.CloudAccounts;
 using Calamari.Common.Commands;
 using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Extensions;
+using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Variables;
@@ -31,8 +32,11 @@ namespace Calamari.AzureAppService.Behaviors
 {
     internal class AzureAppServiceZipDeployBehaviour : IDeployBehaviour
     {
-        public AzureAppServiceZipDeployBehaviour(ILog log)
+        readonly ICalamariFileSystem fileSystem;
+
+        public AzureAppServiceZipDeployBehaviour(ILog log, ICalamariFileSystem fileSystem)
         {
+            this.fileSystem = fileSystem;
             Log = log;
         }
 
@@ -108,7 +112,7 @@ namespace Calamari.AzureAppService.Behaviors
                                                {
                                                    ".zip" => new ZipPackageProvider(),
                                                    ".nupkg" => new NugetPackageProvider(),
-                                                   ".war" => new WarPackageProvider(Log, variables, context),
+                                                   ".war" => new WarPackageProvider(Log, fileSystem, variables, context),
                                                    _ => throw new Exception("Unsupported archive type")
                                                };
 

--- a/source/Calamari.Common/Features/Packages/CombinedPackageExtractor.cs
+++ b/source/Calamari.Common/Features/Packages/CombinedPackageExtractor.cs
@@ -6,6 +6,7 @@ using Calamari.Common.Features.Packages.Decorators;
 using Calamari.Common.Features.Packages.Java;
 using Calamari.Common.Features.Packages.NuGet;
 using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 
@@ -19,7 +20,7 @@ namespace Calamari.Common.Features.Packages
     {
         readonly IPackageExtractor[] extractors;
 
-        public CombinedPackageExtractor(ILog log, IVariables variables, ICommandLineRunner commandLineRunner)
+        public CombinedPackageExtractor(ILog log, ICalamariFileSystem calamariFileSystem, IVariables variables, ICommandLineRunner commandLineRunner)
         {
             extractors = new IPackageExtractor[]
             {
@@ -29,7 +30,7 @@ namespace Calamari.Common.Features.Packages
                 new TarBzipPackageExtractor(log),
                 new ZipPackageExtractor(log),
                 new TarPackageExtractor(log),
-                new JarPackageExtractor(new JarTool(commandLineRunner, log, variables))
+                new JarPackageExtractor(new JarTool(commandLineRunner, log, calamariFileSystem, variables))
             }.Select(e => e.WithExtractionLimits(log, variables)).ToArray();
         }
 

--- a/source/Calamari.Common/Features/Packages/Java/JarTool.cs
+++ b/source/Calamari.Common/Features/Packages/Java/JarTool.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 
@@ -14,12 +15,14 @@ namespace Calamari.Common.Features.Packages.Java
     {
         readonly ICommandLineRunner commandLineRunner;
         readonly ILog log;
+        readonly ICalamariFileSystem calamariFileSystem;
         readonly string toolsPath;
 
-        public JarTool(ICommandLineRunner commandLineRunner, ILog log, IVariables variables)
+        public JarTool(ICommandLineRunner commandLineRunner, ILog log, ICalamariFileSystem calamariFileSystem, IVariables variables)
         {
             this.commandLineRunner = commandLineRunner;
             this.log = log;
+            this.calamariFileSystem = calamariFileSystem;
 
             /*
                 The precondition script will also set the location of the java library files
@@ -60,6 +63,8 @@ namespace Calamari.Common.Features.Packages.Java
         {
             try
             {
+                calamariFileSystem.EnsureDirectoryExists(targetDirectory);
+
                 /*
                     Start by verifying the archive is valid.
                 */

--- a/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/PackageDownloaderStrategy.cs
@@ -62,7 +62,7 @@ namespace Calamari.Integration.Packages.Download
                     downloader = new HelmChartPackageDownloader(fileSystem, log);
                     break;
                 case FeedType.OciRegistry:
-                    downloader = new OciPackageDownloader(fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner), log);
+                    downloader = new OciPackageDownloader(fileSystem, new CombinedPackageExtractor(log, fileSystem, variables, commandLineRunner), log);
                     break;
                 case FeedType.Docker:
                 case FeedType.AwsElasticContainerRegistry:

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
@@ -151,7 +151,7 @@ namespace Calamari.Tests.AWS.CloudFormation
                     log,
                     variables,
                     fileSystem,
-                    new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
+                    new ExtractPackage(new CombinedPackageExtractor(log, fileSystem, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
                     new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                                                          {
                                                              new JsonFormatVariableReplacer(fileSystem, log),
@@ -188,7 +188,7 @@ namespace Calamari.Tests.AWS.CloudFormation
                 var command = new DeployCloudFormationCommand(log,
                                                               variables,
                                                               fileSystem,
-                                                              new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
+                                                              new ExtractPackage(new CombinedPackageExtractor(log, fileSystem, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
                                                               new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                                                               {
                                                                   new JsonFormatVariableReplacer(fileSystem, log),

--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -683,7 +683,7 @@ namespace Calamari.Tests.AWS
                                                      variables,
                                                      fileSystem,
                                                      new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem), variables),
-                                                     new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
+                                                     new ExtractPackage(new CombinedPackageExtractor(log, fileSystem, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
                                                      new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                                                                                           {
                                                                                               new JsonFormatVariableReplacer(fileSystem, log),
@@ -748,7 +748,7 @@ namespace Calamari.Tests.AWS
                                                      variables,
                                                      fileSystem,
                                                      new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem), variables),
-                                                     new ExtractPackage(new CombinedPackageExtractor(log, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
+                                                     new ExtractPackage(new CombinedPackageExtractor(log, fileSystem, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
                                                      new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                                                                                           {
                                                                                               new JsonFormatVariableReplacer(fileSystem, log),

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
@@ -117,8 +117,9 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             var log = new InMemoryLog();
             var variables = new CalamariVariables();
             var commandLineRunner = new TestCommandLineRunner(log, variables);
+            var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
-            return new CombinedPackageExtractor(log, variables, commandLineRunner);
+            return new CombinedPackageExtractor(log, fileSystem, variables, commandLineRunner);
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/CombinedPackageExtractorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/CombinedPackageExtractorFixture.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Packages.NuGet;
+using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Fixtures.Util;
@@ -72,7 +73,8 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         {
             var log = new InMemoryLog();
             var variables = new CalamariVariables();
-            var combinedExtractor = new CombinedPackageExtractor(log, variables, new TestCommandLineRunner(log, variables));
+            var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+            var combinedExtractor = new CombinedPackageExtractor(log, fileSystem, variables, new TestCommandLineRunner(log, variables));
             return combinedExtractor;
         }
     }

--- a/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
@@ -136,7 +136,7 @@ namespace Calamari.Tests.Java.Fixtures.Deployment
                 fileSystem,
                 commandLineRunner,
                 new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem), variables),
-                new ExtractPackage(new CombinedPackageExtractor(log, variables, commandLineRunner), fileSystem, variables, log),
+                new ExtractPackage(new CombinedPackageExtractor(log, fileSystem, variables, commandLineRunner), fileSystem, variables, log),
                 new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                 {
                     new JsonFormatVariableReplacer(fileSystem, log),

--- a/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
+++ b/source/Calamari/Commands/Java/DeployJavaArchiveCommand.cs
@@ -80,7 +80,7 @@ namespace Calamari.Commands.Java
 
             var semaphore = SemaphoreFactory.Get();
             var journal = new DeploymentJournal(fileSystem, semaphore, variables);
-            var jarTools = new JarTool(commandLineRunner, log, variables);
+            var jarTools = new JarTool(commandLineRunner, log, fileSystem, variables);
             var packageExtractor = new JarPackageExtractor(jarTools).WithExtractionLimits(log, variables);
             var embeddedResources = new AssemblyEmbeddedResources();
             var javaRunner = new JavaRunner(commandLineRunner, variables);

--- a/source/Calamari/Commands/RunScriptCommand.cs
+++ b/source/Calamari/Commands/RunScriptCommand.cs
@@ -81,11 +81,11 @@ namespace Calamari.Commands
 
             if (OctopusFeatureToggles.NonPrimaryGitDependencySupportFeatureToggle.IsEnabled(variables))
             {
-                conventions.Add(new StageDependenciesConvention(packageFile, fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner), new PackageVariablesFactory()));
+                conventions.Add(new StageDependenciesConvention(packageFile, fileSystem, new CombinedPackageExtractor(log, fileSystem, variables, commandLineRunner), new PackageVariablesFactory()));
             }
             else
             {
-                conventions.Add(new StageScriptPackagesConvention(packageFile, fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner)));
+                conventions.Add(new StageScriptPackagesConvention(packageFile, fileSystem, new CombinedPackageExtractor(log, fileSystem, variables, commandLineRunner)));
             }
             
             conventions.AddRange(new IConvention[] {

--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -74,18 +74,18 @@ namespace Calamari.Kubernetes.Commands
             {
                 conventions.Add(new StageDependenciesConvention(null,
                                                                       fileSystem,
-                                                                      new CombinedPackageExtractor(log, variables, commandLineRunner),
+                                                                      new CombinedPackageExtractor(log, fileSystem, variables, commandLineRunner),
                                                                       new PackageVariablesFactory(),
                                                                       true));
                 conventions.Add(new StageDependenciesConvention(null,
                                                                       fileSystem,
-                                                                      new CombinedPackageExtractor(log, variables, commandLineRunner),
+                                                                      new CombinedPackageExtractor(log, fileSystem, variables, commandLineRunner),
                                                                       new GitDependencyVariablesFactory(),
                                                                       true));
             }
             else
             {
-                conventions.Add(new StageScriptPackagesConvention(null, fileSystem, new CombinedPackageExtractor(log, variables, commandLineRunner), true));
+                conventions.Add(new StageScriptPackagesConvention(null, fileSystem, new CombinedPackageExtractor(log, fileSystem, variables, commandLineRunner), true));
             }
             
             conventions.AddRange(new IInstallConvention[]


### PR DESCRIPTION
This fixes an issue where extracting an additional package using a Jar tool would fail. When extracting a package that is referenced as an additional package, the package name is appended to the target directory. This does not exist at the time of verifying whether the archive is valid or not, which fails the action. 

When referenced as a main package it extracts to the current working folder, which is why it was not problematic.


**Before**
<img width="1113" alt="Pasted Graphic 7" src="https://github.com/user-attachments/assets/059adf5a-5c9f-488c-9101-ed906913ef23">

**After**
<img width="1162" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/43aa0a8c-ccda-4986-b90a-1ceaa17f4b29">

[sc-50612]

Relates to https://github.com/OctopusDeploy/Issues/issues/8181