### PR TITLE
Authenticate gcloud with generic oidc jwt token

### DIFF
--- a/source/Calamari.GoogleCloudScripting/GoogleCloudContextScriptWrapper.cs
+++ b/source/Calamari.GoogleCloudScripting/GoogleCloudContextScriptWrapper.cs
@@ -95,9 +95,8 @@ namespace Calamari.GoogleCloudScripting
                 var gcloudConfigPath = Path.Combine(workingDirectory, "gcloud-cli");
                 environmentVars.Add("CLOUDSDK_CONFIG", gcloudConfigPath);
                 Directory.CreateDirectory(gcloudConfigPath);
-
-                var isGcloudSet = SetGcloudExecutable();
-                if (!isGcloudSet)
+                
+                if (!TrySetGcloudExecutable())
                 {
                     return errorResult;
                 }
@@ -121,16 +120,14 @@ namespace Calamari.GoogleCloudScripting
 
                     if (!string.IsNullOrWhiteSpace(jsonKey))
                     {
-                        var isServiceAccountAuthValid = AuthenticateWithServiceAccount(jsonKey);
-                        if (!isServiceAccountAuthValid)
+                        if (!TryAuthenticateWithServiceAccount(jsonKey))
                         {
                             return errorResult;
                         }
                     }
                     else if (!string.IsNullOrWhiteSpace(jwtToken))
                     {
-                        var isOidcAuthValid = AuthenticateWithOidc(accountVariable, jwtToken, impersonationEmails);
-                        if (!isOidcAuthValid)
+                        if (!TryAuthenticateWithOidc(accountVariable, jwtToken, impersonationEmails))
                         {
                             return errorResult;
                         }
@@ -205,7 +202,7 @@ namespace Calamari.GoogleCloudScripting
                 return result;
             }
 
-            bool SetGcloudExecutable()
+            bool TrySetGcloudExecutable()
             {
                 gcloud = variables.Get("Octopus.Action.GoogleCloud.CustomExecutable");
                 if (!string.IsNullOrEmpty(gcloud))
@@ -253,7 +250,7 @@ namespace Calamari.GoogleCloudScripting
                 }
             }
 
-            bool AuthenticateWithServiceAccount(string jsonKey)
+            bool TryAuthenticateWithServiceAccount(string jsonKey)
             {
                 log.Verbose("Authenticating to gcloud with key file");
                 var bytes = Convert.FromBase64String(jsonKey);
@@ -272,7 +269,7 @@ namespace Calamari.GoogleCloudScripting
                 return true;
             }
 
-            bool AuthenticateWithOidc(string accountVariable, string jwtToken, string? impersonationEmails)
+            bool TryAuthenticateWithOidc(string accountVariable, string jwtToken, string? impersonationEmails)
             {
                 log.Verbose("Authenticating to gcloud with JWT token.");
                 var serverUri = variables.Get("Octopus.Web.ServerUri");

--- a/source/Calamari.GoogleCloudScripting/GoogleCloudContextScriptWrapper.cs
+++ b/source/Calamari.GoogleCloudScripting/GoogleCloudContextScriptWrapper.cs
@@ -292,10 +292,15 @@ namespace Calamari.GoogleCloudScripting
 
                 File.WriteAllText(jwtFilePath, jwtToken);
 
+                if (audience.Contains("iam.googleapis.com/"))
+                {
+                    audience = audience.Substring(audience.IndexOf("iam.googleapis.com/", StringComparison.Ordinal) + "iam.googleapis.com/".Length);
+                }
+
                 var createConfigResult = ExecuteCommand("iam",
                                                         "workload-identity-pools",
                                                         "create-cred-config",
-                                                        audience.Substring(audience.IndexOf("iam.googleapis.com/", StringComparison.Ordinal) + "iam.googleapis.com/".Length),
+                                                        audience,
                                                         $"--service-account={impersonationEmails}",
                                                         "--service-account-token-lifetime-seconds=3600",
                                                         "--subject-token-type=urn:ietf:params:oauth:token-type:jwt",


### PR DESCRIPTION
When running a gcloud script with an generic oidc account, authenticate using the account's generated jwt token.
[#project-generic-oidc](https://octopusdeploy.slack.com/archives/C081K9EPXT9)

[sc-98276]

generic account:

![image](https://github.com/user-attachments/assets/630392fb-5412-4c80-aed9-a844732bf0d0)

gcloud script:

`GCP is a project variable set to the generic account`

![image](https://github.com/user-attachments/assets/cd8cdbde-76b1-4a8d-a05f-efcdecb9789c)
![image](https://github.com/user-attachments/assets/e6cbaa37-8280-479a-a49e-3e9b9eceec0a)

script run:

![image](https://github.com/user-attachments/assets/928e76b6-e194-4086-b8bd-9d9749146718)



