### PR TITLE
Execute app service tests against static app service plans

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceSettingsBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceSettingsBehaviourFixture.cs
@@ -23,11 +23,10 @@ namespace Calamari.AzureAppService.Tests
         AppServiceConfigurationDictionary existingSettings;
         ConnectionStringDictionary existingConnectionStrings;
 
-        protected override async Task ConfigureTestResources(ResourceGroupResource resourceGroup)
+        public override async Task SetUp()
         {
-            var (_, webSiteResource) = await CreateAppServicePlanAndWebApp(resourceGroup);
-            WebSiteResource = webSiteResource;
-
+            WebSiteResource = await CreateWebApp(WindowsAppServicePlanResource);
+            
             existingSettings = new AppServiceConfigurationDictionary
             {
                 Properties =

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.ResourceManager.AppService;
 using Azure.ResourceManager.AppService.Models;
-using Azure.ResourceManager.Resources;
 using Calamari.AzureAppService.Azure;
 using Calamari.AzureAppService.Behaviors;
 using Calamari.Common.Commands;
@@ -33,39 +32,23 @@ namespace Calamari.AzureAppService.Tests
             CalamariVariables newVariables;
             readonly HttpClient client = new HttpClient();
 
-            //We are having capacity issues in EastUS and WestUS2
-            protected override string DefaultResourceGroupLocation => RandomAzureRegion.GetRandomRegionWithExclusions("eastus", "westus2");
-            
-            protected override async Task ConfigureTestResources(ResourceGroupResource resourceGroup)
+            public override async Task SetUp()
             {
-                var (_, webSite) = await CreateAppServicePlanAndWebApp(resourceGroup,
-                                                                       new AppServicePlanData(resourceGroup.Data.Location)
-                                                                       {
-                                                                           IsXenon = true,
-                                                                           IsHyperV = true,
-                                                                           Sku = new AppServiceSkuDescription
-                                                                           {
-                                                                               Name = "P1V3",
-                                                                               Tier = "PremiumV3"
-                                                                           }
-                                                                       },
-                                                                       webSiteData: new WebSiteData(resourceGroup.Data.Location)
-                                                                       {
-                                                                           SiteConfig = new SiteConfigProperties
-                                                                           {
-                                                                               WindowsFxVersion = "DOCKER|mcr.microsoft.com/dotnet/samples:aspnetapp",
-                                                                               IsAlwaysOn = true,
-                                                                               AppSettings = new List<AppServiceNameValuePair>
-                                                                               {
-                                                                                   new AppServiceNameValuePair { Name = "DOCKER_REGISTRY_SERVER_URL", Value = "https://index.docker.io" },
-                                                                                   new AppServiceNameValuePair { Name = "WEBSITES_ENABLE_APP_SERVICE_STORAGE", Value = "false" },
-                                                                                   new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" }
-                                                                               }
-                                                                           }
-                                                                       });
-
-                WebSiteResource = webSite;
-
+                WebSiteResource = await CreateWebApp(WindowsContainerAppServicePlanResource,
+                                                     new WebSiteData(ResourceGroupResource.Data.Location)
+                                                     {
+                                                         SiteConfig = new SiteConfigProperties
+                                                         {
+                                                             WindowsFxVersion = "DOCKER|mcr.microsoft.com/dotnet/samples:aspnetapp",
+                                                             IsAlwaysOn = true,
+                                                             AppSettings = new List<AppServiceNameValuePair>
+                                                             {
+                                                                 new AppServiceNameValuePair { Name = "DOCKER_REGISTRY_SERVER_URL", Value = "https://index.docker.io" },
+                                                                 new AppServiceNameValuePair { Name = "WEBSITES_ENABLE_APP_SERVICE_STORAGE", Value = "false" },
+                                                                 new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" }
+                                                             }
+                                                         }
+                                                     });
                 await AssertSetupSuccessAsync();
             }
 
@@ -176,39 +159,24 @@ namespace Calamari.AzureAppService.Tests
             CalamariVariables newVariables;
             readonly HttpClient client = new HttpClient();
 
-            // For some reason we are having issues creating these linux resources on Standard in EastUS
-            protected override string DefaultResourceGroupLocation => RandomAzureRegion.GetRandomRegionWithExclusions("eastus");
-
-            protected override async Task ConfigureTestResources(ResourceGroupResource resourceGroup)
+            public override async Task SetUp()
             {
-                var (_, webSite) = await CreateAppServicePlanAndWebApp(resourceGroup,
-                                                                       new AppServicePlanData(resourceGroup.Data.Location)
-                                                                       {
-                                                                           Kind = "linux",
-                                                                           IsReserved = true,
-                                                                           Sku = new AppServiceSkuDescription
-                                                                           {
-                                                                               Name = "P1V3",
-                                                                               Tier = "PremiumV3"
-                                                                           }
-                                                                       },
-                                                                       new WebSiteData(resourceGroup.Data.Location)
-                                                                       {
-                                                                           Kind = "app,linux,container",
-                                                                           SiteConfig = new SiteConfigProperties
-                                                                           {
-                                                                               LinuxFxVersion = "DOCKER|mcr.microsoft.com/dotnet/samples:aspnetapp",
-                                                                               IsAlwaysOn = true,
-                                                                               AppSettings = new List<AppServiceNameValuePair>
-                                                                               {
-                                                                                   new AppServiceNameValuePair { Name = "DOCKER_REGISTRY_SERVER_URL", Value = "https://index.docker.io" },
-                                                                                   new AppServiceNameValuePair { Name = "WEBSITES_ENABLE_APP_SERVICE_STORAGE", Value = "false" },
-                                                                                   new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" }
-                                                                               }
-                                                                           }
-                                                                       });
-
-                WebSiteResource = webSite;
+                WebSiteResource = await CreateWebApp(LinuxAppServicePlanResource,
+                                                     new WebSiteData(ResourceGroupResource.Data.Location)
+                                                     {
+                                                         Kind = "app,linux,container",
+                                                         SiteConfig = new SiteConfigProperties
+                                                         {
+                                                             LinuxFxVersion = "DOCKER|mcr.microsoft.com/dotnet/samples:aspnetapp",
+                                                             IsAlwaysOn = true,
+                                                             AppSettings = new List<AppServiceNameValuePair>
+                                                             {
+                                                                 new AppServiceNameValuePair { Name = "DOCKER_REGISTRY_SERVER_URL", Value = "https://index.docker.io" },
+                                                                 new AppServiceNameValuePair { Name = "WEBSITES_ENABLE_APP_SERVICE_STORAGE", Value = "false" },
+                                                                 new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" }
+                                                             }
+                                                         }
+                                                     });
 
                 await AssertSetupSuccessAsync();
             }

--- a/source/Calamari.AzureAppService.Tests/AzureWebAppHealthCheckActionHandlerFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureWebAppHealthCheckActionHandlerFixture.cs
@@ -22,34 +22,24 @@ namespace Calamari.AzureAppService.Tests
         readonly IWebProxy originalProxy = WebRequest.DefaultWebProxy;
         readonly string originalProxyHost = Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost);
         readonly string originalProxyPort = Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort);
