### PR TITLE
don't early exit if the git dependency name is empty

### DIFF
--- a/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
@@ -114,7 +114,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             var exception = Assert.Throws<CommandException>(() => downloader.DownloadPackage("octopus-echo",
                 new SemanticVersion("1.1"), "docker-feed",
                 new Uri(AuthFeedUri),
-                FeedUsername, "SuperDooper",
+                "Nonexistantuser", "SuperDooper",
                 true, 
                 //we don't want to perform too many of these otherwise jfrog / artifactory gets sad at us
                 2,

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/GitRepositoryValuesFileWriterFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/GitRepositoryValuesFileWriterFixture.cs
@@ -174,5 +174,23 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
                       Path.Combine(deployment.CurrentDirectory, "MyRepo", "values.Development.yaml")
                   });
         }
+        
+        [Test]
+        public void GitRepositoryValuesFileWriter_ChartSourcedValues_ShouldFindChartValuesFiles()
+        {
+            // Arrange
+            fileSystem.EnumerateFilesWithGlob(Arg.Any<string>(), Arg.Any<string[]>())
+                      .Returns(ci =>
+                               {
+                                   return ci.ArgAt<string[]>(1)
+                                            .Select(filename => Path.Combine(ci.ArgAt<string>(0), filename))
+                                            .ToList();
+                               });
+            //Act
+            var result = GitRepositoryValuesFileWriter.FindChartValuesFiles(deployment, fileSystem, log, "values.yaml");
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string> { Path.Combine(deployment.CurrentDirectory, "values.yaml") });
+        } 
     }
 }

--- a/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
+++ b/source/Calamari/Kubernetes/Helm/GitRepositoryValuesFileWriter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Kubernetes.Helm
 {
@@ -15,12 +16,12 @@ namespace Calamari.Kubernetes.Helm
                                                                ILog log,
                                                                string valuesFilePaths,
                                                                bool logIncludedFiles = true)
-            => FindGitDependencyValuesFiles(deployment,
-                                            fileSystem,
-                                            log,
-                                            string.Empty,
-                                            valuesFilePaths,
-                                            logIncludedFiles);
+            => FindValuesFiles(deployment,
+                               fileSystem,
+                               log,
+                               string.Empty,
+                               valuesFilePaths,
+                               logIncludedFiles);
 
         public static IEnumerable<string> FindGitDependencyValuesFiles(RunningDeployment deployment,
                                                                        ICalamariFileSystem fileSystem,
@@ -37,6 +38,18 @@ namespace Calamari.Kubernetes.Helm
                 return null;
             }
 
+            return FindValuesFiles(deployment, fileSystem, log, gitDependencyName,
+                                   valuesFilePaths,
+                                   logIncludedFiles);
+        }
+
+        static IEnumerable<string> FindValuesFiles(RunningDeployment deployment,
+                                                   ICalamariFileSystem fileSystem,
+                                                   ILog log,
+                                                   string gitDependencyName,
+                                                   string valuesFilePaths,
+                                                   bool logIncludedFiles)
+        {
             var valuesPaths = HelmValuesFileUtils.SplitValuesFilePaths(valuesFilePaths);
             if (valuesPaths == null || !valuesPaths.Any())
                 return null;
@@ -46,6 +59,7 @@ namespace Calamari.Kubernetes.Helm
 
             var sanitizedPackageReferenceName = fileSystem.RemoveInvalidFileNameChars(gitDependencyName);
 
+            var variables = deployment.Variables;
             var repositoryUrl = variables.Get(Deployment.SpecialVariables.GitResources.RepositoryUrl(gitDependencyName));
             var commitHash = variables.Get(Deployment.SpecialVariables.GitResources.CommitHash(gitDependencyName));
 


### PR DESCRIPTION
[sc-94444]

Before:
![image](https://github.com/user-attachments/assets/2587c6e8-07b9-4564-a5bd-9e2f2b37ae81)


After:
This is failing due to the missing chart.yaml file. The values file is noted as being found in the log: 

`Performing variable substitution on '/etc/octopus/Work/hRiQvkDl6EePTIZJRabcJg/staging/values.yaml'`

![image](https://github.com/user-attachments/assets/069bbb43-4579-4bee-a6dd-3206602a8c24)
