### PR TITLE
Increase azure app service upload async timeout

### DIFF
--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -307,7 +307,13 @@ namespace Calamari.AzureAppService.Behaviors
 #pragma warning disable DE0003
                 Proxy = WebRequest.DefaultWebProxy
 #pragma warning restore DE0003
-            });
+        })
+        {
+            // Similar to the above increased timeout for sync uploads, we're increasing the timeout.
+            // In this case 10 minutes is selected over an hour as we're not waiting for the single request to complete.
+            // This is likely only relevant for the original upload request, the individual poll requests should always be quick.
+            Timeout = TimeSpan.FromMinutes(10)
+        };
 
             var authenticationHeader = await GetAuthenticationHeaderValue(azureAccount, publishingProfile, scmPublishEnabled);
 


### PR DESCRIPTION
Occasionally async zip uploads to Azure App Services can run for > 100 seconds. I'm increasing this to 10 minutes, we have an hour timeout configured on the sync upload, 10 minutes feels like enough here as we've only had one report of a timeout in these async uploads.

[sc-77456]

https://github.com/OctopusDeploy/Calamari/pull/1339