### PR TITLE
Modify `PrivateKeyAccessRule` to make serialization possible

### DIFF
--- a/source/Calamari.Shared/Integration/Certificates/PrivateKeyAccessRule.cs
+++ b/source/Calamari.Shared/Integration/Certificates/PrivateKeyAccessRule.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Security.AccessControl;
-using System.Security.Principal;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -9,19 +7,13 @@ namespace Calamari.Integration.Certificates
 {
     public class PrivateKeyAccessRule
     {
-        [JsonConstructor]
         public PrivateKeyAccessRule(string identity, PrivateKeyAccess access)
-            :this(new NTAccount(identity), access)
-        {
-        }
-
-        public PrivateKeyAccessRule(IdentityReference identity, PrivateKeyAccess access)
         {
             Identity = identity;
             Access = access;
         }
 
-        public IdentityReference Identity { get; }
+        public string Identity { get; }
         public PrivateKeyAccess Access { get; }
 
         public static ICollection<PrivateKeyAccessRule> FromJson(string json)

--- a/source/Calamari.Shared/Integration/Certificates/PrivateKeyAccessRuleExtensionMethods.cs
+++ b/source/Calamari.Shared/Integration/Certificates/PrivateKeyAccessRuleExtensionMethods.cs
@@ -1,0 +1,24 @@
+﻿#if WINDOWS_CERTIFICATE_STORE_SUPPORT
+
+using System;
+using System.Security.Principal;
+
+namespace Calamari.Integration.Certificates
+{
+    public static class PrivateKeyAccessRuleExtensionMethods {
+    
+        public static IdentityReference GetIdentityReference(this PrivateKeyAccessRule privateKeyAccessRule)
+        {
+            try
+            {
+                return new SecurityIdentifier(privateKeyAccessRule.Identity);
+            }
+            catch (ArgumentException)
+            {
+                return new NTAccount(privateKeyAccessRule.Identity);
+                
+            }
+        }
+    }
+}
+#endif

--- a/source/Calamari.Shared/Integration/Certificates/WindowsX509CertificateStore.cs
+++ b/source/Calamari.Shared/Integration/Certificates/WindowsX509CertificateStore.cs
@@ -95,7 +95,7 @@ namespace Calamari.Integration.Certificates
                 if (certificate.HasPrivateKey())
                 {
                     // Because we have to store the private-key in the machine key-store, we must grant the user access to it
-                    var keySecurity = new[] {new PrivateKeyAccessRule(account, PrivateKeyAccess.FullControl)};
+                    var keySecurity = new[] {new PrivateKeyAccessRule(account.Value, PrivateKeyAccess.FullControl)};
                     AddPrivateKeyAccessRules(keySecurity, certificate);
                 }
             }
@@ -484,11 +484,11 @@ namespace Calamari.Integration.Certificates
             switch (privateKeyAccessRule.Access)
             {
                 case PrivateKeyAccess.ReadOnly:
-                    return new CryptoKeyAccessRule(privateKeyAccessRule.Identity, CryptoKeyRights.GenericRead, AccessControlType.Allow);
+                    return new CryptoKeyAccessRule(privateKeyAccessRule.GetIdentityReference(), CryptoKeyRights.GenericRead, AccessControlType.Allow);
 
                 case PrivateKeyAccess.FullControl:
                     // We use 'GenericAll' here rather than 'FullControl' as 'FullControl' doesn't correctly set the access for CNG keys
-                    return new CryptoKeyAccessRule(privateKeyAccessRule.Identity, CryptoKeyRights.GenericAll, AccessControlType.Allow);
+                    return new CryptoKeyAccessRule(privateKeyAccessRule.GetIdentityReference(), CryptoKeyRights.GenericAll, AccessControlType.Allow);
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(privateKeyAccessRule.Access));
@@ -556,4 +556,5 @@ namespace Calamari.Integration.Certificates
         }
     }
 }
+
 #endif

