### PR TITLE
Bump Nuget dependencies

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="NuGet.Commands" Version="3.5.0" />
+        <PackageReference Include="NuGet.Commands" Version="5.11.5" />
         <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.3.0" />
         <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="Polly" Version="8.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="NuGet.Commands" Version="3.5.0" />
+    <PackageReference Include="NuGet.Commands" Version="5.11.5" />
     <PackageReference Include="Markdown" Version="2.1.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
@@ -67,7 +67,7 @@
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.IO.Packaging" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
-    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' ">
     <PackageReference Include="MarkdownSharp" Version="1.13.0.0" />

--- a/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3LibDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3LibDownloader.cs
@@ -8,10 +8,10 @@ using NuGet.Common;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using System.IO;
-using Calamari.Common.Plumbing.Logging;
+using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Extensions;
-using NuGet.DependencyResolver;
-using NuGet.LibraryModel;
+using NuGet.Commands;
+using NuGet.Packaging.Core;
 using Octopus.Versioning;
 
 namespace Calamari.Integration.Packages.NuGet
@@ -25,14 +25,12 @@ namespace Calamari.Integration.Packages.NuGet
             if (feedCredentials != null)
             {
                 var cred = feedCredentials.GetCredential(feedUri, "basic");
-                sourceRepository.PackageSource.Credentials = new PackageSourceCredential("octopus", cred.UserName, cred.Password, true);
+                sourceRepository.PackageSource.Credentials = new PackageSourceCredential("octopus", cred.UserName, cred.Password, true, null);
             }
 
             using (var sourceCacheContext = new SourceCacheContext() { NoCache = true })
             {
-                var providers = new SourceRepositoryDependencyProvider(sourceRepository, logger, sourceCacheContext);
-                var libraryIdentity = new LibraryIdentity(packageId, version.ToNuGetVersion(), LibraryType.Package);
-
+                var providers = new SourceRepositoryDependencyProvider(sourceRepository, logger, sourceCacheContext, sourceCacheContext.IgnoreFailedSources, false);
                 var targetPath = Directory.GetParent(targetFilePath).FullName;
                 if (!Directory.Exists(targetPath))
                 {
@@ -40,16 +38,14 @@ namespace Calamari.Integration.Packages.NuGet
                 }
 
                 string targetTempNupkg = Path.Combine(targetPath, Path.GetRandomFileName());
-                using (var nupkgStream = new FileStream(targetTempNupkg,
-                                                        FileMode.Create,
-                                                        FileAccess.ReadWrite,
-                                                        FileShare.ReadWrite | FileShare.Delete,
-                                                        4096,
-                                                        true))
+                var packageDownloader =  providers.GetPackageDownloaderAsync(new PackageIdentity(packageId, version.ToNuGetVersion()), sourceCacheContext, logger, CancellationToken.None)
+                                                      .GetAwaiter()
+                                                      .GetResult();
+                var fileCopied = packageDownloader.CopyNupkgFileToAsync(targetTempNupkg, CancellationToken.None).GetAwaiter().GetResult();
+                
+                if (!fileCopied) //I would expect any actual standard exception to be thrown above and not returned as a bool
                 {
-                    providers.CopyToAsync(libraryIdentity, nupkgStream, CancellationToken.None)
-                             .GetAwaiter()
-                             .GetResult();
+                    throw new Exception("Unable to download Nupkg file");
                 }
 
                 File.Move(targetTempNupkg, targetFilePath);
@@ -58,15 +54,57 @@ namespace Calamari.Integration.Packages.NuGet
 
         public class NugetLogger : ILogger
         {
-            public void LogDebug(string data) => Log.Verbose(data);
-            public void LogVerbose(string data) => Log.Verbose(data);
-            public void LogInformation(string data) => Log.Info(data);
-            public void LogMinimal(string data) => Log.Verbose(data);
-            public void LogWarning(string data) => Log.Warn(data);
-            public void LogError(string data) => Log.Error(data);
-            public void LogSummary(string data) => Log.Info(data);
-            public void LogInformationSummary(string data) => Log.Info(data);
-            public void LogErrorSummary(string data) => Log.Error(data);
+            public void LogDebug(string data) => Common.Plumbing.Logging.Log.Verbose(data);
+            public void LogVerbose(string data) => Common.Plumbing.Logging.Log.Verbose(data);
+            public void LogInformation(string data) => Common.Plumbing.Logging.Log.Info(data);
+            public void LogMinimal(string data) => Common.Plumbing.Logging.Log.Verbose(data);
+            public void LogWarning(string data) => Common.Plumbing.Logging.Log.Warn(data);
+            public void LogError(string data) => Common.Plumbing.Logging.Log.Error(data);
+            public void LogInformationSummary(string data) => Common.Plumbing.Logging.Log.Info(data);
+            public void Log(LogLevel level, string data)
+            {
+                switch (level)
+                {
+                    case LogLevel.Debug:
+                        LogDebug(data);
+                        break;
+                    case LogLevel.Verbose:
+                        LogVerbose(data);
+                        break;
+                    case LogLevel.Information:
+                        LogInformation(data);
+                        break;
+                    case LogLevel.Minimal:
+                        LogMinimal(data);
+                        break;
+                    case LogLevel.Warning:
+                        LogWarning(data);
+                        break;
+                    case LogLevel.Error:
+                        LogError(data);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(level), level, null);
+                }
+            }
+
+            public Task LogAsync(LogLevel level, string data)
+            {
+                this.Log(level, data);
+                return Task.CompletedTask;
+            }
+
+            public void Log(ILogMessage message)
+            {
+                this.Log(message.Level, message.Message);
+            }
+
+            public Task LogAsync(ILogMessage message)
+            {
+                this.Log(message);
+                return Task.CompletedTask;
+            }
+
         }
     }
 }

--- a/source/Calamari.Terraform/Calamari.Terraform.csproj
+++ b/source/Calamari.Terraform/Calamari.Terraform.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NuGet.Versioning" Version="5.9.1" />
+    <PackageReference Include="NuGet.Versioning" Version="5.11.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari.CloudAccounts\Calamari.CloudAccounts.csproj" />


### PR DESCRIPTION
`NuGet.Versioning` -> `5.11.6`
`NuGet.Commands` -> `5.11.5`
`System.Security.Cryptography.Cng` -> `5.0.0`

A breaking change to `NuGet.Commands` required some refactoring of one of the downloader classes