### PR TITLE
Remove `CustomResource` service message

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/GatherAndApplyRawYamlExecutorTests.cs
@@ -96,24 +96,16 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             result.Should().BeTrue();
             variables.Get(SpecialVariables.GroupedYamlDirectories).Should().Be(expectedYamlGrouping);
 
-            commandLineRunner.ReceivedCalls().Count().Should().Be(4);
+            commandLineRunner.ReceivedCalls().Count().Should().Be(2);
             var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
             commandLineArgs[0].Should().Contain("apply -f").And.Contain("--recursive").And.Contain("-o json").And.Contain($"{Path.Combine("grouped", "1")}");
             commandLineArgs[1].Should().Contain("apply -f").And.Contain("--recursive").And.Contain("-o json").And.Contain($"{Path.Combine("grouped", "2")}");
-            commandLineArgs[2].Should().Contain("get").And.Contain("basic-deployment");
-            commandLineArgs[3].Should().Contain("get").And.Contain("basic-service");
 
             receivedCallbacks.Should()
                              .BeEquivalentTo(new List<ResourceIdentifier>
                              {
                                  new ResourceIdentifier("Deployment", "basic-deployment", "dev"), new ResourceIdentifier("Service", "basic-service", "dev"), new ResourceIdentifier("Deployment", "basic-deployment", "dev")
                              });
-
-            log.ServiceMessages.Count.Should().Be(2);
-            log.ServiceMessages[0].Name.Should().Be(ServiceMessageNames.SetVariable.Name);
-            log.ServiceMessages[0].Properties.Should().Contain(new KeyValuePair<string, string>("name", "CustomResources(basic-deployment)"));
-            log.ServiceMessages[1].Name.Should().Be(ServiceMessageNames.SetVariable.Name);
-            log.ServiceMessages[1].Properties.Should().Contain(new KeyValuePair<string, string>("name", "CustomResources(basic-service)"));
         }
 
         [Test]
@@ -139,7 +131,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             result.Should().BeTrue();
             variables.Get(SpecialVariables.GroupedYamlDirectories).Should().Be(expectedYamlGrouping);
 
-            commandLineRunner.ReceivedCalls().Count().Should().Be(4);
+            commandLineRunner.ReceivedCalls().Count().Should().Be(2);
             var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
             commandLineArgs[0]
                 .Should()
@@ -185,7 +177,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             result.Should().BeTrue();
             variables.Get(SpecialVariables.GroupedYamlDirectories).Should().Be(expectedYamlGrouping);
 
-            commandLineRunner.ReceivedCalls().Count().Should().Be(4);
+            commandLineRunner.ReceivedCalls().Count().Should().Be(2);
             var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
             commandLineArgs[0]
                 .Should()
@@ -231,7 +223,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             result.Should().BeTrue();
             variables.Get(SpecialVariables.GroupedYamlDirectories).Should().Be(expectedYamlGrouping);
 
-            commandLineRunner.ReceivedCalls().Count().Should().Be(4);
+            commandLineRunner.ReceivedCalls().Count().Should().Be(2);
             var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
             commandLineArgs[0]
                 .Should()

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
@@ -153,22 +153,15 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
 
             // Assert
             result.Should().BeTrue();
-            commandLineRunner.ReceivedCalls().Count().Should().Be(4);
+            commandLineRunner.ReceivedCalls().Count().Should().Be(2);
             var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
             commandLineArgs[0].Should().Contain("version").And.Contain("--client").And.Contain("-o json");
             commandLineArgs[1].Should().Contain("apply -k").And.Contain("-o json").And.Contain(OverlayPath);
-            commandLineArgs[2].Should().Contain("get").And.Contain("basic-service");
-            commandLineArgs[3].Should().Contain("get").And.Contain("basic-deployment");
             receivedCallbacks.Should()
                              .BeEquivalentTo(new List<ResourceIdentifier>
                              {
                                  new ResourceIdentifier("Deployment", "basic-deployment", "dev"), new ResourceIdentifier("Service", "basic-service", "dev")
                              });
-            log.ServiceMessages.Count.Should().Be(2);
-            log.ServiceMessages[0].Name.Should().Be(ServiceMessageNames.SetVariable.Name);
-            log.ServiceMessages[0].Properties.Should().Contain(new KeyValuePair<string, string>("name", "CustomResources(basic-service)"));
-            log.ServiceMessages[1].Name.Should().Be(ServiceMessageNames.SetVariable.Name);
-            log.ServiceMessages[1].Properties.Should().Contain(new KeyValuePair<string, string>("name", "CustomResources(basic-deployment)"));
         }
 
         [Test]
@@ -190,7 +183,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
 
             // Assert
             result.Should().BeTrue();
-            commandLineRunner.ReceivedCalls().Count().Should().Be(4);
+            commandLineRunner.ReceivedCalls().Count().Should().Be(2);
             var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
             commandLineArgs[1]
                 .Should()
@@ -222,7 +215,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
 
             // Assert
             result.Should().BeTrue();
