### PR TITLE
Do not attempt to retrieve the applied Helm manifest when ResourceStatusCheck is disabled

### DIFF
--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
@@ -41,7 +41,9 @@ namespace Calamari.Kubernetes.Conventions.Helm
         {
             await Task.Run(async () =>
                            {
-                               if (deployment.Variables.GetFlag(SpecialVariables.ResourceStatusCheck)
+                               var resourceStatusCheckIsEnabled = deployment.Variables.GetFlag(SpecialVariables.ResourceStatusCheck);
+                               
+                               if (resourceStatusCheckIsEnabled
                                    || FeatureToggle.KubernetesLiveObjectStatusFeatureToggle.IsEnabled(deployment.Variables)
                                    || OctopusFeatureToggles.KubernetesObjectManifestInspectionFeatureToggle.IsEnabled(deployment.Variables))
                                {
@@ -51,7 +53,7 @@ namespace Calamari.Kubernetes.Conventions.Helm
                                    manifestReporter.ReportManifestApplied(manifest);
 
                                    //if resource status (KOS) is enabled, parse the manifest and start monitoring the resources
-                                   if (deployment.Variables.GetFlag(SpecialVariables.ResourceStatusCheck))
+                                   if (resourceStatusCheckIsEnabled)
                                    {
                                        await ParseManifestAndMonitorResourceStatuses(deployment, manifest, cancellationToken);
                                    }


### PR DESCRIPTION
Part of https://github.com/OctopusDeploy/Issues/issues/9160

The Helm upgrade command should not try to retrieve the applied manifest when the ResourceStatusCheck flag is not set (assuming none of the Manifest Inspection and Live Object Status feature toggles are enabled either).

This PR additionally includes more verbose logging around the Helm release name and revision number that Calamari tries to retrieve, to help with debugging cases where the `PollForManifest` method times out and fails.

[sc-99264]