--- a/source/Calamari.Tests/Fixtures/Certificates/PrivateKeyAccessRuleExtensionMethodsTests.cs
+++ b/source/Calamari.Tests/Fixtures/Certificates/PrivateKeyAccessRuleExtensionMethodsTests.cs
@@ -1,0 +1,38 @@
+﻿#if WINDOWS_CERTIFICATE_STORE_SUPPORT 
+using System.Security.Principal;
+using Calamari.Integration.Certificates;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Certificates
+{
+    [TestFixture]
+    public class PrivateKeyAccessRuleExtensionMethodsTests
+    {
+        [Test]
+        public void GetIdentityReference_ShouldResolveNTAccount()
+        {
+            var originalIdentityReference = new NTAccount("Foo\\bar");
+            var privateKeyAccessRule = new PrivateKeyAccessRule(originalIdentityReference.Value, PrivateKeyAccess.ReadOnly);
+
+            var identityReference = privateKeyAccessRule.GetIdentityReference();
+
+            identityReference.Should().BeOfType<NTAccount>();
+            identityReference.Value.Should().Be(originalIdentityReference.Value);
+        }
+
+        [Test]
+        public void GetIdentityReference_ShouldResolveSecurityIdentifier()
+        {
+            var originalIdentityReference = new SecurityIdentifier(WellKnownSidType.LocalServiceSid, null);
+            var privateKeyAccessRule = new PrivateKeyAccessRule(originalIdentityReference.Value, PrivateKeyAccess.ReadOnly);
+
+            var identityReference = privateKeyAccessRule.GetIdentityReference();
+
+            identityReference.Should().BeOfType<SecurityIdentifier>();
+            identityReference.Value.Should().Be(originalIdentityReference.Value);
+                
+        }
+    }
+}
+#endif

--- a/source/Calamari.Tests/Fixtures/Certificates/PrivateKeyAccessRuleSerializationTestFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Certificates/PrivateKeyAccessRuleSerializationTestFixture.cs
@@ -5,7 +5,6 @@ using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment;
 using Calamari.Integration.Certificates;
 using NUnit.Framework;
-using Octostache;
 
 namespace Calamari.Tests.Fixtures.Certificates
 {
@@ -22,9 +21,9 @@ namespace Calamari.Tests.Fixtures.Certificates
             var result = PrivateKeyAccessRule.FromJson(json).ToList();
 
             Assert.AreEqual(2, result.Count);
-            Assert.AreEqual("BUILTIN\\Administrators", result[0].Identity.ToString());
+            Assert.AreEqual("BUILTIN\\Administrators", result[0].Identity);
             Assert.AreEqual(PrivateKeyAccess.FullControl, result[0].Access);
-            Assert.AreEqual("BUILTIN\\Users", result[1].Identity.ToString());
+            Assert.AreEqual("BUILTIN\\Users", result[1].Identity);
             Assert.AreEqual(PrivateKeyAccess.ReadOnly, result[1].Access);
         }
 
@@ -41,7 +40,7 @@ namespace Calamari.Tests.Fixtures.Certificates
             var result = ImportCertificateCommand.GetPrivateKeyAccessRules(variables).ToList();
 
             Assert.AreEqual(1, result.Count);
-            Assert.AreEqual("AmericanEagles\\RogerRamjet", result[0].Identity.ToString());
+            Assert.AreEqual("AmericanEagles\\RogerRamjet", result[0].Identity);
             Assert.AreEqual(PrivateKeyAccess.FullControl, result[0].Access);
         }
     }

--- a/source/Calamari/Deployment/Features/IisWebSiteAfterPostDeployFeature.cs
+++ b/source/Calamari/Deployment/Features/IisWebSiteAfterPostDeployFeature.cs
@@ -66,12 +66,11 @@ namespace Calamari.Deployment.Features
             }
 
             return new PrivateKeyAccessRule(
-                                            GetIdentityForApplicationPoolIdentity(appPoolIdentityType, variables),
+                                            GetIdentityForApplicationPoolIdentity(appPoolIdentityType, variables).Value,
                                             PrivateKeyAccess.FullControl);
         }
 
-        static IdentityReference GetIdentityForApplicationPoolIdentity(ApplicationPoolIdentityType applicationPoolIdentityType,
-                                                                       IVariables variables)
+        static IdentityReference GetIdentityForApplicationPoolIdentity(ApplicationPoolIdentityType applicationPoolIdentityType, IVariables variables)
         {
             switch (applicationPoolIdentityType)
             {


### PR DESCRIPTION
Another small step towards extracting full framework functionality of Calamari.

This change modifies the `PrivateKeyAccessRule` class to remove the `IdentityReference` property as this class will need to be serialized when sent between the separate processes.

Although the class already supports serializing the identity as a string, [this assumes](https://github.com/OctopusDeploy/Calamari/compare/robe/privatekey-identity?expand=1#diff-12a03db61327b49997534d32869cca1e42f0a505a4574572bc02950ada0a1f41L14) that it is in an `NTAccount` format and does not as easily support the `SecurityIdentifier` type which [can be passed](https://github.com/OctopusDeploy/Calamari/compare/robe/privatekey-identity?expand=1#diff-eb75b4cf1e476a44314561886eb2bb5bbb11c504ea7e72dffcde228d44a91e75R73) into this class constructor internally.