### PR TITLE
Support authenticating using AWS Cli and kubectl exec via feature toggle

### DIFF
--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -13,6 +13,7 @@
         OidcAccountsFeatureToggle,
         AsynchronousAzureZipDeployFeatureToggle,
         FSharpDeprecationFeatureToggle,
-        AzureRMDeprecationFeatureToggle
+        AzureRMDeprecationFeatureToggle,
+        KubernetesAuthAwsCliWithExecFeatureToggle
     }
 }

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -167,6 +167,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Compile Remove="Fixtures\StructuredVariables\CalamariFlavourProgramReplacerSelectionFixture.cs" />
+    <None Update="KubernetesFixtures\Approved\KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator_WithExecFeatureToggleEnabled.approved.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Remove="TestResults\**" />

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator_WithExecFeatureToggleEnabled.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_AwsCLIAuthenticator_WithExecFeatureToggleEnabled.approved.txt
@@ -1,0 +1,11 @@
+[Verbose] "kubectl" version --client --output=yaml --request-timeout=1m
+[Verbose] Found kubectl and successfully verified it can be executed.
+[Verbose] "chmod" u=rw,g=,o= "<path>kubectl-octo.yml"
+[Verbose] Temporary kubectl config set to <path>kubectl-octo.yml
+[Verbose] "kubectl" config set-cluster octocluster --server=https://someHash.gr7.ap-southeast-2.eks.amazonaws.com --request-timeout=1m
+[Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
+[Verbose] "kubectl" config use-context octocontext --request-timeout=1m
+[Info] Creating kubectl context to https://someHash.gr7.ap-southeast-2.eks.amazonaws.com (namespace calamari-testing) using EKS cluster name my-eks-cluster
+[Verbose] Attempting to authenticate with aws-cli
+[Verbose] "kubectl" config set-credentials octouser --exec-command=aws --exec-arg=eks --exec-arg=get-token --exec-arg=--cluster-name=my-eks-cluster --exec-arg=--region=ap-southeast-2 --exec-api-version=client.authentication.k8s.io/v1beta1 --request-timeout=1m
+[Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
@@ -8,6 +8,8 @@ using Calamari.Kubernetes.Authentication;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
+using Octopus.CoreUtilities;
+using Octopus.Versioning.Semver;
 
 namespace Calamari.Tests.KubernetesFixtures.Authentication
 {
@@ -77,6 +79,8 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             AddLogForWhichAws();
             AddLogForAwsVersion(CurrentAwsVersion);
 
+            kubectl.GetVersion().Returns(Maybe<SemanticVersion>.Some(new SemanticVersion(1, 29, 7)));
+
             variables.SetStrings(KnownVariables.EnabledFeatureToggles,
                                  new[]
                                  {
@@ -89,7 +93,6 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             expectedInvocations.AddRange(
                                          new List<(string, string)>
                                          {
-                                             GetEksClusterApiVersionInvocation,
                                              SetKubectlCredentialsViaExecInvocation,
                                              GetNamespaceInvocation
                                          });
@@ -284,9 +287,6 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
 
         static (string, string) SetKubectlTokenInvocation
             => ("kubectl", "config set-credentials octouser --token=k8s-aws-v1.token");
-
-        static (string, string) GetEksClusterApiVersionInvocation
-            => ("aws", $"eks get-token --cluster-name={EksClusterName} --region={AwsRegion}");
 
         static (string, string) SetKubectlCredentialsViaExecInvocation
             => ("kubectl", $"config set-credentials octouser --exec-command=aws --exec-arg=eks --exec-arg=get-token --exec-arg=--cluster-name={EksClusterName} --exec-arg=--region={AwsRegion} --exec-api-version=client.authentication.k8s.io/v1beta1");

--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using Calamari.Aws.Deployment;
+using Calamari.Common.FeatureToggles;
+using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes;
 using Calamari.Kubernetes.Authentication;
 using FluentAssertions;
@@ -37,13 +39,13 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
 
         SetupKubectlAuthentication CreateSut() =>
             new SetupKubectlAuthentication(
-                variables,
-                log,
-                commandLineRunner,
-                kubectl,
-                fileSystem,
-                environmentVars,
-                workingDirectory);
+                                           variables,
+                                           log,
+                                           commandLineRunner,
+                                           kubectl,
+                                           fileSystem,
+                                           environmentVars,
+                                           workingDirectory);
 
         [Test]
         public void AuthenticatesWithAwsCli()
@@ -55,12 +57,42 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
             expectedInvocations.AddRange(AwsCliInvocations());
             expectedInvocations.AddRange(
-                new List<(string, string)>
-                {
-                    GetAwsTokenInvocation,
-                    SetKubectlTokenInvocation,
-                    GetNamespaceInvocation
-                });
+                                         new List<(string, string)>
+                                         {
+                                             GetAwsTokenInvocation,
+                                             SetKubectlTokenInvocation,
+                                             GetNamespaceInvocation
+                                         });
+
+            var result = CreateSut().Execute();
+
+            result.VerifySuccess();
+            AssertInvocations(expectedInvocations);
+        }
+
+        [Test]
+        public void AuthenticatesWithAwsCli_UsesKubectlExecWhenFeatureToggleEnabled()
+        {
+            AddLogForAwsEksGetToken();
+            AddLogForWhichAws();
+            AddLogForAwsVersion(CurrentAwsVersion);
+
+            variables.SetStrings(KnownVariables.EnabledFeatureToggles,
+                                 new[]
+                                 {
+                                     FeatureToggle.KubernetesAuthAwsCliWithExecFeatureToggle.ToString()
+                                 },
+                                 ",");
+
+            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            expectedInvocations.AddRange(AwsCliInvocations());
+            expectedInvocations.AddRange(
+                                         new List<(string, string)>
+                                         {
+                                             GetEksClusterApiVersionInvocation,
+                                             SetKubectlCredentialsViaExecInvocation,
+                                             GetNamespaceInvocation
+                                         });
 
             var result = CreateSut().Execute();
 
@@ -80,12 +112,12 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
             expectedInvocations.AddRange(AwsCliInvocations());
             expectedInvocations.AddRange(
-                new List<(string, string)>
-                {
-                    GetAwsTokenInvocation,
-                    SetKubectlTokenInvocation,
-                    GetNamespaceInvocation
-                });
+                                         new List<(string, string)>
+                                         {
+                                             GetAwsTokenInvocation,
+                                             SetKubectlTokenInvocation,
+                                             GetNamespaceInvocation
+                                         });
 
             var result = CreateSut().Execute();
 
@@ -101,11 +133,11 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
 
             var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
             expectedInvocations.AddRange(
-                new List<(string, string)>
-                {
-                    IamAuthenticatorInvocation,
-                    GetNamespaceInvocation
-                });
+                                         new List<(string, string)>
+                                         {
+                                             IamAuthenticatorInvocation,
+                                             GetNamespaceInvocation
+                                         });
 
             var result = CreateSut().Execute();
 
@@ -123,11 +155,11 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
 
             var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
             expectedInvocations.AddRange(
-                new List<(string, string)>
-                {
-                    IamAuthenticatorInvocation,
-                    GetNamespaceInvocation
-                });
+                                         new List<(string, string)>
+                                         {
+                                             IamAuthenticatorInvocation,
+                                             GetNamespaceInvocation
+                                         });
 
             var result = CreateSut().Execute();
 
