### PR TITLE
Increase default timeout for Azure resource group behaviour

### DIFF
--- a/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
+++ b/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
@@ -25,7 +25,7 @@ namespace Calamari.AzureResourceGroup
 {
     class DeployAzureResourceGroupBehaviour : IDeployBehaviour
     {
-        static readonly TimeSpan PollingTimeout = TimeSpan.FromMinutes(3);
+        static readonly TimeSpan PollingTimeout = TimeSpan.FromMinutes(20);
 
         static readonly AsyncTimeoutPolicy<ArmDeploymentResource> AsyncResourceGroupPollingTimeoutPolicy =
             Policy.TimeoutAsync<ArmDeploymentResource>(PollingTimeout, TimeoutStrategy.Optimistic);

--- a/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
+++ b/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
@@ -25,7 +25,7 @@ namespace Calamari.AzureResourceGroup
 {
     class DeployAzureResourceGroupBehaviour : IDeployBehaviour
     {
-        static readonly TimeSpan PollingTimeout = TimeSpan.FromMinutes(20);
+        static readonly TimeSpan PollingTimeout = TimeSpan.FromMinutes(30);
 
         static readonly AsyncTimeoutPolicy<ArmDeploymentResource> AsyncResourceGroupPollingTimeoutPolicy =
             Policy.TimeoutAsync<ArmDeploymentResource>(PollingTimeout, TimeoutStrategy.Optimistic);

--- a/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
+++ b/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
@@ -25,11 +25,6 @@ namespace Calamari.AzureResourceGroup
 {
     class DeployAzureResourceGroupBehaviour : IDeployBehaviour
     {
-        static readonly TimeSpan PollingTimeout = TimeSpan.FromMinutes(30);
-
-        static readonly AsyncTimeoutPolicy<ArmDeploymentResource> AsyncResourceGroupPollingTimeoutPolicy =
-            Policy.TimeoutAsync<ArmDeploymentResource>(PollingTimeout, TimeoutStrategy.Optimistic);
-
         readonly TemplateService templateService;
         readonly IResourceGroupTemplateNormalizer parameterNormalizer;
         readonly ILog log;
@@ -89,7 +84,7 @@ namespace Calamari.AzureResourceGroup
                                                              deploymentMode,
                                                              template,
                                                              parameters);
-            await PollForCompletion(deploymentOperation);
+            await PollForCompletion(deploymentOperation, variables);
             await FinalizeDeployment(deploymentOperation, variables);
         }
 
@@ -128,12 +123,17 @@ namespace Calamari.AzureResourceGroup
             }
         }
 
-        async Task PollForCompletion(ArmOperation<ArmDeploymentResource> deploymentOperation)
+        async Task PollForCompletion(ArmOperation<ArmDeploymentResource> deploymentOperation, IVariables variables)
         {
+            var pollingTimeoutVariableValue = variables.Get(SpecialVariables.Action.Azure.ArmDeploymentTimeout, "30");
+            int.TryParse(pollingTimeoutVariableValue, out var pollingTimeoutValue);
+            var pollingTimeout = TimeSpan.FromMinutes(pollingTimeoutValue);
+            var asyncResourceGroupPollingTimeoutPolicy = Policy.TimeoutAsync<ArmDeploymentResource>(pollingTimeout, TimeoutStrategy.Optimistic);
+            
             log.Info("Polling for deployment completion...");
             try
             {
-                var deploymentResult = await AsyncResourceGroupPollingTimeoutPolicy.ExecuteAsync(async timeoutCancellationToken =>
+                var deploymentResult = await asyncResourceGroupPollingTimeoutPolicy.ExecuteAsync(async timeoutCancellationToken =>
                                                                                                  {
                                                                                                      var delayStrategy = DelayStrategy.CreateExponentialDelayStrategy(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
                                                                                                      var result = await deploymentOperation.WaitForCompletionAsync(delayStrategy, timeoutCancellationToken);

--- a/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
+++ b/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
@@ -127,7 +127,7 @@ namespace Calamari.AzureResourceGroup
         {
             var pollingTimeoutVariableValue = variables.Get(SpecialVariables.Action.Azure.ArmDeploymentTimeout, "30");
             int.TryParse(pollingTimeoutVariableValue, out var pollingTimeoutValue);
-            var pollingTimeout = TimeSpan.FromMinutes(pollingTimeoutValue);
+            var pollingTimeout = TimeSpan.FromMinutes(pollingTimeoutValue > 0 ? pollingTimeoutValue: 30);
             var asyncResourceGroupPollingTimeoutPolicy = Policy.TimeoutAsync<ArmDeploymentResource>(pollingTimeout, TimeoutStrategy.Optimistic);
             
             log.Info("Polling for deployment completion...");

--- a/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
+++ b/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
@@ -135,7 +135,7 @@ namespace Calamari.AzureResourceGroup
             {
                 var deploymentResult = await AsyncResourceGroupPollingTimeoutPolicy.ExecuteAsync(async timeoutCancellationToken =>
                                                                                                  {
-                                                                                                     var delayStrategy = DelayStrategy.CreateExponentialDelayStrategy(TimeSpan.FromSeconds(1), PollingTimeout);
+                                                                                                     var delayStrategy = DelayStrategy.CreateExponentialDelayStrategy(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
                                                                                                      var result = await deploymentOperation.WaitForCompletionAsync(delayStrategy, timeoutCancellationToken);
                                                                                                      return result;
                                                                                                  },

--- a/source/Calamari.AzureResourceGroup/SpecialVariables.cs
+++ b/source/Calamari.AzureResourceGroup/SpecialVariables.cs
@@ -14,6 +14,7 @@
                 public static readonly string Template = "Octopus.Action.Azure.Template";
                 public static readonly string TemplateParameters = "Octopus.Action.Azure.TemplateParameters";
                 public static readonly string TemplateSource = "Octopus.Action.Azure.TemplateSource";
+                public static readonly string ArmDeploymentTimeout = "Octopus.Action.Azure.ArmDeploymentTimeout";
             }
         }
     }


### PR DESCRIPTION
ARM templates vary widely in how many resources they are spinning up and how long they will take. The old behaviour used an incremental backoff with a maximum polling wait time of 30 seconds and did not timeout. I've re-introduced the maximum 30 second poll interval and increased the overall timeout from 3 minutes to 30, this should be long enough to allow all ARM templates to apply successfully.