### PR TITLE
Perform variable substitutions on template values files from dependencies

### DIFF
--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -27,13 +27,15 @@ namespace Calamari.Kubernetes.Conventions
         readonly IScriptEngine scriptEngine;
         readonly ICommandLineRunner commandLineRunner;
         readonly ICalamariFileSystem fileSystem;
+        readonly HelmTemplateValueSourcesParser valueSourcesParser;
 
-        public HelmUpgradeConvention(ILog log, IScriptEngine scriptEngine, ICommandLineRunner commandLineRunner, ICalamariFileSystem fileSystem)
+        public HelmUpgradeConvention(ILog log, IScriptEngine scriptEngine, ICommandLineRunner commandLineRunner, ICalamariFileSystem fileSystem, HelmTemplateValueSourcesParser valueSourcesParser)
         {
             this.log = log;
             this.scriptEngine = scriptEngine;
             this.commandLineRunner = commandLineRunner;
             this.fileSystem = fileSystem;
+            this.valueSourcesParser = valueSourcesParser;
         }
 
         public void Install(RunningDeployment deployment)
@@ -191,7 +193,7 @@ namespace Calamari.Kubernetes.Conventions
 
         void SetOrderedTemplateValues(RunningDeployment deployment, StringBuilder sb)
         {
-            var filenames = HelmTemplateValueSourcesParser.ParseTemplateValuesFilesFromAllSources(deployment, fileSystem, log);
+            var filenames = valueSourcesParser.ParseAndWriteTemplateValuesFilesFromAllSources(deployment);
 
             foreach (var filename in filenames)
             {

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -17,7 +17,6 @@ using Calamari.Deployment.Conventions;
 using Calamari.Kubernetes.Helm;
 using Calamari.Util;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Kubernetes.Conventions
@@ -192,7 +191,7 @@ namespace Calamari.Kubernetes.Conventions
 
         void SetOrderedTemplateValues(RunningDeployment deployment, StringBuilder sb)
         {
-            var filenames = HelmTemplateValueSourcesParser.ParseTemplateValuesSources(deployment, fileSystem, log);
+            var filenames = HelmTemplateValueSourcesParser.ParseTemplateValuesFilesFromAllSources(deployment, fileSystem, log);
 
             foreach (var filename in filenames)
             {

--- a/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
@@ -28,7 +28,7 @@ namespace Calamari.Kubernetes.Helm
             var gitDependencyNames = variables.GetIndexes(Deployment.SpecialVariables.GitResources.GitResourceCollection);
             if (!gitDependencyNames.Contains(gitDependencyName))
             {
-                log.Warn($"Failed to find variables for git resource {gitDependencyName}");
+                log?.Warn($"Failed to find variables for git resource {gitDependencyName}");
                 return null;
             }
 
@@ -58,7 +58,7 @@ namespace Calamari.Kubernetes.Helm
                 foreach (var file in currentFiles)
                 {
                     var relative = file.Substring(Path.Combine(deployment.CurrentDirectory, sanitizedPackageReferenceName).Length);
-                    log.Info($"Including values file `{relative}` from git repository {repositoryUrl}, commit {commitHash}");
+                    log?.Info($"Including values file `{relative}` from git repository {repositoryUrl}, commit {commitHash}");
                     filenames.Add(file);
                 }
             }

--- a/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
+++ b/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
@@ -9,9 +9,18 @@ using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.Helm
 {
-    public static class HelmTemplateValueSourcesParser
+    public class HelmTemplateValueSourcesParser
     {
-        public static IEnumerable<string> ParseTemplateValuesFilesFromAllSources(RunningDeployment deployment, ICalamariFileSystem fileSystem, ILog log)
+        readonly ICalamariFileSystem fileSystem;
+        readonly ILog log;
+
+        public HelmTemplateValueSourcesParser(ICalamariFileSystem fileSystem, ILog log)
+        {
+            this.fileSystem = fileSystem;
+            this.log = log;
+        }
+
+        public IEnumerable<string> ParseAndWriteTemplateValuesFilesFromAllSources(RunningDeployment deployment)
         {
             var templateValueSources = deployment.Variables.Get(SpecialVariables.Helm.TemplateValuesSources);
 
@@ -20,10 +29,10 @@ namespace Calamari.Kubernetes.Helm
 
             var parsedJsonArray = JArray.Parse(templateValueSources);
 
-            return ParseFilenamesFromTemplateValuesArray(deployment, fileSystem, log, parsedJsonArray);
+            return ParseFilenamesFromTemplateValuesArray(deployment, parsedJsonArray, true);
         }
 
-        public static IEnumerable<string> ParseTemplateValuesFilesFromDependencies(RunningDeployment deployment, ICalamariFileSystem fileSystem, ILog log)
+        public IEnumerable<string> ParseTemplateValuesFilesFromDependencies(RunningDeployment deployment, bool logIncludedFiles = true)
         {
             var templateValueSources = deployment.Variables.Get(SpecialVariables.Helm.TemplateValuesSources);
 
@@ -35,17 +44,15 @@ namespace Calamari.Kubernetes.Helm
             //we are only interested in the values files in external dependencies (chart/package/git repo), so filter this array
             var relevantTypes = parsedJsonArray.Where(t =>
                                                       {
-                                                          var type = (TemplateValuesSourceType)Enum.Parse(typeof(TemplateValuesSourceType),t.Value<string>(nameof(TemplateValuesSource.Type)));
+                                                          var type = (TemplateValuesSourceType)Enum.Parse(typeof(TemplateValuesSourceType), t.Value<string>(nameof(TemplateValuesSource.Type)));
                                                           return type == TemplateValuesSourceType.Chart || type == TemplateValuesSourceType.Package || type == TemplateValuesSourceType.GitRepository;
                                                       })
                                                .ToList();
-            
-            
-            
-            return ParseFilenamesFromTemplateValuesArray(deployment, fileSystem, log, relevantTypes);
+
+            return ParseFilenamesFromTemplateValuesArray(deployment, relevantTypes, logIncludedFiles);
         }
 
-        static List<string> ParseFilenamesFromTemplateValuesArray(RunningDeployment deployment, ICalamariFileSystem fileSystem, ILog log, IEnumerable<JToken> parsedJsonArray)
+        List<string> ParseFilenamesFromTemplateValuesArray(RunningDeployment deployment, IEnumerable<JToken> parsedJsonArray, bool logIncludedFiles)
         {
             var filenames = new List<string>();
             // we reverse the order of the array so that we maintain the order that sources at the top take higher precendences (i.e. are adding to the --values list later),
@@ -63,10 +70,10 @@ namespace Calamari.Kubernetes.Helm
                         switch (scriptSource)
                         {
                             case ScriptVariables.ScriptSourceOptions.Package:
-                                chartFilenames = PackageValuesFileWriter.FindChartValuesFiles(deployment, fileSystem, log, chartTvs.ValuesFilePaths);
+                                chartFilenames = PackageValuesFileWriter.FindChartValuesFiles(deployment, fileSystem, log, chartTvs.ValuesFilePaths, logIncludedFiles);
                                 break;
                             case ScriptVariables.ScriptSourceOptions.GitRepository:
-                                chartFilenames = GitRepositoryValuesFileWriter.FindChartValuesFiles(deployment, fileSystem, log, chartTvs.ValuesFilePaths);
+                                chartFilenames = GitRepositoryValuesFileWriter.FindChartValuesFiles(deployment, fileSystem, log, chartTvs.ValuesFilePaths, logIncludedFiles);
                                 break;
                             default:
                                 if (scriptSource is null)
@@ -96,7 +103,8 @@ namespace Calamari.Kubernetes.Helm
                                                                                               log,
                                                                                               packageTvs.ValuesFilePaths,
                                                                                               packageTvs.PackageId,
-                                                                                              packageTvs.PackageName);
+                                                                                              packageTvs.PackageName, 
+                                                                                              logIncludedFiles);
 
                         if (packageFilenames != null)
                         {
@@ -118,7 +126,8 @@ namespace Calamari.Kubernetes.Helm
                                                                                                                 fileSystem,
                                                                                                                 log,
                                                                                                                 gitRepTvs.GitDependencyName,
-                                                                                                                gitRepTvs.ValuesFilePaths);
+                                                                                                                gitRepTvs.ValuesFilePaths, 
+                                                                                                                logIncludedFiles);
 
                         if (gitRepositoryFilenames != null)
                         {

--- a/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
@@ -31,7 +31,7 @@ namespace Calamari.Kubernetes.Helm
             var packageNames = variables.GetIndexes(PackageVariables.PackageCollection);
             if (!packageNames.Contains(packageName))
             {
-                log.Warn($"Failed to find variables for package {packageName}");
+                log?.Warn($"Failed to find variables for package {packageName}");
                 return null;
             }
 
@@ -65,7 +65,7 @@ namespace Calamari.Kubernetes.Helm
 
                 if (!currentFiles.Any() && string.IsNullOrEmpty(packageName)) // Chart archives have chart name root directory
                 {
-                    log.Verbose($"Unable to find values files at path `{valuePath}`. Chart package contains root directory with chart name, so looking for values in there.");
+                    log?.Verbose($"Unable to find values files at path `{valuePath}`. Chart package contains root directory with chart name, so looking for values in there.");
                     var chartRelativePath = Path.Combine(pathedPackedName, relativePath);
                     currentFiles = fileSystem.EnumerateFilesWithGlob(deployment.CurrentDirectory, chartRelativePath).ToList();
                 }
@@ -78,7 +78,7 @@ namespace Calamari.Kubernetes.Helm
                 foreach (var file in currentFiles)
                 {
                     var relative = file.Substring(Path.Combine(deployment.CurrentDirectory, sanitizedPackageReferenceName).Length);
-                    log.Info($"Including values file `{relative}` from package {pathedPackedName} v{version}");
+                    log?.Info($"Including values file `{relative}` from package {pathedPackedName} v{version}");
                     filenames.Add(file);
                 }
             }

--- a/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/PackageValuesFileWriter.cs
@@ -12,26 +12,32 @@ namespace Calamari.Kubernetes.Helm
 {
     public static class PackageValuesFileWriter
     {
-        public static IEnumerable<string> FindChartValuesFiles(RunningDeployment deployment, ICalamariFileSystem fileSystem, ILog log, string valuesFilePaths)
+        public static IEnumerable<string> FindChartValuesFiles(RunningDeployment deployment,
+                                                               ICalamariFileSystem fileSystem,
+                                                               ILog log,
+                                                               string valuesFilePaths,
+                                                               bool logIncludedFiles = true)
             => FindPackageValuesFiles(deployment,
                                       fileSystem,
                                       log,
                                       valuesFilePaths,
                                       string.Empty,
-                                      string.Empty);
+                                      string.Empty,
+                                      logIncludedFiles);
 
         public static IEnumerable<string> FindPackageValuesFiles(RunningDeployment deployment,
                                                                  ICalamariFileSystem fileSystem,
                                                                  ILog log,
                                                                  string valuesFilePaths,
                                                                  string packageId,
-                                                                 string packageName)
+                                                                 string packageName,
+                                                                 bool logIncludedFiles = true)
         {
             var variables = deployment.Variables;
             var packageNames = variables.GetIndexes(PackageVariables.PackageCollection);
             if (!packageNames.Contains(packageName))
             {
-                log?.Warn($"Failed to find variables for package {packageName}");
+                log.Warn($"Failed to find variables for package {packageName}");
                 return null;
             }
 
@@ -44,7 +50,7 @@ namespace Calamari.Kubernetes.Helm
                     return null;
                 }
             }
-            
+
             var valuesPaths = HelmValuesFileUtils.SplitValuesFilePaths(valuesFilePaths);
             if (valuesPaths == null || !valuesPaths.Any())
                 return null;
@@ -53,9 +59,9 @@ namespace Calamari.Kubernetes.Helm
             var errors = new List<string>();
 
             var sanitizedPackageReferenceName = PackageName.ExtractPackageNameFromPathedPackageId(fileSystem.RemoveInvalidFileNameChars(packageName));
-            
+
             var version = variables.Get(PackageVariables.IndexedPackageVersion(packageName));
-            
+
             //we get the package id here
             var pathedPackedName = PackageName.ExtractPackageNameFromPathedPackageId(variables.Get(PackageVariables.IndexedPackageId(packageName)));
             foreach (var valuePath in valuesPaths)
@@ -65,7 +71,7 @@ namespace Calamari.Kubernetes.Helm
 
                 if (!currentFiles.Any() && string.IsNullOrEmpty(packageName)) // Chart archives have chart name root directory
                 {
-                    log?.Verbose($"Unable to find values files at path `{valuePath}`. Chart package contains root directory with chart name, so looking for values in there.");
+                    log.Verbose($"Unable to find values files at path `{valuePath}`. Chart package contains root directory with chart name, so looking for values in there.");
                     var chartRelativePath = Path.Combine(pathedPackedName, relativePath);
                     currentFiles = fileSystem.EnumerateFilesWithGlob(deployment.CurrentDirectory, chartRelativePath).ToList();
                 }
@@ -78,7 +84,12 @@ namespace Calamari.Kubernetes.Helm
                 foreach (var file in currentFiles)
                 {
                     var relative = file.Substring(Path.Combine(deployment.CurrentDirectory, sanitizedPackageReferenceName).Length);
-                    log?.Info($"Including values file `{relative}` from package {pathedPackedName} v{version}");
+
+                    if (logIncludedFiles)
+                    {
+                        log.Info($"Including values file `{relative}` from package {pathedPackedName} v{version}");
+                    }
+
                     filenames.Add(file);
                 }
             }

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -19,6 +19,7 @@ using Calamari.Deployment.PackageRetention;
 using Calamari.Integration.Certificates;
 using Calamari.Integration.FileSystem;
 using Calamari.Kubernetes.Commands.Discovery;
+using Calamari.Kubernetes.Helm;
 using Calamari.Kubernetes.Integration;
 using Calamari.Kubernetes.ResourceStatus;
 using Calamari.LaunchTools;
@@ -81,6 +82,7 @@ namespace Calamari
 #endif
             builder.RegisterType<Kubectl>().AsSelf().As<IKubectl>().InstancePerLifetimeScope();
             builder.RegisterType<KubectlGet>().As<IKubectlGet>().SingleInstance();
+            builder.RegisterType<HelmTemplateValueSourcesParser>().AsSelf().SingleInstance();
 
             builder.RegisterType<KubernetesDiscovererFactory>()
                    .As<IKubernetesDiscovererFactory>()


### PR DESCRIPTION
When adding the new helm template values sources code, I missed the logic that did variable substitution on the files sourced from dependencies (packages/git repos). It's no longer working because we don't store the paths on the `ValuesFilePaths` on the package dependencies themselves anymore

Shortcut story: [sc-89421]