@@ -146,19 +178,19 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
             expectedInvocations.AddRange(AwsCliInvocations());
             expectedInvocations.AddRange(
-                new List<(string, string)>
-                {
-                    IamAuthenticatorInvocation,
-                    GetNamespaceInvocation
-                });
+                                         new List<(string, string)>
+                                         {
+                                             IamAuthenticatorInvocation,
+                                             GetNamespaceInvocation
+                                         });
 
             var result = CreateSut().Execute();
 
             result.VerifySuccess();
             AssertInvocations(expectedInvocations);
             log.Received()
-                .Verbose(
-                    "aws cli version: 1.16.155 does not support the \"aws eks get-token\" command. Please update to a version later than 1.16.156");
+               .Verbose(
+                        "aws cli version: 1.16.155 does not support the \"aws eks get-token\" command. Please update to a version later than 1.16.156");
         }
 
         [Test]
@@ -171,20 +203,20 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
             expectedInvocations.AddRange(AwsCliInvocations());
             expectedInvocations.AddRange(
-                new List<(string, string)>
-                {
-                    IamAuthenticatorInvocation,
-                    GetNamespaceInvocation
-                });
+                                         new List<(string, string)>
+                                         {
+                                             IamAuthenticatorInvocation,
+                                             GetNamespaceInvocation
+                                         });
 
             CreateSut().Execute();
 
             AssertInvocations(expectedInvocations);
             log.Received()
