### PR TITLE
Expose WindowsCertStore as an instance

### DIFF
--- a/source/Calamari.Shared/Integration/Certificates/IWindowsX509CertificateStore.cs
+++ b/source/Calamari.Shared/Integration/Certificates/IWindowsX509CertificateStore.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Calamari.Integration.Certificates
+{
+    public interface IWindowsX509CertificateStore
+    {
+        string? FindCertificateStore(string thumbprint, StoreLocation storeLocation);
+
+        void ImportCertificateToStore(byte[] pfxBytes,
+                                      string password,
+                                      StoreLocation storeLocation,
+                                      string storeName,
+                                      bool privateKeyExportable);
+
+        void AddPrivateKeyAccessRules(string thumbprint,
+                                      StoreLocation storeLocation,
+                                      ICollection<PrivateKeyAccessRule> privateKeyAccessRules);
+
+        void AddPrivateKeyAccessRules(string thumbprint,
+                                      StoreLocation storeLocation,
+                                      string storeName,
+                                      ICollection<PrivateKeyAccessRule> privateKeyAccessRules);
+
+        void ImportCertificateToStore(byte[] pfxBytes,
+                                      string password,
+                                      string userName,
+                                      string storeName,
+                                      bool privateKeyExportable);
+    }
+}

--- a/source/Calamari.Shared/Integration/Certificates/NoOpWindowsX509CertificateStore.cs
+++ b/source/Calamari.Shared/Integration/Certificates/NoOpWindowsX509CertificateStore.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Calamari.Integration.Certificates
+{
+    /// <summary>
+    /// Stand in replacement for IWindowsX509CertificateStore that will be registered for non Windows machines.
+    /// This should never end up being called. If it is, something has gone wrong somewhere else
+    /// </summary>
+    public class NoOpWindowsX509CertificateStore: IWindowsX509CertificateStore
+    {
+        public string? FindCertificateStore(string thumbprint, StoreLocation storeLocation)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ImportCertificateToStore(byte[] pfxBytes,
+                                             string password,
+                                             StoreLocation storeLocation,
+                                             string storeName,
+                                             bool privateKeyExportable)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void AddPrivateKeyAccessRules(string thumbprint, StoreLocation storeLocation, ICollection<PrivateKeyAccessRule> privateKeyAccessRules)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void AddPrivateKeyAccessRules(string thumbprint, StoreLocation storeLocation, string storeName, ICollection<PrivateKeyAccessRule> privateKeyAccessRules)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ImportCertificateToStore(byte[] pfxBytes,
+                                             string password,
+                                             string userName,
+                                             string storeName,
+                                             bool privateKeyExportable)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/Certificates/PrivateKeyAccessRule.cs
+++ b/source/Calamari.Shared/Integration/Certificates/PrivateKeyAccessRule.cs
@@ -1,5 +1,4 @@
-﻿#if WINDOWS_CERTIFICATE_STORE_SUPPORT 
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Security.AccessControl;
 using System.Security.Principal;
@@ -30,22 +29,6 @@ namespace Calamari.Integration.Certificates
             return JsonConvert.DeserializeObject<List<PrivateKeyAccessRule>>(json, JsonSerializerSettings);
         }
 
-        internal CryptoKeyAccessRule ToCryptoKeyAccessRule()
-        {
-                switch (Access)
-                {
-                    case PrivateKeyAccess.ReadOnly:
-                        return new CryptoKeyAccessRule(Identity, CryptoKeyRights.GenericRead, AccessControlType.Allow);
-
-                    case PrivateKeyAccess.FullControl:
-                        // We use 'GenericAll' here rather than 'FullControl' as 'FullControl' doesn't correctly set the access for CNG keys
-                        return new CryptoKeyAccessRule(Identity, CryptoKeyRights.GenericAll, AccessControlType.Allow);
-
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(Access));
-                }
-        }
-
         private static JsonSerializerSettings JsonSerializerSettings => new JsonSerializerSettings
         {
             Converters = new List<JsonConverter>
@@ -56,4 +39,3 @@ namespace Calamari.Integration.Certificates
 
     }
 }
