### PR TITLE
Send desired K8s manifests as YAML instead of JSON

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
@@ -45,8 +45,10 @@ namespace Calamari.Tests.KubernetesFixtures
             //Test that quotes are preserved, especially for numbers
             var yaml = @"name: George Washington
 alphafield: ""fgdsfsd""
-age: 89
-height_in_inches: ""5.75""
+unquoted_int: 89
+quoted_int: ""89""
+unquoted_float: 5.75
+quoted_float: ""5.75""
 ".ReplaceLineEndings();
             
             using (CreateFile(yaml, out var filePath))

--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
@@ -41,7 +41,7 @@ namespace Calamari.Tests.KubernetesFixtures
             var variables = new CalamariVariables();
             variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
             
-            var yaml = "name: George Washington\nalphafield: \"fgdsfsd\"\nage: 89\nheight_in_inches: \"5.75\"\n";
+            var yaml = "name: George Washington\nalphafield: \"fgdsfsd\"\nage: 89\nheight_in_inches: \"5.75\"\n".Replace("\n", Environment.NewLine);
             
             using (CreateFile(yaml, out var filePath))
             {

--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
@@ -8,6 +8,7 @@ using Calamari.Common.Plumbing.ServiceMessages;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes;
 using Calamari.Testing.Helpers;
+using Calamari.Tests.Helpers;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -41,7 +42,12 @@ namespace Calamari.Tests.KubernetesFixtures
             var variables = new CalamariVariables();
             variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
             
-            var yaml = "name: George Washington\nalphafield: \"fgdsfsd\"\nage: 89\nheight_in_inches: \"5.75\"\n".Replace("\n", Environment.NewLine);
+            //Test that quotes are preserved, especially for numbers
+            var yaml = @"name: George Washington
+alphafield: ""fgdsfsd""
+age: 89
+height_in_inches: ""5.75""
+".ReplaceLineEndings();
             
             using (CreateFile(yaml, out var filePath))
             {

--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
@@ -40,16 +40,16 @@ namespace Calamari.Tests.KubernetesFixtures
             var memoryLog = new InMemoryLog();
             var variables = new CalamariVariables();
             variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
-            
-            var yaml = "name: George Washington\nalphafield: \"fgdsfsd\"\nage: 89\nheight_in_inches: \"5.75\"\n";
-            
+
+            var yaml = @"foo: bar";
+            var expectedJson = "{\"foo\": \"bar\"}";
             using (CreateFile(yaml, out var filePath))
             {
                 var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
 
                 mr.ReportManifestApplied(filePath);
 
-                var expected = ServiceMessage.Create(SpecialVariables.ServiceMessageNames.ManifestApplied.Name, ("ns", "default"), ("manifest", yaml));
+                var expected = ServiceMessage.Create(SpecialVariables.ServiceMessageNames.ManifestApplied.Name, ("ns", "default"), ("manifest", expectedJson));
                 memoryLog.ServiceMessages.Should().BeEquivalentTo(new List<ServiceMessage> { expected });
             }
         }

--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
@@ -40,16 +40,16 @@ namespace Calamari.Tests.KubernetesFixtures
             var memoryLog = new InMemoryLog();
             var variables = new CalamariVariables();
             variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
-
-            var yaml = @"foo: bar";
-            var expectedJson = "{\"foo\": \"bar\"}";
+            
+            var yaml = "name: George Washington\nalphafield: \"fgdsfsd\"\nage: 89\nheight_in_inches: \"5.75\"\n";
+            
             using (CreateFile(yaml, out var filePath))
             {
                 var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
 
                 mr.ReportManifestApplied(filePath);
 
-                var expected = ServiceMessage.Create(SpecialVariables.ServiceMessageNames.ManifestApplied.Name, ("ns", "default"), ("manifest", expectedJson));
+                var expected = ServiceMessage.Create(SpecialVariables.ServiceMessageNames.ManifestApplied.Name, ("ns", "default"), ("manifest", yaml));
                 memoryLog.ServiceMessages.Should().BeEquivalentTo(new List<ServiceMessage> { expected });
             }
         }

--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
@@ -41,7 +41,11 @@ namespace Calamari.Tests.KubernetesFixtures
             var variables = new CalamariVariables();
             variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
 
-            var yaml = @"foo: bar";
+            var yaml = @"name: George Washington
+alphafield: ""fgdsfsd""
+age: 89
+height_in_inches: ""5.75""
+";
             //var expectedJson = "{\"foo\": \"bar\"}";
             using (CreateFile(yaml, out var filePath))
             {

--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
@@ -42,14 +42,14 @@ namespace Calamari.Tests.KubernetesFixtures
             variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
 
             var yaml = @"foo: bar";
-            var expectedJson = "{\"foo\": \"bar\"}";
+            //var expectedJson = "{\"foo\": \"bar\"}";
             using (CreateFile(yaml, out var filePath))
             {
                 var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
 
                 mr.ReportManifestApplied(filePath);
 
-                var expected = ServiceMessage.Create(SpecialVariables.ServiceMessageNames.ManifestApplied.Name, ("ns", "default"), ("manifest", expectedJson));
+                var expected = ServiceMessage.Create(SpecialVariables.ServiceMessageNames.ManifestApplied.Name, ("ns", "default"), ("manifest", yaml));
                 memoryLog.ServiceMessages.Should().BeEquivalentTo(new List<ServiceMessage> { expected });
             }
         }

--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
@@ -40,13 +40,9 @@ namespace Calamari.Tests.KubernetesFixtures
             var memoryLog = new InMemoryLog();
             var variables = new CalamariVariables();
             variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