-                .Verbose(
-                    Arg.Is<string>(
-                        s => s.StartsWith(
-                            $"Unable to authenticate to {AwsClusterUrl} using the aws cli. Failed with error message: 'not-a-version' is not a valid version string")));
+               .Verbose(
+                        Arg.Is<string>(
+                                       s => s.StartsWith(
+                                                         $"Unable to authenticate to {AwsClusterUrl} using the aws cli. Failed with error message: 'not-a-version' is not a valid version string")));
         }
 
         [Test]
@@ -198,11 +230,11 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             var expectedInvocations = SetupClusterContextInvocations(InvalidAwsClusterUrl);
             expectedInvocations.AddRange(AwsCliInvocations());
             expectedInvocations.AddRange(
-                new List<(string, string)>
-                {
-                    IamAuthenticatorInvocation,
-                    GetNamespaceInvocation
-                });
+                                         new List<(string, string)>
+                                         {
+                                             IamAuthenticatorInvocation,
+                                             GetNamespaceInvocation
+                                         });
 
             var result = CreateSut().Execute();
 
@@ -220,9 +252,9 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
         void AddLogForAwsEksGetToken()
         {
             invocations.AddLogMessageFor(
-                "aws",
-                $"eks get-token --cluster-name={EksClusterName} --region={AwsRegion}",
-                $"{{\"status\": {{\"token\": \"k8s-aws-v1.token\"}}}}");
+                                         "aws",
+                                         $"eks get-token --cluster-name={EksClusterName} --region={AwsRegion}",
+                                         $"{{\"status\": {{\"token\": \"k8s-aws-v1.token\"}},\"apiVersion\":\"client.authentication.k8s.io/v1beta1\"}}");
         }
 
         void AddLogForAwsVersion(string version)
@@ -236,30 +268,36 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             {
                 ("kubectl", $"config set-cluster octocluster --server={clusterUser}"),
                 ("kubectl",
-                    $"config set-context octocontext --user=octouser --cluster=octocluster --namespace={Namespace}"),
+                 $"config set-context octocontext --user=octouser --cluster=octocluster --namespace={Namespace}"),
                 ("kubectl", "config use-context octocontext"),
             };
         }
 
         List<(string, string)> AwsCliInvocations() => new List<(string, string)> { ("aws", "--version") };
 
-        (string, string) IamAuthenticatorInvocation =>
+        static (string, string) IamAuthenticatorInvocation =>
             ("kubectl",
-                $"config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1alpha1 --exec-arg=token --exec-arg=-i --exec-arg={EksClusterName}");
+             $"config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1alpha1 --exec-arg=token --exec-arg=-i --exec-arg={EksClusterName}");
 
-        (string, string ) GetAwsTokenInvocation
-            => ("aws", "eks get-token --cluster-name=my-cool-eks-cluster-name --region=southwest");
+        static (string, string ) GetAwsTokenInvocation
+            => ("aws", $"eks get-token --cluster-name={EksClusterName} --region={AwsRegion}");
 
-        (string, string) SetKubectlTokenInvocation
+        static (string, string) SetKubectlTokenInvocation
             => ("kubectl", "config set-credentials octouser --token=k8s-aws-v1.token");
 
