### PR TITLE
Remove NetFx Compiler Directives from tests

### DIFF
--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixture.cs
@@ -1,5 +1,4 @@
-﻿#if AWS
-using Calamari.Common.Plumbing.Variables;
+﻿using Calamari.Common.Plumbing.Variables;
 using System.Threading.Tasks;
 using System;
 using System.Collections.Generic;
@@ -92,4 +91,3 @@ namespace Calamari.Tests.AWS.CloudFormation
         }
     }
 }
-#endif

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationVariableReplacementFixture.cs
@@ -1,5 +1,4 @@
-﻿#if AWS
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing.Helpers;
@@ -45,4 +44,3 @@ namespace Calamari.Tests.AWS.CloudFormation
         }
     }
 }
-#endif

--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -1,5 +1,4 @@
-﻿#if AWS
-using System.Linq;
+﻿using System.Linq;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Substitutions;
@@ -776,4 +775,3 @@ namespace Calamari.Tests.AWS
         }
     }
 }
-#endif

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -13,12 +13,13 @@
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <DefineConstants>$(DefineConstants);NETCORE;AWS;AZURE_CORE;JAVA_SUPPORT</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCORE;AZURE_CORE;JAVA_SUPPORT</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);NETFX;AWS;IIS_SUPPORT;USE_NUGET_V2_LIBS;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT;WINDOWS_USER_ACCOUNT_SUPPORT;WINDOWS_REGISTRY_SUPPORT</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETFX;IIS_SUPPORT;USE_NUGET_V2_LIBS;USE_OCTODIFF_EXE;WINDOWS_CERTIFICATE_STORE_SUPPORT;</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.7.0" />
     <PackageReference Include="XPath2" Version="1.0.12" />
     <ProjectReference Include="..\Calamari.Testing\Calamari.Testing.csproj" />
     <ProjectReference Include="..\Calamari\Calamari.csproj" />

--- a/source/Calamari.Tests/Fixtures/Certificates/ImportCertificateCommandFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Certificates/ImportCertificateCommandFixture.cs
@@ -1,4 +1,4 @@
-﻿#if NETFX
+﻿#if WINDOWS_CERTIFICATE_STORE_SUPPORT
 using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;

--- a/source/Calamari.Tests/Fixtures/Deployment/DeployWindowsServiceFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/DeployWindowsServiceFixture.cs
@@ -49,10 +49,6 @@ namespace Calamari.Tests.Fixtures.Deployment
         [Test]
         public void ShouldDeployAndInstallWithCustomUserName()
         {
-            if (!CalamariEnvironment.IsRunningOnWindows)
-                Assert.Inconclusive("Services are only supported on windows");
-
-#if WINDOWS_USER_ACCOUNT_SUPPORT
             TestUserPrincipal userPrincipal = null;
             try
             {
@@ -68,9 +64,6 @@ namespace Calamari.Tests.Fixtures.Deployment
             {
                 userPrincipal?.Delete();
             }
-#else
-            Assert.Inconclusive("Not yet able to configure user accounts under netcore to test service accounts");
-#endif
 
         }
     }


### PR DESCRIPTION
With some recent (and long ago) changes, we can remove some of the compiler directives used in tests resulting in different tests between netfx and netcore builds.
Just another step toward confidence and consolidation.