-
-            var yaml = @"name: George Washington
-alphafield: ""fgdsfsd""
-age: 89
-height_in_inches: ""5.75""
-";
-            //var expectedJson = "{\"foo\": \"bar\"}";
+            
+            var yaml = "name: George Washington\nalphafield: \"fgdsfsd\"\nage: 89\nheight_in_inches: \"5.75\"\n";
+            
             using (CreateFile(yaml, out var filePath))
             {
                 var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);

--- a/source/Calamari/Kubernetes/ManifestReporter.cs
+++ b/source/Calamari/Kubernetes/ManifestReporter.cs
@@ -25,7 +25,6 @@ namespace Calamari.Kubernetes
         readonly ILog log;
 
         static readonly ISerializer YamlSerializer = new SerializerBuilder()
-                                                     .WithNamingConvention(CamelCaseNamingConvention.Instance)
                                                      .Build();
 
         public ManifestReporter(IVariables variables, ICalamariFileSystem fileSystem, ILog log)

--- a/source/Calamari/Kubernetes/ManifestReporter.cs
+++ b/source/Calamari/Kubernetes/ManifestReporter.cs
@@ -51,7 +51,7 @@ namespace Calamari.Kubernetes
             if (!FeatureToggle.KubernetesLiveObjectStatusFeatureToggle.IsEnabled(variables) && !OctopusFeatureToggles.KubernetesObjectManifestInspectionFeatureToggle.IsEnabled(variables))
                 return;
 
-            using (var yamlFile = fileSystem.OpenFile(filePath, FileAccess.ReadWrite))
+            using (var yamlFile = fileSystem.OpenFile(filePath, FileAccess.Read, FileShare.Read))
             {
                 try
                 {

--- a/source/Calamari/Kubernetes/ManifestReporter.cs
+++ b/source/Calamari/Kubernetes/ManifestReporter.cs
@@ -28,7 +28,7 @@ namespace Calamari.Kubernetes
 
         static readonly ISerializer YamlSerializer = new SerializerBuilder()
                                                      .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                                                     .JsonCompatible()
+                                                     //.JsonCompatible()
                                                      .Build();
 
         public ManifestReporter(IVariables variables, ICalamariFileSystem fileSystem, ILog log)

--- a/source/Calamari/Kubernetes/ManifestReporter.cs
+++ b/source/Calamari/Kubernetes/ManifestReporter.cs
@@ -24,11 +24,8 @@ namespace Calamari.Kubernetes
         readonly ICalamariFileSystem fileSystem;
         readonly ILog log;
 
-        static readonly IDeserializer YamlDeserializer = new Deserializer();
-
         static readonly ISerializer YamlSerializer = new SerializerBuilder()
                                                      .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                                                     //.JsonCompatible()
                                                      .Build();
 
         public ManifestReporter(IVariables variables, ICalamariFileSystem fileSystem, ILog log)

--- a/source/Calamari/Kubernetes/ManifestReporter.cs
+++ b/source/Calamari/Kubernetes/ManifestReporter.cs
@@ -90,17 +90,18 @@ namespace Calamari.Kubernetes
 
         static string YamlNodeToJson(YamlNode node)
         {
-            var stream = new YamlStream { new YamlDocument(node) };
-            using (var writer = new StringWriter())
-            {
-                stream.Save(writer);
-
-                using (var reader = new StringReader(writer.ToString()))
-                {
-                    var yamlObject = YamlDeserializer.Deserialize(reader);
-                    return yamlObject is null ? string.Empty : YamlSerializer.Serialize(yamlObject).Trim();
-                }
-            }
+           return YamlSerializer.Serialize(node);
+            // var stream = new YamlStream { new YamlDocument(node) };
+            // using (var writer = new StringWriter())
+            // {
+            //     stream.Save(writer);
+            //
+            //     using (var reader = new StringReader(writer.ToString()))
+            //     {
+            //         var yamlObject = YamlDeserializer.Deserialize(reader);
+            //         return yamlObject is null ? string.Empty : YamlSerializer.Serialize(yamlObject).Trim();
+            //     }
+            // }
         }
     }
 }

--- a/source/Calamari/Kubernetes/ManifestReporter.cs
+++ b/source/Calamari/Kubernetes/ManifestReporter.cs
@@ -70,7 +70,7 @@ namespace Calamari.Kubernetes
                             continue;
                         }
 
-                        var updatedDocument = YamlNodeToJson(rootNode);
+                        var updatedDocument = SerializeManifest(rootNode);
 
                         var ns = GetNamespace(rootNode);
                         log.WriteServiceMessage(new ServiceMessage(SpecialVariables.ServiceMessageNames.ManifestApplied.Name,
@@ -88,20 +88,9 @@ namespace Calamari.Kubernetes
             }
         }
 
-        static string YamlNodeToJson(YamlNode node)
+        static string SerializeManifest(YamlMappingNode node)
         {
            return YamlSerializer.Serialize(node);
-            // var stream = new YamlStream { new YamlDocument(node) };
-            // using (var writer = new StringWriter())
-            // {
-            //     stream.Save(writer);
-            //
-            //     using (var reader = new StringReader(writer.ToString()))
-            //     {
-            //         var yamlObject = YamlDeserializer.Deserialize(reader);
-            //         return yamlObject is null ? string.Empty : YamlSerializer.Serialize(yamlObject).Trim();
-            //     }
-            // }
         }
     }
 }


### PR DESCRIPTION
[#project-md-k8s-live-object-status](https://octopusdeploy.slack.com/archives/C06HYUY4XLH)

We want to store the desired resource manifests as YAML for manifest inspection. Also, the JSON serialization had a bug where a number would get quoted when serialized.