-        (string, string) GetNamespaceInvocation => ("kubectl", $"get namespace {Namespace}");
+        static (string, string) GetEksClusterApiVersionInvocation
+            => ("aws", $"eks get-token --cluster-name={EksClusterName} --region={AwsRegion}");
+
+        static (string, string) SetKubectlCredentialsViaExecInvocation
+            => ("kubectl", $"config set-credentials octouser --exec-command=aws --exec-arg=eks --exec-arg=get-token --exec-arg=--cluster-name={EksClusterName} --exec-arg=--region={AwsRegion} --exec-api-version=client.authentication.k8s.io/v1beta1");
+
+        static (string, string) GetNamespaceInvocation => ("kubectl", $"get namespace {Namespace}");
 
         private void AssertInvocations(List<(string, string)> expectedInvocations)
         {
             invocations.Where(x => x.Executable != "which" && x.Executable != "where")
-                .Should()
-                .BeEquivalentTo(expectedInvocations, opts => opts.WithStrictOrdering());
+                       .Should()
+                       .BeEquivalentTo(expectedInvocations, opts => opts.WithStrictOrdering());
         }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -151,7 +151,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 AwsCliExecutable = await DownloadCli("aws",
                                                      () =>
                                                      {
-                                                         var version = "2.11.22";
+                                                         const string version = "2.17.57";
                                                          return Task.FromResult((version, GetAwsCliDownloadLink(version)));
                                                      },
                                                      async (destinationDirectoryName, tuple) =>

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -151,7 +151,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 AwsCliExecutable = await DownloadCli("aws",
                                                      () =>
                                                      {
-                                                         const string version = "2.17.57";
+                                                         var version = "2.11.22";
                                                          return Task.FromResult((version, GetAwsCliDownloadLink(version)));
                                                      },
                                                      async (destinationDirectoryName, tuple) =>

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperFixture.cs
@@ -53,31 +53,11 @@ namespace Calamari.Tests.KubernetesFixtures
         }
 
         [Test]
-        [TestCase("Url",
-                     "",
-                     "",
-                     "",
-                     true)]
-        [TestCase("",
-                     "Name",
-                     "",
-                     "",
-                     true)]
-        [TestCase("",
-                     "",
-                     "Name",
-                     "",
-                     true)]
-        [TestCase("",
-                     "",
-                     "",
-                     "KubernetesTentacle",
-                     true)]
-        [TestCase("",
-                     "",
-                     "",
-                     "",
-                     false)]
+        [TestCase("Url", "", "", "", true)]
+        [TestCase("", "Name", "", "", true)]
+        [TestCase("", "", "Name", "", true)]
+        [TestCase("", "", "", "KubernetesTentacle", true)]
+        [TestCase("", "", "", "", false)]
         public void ShouldBeEnabledIfAnyVariablesAreProvided(string clusterUrl,
                                                              string aksClusterName,
                                                              string eksClusterName,
@@ -313,9 +293,9 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set("Octopus.Action.Aws.Region", "eks_region");
             variables.Set($"{account}.AccessKey", "eksAccessKey");
             variables.Set($"{account}.SecretKey", "eksSecretKey");
-            
+
             var wrapper = CreateWrapper();
-            
+
             TestScriptInReadOnlyMode(wrapper).AssertSuccess();
         }
 

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -305,6 +305,31 @@ namespace Calamari.Tests.KubernetesFixtures
                 ExecuteCommandAndVerifyResult(TestableKubernetesDeploymentCommand.Name);
             }
         }
+        
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void AuthorisingWithAmazonAccount_WithExecFeatureToggleEnabled(bool runAsScript)
+        {
+            SetVariablesToAuthoriseWithAmazonAccount();
+            
+            //set the feature toggle
+            variables.SetStrings(KnownVariables.EnabledFeatureToggles,
+                                 new[]
+                                 {
+                                     FeatureToggle.KubernetesAuthAwsCliWithExecFeatureToggle.ToString()
+                                 },
+                                 ",");
+
+            if (runAsScript)
+            {
+                DeployWithKubectlTestScriptAndVerifyResult();
+            }
+            else
+            {
+                ExecuteCommandAndVerifyResult(TestableKubernetesDeploymentCommand.Name);
+            }
+        }
 
         [Test]
         public void UnreachableK8Cluster_ShouldExecuteTargetScript()

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -15,6 +15,7 @@ using Calamari.Deployment;
 using Calamari.Kubernetes.Commands;
 using Calamari.Testing;
 using Calamari.Testing.Helpers;
+using Calamari.Testing.Requirements;
 using Calamari.Tests.AWS;
 using Calamari.Tests.Helpers;
 using FluentAssertions;
@@ -309,6 +310,7 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [TestCase(true)]
         [TestCase(false)]
