### PR TITLE
Move `FindCertificateInLocalMachineStore` into Cert Tool

### DIFF
--- a/source/Calamari.Shared/Integration/Certificates/WindowsX509CertificateStore.cs
+++ b/source/Calamari.Shared/Integration/Certificates/WindowsX509CertificateStore.cs
@@ -31,6 +31,25 @@ namespace Calamari.Integration.Certificates
             return Semaphores.Acquire(SemaphoreName, "Another process is working with the certificate store, please wait...");
         }
 
+        public static string? FindCertificateStore(string thumbprint, StoreLocation storeLocation)
+        {
+            foreach (var storeName in GetStoreNames(storeLocation))
+            {
+                var store = new X509Store(storeName, storeLocation);
+                store.Open(OpenFlags.ReadOnly);
+
+                var found = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, false);
+                if (found.Count != 0 && found[0].HasPrivateKey)
+                {
+                    return storeName;
+                }
+
+                store.Close();
+            }
+
+            return null;
+        }
+        
         public static void ImportCertificateToStore(byte[] pfxBytes, string password, StoreLocation storeLocation,
             string storeName, bool privateKeyExportable)
         {
@@ -82,6 +101,14 @@ namespace Calamari.Integration.Certificates
                     AddPrivateKeyAccessRules(keySecurity, certificate);
                 }
             }
+        }
+
+        public static void AddPrivateKeyAccessRules(string thumbprint,
+                                                    StoreLocation storeLocation,
+                                                    ICollection<PrivateKeyAccessRule> privateKeyAccessRules)
+        {
+            var storeName = FindCertificateStore(thumbprint, StoreLocation.LocalMachine);
+            AddPrivateKeyAccessRules(thumbprint, storeLocation, storeName, privateKeyAccessRules);
         }
 
         public static void AddPrivateKeyAccessRules(string thumbprint, StoreLocation storeLocation, string storeName,

--- a/source/Calamari/Deployment/Features/IisWebSiteAfterPostDeployFeature.cs
+++ b/source/Calamari/Deployment/Features/IisWebSiteAfterPostDeployFeature.cs
@@ -41,12 +41,9 @@ namespace Calamari.Deployment.Features
 
                 var thumbprint = variables.Get($"{certificateVariable}.{CertificateVariables.Properties.Thumbprint}");
                 var privateKeyAccess = CreatePrivateKeyAccessForApplicationPoolAccount(variables);
- 
-                var storeName = IisWebSiteBeforeDeployFeature.FindCertificateInLocalMachineStore(thumbprint);
 
                 WindowsX509CertificateStore.AddPrivateKeyAccessRules(thumbprint,
                                                                      StoreLocation.LocalMachine,
-                                                                     storeName,
                                                                      new List<PrivateKeyAccessRule> { privateKeyAccess });
             }
         }

--- a/source/Calamari/Deployment/Features/IisWebSiteBeforeDeployFeature.cs
+++ b/source/Calamari/Deployment/Features/IisWebSiteBeforeDeployFeature.cs
@@ -48,7 +48,7 @@ namespace Calamari.Deployment.Features
         {
             var thumbprint = variables.Get($"{certificateVariable}.{CertificateVariables.Properties.Thumbprint}");
 
-            var storeName = FindCertificateInLocalMachineStore(thumbprint);
+            var storeName = WindowsX509CertificateStore.FindCertificateStore(thumbprint, StoreLocation.LocalMachine);
             if (storeName != null)
             {
                 Log.Verbose($"Found existing certificate with thumbprint '{thumbprint}' in Cert:\\LocalMachine\\{storeName}");
@@ -66,24 +66,7 @@ namespace Calamari.Deployment.Features
             Log.SetOutputVariable(SpecialVariables.Action.IisWebSite.Output.CertificateStoreName, storeNamesVariable, variables);
         }
 
-        public static string FindCertificateInLocalMachineStore(string thumbprint)
-        {
-            foreach (var storeName in WindowsX509CertificateStore.GetStoreNames(StoreLocation.LocalMachine))
-            {
-                var store = new X509Store(storeName, StoreLocation.LocalMachine);
-                store.Open(OpenFlags.ReadOnly);
-
-                var found = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, false);
-                if (found.Count != 0 && found[0].HasPrivateKey)
-                {
-                    return storeName;
-                }
-
-                store.Close();
-            }
-
-            return null;
-        }
+       
 
         static string AddCertificateToLocalMachineStore(IVariables variables, string certificateVariable)
         {


### PR DESCRIPTION
Small shift of `FindCertificateInLocalMachineStore` to cert tool to isolate cert x509 interactions in a single place. This feeds into broader full framework deprecation work