### PR TITLE
Report helm manifests for live status

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Integration/HelmCliTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Integration/HelmCliTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes;
+using Calamari.Kubernetes.Integration;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.Integration
+{
+    [TestFixture]
+    public class HelmCliTests
+    {
+        [Test]
+        public void ExecutesWithBuiltInArguments()
+        {
+            const string expectedExecutable = "some-exe";
+            const string expectedNamespace = "some-namespace";
+            const string expectedArgument = "additional-arg";
+
+            var (helm, commandLineRunner, _) = GetHelmCli();
+            CommandLineInvocation actual = null;
+            commandLineRunner.When(x => x.Execute(Arg.Any<CommandLineInvocation>())).Do(x => actual = x.Arg<CommandLineInvocation>());
+
+            helm.WithExecutable(expectedExecutable);
+            helm.WithNamespace(expectedNamespace);
+
+            helm.ExecuteCommandAndReturnOutput(expectedArgument);
+
+            using (var _ = new AssertionScope())
+            {
+                actual.Executable.Should().BeEquivalentTo(expectedExecutable);
+                actual.Arguments.Should().BeEquivalentTo($"--namespace {expectedNamespace} {expectedArgument}");
+            }
+        }
+
+        [Test]
+        public void UsesCustomHelmExecutable()
+        {
+            var (helm, commandLineRunner, _) = GetHelmCli();
+            CommandLineInvocation actual = null;
+            commandLineRunner.When(x => x.Execute(Arg.Any<CommandLineInvocation>())).Do(x => actual = x.Arg<CommandLineInvocation>());
+
+            const string expectedExecutable = "my-custom-exe";
+
+            helm.WithExecutable(new CalamariVariables
+            {
+                { SpecialVariables.Helm.CustomHelmExecutable, expectedExecutable }
+            });
+
+            helm.ExecuteCommandAndReturnOutput();
+
+            actual.Executable.Should().BeEquivalentTo(expectedExecutable);
+        }
+
+        [Test]
+        public void UsesCustomHelmExecutableFromPackage()
+        {
+            var (helm, commandLineRunner, workingDirectory) = GetHelmCli();
+            CommandLineInvocation actual = null;
+            commandLineRunner.When(x => x.Execute(Arg.Any<CommandLineInvocation>())).Do(x => actual = x.Arg<CommandLineInvocation>());
+
+            const string expectedExecutable = "my-custom-exe";
+            const string expectedPackageKey = "helm-exe-package";
+            var expectedExecutablePath = Path.Combine(workingDirectory.DirectoryPath, SpecialVariables.Helm.Packages.CustomHelmExePackageKey, expectedExecutable);
+
+            helm.WithExecutable(new CalamariVariables
+            {
+                { SpecialVariables.Helm.CustomHelmExecutable, expectedExecutable },
+                { SpecialVariables.Helm.Packages.CustomHelmExePackageKey, expectedPackageKey },
+                { $"{PackageVariables.PackageCollection}[{expectedPackageKey}]", SpecialVariables.Helm.Packages.CustomHelmExePackageKey }
+            });
+
+            helm.ExecuteCommandAndReturnOutput();
+
+            actual.Executable.Should().BeEquivalentTo(expectedExecutablePath);
+        }
+
+        [Test]
+        public void AlwaysUsesCustomHelmExecutableWhenRooted()
+        {
+            var (helm, commandLineRunner, _) = GetHelmCli();
+            CommandLineInvocation actual = null;
+            commandLineRunner.When(x => x.Execute(Arg.Any<CommandLineInvocation>())).Do(x => actual = x.Arg<CommandLineInvocation>());
+
+            const string expectedExecutable = "/my-custom-exe";
+            const string expectedPackageKey = "helm-exe-package";
+
+            helm.WithExecutable(new CalamariVariables
+            {
+                { SpecialVariables.Helm.CustomHelmExecutable, expectedExecutable },
+                { SpecialVariables.Helm.Packages.CustomHelmExePackageKey, expectedPackageKey },
+                { $"{PackageVariables.PackageCollection}[{expectedPackageKey}]", SpecialVariables.Helm.Packages.CustomHelmExePackageKey }
+            });
+
+            helm.ExecuteCommandAndReturnOutput();
+
+            actual.Executable.Should().BeEquivalentTo(expectedExecutable);
+        }
+
+        static (HelmCli, ICommandLineRunner, TemporaryDirectory) GetHelmCli()
+        {
+            var memoryLog = new InMemoryLog();
+            var commandLineRunner = Substitute.For<ICommandLineRunner>();
+            var workingDirectory = TemporaryDirectory.Create();
+            var helm = new HelmCli(memoryLog, commandLineRunner, workingDirectory.DirectoryPath, new Dictionary<string, string>());
+
+            return (helm, commandLineRunner, workingDirectory);
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReporterTests.cs
@@ -23,19 +23,103 @@ namespace Calamari.Tests.KubernetesFixtures
             var variables = new CalamariVariables();
 
             var yaml = @"foo: bar";
-            using (CreateFile(yaml, out var filePath))
-            {
-                var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
+            var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
 
-                mr.ReportManifestApplied(filePath);
+            mr.ReportManifestApplied(yaml);
 
-                memoryLog.ServiceMessages.Should().BeEmpty();
-            }
+            memoryLog.ServiceMessages.Should().BeEmpty();
         }
-        
+
         [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
-        [TestCase( OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
+        [TestCase(OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
         public void GivenValidYaml_ShouldPostSingleServiceMessage(string enabledFeatureToggle)
+        {
+            var memoryLog = new InMemoryLog();
+            var variables = new CalamariVariables();
+            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
+
+            var yaml = @"foo: bar";
+            var expectedJson = "{\"foo\": \"bar\"}";
+            var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
+
+            mr.ReportManifestApplied(yaml);
+
+            var expected = ServiceMessage.Create(SpecialVariables.ServiceMessageNames.ManifestApplied.Name, ("ns", "default"), ("manifest", expectedJson));
+            memoryLog.ServiceMessages.Should().BeEquivalentTo(new List<ServiceMessage> { expected });
+        }
+
+        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
+        [TestCase(OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
+        public void GivenInValidManifest_ShouldNotPostServiceMessage(string enabledFeatureToggle)
+        {
+            var memoryLog = new InMemoryLog();
+            var variables = new CalamariVariables();
+            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
+
+            var yaml = @"text - Bar";
+            var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
+
+            mr.ReportManifestApplied(yaml);
+
+            memoryLog.ServiceMessages.Should().BeEmpty();
+        }
+
+        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
+        [TestCase(OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
+        public void GivenNamespaceInManifest_ShouldReportManifestNamespace(string enabledFeatureToggle)
+        {
+            var memoryLog = new InMemoryLog();
+            var variables = new CalamariVariables();
+            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
+            var yaml = @"metadata:
+  name: game-demo
+  namespace: XXX";
+
+            var variableNs = Some.String();
+            variables.Set(SpecialVariables.Namespace, variableNs);
+            var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
+
+            mr.ReportManifestApplied(yaml);
+
+            memoryLog.ServiceMessages.First().Properties.Should().Contain(new KeyValuePair<string, string>("ns", "XXX"));
+        }
+
+        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
+        [TestCase(OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
+        public void GivenNamespaceNotInManifest_ShouldReportVariableNamespace(string enabledFeatureToggle)
+        {
+            var memoryLog = new InMemoryLog();
+            var variables = new CalamariVariables();
+            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
+            var yaml = @"foo: bar";
+
+            var variableNs = Some.String();
+            variables.Set(SpecialVariables.Namespace, variableNs);
+            var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
+
+            mr.ReportManifestApplied(yaml);
+
+            memoryLog.ServiceMessages.First().Properties.Should().Contain(new KeyValuePair<string, string>("ns", variableNs));
+        }
+
+        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
+        [TestCase(OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
+        public void GiveNoNamespaces_ShouldDefaultNamespace(string enabledFeatureToggle)
+        {
+            var memoryLog = new InMemoryLog();
+            var variables = new CalamariVariables();
+            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
+            var yaml = @"foo: bar";
+            var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
+
+            mr.ReportManifestApplied(yaml);
+
+            memoryLog.ServiceMessages.First().Properties.Should().Contain(new KeyValuePair<string, string>("ns", "default"));
+        }
+
+        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
+        [TestCase(OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
+        public void GivenValidYamlFile_ShouldPostSingleServiceMessage(string enabledFeatureToggle)
         {
             var memoryLog = new InMemoryLog();
             var variables = new CalamariVariables();
@@ -47,89 +131,10 @@ namespace Calamari.Tests.KubernetesFixtures
             {
                 var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
 
-                mr.ReportManifestApplied(filePath);
+                mr.ReportManifestFileApplied(filePath);
 
                 var expected = ServiceMessage.Create(SpecialVariables.ServiceMessageNames.ManifestApplied.Name, ("ns", "default"), ("manifest", expectedJson));
                 memoryLog.ServiceMessages.Should().BeEquivalentTo(new List<ServiceMessage> { expected });
-            }
-        }
-
-        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
-        [TestCase( OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
-        public void GivenInValidManifest_ShouldNotPostServiceMessage(string enabledFeatureToggle)
-        {
-            var memoryLog = new InMemoryLog();
-            var variables = new CalamariVariables();
-            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
-
-            var yaml = @"text - Bar";
-            using (CreateFile(yaml, out var filePath))
-            {
-                var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
-
-                mr.ReportManifestApplied(filePath);
-
-                memoryLog.ServiceMessages.Should().BeEmpty();
-            }
-        }
-
-        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
-        [TestCase( OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
-        public void GivenNamespaceInManifest_ShouldReportManifestNamespace(string enabledFeatureToggle)
-        {
-            var memoryLog = new InMemoryLog();
-            var variables = new CalamariVariables();
-            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
-            var yaml = @"metadata:
-  name: game-demo
-  namespace: XXX";
-            using (CreateFile(yaml, out var filePath))
-            {
-                var variableNs = Some.String();
-                variables.Set(SpecialVariables.Namespace, variableNs);
-                var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
-
-                mr.ReportManifestApplied(filePath);
-
-                memoryLog.ServiceMessages.First().Properties.Should().Contain(new KeyValuePair<string, string>("ns", "XXX"));
-            }
-        }
-
-        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
-        [TestCase( OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
-        public void GivenNamespaceNotInManifest_ShouldReportVariableNamespace(string enabledFeatureToggle)
-        {
-            var memoryLog = new InMemoryLog();
-            var variables = new CalamariVariables();
-            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
-            var yaml = @"foo: bar";
-            using (CreateFile(yaml, out var filePath))
-            {
-                var variableNs = Some.String();
-                variables.Set(SpecialVariables.Namespace, variableNs);
-                var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
-
-                mr.ReportManifestApplied(filePath);
-
-                memoryLog.ServiceMessages.First().Properties.Should().Contain(new KeyValuePair<string, string>("ns", variableNs));
-            }
-        }
-
-        [TestCase(nameof(FeatureToggle.KubernetesLiveObjectStatusFeatureToggle))]
-        [TestCase( OctopusFeatureToggles.KnownSlugs.KubernetesObjectManifestInspection)]
-        public void GiveNoNamespaces_ShouldDefaultNamespace(string enabledFeatureToggle)
-        {
-            var memoryLog = new InMemoryLog();
-            var variables = new CalamariVariables();
-            variables.Set(KnownVariables.EnabledFeatureToggles, enabledFeatureToggle);
-            var yaml = @"foo: bar";
-            using (CreateFile(yaml, out var filePath))
-            {
-                var mr = new ManifestReporter(variables, CalamariPhysicalFileSystem.GetPhysicalFileSystem(), memoryLog);
-
-                mr.ReportManifestApplied(filePath);
-
-                memoryLog.ServiceMessages.First().Properties.Should().Contain(new KeyValuePair<string, string>("ns", "default"));
             }
         }
 

--- a/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/GatherAndApplyRawYamlExecutor.cs
@@ -90,7 +90,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             {
                 var fullFilePath = fileSystem.GetRelativePath(directoryWithTrailingSlash, file);
                 log.Verbose($"Matched file: {fullFilePath}");
-                manifestReporter.ReportManifestApplied(file);
+                manifestReporter.ReportManifestFileApplied(file);
             }
         }
     }

--- a/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/HelmUpgradeCommand.cs
@@ -36,6 +36,7 @@ namespace Calamari.Kubernetes.Commands
         readonly IExtractPackage extractPackage;
         readonly HelmTemplateValueSourcesParser templateValueSourcesParser;
         readonly ICommandLineRunner commandLineRunner;
+        readonly IManifestReporter manifestReporter;
 
         public HelmUpgradeCommand(
             ILog log,
@@ -45,8 +46,8 @@ namespace Calamari.Kubernetes.Commands
             ICalamariFileSystem fileSystem,
             ISubstituteInFiles substituteInFiles,
             IExtractPackage extractPackage,
-            HelmTemplateValueSourcesParser templateValueSourcesParser
-        )
+            HelmTemplateValueSourcesParser templateValueSourcesParser,
+            IManifestReporter manifestReporter)
         {
             Options.Add("package=", "Path to the NuGet package to install.", v => pathToPackage = new PathToPackage(Path.GetFullPath(v)));
             this.log = log;
@@ -56,6 +57,7 @@ namespace Calamari.Kubernetes.Commands
             this.substituteInFiles = substituteInFiles;
             this.extractPackage = extractPackage;
             this.templateValueSourcesParser = templateValueSourcesParser;
+            this.manifestReporter = manifestReporter;
             this.commandLineRunner = commandLineRunner;
         }
 
@@ -99,6 +101,7 @@ namespace Calamari.Kubernetes.Commands
                 new DelegateInstallConvention(d => substituteInFiles.Substitute(d.CurrentDirectory, TemplateValuesFiles(d)  , true)),
                 new ConfiguredScriptConvention(new DeployConfiguredScriptBehaviour(log, fileSystem, scriptEngine, commandLineRunner)),
                 new HelmUpgradeConvention(log, scriptEngine, commandLineRunner, fileSystem, templateValueSourcesParser),
+                new ReportHelmManifestConvention(log, commandLineRunner, manifestReporter),
                 new ConfiguredScriptConvention(new PostDeployConfiguredScriptBehaviour(log, fileSystem, scriptEngine, commandLineRunner))
             });
             

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -119,6 +119,8 @@ namespace Calamari.Kubernetes.Conventions
         {
             if (customHelmExecutable != null)
             {
+                // Not fixing this in my current change but the chmod here is redundant as we already try to run
+                // the exe as part of CheckHelmToolVersion() early in the script.
                 // With PowerShell we need to invoke custom executables
                 sb.Append(syntax == ScriptSyntax.PowerShell ? ". " : $"chmod +x \"{customHelmExecutable}\"\n");
                 sb.Append($"\"{customHelmExecutable}\"");

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -62,6 +62,7 @@ namespace Calamari.Kubernetes.Conventions
             }
         }
 
+        // This could/should be refactored to use `HelmCli` at somepoint
         string BuildHelmCommand(RunningDeployment deployment, ScriptSyntax syntax)
         {
             var releaseName = GetReleaseName(deployment.Variables);

--- a/source/Calamari/Kubernetes/Conventions/ReportHelmManifestConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/ReportHelmManifestConvention.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Deployment.Conventions;
 using Calamari.Kubernetes.Integration;
@@ -24,6 +25,10 @@ namespace Calamari.Kubernetes.Conventions
 
         public void Install(RunningDeployment deployment)
         {
+            if (!FeatureToggle.KubernetesLiveObjectStatusFeatureToggle.IsEnabled(deployment.Variables)
+                && !OctopusFeatureToggles.KubernetesObjectManifestInspectionFeatureToggle.IsEnabled(deployment.Variables))
+                return;
+
             var releaseName = deployment.Variables.Get("ReleaseName");
 
             var helm = new HelmCli(log, commandLineRunner, deployment.CurrentDirectory, deployment.EnvironmentVariables)

--- a/source/Calamari/Kubernetes/Conventions/ReportHelmManifestConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/ReportHelmManifestConvention.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Deployment.Conventions;
+using Calamari.Kubernetes.Integration;
+
+namespace Calamari.Kubernetes.Conventions
+{
+    public class ReportHelmManifestConvention : IInstallConvention
+    {
+        readonly ILog log;
+        readonly ICommandLineRunner commandLineRunner;
+        readonly IManifestReporter manifestReporter;
+
+        public ReportHelmManifestConvention(ILog log,
+                                            ICommandLineRunner commandLineRunner,
+                                            IManifestReporter manifestReporter)
+        {
+            this.log = log;
+            this.commandLineRunner = commandLineRunner;
+            this.manifestReporter = manifestReporter;
+        }
+
+        public void Install(RunningDeployment deployment)
+        {
+            var releaseName = deployment.Variables.Get("ReleaseName");
+
+            var helm = new HelmCli(log, commandLineRunner, deployment.CurrentDirectory, deployment.EnvironmentVariables)
+                       .WithExecutable(deployment.Variables)
+                       .WithNamespace(deployment.Variables.Get(SpecialVariables.Helm.Namespace));
+
+            var manifest = helm.GetManifest(releaseName);
+            manifestReporter.ReportManifestApplied(manifest);
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Integration/CaptureCommandOutput.cs
+++ b/source/Calamari/Kubernetes/Integration/CaptureCommandOutput.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Calamari.Common.Plumbing.Commands;
 
@@ -8,13 +9,17 @@ namespace Calamari.Kubernetes.Integration
     {
         Message[] Messages { get; }
         IEnumerable<string> InfoLogs { get; }
+        string MergeInfoLogs();
     }
+
     public class CaptureCommandOutput : ICommandInvocationOutputSink, ICommandOutput
     {
         private readonly List<Message> messages = new List<Message>();
         public Message[] Messages => messages.ToArray();
 
         public IEnumerable<string> InfoLogs => Messages.Where(m => m.Level == Level.Info).Select(m => m.Text).ToArray();
+
+        public string MergeInfoLogs() => string.Join(Environment.NewLine, InfoLogs);
 
         public void WriteInfo(string line)
         {

--- a/source/Calamari/Kubernetes/Integration/HelmCli.cs
+++ b/source/Calamari/Kubernetes/Integration/HelmCli.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Kubernetes.Integration
+{
+    public class HelmCli : CommandLineTool
+    {
+        public HelmCli(ILog log, ICommandLineRunner commandLineRunner, string workingDirectory, Dictionary<string, string> environmentVars)
+            : base(log, commandLineRunner, workingDirectory, environmentVars)
+        {
+            ExecutableLocation = "helm";
+        }
+
+        readonly List<string> builtInArguments = new List<string>();
+
+        public HelmCli WithExecutable(string customExecutable)
+        {
+            ExecutableLocation = customExecutable;
+            return this;
+        }
+
+        public HelmCli WithExecutable(IVariables variables)
+        {
+            var helmExecutable = variables.Get(SpecialVariables.Helm.CustomHelmExecutable);
+            if (string.IsNullOrWhiteSpace(helmExecutable))
+            {
+                return this;
+            }
+
+            if (variables.GetIndexes(PackageVariables.PackageCollection)
+                         .Contains(SpecialVariables.Helm.Packages.CustomHelmExePackageKey)
+                && !Path.IsPathRooted(helmExecutable))
+            {
+                var fullPath = Path.GetFullPath(Path.Combine(workingDirectory, SpecialVariables.Helm.Packages.CustomHelmExePackageKey, helmExecutable));
+                log.Info($"Using custom helm executable at {helmExecutable} from inside package. Full path at {fullPath}");
+
+                return WithExecutable(fullPath);
+            }
+            else
+            {
+                log.Info($"Using custom helm executable at {helmExecutable}");
+                return WithExecutable(helmExecutable);
+            }
+        }
+
+        public HelmCli WithNamespace(string @namespace)
+        {
+            builtInArguments.Add($"--namespace {@namespace}");
+            return this;
+        }
+
+        public string GetManifest(string releaseName)
+        {
+            var result = ExecuteCommandAndReturnOutput("get", "manifest", $"\"{releaseName}\"");
+            result.Result.VerifySuccess();
+
+            return result.Output.MergeInfoLogs();
+        }
+
+        public CommandResultWithOutput ExecuteCommandAndReturnOutput(params string[] arguments) =>
+            base.ExecuteCommandAndReturnOutput(ExecutableLocation, builtInArguments.Concat(arguments).ToArray());
+    }
+}

--- a/source/Calamari/Kubernetes/Integration/HelmCli.cs
+++ b/source/Calamari/Kubernetes/Integration/HelmCli.cs
@@ -56,7 +56,7 @@ namespace Calamari.Kubernetes.Integration
 
         public string GetManifest(string releaseName)
         {
-            var result = ExecuteCommandAndReturnOutput("get", "manifest", $"\"{releaseName}\"");
+            var result = ExecuteCommandAndReturnOutput("get", "manifest", releaseName);
             result.Result.VerifySuccess();
 
             return result.Output.MergeInfoLogs();

--- a/source/Calamari/Kubernetes/ManifestReporter.cs
+++ b/source/Calamari/Kubernetes/ManifestReporter.cs
@@ -15,7 +15,8 @@ namespace Calamari.Kubernetes
 {
     public interface IManifestReporter
     {
-        void ReportManifestApplied(string filePath);
+        void ReportManifestFileApplied(string filePath);
+        void ReportManifestApplied(string yaml);
     }
 
     public class ManifestReporter : IManifestReporter
@@ -50,9 +51,10 @@ namespace Calamari.Kubernetes
             return implicitNamespace;
         }
 
-        public void ReportManifestApplied(string filePath)
+        public void ReportManifestFileApplied(string filePath)
         {
-            if (!FeatureToggle.KubernetesLiveObjectStatusFeatureToggle.IsEnabled(variables) && !OctopusFeatureToggles.KubernetesObjectManifestInspectionFeatureToggle.IsEnabled(variables))
+            if (!FeatureToggle.KubernetesLiveObjectStatusFeatureToggle.IsEnabled(variables)
+                && !OctopusFeatureToggles.KubernetesObjectManifestInspectionFeatureToggle.IsEnabled(variables))
                 return;
 
             using (var yamlFile = fileSystem.OpenFile(filePath, FileAccess.ReadWrite))
@@ -61,30 +63,55 @@ namespace Calamari.Kubernetes
                 {
                     var yamlStream = new YamlStream();
                     yamlStream.Load(new StreamReader(yamlFile));
-
-                    foreach (var document in yamlStream.Documents)
-                    {
-                        if (!(document.RootNode is YamlMappingNode rootNode))
-                        {
-                            log.Warn("Could not parse manifest, resources will not be added to live object status");
-                            continue;
-                        }
-
-                        var updatedDocument = YamlNodeToJson(rootNode);
-
-                        var ns = GetNamespace(rootNode);
-                        log.WriteServiceMessage(new ServiceMessage(SpecialVariables.ServiceMessageNames.ManifestApplied.Name,
-                                                                   new Dictionary<string, string>
-                                                                   {
-                                                                       { SpecialVariables.ServiceMessageNames.ManifestApplied.ManifestAttribute, updatedDocument },
-                                                                       { SpecialVariables.ServiceMessageNames.ManifestApplied.NamespaceAttribute, ns }
-                                                                   }));
-                    }
+                    ReportManifestStreamApplied(yamlStream);
                 }
                 catch (SemanticErrorException)
                 {
                     log.Warn("Invalid YAML syntax found, resources will not be added to live object status");
                 }
+            }
+        }
+
+        public void ReportManifestApplied(string yamlManifest)
+        {
+            if (!FeatureToggle.KubernetesLiveObjectStatusFeatureToggle.IsEnabled(variables)
+                && !OctopusFeatureToggles.KubernetesObjectManifestInspectionFeatureToggle.IsEnabled(variables))
+                return;
+
+            try
+            {
+                var yamlStream = new YamlStream();
+                yamlStream.Load(new StringReader(yamlManifest));
+                ReportManifestStreamApplied(yamlStream);
+            }
+            catch (SemanticErrorException)
+            {
+                log.Warn("Invalid YAML syntax found, resources will not be added to live object status");
+            }
+        }
+
+        void ReportManifestStreamApplied(YamlStream yamlStream)
+        {
+            foreach (var document in yamlStream.Documents)
+            {
+                if (!(document.RootNode is YamlMappingNode rootNode))
+                {
+                    log.Warn("Could not parse manifest, resources will not be added to live object status");
+                    continue;
+                }
+
+                var updatedDocument = YamlNodeToJson(rootNode);
+
+                var ns = GetNamespace(rootNode);
+                var message = new ServiceMessage(
+                                                 SpecialVariables.ServiceMessageNames.ManifestApplied.Name,
+                                                 new Dictionary<string, string>
+                                                 {
+                                                     { SpecialVariables.ServiceMessageNames.ManifestApplied.ManifestAttribute, updatedDocument },
+                                                     { SpecialVariables.ServiceMessageNames.ManifestApplied.NamespaceAttribute, ns }
+                                                 });
+
+                log.WriteServiceMessage(message);
             }
         }
 


### PR DESCRIPTION
Sends manifests for helm installations back to server _after_ the helm installation is completed.

This is the first pass at implementing helm support, but isn't yet ideal because we won't get any information back during deployments if `--wait` or `--atomic` flags are used. This is known and we will be coming back to solve for this.

I have added a `HelmCli` class to capture the logic used for helm (similar to what we have done with other CLI tools). For now this is purely for `helm get manifest` but there is no reason that it shouldn't be used for `helm upgrade` once we've proven it out. I opted not to do any actual refactoring here for the sake of time, but this is a step in the right direction imo. 
There are so many ways of running things in Calamari (eg. the existing helm convention uses the `ScriptEngine`, is there a reason for that?) so I'm hoping that creating a `HelmCli` is the right approach. - (28-10-24) Discussed this with Rob and we think it's a decent approach