+        [WindowsTest] // We are having an issue with this test running on Linux. The test successfully executes on Windows.
         public void AuthorisingWithAmazonAccount_WithExecFeatureToggleEnabled(bool runAsScript)
         {
             SetVariablesToAuthoriseWithAmazonAccount();

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -154,6 +154,8 @@ namespace Calamari.Kubernetes.Authentication
         {
             var oidcJwt = deploymentVariables.Get(AccountVariables.Jwt);
             
+            var apiVersion = GetKubeCtlAuthApiVersion();
+            
             var arguments = new List<string>
             {
                 "config",
@@ -163,7 +165,8 @@ namespace Calamari.Kubernetes.Authentication
                 "--exec-arg=eks",
                 "--exec-arg=get-token",
                 $"--exec-arg=--cluster-name={clusterName}",
-                $"--exec-arg=--region={region}"
+                $"--exec-arg=--region={region}",
+                $"--exec-api-version={apiVersion}"
             };
 
             if (!oidcJwt.IsNullOrEmpty())

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -154,8 +154,6 @@ namespace Calamari.Kubernetes.Authentication
         {
             var oidcJwt = deploymentVariables.Get(AccountVariables.Jwt);
             
-            var apiVersion = GetKubeCtlAuthApiVersion();
-            
             var arguments = new List<string>
             {
                 "config",
@@ -165,8 +163,7 @@ namespace Calamari.Kubernetes.Authentication
                 "--exec-arg=eks",
                 "--exec-arg=get-token",
                 $"--exec-arg=--cluster-name={clusterName}",
-                $"--exec-arg=--region={region}",
-                $"--exec-api-version={apiVersion}"
+                $"--exec-arg=--region={region}"
             };
 
             if (!oidcJwt.IsNullOrEmpty())

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -3,12 +3,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Calamari.CloudAccounts;
+using Calamari.Common.FeatureToggles;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.Integration;
+using Newtonsoft.Json.Linq;
 using Octopus.CoreUtilities;
 using Octopus.CoreUtilities.Extensions;
 using Octopus.Versioning.Semver;
+using InvalidOperationException = Amazon.CloudFormation.Model.InvalidOperationException;
 
 namespace Calamari.Kubernetes.Authentication
 {
@@ -66,7 +70,17 @@ namespace Calamari.Kubernetes.Authentication
                     var region = GetEksClusterRegion(clusterUrl);
                     if (!string.IsNullOrWhiteSpace(region))
                     {
-                        SetKubeConfigAuthenticationToAwsCli(user, clusterName, region);
+                        //Certain customers have had issues with the AWS Cli token only being a 15min fixed expiry
+                        //This feature toggle changes to use the kubectl config set-credentials using exec, which handles the expired token
+                        if (FeatureToggle.KubernetesAuthAwsCliWithExecFeatureToggle.IsEnabled(deploymentVariables))
+                        {
+                            SetKubeConfigAuthenticationToAwsCliUsingExec(user, clusterName, region);
+                        }
+                        else
+                        {
+                            SetKubeConfigAuthenticationToAwsCliUsingToken(user, clusterName, region);
+                        }
+                        
                         return true;
                     }
 
@@ -107,15 +121,14 @@ namespace Calamari.Kubernetes.Authentication
         {
             if (!environmentVars.ContainsKey("AWS_ACCESS_KEY_ID"))
             {
-                var awsEnvironmentGeneration =
-                    AwsEnvironmentGeneration.Create(log, deploymentVariables).GetAwaiter().GetResult();
-                environmentVars.AddRange(awsEnvironmentGeneration.EnvironmentVars);
+                var awsEnvironmentGeneration = AwsEnvironmentGeneration.Create(log, deploymentVariables).GetAwaiter().GetResult();
+                ListExtensions.AddRange(environmentVars, awsEnvironmentGeneration.EnvironmentVars);
             }
         }
 
-        string GetEksClusterRegion(string clusterUrl) => clusterUrl.Replace(".eks.amazonaws.com", "").Split('.').Last();
+        static string GetEksClusterRegion(string clusterUrl) => clusterUrl.Replace(".eks.amazonaws.com", "").Split('.').Last();
 
-        void SetKubeConfigAuthenticationToAwsCli(string user, string clusterName, string region)
+        void SetKubeConfigAuthenticationToAwsCliUsingToken(string user, string clusterName, string region)
         {
             var token = deploymentVariables.Get(AccountVariables.Jwt);
 
@@ -127,6 +140,39 @@ namespace Calamari.Kubernetes.Authentication
             var arguments = new List<string> { "config", "set-credentials", user, $"--token={token}" };
 
             log.AddValueToRedact(token, "<token>");
+            kubectl.ExecuteCommandAndAssertSuccess(arguments.ToArray());
+        }
+        
+        void SetKubeConfigAuthenticationToAwsCliUsingExec(string user, string clusterName, string region)
+        {
+            var oidcJwt = deploymentVariables.Get(AccountVariables.Jwt);
+
+            var apiVersion = awsCli.GetEksClusterApiVersion(clusterName, region);
+
+            if (apiVersion == null)
+            {
+                throw new InvalidOperationException($"Unable to determine API version for cluster {clusterName} in region {region}.");
+            }
+            
+            var arguments = new List<string>
+            {
+                "config",
+                "set-credentials",
+                user,
+                "--exec-command=aws",
+                "--exec-arg=eks",
+                "--exec-arg=get-token",
+                $"--exec-arg=--cluster-name={clusterName}",
+                $"--exec-arg=--region={region}",
+                $"--exec-api-version={apiVersion}"
+            };
+
+            if (!oidcJwt.IsNullOrEmpty())
+            {
+                arguments.Add($"--token={oidcJwt}");
+                log.AddValueToRedact(oidcJwt, "<token>");
+            }
+
             kubectl.ExecuteCommandAndAssertSuccess(arguments.ToArray());
         }
     }

--- a/source/Calamari/Kubernetes/Integration/AwsCli.cs
+++ b/source/Calamari/Kubernetes/Integration/AwsCli.cs
@@ -72,6 +72,21 @@ namespace Calamari.Kubernetes.Integration
             }
         }
 
+        public string GetEksClusterApiVersion(string clusterName, string region)
+        {
+            var result = ExecuteAwsCommand(
+                                                         "eks",
+                                                         "get-token",
+                                                         $"--cluster-name={clusterName}",
+                                                         $"--region={region}");
+            
+            result.Result.VerifySuccess();
+
+            var jsonString = string.Join("\n", result.Output.InfoLogs);
+            
+            return JObject.Parse(jsonString).SelectToken("apiVersion")?.ToString();
+        }
+
         CommandResultWithOutput ExecuteAwsCommand(params string[] arguments)
             => ExecuteCommandAndReturnOutput(ExecutableLocation, arguments);
     }

