### PR TITLE
Update KOS to watch for new secret and configmap manifest files

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportWrapperTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceStatusReportWrapperTests.cs
@@ -126,6 +126,8 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                  new ResourceIdentifier(SupportedResourceGroupVersionKinds.DeploymentV1, "deployment", "default"),
                  new ResourceIdentifier(SupportedResourceGroupVersionKinds.IngressV1, "ingress", "default"),
                  new ResourceIdentifier(SupportedResourceGroupVersionKinds.SecretV1, "secret", "default"),
+                 new ResourceIdentifier(SupportedResourceGroupVersionKinds.SecretV1, "feed-secret", "default"),
+                 new ResourceIdentifier(SupportedResourceGroupVersionKinds.ConfigMapV1, "configmap", "default"),
                  new ResourceIdentifier(SupportedResourceGroupVersionKinds.ServiceV1, "service", "default"),
                  new ResourceIdentifier(new ResourceGroupVersionKind(null, null, "CustomResource"), "custom-resource", "default"));
          }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/manifests/configmap.yml
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/manifests/configmap.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/manifests/feedsecrets.yml
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/manifests/feedsecrets.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: feed-secret

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/manifests/unknown.yml
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/manifests/unknown.yml
@@ -1,0 +1,4 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: should-be-ignored

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceFinder.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceFinder.cs
@@ -67,7 +67,8 @@ namespace Calamari.Kubernetes.ResourceStatus
 
             return new[]
             {
-                "secret.yml", "feedsecrets.yml", customResourceFileName, "deployment.yml", "service.yml", "ingress.yml", "configmap.yml"            }.Select(p => Path.Combine(workingDirectory, p));
+                "secret.yml", "feedsecrets.yml", customResourceFileName, "deployment.yml", "service.yml", "ingress.yml", "configmap.yml"
+            }.Select(p => Path.Combine(workingDirectory, p));
         }
 
         private IEnumerable<string> GetGroupedYamlDirectories(string workingDirectory)

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceFinder.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceFinder.cs
@@ -67,8 +67,7 @@ namespace Calamari.Kubernetes.ResourceStatus
 
             return new[]
             {
-                "secret.yml", customResourceFileName, "deployment.yml", "service.yml", "ingress.yml",
-            }.Select(p => Path.Combine(workingDirectory, p));
+                "secret.yml", "feedsecrets.yml", customResourceFileName, "deployment.yml", "service.yml", "ingress.yml", "configmap.yml"            }.Select(p => Path.Combine(workingDirectory, p));
         }
 
         private IEnumerable<string> GetGroupedYamlDirectories(string workingDirectory)


### PR DESCRIPTION
This change is needed for https://github.com/OctopusDeploy/OctopusDeploy/pull/29574 to ensure KOS continues to work.

It supports the changes to convert the Deploy Secret & Config map actions to use `kubectl apply -f` instead of `kubectl create --from-file`.

[sc-98555]