-#endif

--- a/source/Calamari.Tests/Fixtures/Certificates/WindowsX509CertificateStoreFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Certificates/WindowsX509CertificateStoreFixture.cs
@@ -33,8 +33,8 @@ namespace Calamari.Tests.Fixtures.Certificates
 
             sampleCertificate.EnsureCertificateNotInStore(storeName, storeLocation);
 
-            WindowsX509CertificateStore.ImportCertificateToStore(Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
-                storeLocation, storeName, sampleCertificate.HasPrivateKey);
+            new WindowsX509CertificateStore().ImportCertificateToStore(Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
+                                                                     storeLocation, storeName, sampleCertificate.HasPrivateKey);
 
             sampleCertificate.AssertCertificateIsInStore(storeName, storeLocation);
 
@@ -64,9 +64,9 @@ namespace Calamari.Tests.Fixtures.Certificates
                     var exceptions = new BlockingCollection<Exception>();
                     void Log(string message) => Console.WriteLine($"{sw.Elapsed} {Thread.CurrentThread.Name}: {message}");
 
-                    WindowsX509CertificateStore.ImportCertificateToStore(
-                        Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
-                        StoreLocation.LocalMachine, "My", sampleCertificate.HasPrivateKey);
+                    new WindowsX509CertificateStore().ImportCertificateToStore(
+                                                                             Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
+                                                                             StoreLocation.LocalMachine, "My", sampleCertificate.HasPrivateKey);
 
                     CountdownEvent allThreadsReady = null;
                     CountdownEvent allThreadsFinished = null;
