### PR TITLE
Handle empty outputs in arm templates

### DIFF
--- a/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
+++ b/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
@@ -152,7 +152,7 @@ namespace Calamari.AzureResourceGroup
         async Task FinalizeDeployment(ArmOperation<ArmDeploymentResource> operation, IVariables variables)
         {
             await LogOperationResults(operation);
-            CaptureOutputs(operation.Value.Data.Properties.Outputs.ToString(), variables);
+            CaptureOutputs(operation.Value.Data.Properties.Outputs?.ToString(), variables);
         }
 
         async Task LogOperationResults(ArmOperation<ArmDeploymentResource> operation)
@@ -178,7 +178,7 @@ namespace Calamari.AzureResourceGroup
             log.Info(sb.ToString());
         }
 
-        void CaptureOutputs(string outputsJson, IVariables variables)
+        void CaptureOutputs(string? outputsJson, IVariables variables)
         {
             if (string.IsNullOrWhiteSpace(outputsJson))
                 return;


### PR DESCRIPTION
When the Outputs is not provided in an ARM template the outputs return as null. As a workaround you can just add empty outputs `"outputs": {}`. This change removes the requirement for the outputs block in ARM templates processed by Octopus.