### PR TITLE
POC indicating bug in helm values parsing

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesCreatorFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesCreatorFixture.cs
@@ -279,7 +279,7 @@ secondary.Development.yaml"
                                                                             },
                                                                             new HelmTemplateValueSourcesParser.InlineYamlTemplateValuesSource
                                                                             {
-                                                                                Value = @"yes: '1234'"
+                                                                                Value = @"#{Service.HelmYaml}"
                                                                             },
                                                                             new HelmTemplateValueSourcesParser.KeyValuesTemplateValuesSource
                                                                             {
@@ -293,6 +293,7 @@ secondary.Development.yaml"
 
             var variables = new CalamariVariables
             {
+                ["Service.HelmYaml"] = @"{""Foo"": [""SOMETHING""]}",
                 [SpecialVariables.Helm.TemplateValuesSources] = templateValuesSourcesJson,
                 [KnownVariables.OriginalPackageDirectoryPath] = RootDir,
                 [ScriptVariables.ScriptSource] = ScriptVariables.ScriptSourceOptions.GitRepository,

--- a/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
+++ b/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
@@ -34,7 +34,7 @@ namespace Calamari.Kubernetes.Helm
 
         public IEnumerable<string> ParseTemplateValuesFilesFromDependencies(RunningDeployment deployment, bool logIncludedFiles = true)
         {
-            var templateValueSources = deployment.Variables.Get(SpecialVariables.Helm.TemplateValuesSources);
+            var templateValueSources = deployment.Variables.GetRaw(SpecialVariables.Helm.TemplateValuesSources);
 
             if (string.IsNullOrWhiteSpace(templateValueSources))
                 return Enumerable.Empty<string>();
@@ -115,7 +115,9 @@ namespace Calamari.Kubernetes.Helm
 
                     case TemplateValuesSourceType.InlineYaml:
                         var inlineYamlTvs = json.ToObject<InlineYamlTemplateValuesSource>();
-                        var inlineYamlFilename = InlineYamlValuesFileWriter.WriteToFile(deployment, fileSystem, inlineYamlTvs.Value, index);
+
+                        var val = deployment.Variables.Evaluate(inlineYamlTvs.Value);
+                        var inlineYamlFilename = InlineYamlValuesFileWriter.WriteToFile(deployment, fileSystem, val, index);
 
                         AddIfNotNull(filenames, inlineYamlFilename);
                         break;


### PR DESCRIPTION
This should not be merged (yet)

This demonstrates a bug in the parsing of Helm values files.

Since we encode the input from the portal into a JSON value, if we attempt to evaluate the Octopus variable in its JSON-serialized format, any inner variables that also get evaluated at the same time may result in invalid JSON. 

i.e. this property represents a twice serialized value, and evaluating it before deserializing the json can lead to crashes.