### PR TITLE
Report applied Kubernetes manifests for the ScriptWrapper-based Octopus Kubernetes steps

### DIFF
--- a/source/Calamari.Common/Features/Scripting/ScriptWrapperPriorities.cs
+++ b/source/Calamari.Common/Features/Scripting/ScriptWrapperPriorities.cs
@@ -10,7 +10,12 @@ namespace Calamari.Common.Features.Scripting
         /// <summary>
         /// The priority for the script wrapper that checks deployed Kubernetes resources status
         /// </summary>
-        public const int KubernetesStatusCheckPriority = 1002;
+        public const int KubernetesStatusCheckPriority = 1003;
+        
+        /// <summary>
+        /// The priority for the script wrapper that reports applied Kubernetes manifests
+        /// </summary>
+        public const int KubernetesManifestReportPriority = 1002;
         
         /// <summary>
         /// The priority for script wrappers that configure kubernetes authentication

--- a/source/Calamari.Tests/Helpers/StubScriptWrapper.cs
+++ b/source/Calamari.Tests/Helpers/StubScriptWrapper.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Features.Scripting;
+using Calamari.Common.Features.Scripts;
+
+namespace Calamari.Tests.Helpers
+{
+    class StubScriptWrapper : IScriptWrapper
+    {
+        bool isEnabled;
+
+        public int Priority { get; } = 1;
+        public IScriptWrapper NextWrapper { get; set; }
+
+        public bool IsEnabled(ScriptSyntax syntax)
+        {
+            return isEnabled;
+        }
+
+        // We manually enable this wrapper when needed,
+        // to avoid this wrapper being auto-registered and called from real programs
+        public StubScriptWrapper Enable()
+        {
+            isEnabled = true;
+            return this;
+        }
+
+        public CommandResult ExecuteScript(
+            Script script,
+            ScriptSyntax scriptSyntax,
+            ICommandLineRunner commandLineRunner,
+            Dictionary<string, string> environmentVars)
+        {
+            return new CommandResult("stub", 0);
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReportScriptWrapperTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReportScriptWrapperTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Features.Scripting;
+using Calamari.Common.Features.Scripts;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes;
+using Calamari.Testing.Helpers;
+using Calamari.Tests.Fixtures.Integration.FileSystem;
+using Calamari.Tests.Helpers;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures
+{
+    [TestFixture]
+    public class ManifestReportScriptWrapperTests
+    {
+        const ScriptSyntax Syntax = ScriptSyntax.Bash;
+        readonly IManifestReporter manifestReporter = Substitute.For<IManifestReporter>();
+        
+        [SetUp]
+        public void Setup()
+        {
+            manifestReporter.ClearReceivedCalls();
+        }
+        
+        [Test]
+        public void NotEnabled_WhenNotDeployingToAKubernetesCluster()
+        {
+            var variables = new CalamariVariables();
+            
+            var wrapper = CreateManifestReportScriptWrapper(variables);
+            
+            wrapper.IsEnabled(Syntax).Should().BeFalse();
+            manifestReporter.DidNotReceive().ReportManifestApplied(Arg.Any<string>());
+        }
+        
+        [TestCase(SpecialVariables.ClusterUrl, "MyClusterUrl")]
+        [TestCase(MachineVariables.DeploymentTargetType, "KubernetesTentacle")]
+        [TestCase(SpecialVariables.AksClusterName, "Aks")]
+        [TestCase(SpecialVariables.EksClusterName, "Eks")]
+        [TestCase(SpecialVariables.GkeClusterName, "Gke")]
+        public void Enabled_WhenDeployingToAKubernetesCluster(string variableName, string variableValue)
+        {
+            var variables = new CalamariVariables();
+            variables.Set(variableName, variableValue);
+
+            var wrapper = CreateManifestReportScriptWrapper(variables);
+
+            wrapper.IsEnabled(Syntax).Should().BeTrue();
+            manifestReporter.DidNotReceive().ReportManifestApplied(Arg.Any<string>());
+        }
+        
+        [Test]
+        public void FindsAndReportsCorrectManifestFiles()
+        {
+            var variables = new CalamariVariables();
+            variables.Set(SpecialVariables.CustomResourceYamlFileName, "custom.yml");
+
+            var fileSystem = new TestCalamariPhysicalFileSystem();
+            var testDirectory = TestEnvironment.GetTestPath("KubernetesFixtures", "ResourceStatus", "assets", "manifests");
+            fileSystem.SetFileBasePath(testDirectory);
+
+            var wrapper = CreateManifestReportScriptWrapper(variables, fileSystem);
+
+            wrapper.ExecuteScript(
+                                  new Script("stub"),
+                                  Syntax,
+                                  new CommandLineRunner(new SilentLog(), variables),
+                                  new Dictionary<string, string>());
+
+            foreach (var expectedManifest in GetExpectedManifests(testDirectory))
+            {
+                manifestReporter.Received().ReportManifestApplied(expectedManifest);
+            }
+        }
+
+        static IEnumerable<string> GetExpectedManifests(string testDirectory) => Directory.GetFiles(testDirectory).Select(File.ReadAllText);
+
+        ManifestReportScriptWrapper CreateManifestReportScriptWrapper(IVariables variables, ICalamariFileSystem fileSystem = null)
+        {
+            fileSystem = fileSystem ?? new TestCalamariPhysicalFileSystem();
+            var manifestRetriever = new ManifestRetriever(variables, fileSystem);
+            
+            return new ManifestReportScriptWrapper(variables, fileSystem, manifestRetriever, manifestReporter)
+            {
+                NextWrapper = new StubScriptWrapper().Enable()
+            };
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/ManifestReportScriptWrapperTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ManifestReportScriptWrapperTests.cs
@@ -37,7 +37,6 @@ namespace Calamari.Tests.KubernetesFixtures
             var wrapper = CreateManifestReportScriptWrapper(variables);
             
             wrapper.IsEnabled(Syntax).Should().BeFalse();
-            manifestReporter.DidNotReceive().ReportManifestApplied(Arg.Any<string>());
         }
         
         [TestCase(SpecialVariables.ClusterUrl, "MyClusterUrl")]
@@ -53,7 +52,6 @@ namespace Calamari.Tests.KubernetesFixtures
             var wrapper = CreateManifestReportScriptWrapper(variables);
 
             wrapper.IsEnabled(Syntax).Should().BeTrue();
-            manifestReporter.DidNotReceive().ReportManifestApplied(Arg.Any<string>());
         }
         
         [Test]
@@ -74,7 +72,9 @@ namespace Calamari.Tests.KubernetesFixtures
                                   new CommandLineRunner(new SilentLog(), variables),
                                   new Dictionary<string, string>());
 
-            foreach (var expectedManifest in GetExpectedManifests(testDirectory))
+            var expectedManifests = GetExpectedManifests(testDirectory).ToArray();
+            expectedManifests.Count().Should().BePositive();
+            foreach (var expectedManifest in expectedManifests)
             {
                 manifestReporter.Received().ReportManifestApplied(expectedManifest);
             }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportScriptWrapperTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportScriptWrapperTests.cs
@@ -96,6 +96,8 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                                                 new ResourceIdentifier(SupportedResourceGroupVersionKinds.DeploymentV1, "deployment", "default"),
                                                 new ResourceIdentifier(SupportedResourceGroupVersionKinds.IngressV1, "ingress", "default"),
                                                 new ResourceIdentifier(SupportedResourceGroupVersionKinds.SecretV1, "secret", "default"),
+                                                new ResourceIdentifier(SupportedResourceGroupVersionKinds.SecretV1, "feed-secret", "default"),
+                                                new ResourceIdentifier(SupportedResourceGroupVersionKinds.ConfigMapV1, "configmap", "default"),
                                                 new ResourceIdentifier(SupportedResourceGroupVersionKinds.ServiceV1, "service", "default"),
                                                 new ResourceIdentifier(new ResourceGroupVersionKind(null, null, "CustomResource"), "custom-resource", "default"));
         }

--- a/source/Calamari/Kubernetes/ManifestReportScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/ManifestReportScriptWrapper.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Features.Scripting;
+using Calamari.Common.Features.Scripts;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Kubernetes
+{
+    public class ManifestReportScriptWrapper : IScriptWrapper
+    {
+        readonly IVariables variables;
+        readonly ICalamariFileSystem fileSystem;
+        readonly IManifestRetriever manifestRetriever;
+        readonly IManifestReporter manifestReporter;
+    
+        public ManifestReportScriptWrapper(
+            IVariables variables, 
+            ICalamariFileSystem fileSystem,
+            IManifestRetriever manifestRetriever,
+            IManifestReporter manifestReporter)
+        {
+            this.variables = variables;
+            this.fileSystem = fileSystem;
+            this.manifestRetriever = manifestRetriever;
+            this.manifestReporter = manifestReporter;
+        }
+        public int Priority => ScriptWrapperPriorities.KubernetesManifestReportPriority;
+        public IScriptWrapper NextWrapper { get; set; }
+        public bool IsEnabled(ScriptSyntax syntax) => variables.IsKubernetesScript();
+    
+        public CommandResult ExecuteScript(Script script, ScriptSyntax scriptSyntax, ICommandLineRunner commandLineRunner, Dictionary<string, string> environmentVars)
+        {
+            var workingDirectory = Path.GetDirectoryName(script.File);
+            var manifests = manifestRetriever.GetManifests(workingDirectory);
+
+            foreach (var manifest in manifests)
+            {
+                manifestReporter.ReportManifestApplied(manifest);
+            }
+            
+            return NextWrapper.ExecuteScript(script, scriptSyntax, commandLineRunner, environmentVars);
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/ManifestRetriever.cs
+++ b/source/Calamari/Kubernetes/ManifestRetriever.cs
@@ -45,7 +45,7 @@ namespace Calamari.Kubernetes
 
             return new[]
             {
-                "secret.yml", customResourceFileName, "deployment.yml", "service.yml", "ingress.yml",
+                "secret.yml", "feedsecrets.yml", customResourceFileName, "deployment.yml", "service.yml", "ingress.yml", "configmap.yml"
             }.Select(p => Path.Combine(workingDirectory, p));
         }
 

--- a/source/Calamari/Kubernetes/ManifestRetriever.cs
+++ b/source/Calamari/Kubernetes/ManifestRetriever.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Kubernetes
+{
+    public interface IManifestRetriever
+    {
+        IEnumerable<string> GetManifests(string workingDirectory);
+    }
+    
+    public class ManifestRetriever : IManifestRetriever
+    {
+        readonly IVariables variables;
+        readonly ICalamariFileSystem fileSystem;
+
+        public ManifestRetriever(IVariables variables, ICalamariFileSystem fileSystem)
+        {
+            this.variables = variables;
+            this.fileSystem = fileSystem;
+        }
+        
+        public IEnumerable<string> GetManifests(string workingDirectory)
+        {
+            var groupedFiles = GetGroupedYamlDirectories(workingDirectory).ToList();
+            if (groupedFiles.Any())
+            {
+                return from file in groupedFiles
+                       where fileSystem.FileExists(file)
+                       select fileSystem.ReadFile(file);
+            }
+
+            return from file in GetManifestFileNames(workingDirectory)
+                   where fileSystem.FileExists(file)
+                   select fileSystem.ReadFile(file);
+        }
+
+        IEnumerable<string> GetManifestFileNames(string workingDirectory)
+        {
+            var customResourceFileName =
+                variables.Get(SpecialVariables.CustomResourceYamlFileName) ?? "customresource.yml";
+
+            return new[]
+            {
+                "secret.yml", customResourceFileName, "deployment.yml", "service.yml", "ingress.yml",
+            }.Select(p => Path.Combine(workingDirectory, p));
+        }
+
+        IEnumerable<string> GetGroupedYamlDirectories(string workingDirectory)
+        {
+            var groupedDirectories = variables.Get(SpecialVariables.GroupedYamlDirectories);
+            return groupedDirectories != null
+                ? groupedDirectories.Split(';').SelectMany(d => fileSystem.EnumerateFilesRecursively(Path.Combine(workingDirectory, d)))
+                : Enumerable.Empty<string>();
+        }
+
+        
+    }
+}

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceFinder.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceFinder.cs
@@ -1,21 +1,24 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.ResourceStatus.Resources;
 
 namespace Calamari.Kubernetes.ResourceStatus
 {
-    public class ResourceFinder
+    public interface IResourceFinder
     {
-        private readonly IVariables variables;
-        private readonly ICalamariFileSystem fileSystem;
+        IEnumerable<ResourceIdentifier> FindResources(string workingDirectory);
+    }
+    
+    public class ResourceFinder : IResourceFinder
+    {
+        readonly IVariables variables;
+        readonly IManifestRetriever manifestRetriever;
 
-        public ResourceFinder(IVariables variables, ICalamariFileSystem fileSystem)
+        public ResourceFinder(IVariables variables, IManifestRetriever manifestRetriever)
         {
             this.variables = variables;
-            this.fileSystem = fileSystem;
+            this.manifestRetriever = manifestRetriever;
         }
 
         public IEnumerable<ResourceIdentifier> FindResources(string workingDirectory)
@@ -27,7 +30,7 @@ namespace Calamari.Kubernetes.ResourceStatus
                 defaultNamespace = "default";
             }
 
-            var manifests = ReadManifestFiles(workingDirectory).ToList();
+            var manifests = manifestRetriever.GetManifests(workingDirectory).ToList();
             var definedResources = KubernetesYaml.GetDefinedResources(manifests, defaultNamespace).ToList();
 
             var secret = GetSecret(defaultNamespace);
@@ -45,41 +48,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             return definedResources;
         }
 
-        private IEnumerable<string> ReadManifestFiles(string workingDirectory)
-        {
-            var groupedFiles = GetGroupedYamlDirectories(workingDirectory).ToList();
-            if (groupedFiles.Any())
-            {
-                return from file in groupedFiles
-                       where fileSystem.FileExists(file)
-                       select fileSystem.ReadFile(file);
-            }
-
-            return from file in GetManifestFileNames(workingDirectory)
-                   where fileSystem.FileExists(file)
-                   select fileSystem.ReadFile(file);
-        }
-
-        private IEnumerable<string> GetManifestFileNames(string workingDirectory)
-        {
-            var customResourceFileName =
-                variables.Get(SpecialVariables.CustomResourceYamlFileName) ?? "customresource.yml";
-
-            return new[]
-            {
-                "secret.yml", customResourceFileName, "deployment.yml", "service.yml", "ingress.yml",
-            }.Select(p => Path.Combine(workingDirectory, p));
-        }
-
-        private IEnumerable<string> GetGroupedYamlDirectories(string workingDirectory)
-        {
-            var groupedDirectories = variables.Get(SpecialVariables.GroupedYamlDirectories);
-            return groupedDirectories != null
-                ? groupedDirectories.Split(';').SelectMany(d => fileSystem.EnumerateFilesRecursively(Path.Combine(workingDirectory, d)))
-                : Enumerable.Empty<string>();
-        }
-
-        private ResourceIdentifier? GetConfigMap(string defaultNamespace)
+        ResourceIdentifier? GetConfigMap(string defaultNamespace)
         {
             if (!variables.GetFlag("Octopus.Action.KubernetesContainers.KubernetesConfigMapEnabled"))
             {
@@ -96,7 +65,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             return string.IsNullOrEmpty(configMapName) ? (ResourceIdentifier?)null : new ResourceIdentifier(SupportedResourceGroupVersionKinds.ConfigMapV1, configMapName, defaultNamespace);
         }
 
-        private ResourceIdentifier? GetSecret(string defaultNamespace)
+        ResourceIdentifier? GetSecret(string defaultNamespace)
         {
             if (!variables.GetFlag("Octopus.Action.KubernetesContainers.KubernetesSecretEnabled"))
             {

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportScriptWrapper.cs
@@ -10,14 +10,14 @@ using Calamari.Kubernetes.Integration;
 
 namespace Calamari.Kubernetes.ResourceStatus
 {
-    public class ResourceStatusReportWrapper : IScriptWrapper
+    public class ResourceStatusReportScriptWrapper : IScriptWrapper
     {
         readonly Kubectl kubectl;
         readonly IVariables variables;
         readonly IResourceFinder resourceFinder;
         readonly IResourceStatusReportExecutor statusReportExecutor;
 
-        public ResourceStatusReportWrapper(
+        public ResourceStatusReportScriptWrapper(
             Kubectl kubectl,
             IVariables variables,
             IResourceFinder resourceFinder,

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportWrapper.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.Scripts;
-using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.Integration;
 
@@ -13,20 +12,20 @@ namespace Calamari.Kubernetes.ResourceStatus
 {
     public class ResourceStatusReportWrapper : IScriptWrapper
     {
-        private readonly Kubectl kubectl;
-        private readonly IVariables variables;
-        private readonly ICalamariFileSystem fileSystem;
-        private readonly IResourceStatusReportExecutor statusReportExecutor;
+        readonly Kubectl kubectl;
+        readonly IVariables variables;
+        readonly IResourceFinder resourceFinder;
+        readonly IResourceStatusReportExecutor statusReportExecutor;
 
         public ResourceStatusReportWrapper(
             Kubectl kubectl,
             IVariables variables,
-            ICalamariFileSystem fileSystem,
+            IResourceFinder resourceFinder,
             IResourceStatusReportExecutor statusReportExecutor)
         {
             this.kubectl = kubectl;
             this.variables = variables;
-            this.fileSystem = fileSystem;
+            this.resourceFinder = resourceFinder;
             this.statusReportExecutor = statusReportExecutor;
         }
 
@@ -65,7 +64,6 @@ namespace Calamari.Kubernetes.ResourceStatus
             var workingDirectory = Path.GetDirectoryName(script.File);
             kubectl.SetWorkingDirectory(workingDirectory);
             kubectl.SetEnvironmentVariables(environmentVars);
-            var resourceFinder = new ResourceFinder(variables, fileSystem);
 
             var result = NextWrapper.ExecuteScript(script, scriptSyntax, commandLineRunner, environmentVars);
             if (result.ExitCode != 0)

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -73,6 +73,8 @@ namespace Calamari
             builder.RegisterType<ResourceStatusCheckTask>().AsSelf();
             builder.RegisterType<ResourceUpdateReporter>().As<IResourceUpdateReporter>().SingleInstance();
             builder.RegisterType<ManifestReporter>().As<IManifestReporter>().SingleInstance();
+            builder.RegisterType<ManifestRetriever>().As<IManifestRetriever>().SingleInstance();
+            builder.RegisterType<ResourceFinder>().As<IResourceFinder>().SingleInstance();
             builder.RegisterType<ResourceStatusReportExecutor>().As<IResourceStatusReportExecutor>();
             builder.RegisterType<GatherAndApplyRawYamlExecutor>().As<IRawYamlKubernetesApplyExecutor>();
             builder.RegisterType<KustomizeExecutor>().As<IKustomizeKubernetesApplyExecutor>();


### PR DESCRIPTION
Adds manifest reporting capability (via service messages) to the Octopus Kubernetes steps that are implemented using the ScriptWrapper. These steps are currently:

- Configure and apply a Kubernetes Ingress
- Configure and apply a Kubernetes Service

The following steps are script wrapper steps by do not yet support manifest reporting as of this PR. The reason is due to the way that secrets and configmaps are currently being created via `kubectl create --from-file` in the script, instead of via a `kubectl apply`. This means that there isn't a yaml manifest available for the script wrapper to report on ahead of the actual execution. 
- Configure and apply a Kubernetes ConfigMap
- Configure and apply a Kubernetes Secret
- Configure and apply Kubernetes resources (Deployment, Ingress, and Service objects get reported but secret and configmap objects do not for the same reason above) 

Config maps and secrets will be handled separately in a future PR, as they require additional Octopus Server changes.

[sc-98555]