### PR TITLE
Fail if customer is using Legacy IIS (IIS6)

### DIFF
--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -34,6 +34,7 @@ namespace Calamari.Deployment
         }
 
         public const string UseLegacyIisSupport = "OctopusUseLegacyIisSupport";
+        public const string UseLegacyIisSupportForce = "OctopusForceUseLegacyIisSupport";
 
         public static readonly string RetentionPolicyItemsToKeep = "OctopusRetentionPolicyItemsToKeep";
         public static readonly string RetentionPolicyDaysToKeep = "OctopusRetentionPolicyDaysToKeep";

--- a/source/Calamari.Tests/Fixtures/Deployment/Conventions/LegacyIisWebSiteConventionFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Conventions/LegacyIisWebSiteConventionFixture.cs
@@ -6,6 +6,7 @@ using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment;
 using Calamari.Deployment.Conventions;
 using Calamari.Integration.Iis;
+using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -61,7 +62,23 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
         }
 
         [Test]
-        public void ShouldForceIis6CompatibilityIfFlagSet()
+        public void ShouldForceIis6CompatibilityIfSuperForceFlagSet()
+        {
+            const string websiteName = "AcmeOnline";
+            variables.Set(SpecialVariables.Package.UpdateIisWebsite, true.ToString());
+            variables.Set(SpecialVariables.Package.UpdateIisWebsiteName, websiteName);
+            variables.Set(SpecialVariables.UseLegacyIisSupport, true.ToString());
+            variables.Set(SpecialVariables.UseLegacyIisSupportForce, true.ToString());
+            fileSystem.FileExists(Path.Combine(stagingDirectory, "Web.config")).Returns(true);
+            iis.OverwriteHomeDirectory(websiteName, stagingDirectory, true).Returns(true);
+
+            CreateConvention().Install(deployment);
+
+            iis.Received().OverwriteHomeDirectory(websiteName, stagingDirectory, true);
+        }
+        
+        [Test]
+        public void ShouldFailIis6CompatibilityIfFlagSet()
         {
             const string websiteName = "AcmeOnline";
             variables.Set(SpecialVariables.Package.UpdateIisWebsite, true.ToString());
@@ -70,9 +87,12 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
             fileSystem.FileExists(Path.Combine(stagingDirectory, "Web.config")).Returns(true);
             iis.OverwriteHomeDirectory(websiteName, stagingDirectory, true).Returns(true);
 
-            CreateConvention().Install(deployment);
+            var exception = Assert.Throws<CommandException>(() =>
+                                                                CreateConvention().Install(deployment)
+                                                           );
+            exception.Message.Should().Contain("Support for IIS6 is no longer supported.");
 
-            iis.Received().OverwriteHomeDirectory(websiteName, stagingDirectory, true);
+            iis.DidNotReceive().OverwriteHomeDirectory(websiteName, stagingDirectory, true);
         }
 
         [Test]

--- a/source/Calamari/Deployment/Conventions/LegacyIisWebSiteConvention.cs
+++ b/source/Calamari/Deployment/Conventions/LegacyIisWebSiteConvention.cs
@@ -63,9 +63,7 @@ namespace Calamari.Deployment.Conventions
             var forceLegacySupport = deployment.Variables.GetFlag(SpecialVariables.UseLegacyIisSupportForce);
             if (!forceLegacySupport)
                 throw new CommandException($"Support for IIS6 is no longer supported.\r\n"
-                                           + $"Remove the {SpecialVariables.UseLegacyIisSupportForce} variable and ensure you are targeting IIS7+.\r\n"
-                                           + $"To provide a temporary work around set the `{SpecialVariables.UseLegacyIisSupportForce}` to `true`.\r\n"
-                                           + $"This capability will be very shortly removed without further warning.");
+                                           + $"Remove the {SpecialVariables.UseLegacyIisSupportForce} variable and ensure you are targeting IIS7+.");
 
             Log.Warn($"LegacyIIS support confirmed.\r\n"
                      + $"Support for IIS6 is no longer supported.\r\n"


### PR DESCRIPTION
LegacyIIS support was added [many moon ago](https://github.com/OctopusDeploy/Calamari/pull/7) when IIS6 on Windows2003 was still supported however IIS7 on Windows 2008+ used different API.

As noted in the [AutoDetect code](https://github.com/OctopusDeploy/Calamari/blob/07a75ce2baa77832ac1046c3aaf31f9da8bd18da/source/Calamari/Integration/Iis/WebServerSupport.cs#L25) the auto selection of this process only apples for Windows 2003 and below. Windows 2003 is no longer supported and so no customers should be relying on this code path.

Since the pending removal of this code path has never been warned, a temporary last-ditch support will be temporarily be supplied via an additional force variable.

Given the lack of support for servers that should be running IIS6, It is expected that this code will be removed within a few months.