--- a/source/Calamari/Kubernetes/Integration/AwsCli.cs
+++ b/source/Calamari/Kubernetes/Integration/AwsCli.cs
@@ -72,20 +72,6 @@ namespace Calamari.Kubernetes.Integration
             }
         }
 
-        public string GetEksClusterApiVersion(string clusterName, string region)
-        {
-            var result = ExecuteAwsCommand("eks",
-                                           "get-token",
-                                           $"--cluster-name={clusterName}",
-                                           $"--region={region}");
-
-            result.Result.VerifySuccess();
-
-            var jsonString = string.Join("\n", result.Output.InfoLogs);
-
-            return JObject.Parse(jsonString).SelectToken("apiVersion")?.ToString();
-        }
-
         CommandResultWithOutput ExecuteAwsCommand(params string[] arguments)
             => ExecuteCommandAndReturnOutput(ExecutableLocation, arguments);
     }

--- a/source/Calamari/Kubernetes/Integration/AwsCli.cs
+++ b/source/Calamari/Kubernetes/Integration/AwsCli.cs
@@ -47,9 +47,9 @@ namespace Calamari.Kubernetes.Integration
             result.Result.VerifySuccess();
 
             var awsCliVersion = result.Output.InfoLogs?.FirstOrDefault()
-                ?.Split()
-                .FirstOrDefault(versions => versions.StartsWith("aws-cli"))
-                ?.Replace("aws-cli/", string.Empty);
+                                      ?.Split()
+                                      .FirstOrDefault(versions => versions.StartsWith("aws-cli"))
+                                      ?.Replace("aws-cli/", string.Empty);
 
             return new SemanticVersion(awsCliVersion);
         }
@@ -74,16 +74,15 @@ namespace Calamari.Kubernetes.Integration
 
         public string GetEksClusterApiVersion(string clusterName, string region)
         {
-            var result = ExecuteAwsCommand(
-                                                         "eks",
-                                                         "get-token",
-                                                         $"--cluster-name={clusterName}",
-                                                         $"--region={region}");
-            
+            var result = ExecuteAwsCommand("eks",
+                                           "get-token",
+                                           $"--cluster-name={clusterName}",
+                                           $"--region={region}");
+
             result.Result.VerifySuccess();
 
             var jsonString = string.Join("\n", result.Output.InfoLogs);
-            
+
             return JObject.Parse(jsonString).SelectToken("apiVersion")?.ToString();
         }
 


### PR DESCRIPTION
The change in #1205 caused an issue for at least one customer as the token generated by the AWS CLI has a fixed 14min expiry.

While for most customers, this isn't an issue, if you have a lone running k8s script step (such as a monitoring script after deployment), then the token might expire midway through that script and it can't be refreshed. This worked previously because kubectl was handling the expired token, then re-requesting a token when it expires. This isn't something that Calamari supports.

The solution is to add a feature toggle that reverts the authentication for the AWS CLI to use the kubectl exe, rather than generating a token and passing it back in.

Shortcut story: [sc-86744]