-            commandLineRunner.ReceivedCalls().Count().Should().Be(4);
+            commandLineRunner.ReceivedCalls().Count().Should().Be(2);
             var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
             commandLineArgs[1]
                 .Should()
@@ -254,7 +247,7 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
 
             // Assert
             result.Should().BeTrue();
-            commandLineRunner.ReceivedCalls().Count().Should().Be(4);
+            commandLineRunner.ReceivedCalls().Count().Should().Be(2);
             var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
             commandLineArgs[1]
                 .Should()

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -130,9 +130,9 @@ namespace Calamari.Tests.KubernetesFixtures
 
             var rawLogs = Log.Messages.Select(m => m.FormattedMessage).ToArray();
 
-            var scrubbedJson = AssertResourceCreatedAndGetJson(SimpleDeploymentResourceName);
+            //var scrubbedJson = AssertResourceCreatedAndGetJson(SimpleDeploymentResourceName);
 
-            this.Assent(scrubbedJson, configuration: AssentConfiguration.Default);
+            //this.Assent(scrubbedJson, configuration: AssentConfiguration.Default);
 
             AssertObjectStatusMonitoringStarted(rawLogs, (SimpleDeploymentResourceType, SimpleDeploymentResourceName));
 
@@ -154,7 +154,7 @@ namespace Calamari.Tests.KubernetesFixtures
             }
         }
 
-        private string AssertResourceCreatedAndGetJson(string resourceName)
+        /*private string AssertResourceCreatedAndGetJson(string resourceName)
         {
             var variableMessages = Log.Messages.GetServiceMessagesOfType("setVariable");
 
@@ -171,7 +171,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 p.Name == "status" ||
                 p.Name == "generation" ||
                 p.Name.StartsWith("clusterIP"));
-        }
+        }*/
 
         [Test]
         [TestCase(true)]
@@ -198,9 +198,9 @@ namespace Calamari.Tests.KubernetesFixtures
 
             var rawLogs = Log.Messages.Select(m => m.FormattedMessage).ToArray();
 
-            var scrubbedJson = AssertResourceCreatedAndGetJson(SimpleDeploymentResourceName);
+            //var scrubbedJson = AssertResourceCreatedAndGetJson(SimpleDeploymentResourceName);
 
-            this.Assent(scrubbedJson, configuration: AssentConfiguration.Default);
+                //this.Assent(scrubbedJson, configuration: AssentConfiguration.Default);
 
             AssertObjectStatusMonitoringStarted(rawLogs, (SimpleDeploymentResourceType, SimpleDeploymentResourceName));
 
@@ -278,8 +278,8 @@ namespace Calamari.Tests.KubernetesFixtures
             foreach (var (name, label) in resources)
             {
                 // Check that each resource was created and the appropriate setvariable service message was created.
-                var resource = AssertResourceCreatedAndGetJson(name);
-                this.Assent(resource, configuration: AssentConfiguration.DefaultWithPostfix(label));
+                //var resource = AssertResourceCreatedAndGetJson(name);
+                //this.Assent(resource, configuration: AssentConfiguration.DefaultWithPostfix(label));
 
                 // Check that each deployed resource has a "Successful" status reported.
                 statusMessages.Should().Contain(m => m.Properties["name"] == name && m.Properties["status"] == "Successful");

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -130,10 +130,6 @@ namespace Calamari.Tests.KubernetesFixtures
 
             var rawLogs = Log.Messages.Select(m => m.FormattedMessage).ToArray();
 
-            //var scrubbedJson = AssertResourceCreatedAndGetJson(SimpleDeploymentResourceName);
-
-            //this.Assent(scrubbedJson, configuration: AssentConfiguration.Default);
-
             AssertObjectStatusMonitoringStarted(rawLogs, (SimpleDeploymentResourceType, SimpleDeploymentResourceName));
 
             var objectStatusUpdates = Log.Messages.GetServiceMessagesOfType("k8s-status");
@@ -153,25 +149,6 @@ namespace Calamari.Tests.KubernetesFixtures
                 rawLogs[idx + i + 1].Should().Be($" - {type}/{name} in namespace calamari-testing");
             }
         }
-
-        /*private string AssertResourceCreatedAndGetJson(string resourceName)
-        {
-            var variableMessages = Log.Messages.GetServiceMessagesOfType("setVariable");
-
-            var variableMessage =
-                variableMessages.Should().ContainSingle(m => m.Properties["name"] == $"CustomResources({resourceName})")
-                                .Subject;
-
-            return KubernetesJsonResourceScrubber.ScrubRawJson(variableMessage.Properties["value"], p =>
-                p.Name.Contains("Time") ||
-                p.Name == "annotations" ||
-                p.Name == "uid" ||
-                p.Name == "conditions" ||
-                p.Name == "resourceVersion" ||
-                p.Name == "status" ||
-                p.Name == "generation" ||
-                p.Name.StartsWith("clusterIP"));
-        }*/
 
         [Test]
         [TestCase(true)]
@@ -197,10 +174,6 @@ namespace Calamari.Tests.KubernetesFixtures
             SetupAndRunKubernetesRawYamlDeployment(usePackage, FailToDeploymentResource, shouldSucceed: false);
 
             var rawLogs = Log.Messages.Select(m => m.FormattedMessage).ToArray();
