### PR TITLE
Upgrade Bouncy Castle to latest non Octopus version

### DIFF
--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -69,7 +69,6 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' ">
-<!--    <PackageReference Include="BouncyCastle" Version="1.8.1-octopus" />-->
     <PackageReference Include="MarkdownSharp" Version="1.13.0.0" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="Microsoft.Web.Administration" Version="7.0.0.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.8.8" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
@@ -68,7 +69,7 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="BouncyCastle" Version="1.8.1-octopus" />
+<!--    <PackageReference Include="BouncyCastle" Version="1.8.1-octopus" />-->
     <PackageReference Include="MarkdownSharp" Version="1.13.0.0" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="Microsoft.Web.Administration" Version="7.0.0.0" />

--- a/source/Calamari.Shared/Integration/Certificates/WindowsX509CertificateStore.cs
+++ b/source/Calamari.Shared/Integration/Certificates/WindowsX509CertificateStore.cs
@@ -516,11 +516,15 @@ namespace Calamari.Integration.Certificates
             }
         }
 
-        static IList<Org.BouncyCastle.X509.X509Certificate> GetCertificatesToImport(byte[] pfxBytes, string password)
+        static IList<Org.BouncyCastle.X509.X509Certificate> GetCertificatesToImport(byte[] pfxBytes, string? password)
         {
             using (var memoryStream = new MemoryStream(pfxBytes))
             {
-                var pkcs12Store = new Pkcs12Store(memoryStream, password?.ToCharArray() ?? "".ToCharArray());
+                // The latest version of BouncyCastle fails if the cert doesn't require a key, but we pass an empty array key.
+                // Will issue a PR to make this configurable at least in a way that doesn't require writing environment variables.
+                Environment.SetEnvironmentVariable("Org.BouncyCastle.Pkcs12.IgnoreUselessPassword", "true");
+                var pkcs12Store = new Pkcs12StoreBuilder().Build();
+                pkcs12Store.Load(memoryStream, password?.ToCharArray() ?? "".ToCharArray());
 
                 if (pkcs12Store.Count < 1)
                     throw new Exception("No certificates were found in PFX");

--- a/source/Calamari.Shared/Integration/Certificates/WindowsX509CertificateStore.cs
+++ b/source/Calamari.Shared/Integration/Certificates/WindowsX509CertificateStore.cs
@@ -522,7 +522,7 @@ namespace Calamari.Integration.Certificates
             {
                 // The latest version of BouncyCastle fails if the cert doesn't require a key, but we pass an empty array key.
                 // Will issue a PR to make this configurable at least in a way that doesn't require writing environment variables.
-                Environment.SetEnvironmentVariable("Org.BouncyCastle.Pkcs12.IgnoreUselessPassword", "true");
+                Environment.SetEnvironmentVariable(Org.BouncyCastle.Pkcs.Pkcs12Store.IgnoreUselessPasswordProperty, "true");
                 var pkcs12Store = new Pkcs12StoreBuilder().Build();
                 pkcs12Store.Load(memoryStream, password?.ToCharArray() ?? "".ToCharArray());
 


### PR DESCRIPTION
The change in our for https://github.com/bcgit/bc-csharp/compare/master...OctopusDeploy:bc-csharp:octopus
Looks to have long merged with the upstream repo (https://github.com/bcgit/bc-csharp/issues/74)

As such we should be able to retarget the source.
