### PR TITLE
Deprecate AzureRM - PowerShellContext

### DIFF
--- a/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/KubernetesContextScriptWrapper.cs
@@ -6,6 +6,7 @@ using Calamari.Common.Features.EmbeddedResources;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.Scripts;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -81,6 +82,7 @@ namespace Calamari.Kubernetes
             {
                 variables.Set("OctopusKubernetesTargetScript", $"{script.File}");
                 variables.Set("OctopusKubernetesTargetScriptParameters", script.Parameters);
+                variables.Set("OctopusAzureRmIsDeprecated", FeatureToggle.AzureRMDeprecationFeatureToggle.IsEnabled(variables).ToString());
 
                 using (var contextScriptFile = new TemporaryFile(CreateContextScriptFile(workingDirectory)))
                 {

--- a/source/Calamari/Kubernetes/Scripts/AzurePowershellContext.ps1
+++ b/source/Calamari/Kubernetes/Scripts/AzurePowershellContext.ps1
@@ -153,7 +153,14 @@ function ConnectAzAccount
         }
         elseif (Get-AzureRmModuleInstalled)
         {
-            Initialize-AzureRmContext
+            if($OctopusAzureRmIsDeprecated -like [Boolean]::TrueString) {
+                Write-Error "Azure Resource Manager modules are no longer available for authenticating with Azure, you are required to move to Azure CLI or the Az powershell modules."
+                exit 2
+            }
+            else {
+                Write-Warning "Azure Resource Manager powershell module has reached end-of-life; please authenticate using Azure CLI or the Az module, Octopus will prevent usage of the AzureRM module in 2024.3."
+                Initialize-AzureRmContext
+            }
         }
     }
 }


### PR DESCRIPTION
The AzureRM deprecation flag is required to be included in the AzurePowershellContext.ps1 to show a warning if users
are still using AzureRM module (Rather than Azure CLI).

This feature flag means users are presented with a warning atm - which will become an error at some point in the future.