@@ -97,14 +97,14 @@ namespace Calamari.Tests.Fixtures.Certificates
                     var threads =
                         CreateThreads(numThreads, "ImportCertificateToStore", () =>
                             {
-                                WindowsX509CertificateStore.ImportCertificateToStore(
-                                    Convert.FromBase64String(sampleCertificate.Base64Bytes()),
-                                    sampleCertificate.Password,
-                                    StoreLocation.LocalMachine, "My", sampleCertificate.HasPrivateKey);
+                                new WindowsX509CertificateStore().ImportCertificateToStore(
+                                                                                         Convert.FromBase64String(sampleCertificate.Base64Bytes()),
+                                                                                         sampleCertificate.Password,
+                                                                                         StoreLocation.LocalMachine, "My", sampleCertificate.HasPrivateKey);
                             })
                             .Concat(CreateThreads(numThreads, "AddPrivateKeyAccessRules", () =>
                             {
-                                WindowsX509CertificateStore.AddPrivateKeyAccessRules(
+                                new WindowsX509CertificateStore().AddPrivateKeyAccessRules(
                                     sampleCertificate.Thumbprint, StoreLocation.LocalMachine, "My",
                                     new List<PrivateKeyAccessRule>
                                     {
@@ -113,7 +113,7 @@ namespace Calamari.Tests.Fixtures.Certificates
                             }))
                             .Concat(CreateThreads(numThreads, "GetPrivateKeySecurity", () =>
                             {
-                                var unused = WindowsX509CertificateStore.GetPrivateKeySecurity(
+                                var unused = new WindowsX509CertificateStore().GetPrivateKeySecurity(
                                     sampleCertificate.Thumbprint, StoreLocation.LocalMachine, "My");
                             })).ToArray();
 
@@ -169,7 +169,7 @@ namespace Calamari.Tests.Fixtures.Certificates
 
             sampleCertificate.EnsureCertificateNotInStore(storeName, StoreLocation.CurrentUser);
 
-            WindowsX509CertificateStore.ImportCertificateToStore(Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
+            new WindowsX509CertificateStore().ImportCertificateToStore(Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
                 user, storeName, sampleCertificate.HasPrivateKey);
 
             sampleCertificate.AssertCertificateIsInStore(storeName, StoreLocation.CurrentUser);
@@ -187,7 +187,7 @@ namespace Calamari.Tests.Fixtures.Certificates
 
             sampleCertificate.EnsureCertificateNotInStore(storeName, StoreLocation.CurrentUser);
 
-            WindowsX509CertificateStore.ImportCertificateToStore(Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
+            new WindowsX509CertificateStore().ImportCertificateToStore(Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
                 user, storeName, sampleCertificate.HasPrivateKey);
 
             sampleCertificate.AssertCertificateIsInStore(storeName, StoreLocation.CurrentUser);
@@ -207,21 +207,21 @@ namespace Calamari.Tests.Fixtures.Certificates
 
             sampleCertificate.EnsureCertificateNotInStore(storeName, storeLocation);
 
-            WindowsX509CertificateStore.ImportCertificateToStore(
+            new WindowsX509CertificateStore().ImportCertificateToStore(
                 Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
                 storeLocation, storeName, sampleCertificate.HasPrivateKey);
 
-            WindowsX509CertificateStore.AddPrivateKeyAccessRules(sampleCertificate.Thumbprint, storeLocation, storeName,
+            new WindowsX509CertificateStore().AddPrivateKeyAccessRules(sampleCertificate.Thumbprint, storeLocation, storeName,
                 new List<PrivateKeyAccessRule>
                 {
                     new PrivateKeyAccessRule("BUILTIN\\Users", PrivateKeyAccess.FullControl)
                 });
 
-            WindowsX509CertificateStore.ImportCertificateToStore(
+            new WindowsX509CertificateStore().ImportCertificateToStore(
                 Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
                 storeLocation, storeName, sampleCertificate.HasPrivateKey);
 
-            var privateKeySecurity = WindowsX509CertificateStore.GetPrivateKeySecurity(sampleCertificate.Thumbprint,
+            var privateKeySecurity = new WindowsX509CertificateStore().GetPrivateKeySecurity(sampleCertificate.Thumbprint,
                 storeLocation, storeName);
             AssertHasPrivateKeyRights(privateKeySecurity, "BUILTIN\\Users", CryptoKeyRights.GenericAll);
 
@@ -248,7 +248,7 @@ namespace Calamari.Tests.Fixtures.Certificates
 
             sampleCertificate.EnsureCertificateNotInStore(storeName, storeLocation);
 
-            WindowsX509CertificateStore.ImportCertificateToStore(Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
+            new WindowsX509CertificateStore().ImportCertificateToStore(Convert.FromBase64String(sampleCertificate.Base64Bytes()), sampleCertificate.Password,
                 storeLocation, storeName, sampleCertificate.HasPrivateKey);
 
             sampleCertificate.AssertCertificateIsInStore(storeName, storeLocation);
@@ -269,10 +269,10 @@ namespace Calamari.Tests.Fixtures.Certificates
 
         void RemoveChainCertificatesFromStore(X509Store rootAuthorityStore, X509Store intermediateAuthorityStore, string rootAuthorityThumbprint, string intermediateAuthorityThumbprint)
         {
-            WindowsX509CertificateStore.RemoveCertificateFromStore(rootAuthorityThumbprint, StoreLocation.LocalMachine, rootAuthorityStore.Name);
+            new WindowsX509CertificateStore().RemoveCertificateFromStore(rootAuthorityThumbprint, StoreLocation.LocalMachine, rootAuthorityStore.Name);
 
             if (!string.IsNullOrEmpty(intermediateAuthorityThumbprint))
-                WindowsX509CertificateStore.RemoveCertificateFromStore(intermediateAuthorityThumbprint, StoreLocation.LocalMachine, intermediateAuthorityStore.Name);
+                new WindowsX509CertificateStore().RemoveCertificateFromStore(intermediateAuthorityThumbprint, StoreLocation.LocalMachine, intermediateAuthorityStore.Name);
         }
 
         private static void AssertCertificateInStore(X509Store store, string thumbprint)

--- a/source/Calamari.Tests/Helpers/Certificates/SampleCertificate.cs
+++ b/source/Calamari.Tests/Helpers/Certificates/SampleCertificate.cs
@@ -102,7 +102,7 @@ namespace Calamari.Tests.Helpers.Certificates
             if (certificates.Count == 0)
                 return;
 
-            WindowsX509CertificateStore.RemoveCertificateFromStore(Thumbprint, store.Location, store.Name);
+            new WindowsX509CertificateStore().RemoveCertificateFromStore(Thumbprint, store.Location, store.Name);
         }
 
         public void AssertCertificateIsInStore(string storeName, StoreLocation storeLocation)

--- a/source/Calamari/Commands/DeployPackageCommand.cs
+++ b/source/Calamari/Commands/DeployPackageCommand.cs
@@ -25,6 +25,7 @@ using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
 using Calamari.Deployment.Features;
 using Calamari.Deployment.PackageRetention;
+using Calamari.Integration.Certificates;
 using Calamari.Integration.Iis;
 using Calamari.Integration.Nginx;
 
@@ -42,6 +43,7 @@ namespace Calamari.Commands
         readonly IExtractPackage extractPackage;
         readonly IStructuredConfigVariablesService structuredConfigVariablesService;
         readonly IDeploymentJournalWriter deploymentJournalWriter;
+        readonly IWindowsX509CertificateStore windowsX509CertificateStore;
         PathToPackage pathToPackage;
 
         public DeployPackageCommand(
@@ -53,7 +55,8 @@ namespace Calamari.Commands
             ISubstituteInFiles substituteInFiles,
             IExtractPackage extractPackage,
             IStructuredConfigVariablesService structuredConfigVariablesService,
-            IDeploymentJournalWriter deploymentJournalWriter)
+            IDeploymentJournalWriter deploymentJournalWriter,
+            IWindowsX509CertificateStore windowsX509CertificateStore)
         {
             Options.Add("package=", "Path to the deployment package to install.", v => pathToPackage = new PathToPackage(Path.GetFullPath(v)));
 
@@ -66,6 +69,7 @@ namespace Calamari.Commands
             this.extractPackage = extractPackage;
             this.structuredConfigVariablesService = structuredConfigVariablesService;
             this.deploymentJournalWriter = deploymentJournalWriter;
+            this.windowsX509CertificateStore = windowsX509CertificateStore;
         }
 
         public override int Execute(string[] commandLineArguments)
@@ -87,7 +91,7 @@ namespace Calamari.Commands
             var embeddedResources = new AssemblyEmbeddedResources();
 #if IIS_SUPPORT
             var iis = new InternetInformationServer();
-            featureClasses.AddRange(new IFeature[] { new IisWebSiteBeforeDeployFeature(), new IisWebSiteAfterPostDeployFeature() });
+            featureClasses.AddRange(new IFeature[] { new IisWebSiteBeforeDeployFeature(windowsX509CertificateStore), new IisWebSiteAfterPostDeployFeature(windowsX509CertificateStore) });
 #endif
             if (!CalamariEnvironment.IsRunningOnWindows)
             {

--- a/source/Calamari/Commands/ImportCertificateCommand.cs
+++ b/source/Calamari/Commands/ImportCertificateCommand.cs
@@ -16,10 +16,12 @@ namespace Calamari.Commands
     public class ImportCertificateCommand : Command
     {
         readonly IVariables variables;
-        
-        public ImportCertificateCommand(IVariables variables)
+        readonly IWindowsX509CertificateStore windowsX509CertificateStore;
+
+        public ImportCertificateCommand(IVariables variables, IWindowsX509CertificateStore windowsX509CertificateStore)
         {
             this.variables = variables;
+            this.windowsX509CertificateStore = windowsX509CertificateStore;
         }
 
         public override int Execute(string[] commandLineArguments)
@@ -50,16 +52,14 @@ namespace Calamari.Commands
                 {
                     Log.Info(
                         $"Importing certificate '{variables.Get($"{certificateVariable}.{CertificateVariables.Properties.Subject}")}' with thumbprint '{thumbprint}' into store '{storeLocation}\\{storeName}'");
-                    WindowsX509CertificateStore.ImportCertificateToStore(pfxBytes, password, storeLocation, storeName,
-                        privateKeyExportable);
+                    windowsX509CertificateStore.ImportCertificateToStore(pfxBytes, password, storeLocation, storeName, privateKeyExportable);
 
                     if (storeLocation == StoreLocation.LocalMachine)
                     {
                         // Set private-key access
                         var privateKeyAccessRules = GetPrivateKeyAccessRules(variables);
                         if (privateKeyAccessRules.Any())
-                            WindowsX509CertificateStore.AddPrivateKeyAccessRules(thumbprint, storeLocation, storeName,
-                                privateKeyAccessRules);
+                            windowsX509CertificateStore.AddPrivateKeyAccessRules(thumbprint, storeLocation, storeName, privateKeyAccessRules);
                     }
                 }
                 else // Import into a specific user's store
@@ -74,8 +74,7 @@ namespace Calamari.Commands
 
                     Log.Info(
                         $"Importing certificate '{variables.Get($"{certificateVariable}.{CertificateVariables.Properties.Subject}")}' with thumbprint '{thumbprint}' into store '{storeName}' for user '{storeUser}'");
-                    WindowsX509CertificateStore.ImportCertificateToStore(pfxBytes, password, storeUser, storeName,
-                        privateKeyExportable);
+                    windowsX509CertificateStore.ImportCertificateToStore(pfxBytes, password, storeUser, storeName, privateKeyExportable);
                 }
 
             }

--- a/source/Calamari/Deployment/Features/IisWebSiteAfterPostDeployFeature.cs
+++ b/source/Calamari/Deployment/Features/IisWebSiteAfterPostDeployFeature.cs
@@ -13,6 +13,13 @@ namespace Calamari.Deployment.Features
 {
     public class IisWebSiteAfterPostDeployFeature : IisWebSiteFeature
     {
+        readonly IWindowsX509CertificateStore windowsX509CertificateStore;
+
+        public IisWebSiteAfterPostDeployFeature(IWindowsX509CertificateStore windowsX509CertificateStore)
+        {
+            this.windowsX509CertificateStore = windowsX509CertificateStore;
+        }
+        
         public override string DeploymentStage => DeploymentStages.AfterPostDeploy;
 
         public override void Execute(RunningDeployment deployment)
@@ -30,7 +37,7 @@ namespace Calamari.Deployment.Features
         }
 
 #if WINDOWS_CERTIFICATE_STORE_SUPPORT
-        static void EnsureApplicationPoolHasCertificatePrivateKeyAccess(IVariables variables)
+        void EnsureApplicationPoolHasCertificatePrivateKeyAccess(IVariables variables)
         {
             foreach (var binding in GetEnabledBindings(variables))
             {
@@ -42,7 +49,7 @@ namespace Calamari.Deployment.Features
                 var thumbprint = variables.Get($"{certificateVariable}.{CertificateVariables.Properties.Thumbprint}");
                 var privateKeyAccess = CreatePrivateKeyAccessForApplicationPoolAccount(variables);
 
-                WindowsX509CertificateStore.AddPrivateKeyAccessRules(thumbprint,
+                windowsX509CertificateStore.AddPrivateKeyAccessRules(thumbprint,
                                                                      StoreLocation.LocalMachine,
                                                                      new List<PrivateKeyAccessRule> { privateKeyAccess });
             }

--- a/source/Calamari/Deployment/Features/IisWebSiteBeforeDeployFeature.cs
+++ b/source/Calamari/Deployment/Features/IisWebSiteBeforeDeployFeature.cs
@@ -11,6 +11,12 @@ namespace Calamari.Deployment.Features
 {
     public class IisWebSiteBeforeDeployFeature : IisWebSiteFeature
     {
+        readonly IWindowsX509CertificateStore windowsX509CertificateStore;
+
+        public IisWebSiteBeforeDeployFeature(IWindowsX509CertificateStore windowsX509CertificateStore)
+        {
+            this.windowsX509CertificateStore = windowsX509CertificateStore;
+        }
         public override string DeploymentStage => DeploymentStages.BeforeDeploy;
 
         public override void Execute(RunningDeployment deployment)
@@ -31,7 +37,7 @@ namespace Calamari.Deployment.Features
 
 
 #if WINDOWS_CERTIFICATE_STORE_SUPPORT
-        static void EnsureCertificatesUsedInBindingsAreInStore(IVariables variables)
+        void EnsureCertificatesUsedInBindingsAreInStore(IVariables variables)
         {
             foreach (var binding in GetEnabledBindings(variables))
             {
@@ -44,11 +50,11 @@ namespace Calamari.Deployment.Features
             }
         }
 
-        static void EnsureCertificateInStore(IVariables variables, string certificateVariable)
+        void EnsureCertificateInStore(IVariables variables, string certificateVariable)
         {
             var thumbprint = variables.Get($"{certificateVariable}.{CertificateVariables.Properties.Thumbprint}");
 
-            var storeName = WindowsX509CertificateStore.FindCertificateStore(thumbprint, StoreLocation.LocalMachine);
+            var storeName = windowsX509CertificateStore.FindCertificateStore(thumbprint, StoreLocation.LocalMachine);
             if (storeName != null)
             {
                 Log.Verbose($"Found existing certificate with thumbprint '{thumbprint}' in Cert:\\LocalMachine\\{storeName}");
@@ -66,9 +72,7 @@ namespace Calamari.Deployment.Features
             Log.SetOutputVariable(SpecialVariables.Action.IisWebSite.Output.CertificateStoreName, storeNamesVariable, variables);
         }
 
-       
-
-        static string AddCertificateToLocalMachineStore(IVariables variables, string certificateVariable)
+        string AddCertificateToLocalMachineStore(IVariables variables, string certificateVariable)
         {
             var pfxBytes = Convert.FromBase64String(variables.Get($"{certificateVariable}.{CertificateVariables.Properties.Pfx}"));
             var password = variables.Get($"{certificateVariable}.{CertificateVariables.Properties.Password}");
@@ -78,7 +82,7 @@ namespace Calamari.Deployment.Features
 
             try
             {
-                WindowsX509CertificateStore.ImportCertificateToStore(pfxBytes, password, StoreLocation.LocalMachine, "My", true);
+                windowsX509CertificateStore.ImportCertificateToStore(pfxBytes, password, StoreLocation.LocalMachine, "My", true);
                 return "My";
             }
             catch (Exception)

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -81,6 +81,13 @@ namespace Calamari
             builder.RegisterType<KubectlGet>().As<IKubectlGet>().SingleInstance();
             builder.RegisterType<HelmTemplateValueSourcesParser>().AsSelf().SingleInstance();
 
+            
+#if WINDOWS_CERTIFICATE_STORE_SUPPORT 
+            builder.RegisterType<WindowsX509CertificateStore>().As<IWindowsX509CertificateStore>().SingleInstance();
+#else
+            builder.RegisterType<NoOpWindowsX509CertificateStore>().As<IWindowsX509CertificateStore>().SingleInstance();
+#endif
+            
             builder.RegisterType<KubernetesDiscovererFactory>()
                    .As<IKubernetesDiscovererFactory>()
                    .SingleInstance();


### PR DESCRIPTION
As part of the continued work to remove our full framework builds, we will be moving the exclusively full-framework functionality to a separate process. This is one of several PRs that will slowly move us towards this approach. It is hoped that by breaking the change up into self-contained changes will make it more reviewable.

To move towards this, the interaction with the WindowsCertStore should take place through an instance, and not a static utility class.

This PR should have no functional change beyond constructing an instance of the `WindowsX509CertificateStore`