### PR TITLE
Add new KubernetesObjectManifestInspectionFeatureToggle

### DIFF
--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -14,6 +14,6 @@
         AzureRMDeprecationFeatureToggle,
         PreventHelmV2DeploymentsFeatureToggle,
         KubernetesLiveObjectStatusFeatureToggle,
-        KubernetesAuthAwsCliWithExecFeatureToggle,
+        KubernetesAuthAwsCliWithExecFeatureToggle
     }
 }

--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -14,6 +14,6 @@
         AzureRMDeprecationFeatureToggle,
         PreventHelmV2DeploymentsFeatureToggle,
         KubernetesLiveObjectStatusFeatureToggle,
-        KubernetesAuthAwsCliWithExecFeatureToggle
+        KubernetesAuthAwsCliWithExecFeatureToggle,
     }
 }

--- a/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
@@ -4,8 +4,14 @@ namespace Calamari.Common.FeatureToggles
 {
     public static class OctopusFeatureToggles
     {
+        public static class KnownSlugs
+        {
+            public const string KubernetesObjectManifestInspection = "kubernetes-object-manifest-inspection";
+        };
+
         public static readonly OctopusFeatureToggle NonPrimaryGitDependencySupportFeatureToggle = new OctopusFeatureToggle("non-primary-git-dependency-support");
-        
+        public static readonly OctopusFeatureToggle KubernetesObjectManifestInspectionFeatureToggle = new OctopusFeatureToggle(KnownSlugs.KubernetesObjectManifestInspection);
+
         public class OctopusFeatureToggle
         {
             readonly string slug;

--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
@@ -33,12 +33,13 @@ namespace Calamari.Tests.KubernetesFixtures
             }
         }
         
-        [Test]
-        public void GivenValidYaml_ShouldPostSingleServiceMessage()
+        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
+        [TestCase( OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
+        public void GivenValidYaml_ShouldPostSingleServiceMessage(string enabledFeatureToggle)
         {
             var memoryLog = new InMemoryLog();
             var variables = new CalamariVariables();
-            variables.Set(KnownVariables.EnabledFeatureToggles, nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle));
+            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
 
             var yaml = @"foo: bar";
             var expectedJson = "{\"foo\": \"bar\"}";
@@ -53,12 +54,13 @@ namespace Calamari.Tests.KubernetesFixtures
             }
         }
 
-        [Test]
-        public void GivenInValidManifest_ShouldNotPostServiceMessage()
+        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
+        [TestCase( OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
+        public void GivenInValidManifest_ShouldNotPostServiceMessage(string enabledFeatureToggle)
         {
             var memoryLog = new InMemoryLog();
             var variables = new CalamariVariables();
-            variables.Set(KnownVariables.EnabledFeatureToggles, nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle));
+            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
 
             var yaml = @"text - Bar";
             using (CreateFile(yaml, out var filePath))
@@ -71,12 +73,13 @@ namespace Calamari.Tests.KubernetesFixtures
             }
         }
 
-        [Test]
-        public void GivenNamespaceInManifest_ShouldReportManifestNamespace()
+        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
+        [TestCase( OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
+        public void GivenNamespaceInManifest_ShouldReportManifestNamespace(string enabledFeatureToggle)
         {
             var memoryLog = new InMemoryLog();
             var variables = new CalamariVariables();
-            variables.Set(KnownVariables.EnabledFeatureToggles, nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle));
+            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
             var yaml = @"metadata:
   name: game-demo
   namespace: XXX";
@@ -92,12 +95,13 @@ namespace Calamari.Tests.KubernetesFixtures
             }
         }
 
-        [Test]
-        public void GivenNamespaceNotInManifest_ShouldReportVariableNamespace()
+        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
+        [TestCase( OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
+        public void GivenNamespaceNotInManifest_ShouldReportVariableNamespace(string enabledFeatureToggle)
         {
             var memoryLog = new InMemoryLog();
             var variables = new CalamariVariables();
-            variables.Set(KnownVariables.EnabledFeatureToggles, nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle));
+            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
             var yaml = @"foo: bar";
             using (CreateFile(yaml, out var filePath))
             {
@@ -111,12 +115,13 @@ namespace Calamari.Tests.KubernetesFixtures
             }
         }
 
-        [Test]
-        public void GiveNoNamespaces_ShouldDefaultNamespace()
+        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
+        [TestCase( OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
+        public void GiveNoNamespaces_ShouldDefaultNamespace(string enabledFeatureToggle)
         {
             var memoryLog = new InMemoryLog();
             var variables = new CalamariVariables();
-            variables.Set(KnownVariables.EnabledFeatureToggles, nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle));
+            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
             var yaml = @"foo: bar";
             using (CreateFile(yaml, out var filePath))
             {
@@ -128,7 +133,7 @@ namespace Calamari.Tests.KubernetesFixtures
             }
         }
 
-        IDisposable CreateFile(string yaml, out string filePath)
+        static IDisposable CreateFile(string yaml, out string filePath)
         {
             var tempDir = TemporaryDirectory.Create();
             filePath = Path.Combine(tempDir.DirectoryPath, $"{Guid.NewGuid():d}.tmp");

--- a/source/Calamari/Kubernetes/ManifestReporter.cs
+++ b/source/Calamari/Kubernetes/ManifestReporter.cs
@@ -42,9 +42,7 @@ namespace Calamari.Kubernetes
         {
             var implicitNamespace = variables.Get(SpecialVariables.Namespace) ?? "default";
 
-            if (yamlRoot.Children.TryGetValue("metadata", out var metadataNode) && metadataNode is YamlMappingNode metadataMappingNode &&
-                metadataMappingNode.Children.TryGetValue("namespace", out var namespaceNode) && namespaceNode is YamlScalarNode namespaceScalarNode &&
-                !string.IsNullOrWhiteSpace(namespaceScalarNode.Value))
+            if (yamlRoot.Children.TryGetValue("metadata", out var metadataNode) && metadataNode is YamlMappingNode metadataMappingNode && metadataMappingNode.Children.TryGetValue("namespace", out var namespaceNode) && namespaceNode is YamlScalarNode namespaceScalarNode && !string.IsNullOrWhiteSpace(namespaceScalarNode.Value))
             {
                 implicitNamespace = namespaceScalarNode.Value;
             }
@@ -54,9 +52,9 @@ namespace Calamari.Kubernetes
 
         public void ReportManifestApplied(string filePath)
         {
-            if (!FeatureToggle.KubernetesLiveObjectStatusFeatureToggle.IsEnabled(variables))
+            if (!FeatureToggle.KubernetesLiveObjectStatusFeatureToggle.IsEnabled(variables) && !OctopusFeatureToggles.KubernetesObjectManifestInspectionFeatureToggle.IsEnabled(variables))
                 return;
-            
+
             using (var yamlFile = fileSystem.OpenFile(filePath, FileAccess.ReadWrite))
             {
                 try


### PR DESCRIPTION
Adds a new `KubernetesObjectManifestInspectionFeatureToggle` which enables the k8s manifests being sent back to Server. This just enables the same code path as the `KubernetesLiveObjectStatusFeatureToggle`