-
-        protected override async Task ConfigureTestResources(ResourceGroupResource resourceGroup)
+        
+        public override async Task SetUp()
         {
-            var (_, webSiteResource) = await CreateAppServicePlanAndWebApp(resourceGroup,
-                                                                           new AppServicePlanData(resourceGroup.Data.Location)
-                                                                           {
-                                                                               Sku = new AppServiceSkuDescription
-                                                                               {
-                                                                                   Name = "B1",
-                                                                                   Tier = "Basic"
-                                                                               }
-                                                                           },
-                                                                           new WebSiteData(resourceGroup.Data.Location)
-                                                                           {
-                                                                               SiteConfig = new SiteConfigProperties
-                                                                               {
-                                                                                   NetFrameworkVersion = "v6.0"
-                                                                               }
-                                                                           });
-            WebSiteResource = webSiteResource;
+            WebSiteResource = await CreateWebApp(WindowsAppServicePlanResource,
+                                                 new WebSiteData(ResourceGroupResource.Data.Location)
+                                                 {
+                                                     SiteConfig = new SiteConfigProperties
+                                                     {
+                                                         NetFrameworkVersion = "v6.0"
+                                                     }
+                                                 });
         }
 
-        public override async Task Cleanup()
+        [OneTimeTearDown]
+        public void Cleanup()
         {
             RestoreLocalEnvironmentProxySettings();
             RestoreCiEnvironmentProxySettings();
-
-            await base.Cleanup();
         }
 
         [Test]


### PR DESCRIPTION
We have flaky issues in Calamari tests due to capacity issues creating app service plans.

To avoid this, we now have 3 static app service plans that all the test app services are created against. Each test now creates it's own app service against the static plan.

The plans are in the `calamari-testing-static-rg` resource group, but the per-test resources are created in their own resource groups, which are torn-down at the end of the test (not test fixture)