-
-            //var scrubbedJson = AssertResourceCreatedAndGetJson(SimpleDeploymentResourceName);
-
-                //this.Assent(scrubbedJson, configuration: AssentConfiguration.Default);
 
             AssertObjectStatusMonitoringStarted(rawLogs, (SimpleDeploymentResourceType, SimpleDeploymentResourceName));
 
@@ -277,10 +250,6 @@ namespace Calamari.Tests.KubernetesFixtures
 
             foreach (var (name, label) in resources)
             {
-                // Check that each resource was created and the appropriate setvariable service message was created.
-                //var resource = AssertResourceCreatedAndGetJson(name);
-                //this.Assent(resource, configuration: AssentConfiguration.DefaultWithPostfix(label));
-
                 // Check that each deployed resource has a "Successful" status reported.
                 statusMessages.Should().Contain(m => m.Properties["name"] == name && m.Properties["status"] == "Successful");
             }

--- a/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
-using Calamari.Common.Plumbing.ServiceMessages;
 using Calamari.Kubernetes.Integration;
 using Calamari.Kubernetes.ResourceStatus.Resources;
 using Newtonsoft.Json.Linq;
@@ -17,12 +16,10 @@ namespace Calamari.Kubernetes.Commands.Executors
     abstract class BaseKubernetesApplyExecutor : IKubernetesApplyExecutor
     {
         readonly ILog log;
-        readonly Kubectl kubectl;
 
-        protected BaseKubernetesApplyExecutor(ILog log, Kubectl kubectl)
+        protected BaseKubernetesApplyExecutor(ILog log)
         {
             this.log = log;
-            this.kubectl = kubectl;
         }
      
         public async Task<bool> Execute(RunningDeployment deployment, Func<ResourceIdentifier[], Task> appliedResourcesCallback = null)
@@ -30,7 +27,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             try
             {
                 var resourceIdentifiers = await ApplyAndGetResourceIdentifiers(deployment, appliedResourcesCallback);
-                WriteResourcesToOutputVariables(resourceIdentifiers);
+              //  WriteResourcesToOutputVariables(resourceIdentifiers);
                 return true;
             }
             catch (KubernetesApplyException)
@@ -105,29 +102,6 @@ namespace Calamari.Kubernetes.Commands.Executors
                 LogParsingError(outputJson, deployment.Variables.GetFlag(SpecialVariables.PrintVerboseKubectlOutputOnError));
 
                 throw new KubernetesApplyException();
-            }
-        }
-
-        void WriteResourcesToOutputVariables(IEnumerable<ResourceIdentifier> resources)
-        {
-            foreach (var resource in resources)
-            {
-                try
-                {
-                    var result = kubectl.ExecuteCommandAndReturnOutput("get", resource.Kind, resource.Name,
-                                                                       "-o", "json", "-n", resource.Namespace);
-
-                    log.WriteServiceMessage(new ServiceMessage(ServiceMessageNames.SetVariable.Name, new Dictionary<string, string>
-                    {
-                        {ServiceMessageNames.SetVariable.NameAttribute, $"CustomResources({resource.Name})"},
-                        {ServiceMessageNames.SetVariable.ValueAttribute, result.Output.InfoLogs.Join("\n")}
-                    }));
-                }
-                catch
-                {
-                    log.Warn(
-                             $"Could not save json for resource to output variable for '{resource.Kind}/{resource.Name}'");
-                }
             }
         }
         

--- a/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/BaseKubernetesApplyExecutor.cs
@@ -26,8 +26,7 @@ namespace Calamari.Kubernetes.Commands.Executors
         {
             try
             {
-                var resourceIdentifiers = await ApplyAndGetResourceIdentifiers(deployment, appliedResourcesCallback);
-              //  WriteResourcesToOutputVariables(resourceIdentifiers);
+                await ApplyAndGetResourceIdentifiers(deployment, appliedResourcesCallback);
                 return true;
             }
             catch (KubernetesApplyException)

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -29,7 +29,7 @@ namespace Calamari.Kubernetes.Commands.Executors
         public GatherAndApplyRawYamlExecutor(
             ILog log,
             ICalamariFileSystem fileSystem,
-            Kubectl kubectl) : base(log, kubectl)
+            Kubectl kubectl) : base(log)
         {
             this.log = log;
             this.fileSystem = fileSystem;

--- a/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
@@ -24,7 +24,7 @@ namespace Calamari.Kubernetes.Commands.Executors
         readonly ILog log;
         readonly Kubectl kubectl;
 
-        public KustomizeExecutor(ILog log, Kubectl kubectl) : base(log, kubectl)
+        public KustomizeExecutor(ILog log, Kubectl kubectl) : base(log)
         {
             this.log = log;
             this.kubectl = kubectl;


### PR DESCRIPTION
Looks like we dont use the customresource service message
As noted in [slack thread](https://octopusdeploy.slack.com/archives/C0431AXP230/p1723786921041459) it looks like nothing is relying on this output variable. To help simplify this PR removes it.