### PR TITLE
Update AES Encryption to 256bits for script + step package bootstrappers

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -20,7 +20,7 @@ namespace Calamari.Common.Features.Scripting.Bash
 
         static readonly string BootstrapScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
+        static readonly AesEncryption VariableEncryptor = AesEncryption.ForScripts(SensitiveVariablePassword);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static BashScriptBootstrapper()
@@ -30,7 +30,7 @@ namespace Calamari.Common.Features.Scripting.Bash
 
         public static string FormatCommandArguments(string bootstrapFile)
         {
-            var encryptionKey = ToHex(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
+            var encryptionKey = ToHex(VariableEncryptor.EncryptionKey);
             var commandArguments = new StringBuilder();
             commandArguments.AppendFormat("\"{0}\" \"{1}\"", bootstrapFile, encryptionKey);
             return commandArguments.ToString();

--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -20,7 +20,7 @@ namespace Calamari.Common.Features.Scripting.Bash
 
         static readonly string BootstrapScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword);
+        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static BashScriptBootstrapper()
@@ -30,7 +30,7 @@ namespace Calamari.Common.Features.Scripting.Bash
 
         public static string FormatCommandArguments(string bootstrapFile)
         {
-            var encryptionKey = ToHex(AesEncryption.GetEncryptionKey(SensitiveVariablePassword));
+            var encryptionKey = ToHex(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
             var commandArguments = new StringBuilder();
             commandArguments.AppendFormat("\"{0}\" \"{1}\"", bootstrapFile, encryptionKey);
             return commandArguments.ToString();

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -46,7 +46,7 @@ __mask_sensitive_value $sensitiveVariableKey
 # -----------------------------------------------------------------------------
 function decrypt_variable
 {
-	echo $1 | openssl enc -a -A -d -aes-128-cbc -nosalt -K $sensitiveVariableKey -iv $2
+	echo $1 | openssl enc -a -A -d -aes-256-cbc -nosalt -K $sensitiveVariableKey -iv $2
 }
 
 #	---------------------------------------------------------------------------

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/Bootstrap.csx
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/Bootstrap.csx
@@ -103,7 +103,7 @@ public class OctopusParametersDictionary : System.Collections.Generic.Dictionary
         {
             algorithm.Mode = CipherMode.CBC;
             algorithm.Padding = PaddingMode.PKCS7;
-            algorithm.KeySize = 128;
+            algorithm.KeySize = 256;
             algorithm.BlockSize = 128;
             algorithm.Key = Key;
             algorithm.IV = Convert.FromBase64String(iv);

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/ClassBootstrap.csx
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/ClassBootstrap.csx
@@ -108,7 +108,7 @@ public static class Octopus
             {
                 algorithm.Mode = CipherMode.CBC;
                 algorithm.Padding = PaddingMode.PKCS7;
-                algorithm.KeySize = 128;
+                algorithm.KeySize = 256;
                 algorithm.BlockSize = 128;
                 algorithm.Key = Key;
                 algorithm.IV = Convert.FromBase64String(iv);

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
@@ -22,7 +22,7 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
         static readonly string BootstrapScriptTemplate;
         static readonly string ClassBasedBootstrapScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
+        static readonly AesEncryption VariableEncryptor = AesEncryption.ForScripts(SensitiveVariablePassword);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
         static readonly Regex ScriptParameterArgumentsRegex = new Regex(@"^(?<scriptCommandArgs>.*)\s*--\s(?<scriptArgs>.*)$", RegexOptions.Compiled);
         static DotnetScriptBootstrapper()
@@ -101,7 +101,7 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
         public static string FormatCommandArguments(string bootstrapFile, string? scriptParameters)
         {
             var (scriptCommandArguments, scriptArguments) = RetrieveParameterValues(scriptParameters);
-            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
+            var encryptionKey = Convert.ToBase64String(VariableEncryptor.EncryptionKey);
             var commandArguments = new StringBuilder();
             commandArguments.Append("-s https://api.nuget.org/v3/index.json ");
             if (!string.IsNullOrWhiteSpace(scriptCommandArguments)) commandArguments.Append($"{scriptCommandArguments} ");

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
@@ -22,7 +22,7 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
         static readonly string BootstrapScriptTemplate;
         static readonly string ClassBasedBootstrapScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword);
+        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
         static readonly Regex ScriptParameterArgumentsRegex = new Regex(@"^(?<scriptCommandArgs>.*)\s*--\s(?<scriptArgs>.*)$", RegexOptions.Compiled);
         static DotnetScriptBootstrapper()
@@ -101,7 +101,7 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
         public static string FormatCommandArguments(string bootstrapFile, string? scriptParameters)
         {
             var (scriptCommandArguments, scriptArguments) = RetrieveParameterValues(scriptParameters);
-            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword));
+            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
             var commandArguments = new StringBuilder();
             commandArguments.Append("-s https://api.nuget.org/v3/index.json ");
             if (!string.IsNullOrWhiteSpace(scriptCommandArguments)) commandArguments.Append($"{scriptCommandArguments} ");

--- a/source/Calamari.Common/Features/Scripting/FSharp/Bootstrap.fsx
+++ b/source/Calamari.Common/Features/Scripting/FSharp/Bootstrap.fsx
@@ -33,7 +33,7 @@ let private getCustomCredentials proxyUserName =
 
 let private decryptString encrypted iv =
     let key =  fsi.CommandLineArgs.[fsi.CommandLineArgs.Length - 1]
-    use algorithm = new AesCryptoServiceProvider(Mode = CipherMode.CBC, Padding = PaddingMode.PKCS7, KeySize = 128, BlockSize = 128, Key = Convert.FromBase64String(key), IV =  Convert.FromBase64String(iv))
+    use algorithm = new AesCryptoServiceProvider(Mode = CipherMode.CBC, Padding = PaddingMode.PKCS7, KeySize = 256, BlockSize = 128, Key = Convert.FromBase64String(key), IV =  Convert.FromBase64String(iv))
     use decryptor = algorithm.CreateDecryptor()
     use memoryStream = new MemoryStream(Convert.FromBase64String(encrypted))
     use cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read)

--- a/source/Calamari.Common/Features/Scripting/FSharp/FSharpBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/FSharp/FSharpBootstrapper.cs
@@ -17,7 +17,7 @@ namespace Calamari.Common.Features.Scripting.FSharp
     {
         static readonly string BootstrapScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
+        static readonly AesEncryption VariableEncryptor = AesEncryption.ForScripts(SensitiveVariablePassword);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static FSharpBootstrapper()
@@ -42,7 +42,7 @@ namespace Calamari.Common.Features.Scripting.FSharp
 
         public static string FormatCommandArguments(string bootstrapFile, string? scriptParameters)
         {
-            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
+            var encryptionKey = Convert.ToBase64String(VariableEncryptor.EncryptionKey);
             var commandArguments = new StringBuilder();
             commandArguments.AppendFormat("\"{0}\" {1} \"{2}\"", bootstrapFile, scriptParameters, encryptionKey);
             return commandArguments.ToString();

--- a/source/Calamari.Common/Features/Scripting/FSharp/FSharpBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/FSharp/FSharpBootstrapper.cs
@@ -17,7 +17,7 @@ namespace Calamari.Common.Features.Scripting.FSharp
     {
         static readonly string BootstrapScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword);
+        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static FSharpBootstrapper()
@@ -42,7 +42,7 @@ namespace Calamari.Common.Features.Scripting.FSharp
 
         public static string FormatCommandArguments(string bootstrapFile, string? scriptParameters)
         {
-            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword));
+            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
             var commandArguments = new StringBuilder();
             commandArguments.AppendFormat("\"{0}\" {1} \"{2}\"", bootstrapFile, scriptParameters, encryptionKey);
             return commandArguments.ToString();

--- a/source/Calamari.Common/Features/Scripting/Python/PythonBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Python/PythonBootstrapper.cs
@@ -20,7 +20,7 @@ namespace Calamari.Common.Features.Scripting.Python
         static readonly string ConfigurationScriptTemplate;
         static readonly string InstallDependenciesScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
+        static readonly AesEncryption VariableEncryptor = AesEncryption.ForScripts(SensitiveVariablePassword);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static PythonBootstrapper()
@@ -31,7 +31,7 @@ namespace Calamari.Common.Features.Scripting.Python
 
         public static string FormatCommandArguments(string bootstrapFile, string? scriptParameters)
         {
-            var encryptionKey = ToHex(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
+            var encryptionKey = ToHex(VariableEncryptor.EncryptionKey);
             var commandArguments = new StringBuilder();
             commandArguments.Append($"\"-u\" \"{bootstrapFile}\" {scriptParameters} \"{encryptionKey}\"");
             return commandArguments.ToString();

--- a/source/Calamari.Common/Features/Scripting/Python/PythonBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Python/PythonBootstrapper.cs
@@ -20,7 +20,7 @@ namespace Calamari.Common.Features.Scripting.Python
         static readonly string ConfigurationScriptTemplate;
         static readonly string InstallDependenciesScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword);
+        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static PythonBootstrapper()
@@ -31,7 +31,7 @@ namespace Calamari.Common.Features.Scripting.Python
 
         public static string FormatCommandArguments(string bootstrapFile, string? scriptParameters)
         {
-            var encryptionKey = ToHex(AesEncryption.GetEncryptionKey(SensitiveVariablePassword));
+            var encryptionKey = ToHex(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
             var commandArguments = new StringBuilder();
             commandArguments.Append($"\"-u\" \"{bootstrapFile}\" {scriptParameters} \"{encryptionKey}\"");
             return commandArguments.ToString();

--- a/source/Calamari.Common/Features/Scripting/ScriptCS/Bootstrap.csx
+++ b/source/Calamari.Common/Features/Scripting/ScriptCS/Bootstrap.csx
@@ -106,7 +106,7 @@ public static class Octopus
             {
                 Mode = CipherMode.CBC,
                 Padding = PaddingMode.PKCS7,
-                KeySize = 128,
+                KeySize = 256,
                 BlockSize = 128
             })
             {

--- a/source/Calamari.Common/Features/Scripting/ScriptCS/ScriptCSBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/ScriptCS/ScriptCSBootstrapper.cs
@@ -18,7 +18,7 @@ namespace Calamari.Common.Features.Scripting.ScriptCS
     {
         static readonly string BootstrapScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
+        static readonly AesEncryption VariableEncryptor = AesEncryption.ForScripts(SensitiveVariablePassword);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static ScriptCSBootstrapper()
@@ -44,7 +44,7 @@ namespace Calamari.Common.Features.Scripting.ScriptCS
         public static string FormatCommandArguments(string bootstrapFile, string? scriptParameters)
         {
             scriptParameters = RetrieveParameterValues(scriptParameters);
-            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
+            var encryptionKey = Convert.ToBase64String(VariableEncryptor.EncryptionKey);
             var commandArguments = new StringBuilder();
             commandArguments.AppendFormat("-script \"{0}\" -- {1} \"{2}\"", bootstrapFile, scriptParameters, encryptionKey);
             return commandArguments.ToString();

--- a/source/Calamari.Common/Features/Scripting/ScriptCS/ScriptCSBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/ScriptCS/ScriptCSBootstrapper.cs
@@ -18,7 +18,7 @@ namespace Calamari.Common.Features.Scripting.ScriptCS
     {
         static readonly string BootstrapScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword);
+        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static ScriptCSBootstrapper()
@@ -44,7 +44,7 @@ namespace Calamari.Common.Features.Scripting.ScriptCS
         public static string FormatCommandArguments(string bootstrapFile, string? scriptParameters)
         {
             scriptParameters = RetrieveParameterValues(scriptParameters);
-            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword));
+            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
             var commandArguments = new StringBuilder();
             commandArguments.AppendFormat("-script \"{0}\" -- {1} \"{2}\"", bootstrapFile, scriptParameters, encryptionKey);
             return commandArguments.ToString();

--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -373,7 +373,7 @@ function Decrypt-Variables($iv, $Encrypted)
 
 	$algorithm.Mode = [System.Security.Cryptography.CipherMode]::CBC
 	$algorithm.Padding = [System.Security.Cryptography.PaddingMode]::PKCS7
-	$algorithm.KeySize = 128
+	$algorithm.KeySize = 256
 	$algorithm.BlockSize = 128 # AES is just Rijndael with a fixed block size
 	$algorithm.Key = [System.Convert]::FromBase64String($OctopusKey)
 	$algorithm.IV =[System.Convert]::FromBase64String($iv)

--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -162,7 +162,7 @@ namespace Calamari.Common.Features.Scripting.WindowsPowerShell
         static readonly string BootstrapScriptTemplate;
         static readonly string DebugBootstrapScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword);
+        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static PowerShellBootstrapper()
@@ -177,7 +177,7 @@ namespace Calamari.Common.Features.Scripting.WindowsPowerShell
 
         public string FormatCommandArguments(string bootstrapFile, string debuggingBootstrapFile, IVariables variables)
         {
-            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword));
+            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
             var commandArguments = new StringBuilder();
             var executeWithoutProfile = variables[PowerShellVariables.ExecuteWithoutProfile];
             var traceCommand = GetPsDebugCommand(variables);

--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -162,7 +162,7 @@ namespace Calamari.Common.Features.Scripting.WindowsPowerShell
         static readonly string BootstrapScriptTemplate;
         static readonly string DebugBootstrapScriptTemplate;
         static readonly string SensitiveVariablePassword = AesEncryption.RandomString(16);
-        static readonly AesEncryption VariableEncryptor = new AesEncryption(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize);
+        static readonly AesEncryption VariableEncryptor = AesEncryption.ForScripts(SensitiveVariablePassword);
         static readonly ICalamariFileSystem CalamariFileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
         static PowerShellBootstrapper()
@@ -177,7 +177,7 @@ namespace Calamari.Common.Features.Scripting.WindowsPowerShell
 
         public string FormatCommandArguments(string bootstrapFile, string debuggingBootstrapFile, IVariables variables)
         {
-            var encryptionKey = Convert.ToBase64String(AesEncryption.GetEncryptionKey(SensitiveVariablePassword, AesEncryption.ScriptBootstrapKeySize));
+            var encryptionKey = Convert.ToBase64String(VariableEncryptor.EncryptionKey);
             var commandArguments = new StringBuilder();
             var executeWithoutProfile = variables[PowerShellVariables.ExecuteWithoutProfile];
             var traceCommand = GetPsDebugCommand(variables);

--- a/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
@@ -8,6 +8,12 @@ namespace Calamari.Common.Plumbing.Extensions
 {
     public class AesEncryption
     {
+        const int KeySizeBits = 256;
+        const int KeySizeBytes = KeySizeBits / 8;
+
+        const int BlockSizeBits = 128;
+        const int BlockSizeBytes = KeySizeBits / 8;
+
         const int PasswordSaltIterations = 1000;
         public const string SaltRaw = "Octopuss";
         static readonly byte[] PasswordPaddingSalt = Encoding.UTF8.GetBytes(SaltRaw);
@@ -67,18 +73,19 @@ namespace Calamari.Common.Plumbing.Extensions
             {
                 Mode = CipherMode.CBC,
                 Padding = PaddingMode.PKCS7,
-                KeySize = 256,
-                BlockSize = 128,
+                KeySize = KeySizeBits,
+                BlockSize = BlockSizeBits,
                 Key = key
             };
             if (iv != null)
                 provider.IV = iv;
+            
             return provider;
         }
 
         public static byte[] ExtractIV(byte[] encrypted, out byte[] iv)
         {
-            var ivLength = 16;
+            var ivLength = BlockSizeBytes;
             iv = new byte[ivLength];
             Buffer.BlockCopy(encrypted,
                 IvPrefix.Length,
@@ -100,7 +107,7 @@ namespace Calamari.Common.Plumbing.Extensions
         public static byte[] GetEncryptionKey(string encryptionPassword)
         {
             var passwordGenerator = new Rfc2898DeriveBytes(encryptionPassword, PasswordPaddingSalt, PasswordSaltIterations);
-            return passwordGenerator.GetBytes(16);
+            return passwordGenerator.GetBytes(KeySizeBytes);
         }
 
         public static string RandomString(int length)

--- a/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
@@ -12,7 +12,7 @@ namespace Calamari.Common.Plumbing.Extensions
         const int KeySizeBytes = KeySizeBits / 8;
 
         const int BlockSizeBits = 128;
-        const int BlockSizeBytes = KeySizeBits / 8;
+        const int BlockSizeBytes = BlockSizeBits / 8;
 
         const int PasswordSaltIterations = 1000;
         public const string SaltRaw = "Octopuss";

--- a/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
@@ -15,9 +15,9 @@ namespace Calamari.Common.Plumbing.Extensions
         //Key size used to decrypt the variables file sent by Octopus Server
         public static readonly int VariablesFileKeySize = 128;
         
-        //Key size used to encrypt variables for step packages (step-api bootstrapper)
+        //Key size used to encrypt variables for step packages (`step-bootstrapper` package referenced by Server)
         //The variables are decrypted in the step package bootstrapper
-        public static readonly int StepPackageBootstrapKeySize = 128;
+        public static readonly int StepPackageBootstrapKeySize = 256;
         
         readonly int keySizeBits;
 

--- a/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
@@ -67,7 +67,7 @@ namespace Calamari.Common.Plumbing.Extensions
             {
                 Mode = CipherMode.CBC,
                 Padding = PaddingMode.PKCS7,
-                KeySize = 128,
+                KeySize = 256,
                 BlockSize = 128,
                 Key = key
             };

--- a/source/Calamari.Common/Plumbing/Variables/VariablesFactory.cs
+++ b/source/Calamari.Common/Plumbing/Variables/VariablesFactory.cs
@@ -132,7 +132,7 @@ namespace Calamari.Common.Plumbing.Variables
         {
             try
             {
-                return new AesEncryption(encryptionPassword, AesEncryption.VariablesFileKeySize).Decrypt(encryptedVariables);
+                return AesEncryption.ForServerVariables(encryptionPassword).Decrypt(encryptedVariables);
             }
             catch (CryptographicException)
             {

--- a/source/Calamari.Common/Plumbing/Variables/VariablesFactory.cs
+++ b/source/Calamari.Common/Plumbing/Variables/VariablesFactory.cs
@@ -132,7 +132,7 @@ namespace Calamari.Common.Plumbing.Variables
         {
             try
             {
-                return new AesEncryption(encryptionPassword).Decrypt(encryptedVariables);
+                return new AesEncryption(encryptionPassword, AesEncryption.VariablesFileKeySize).Decrypt(encryptedVariables);
             }
             catch (CryptographicException)
             {

--- a/source/Calamari.Tests/Fixtures/Util/ScriptVariableEncryptorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/ScriptVariableEncryptorFixture.cs
@@ -7,13 +7,14 @@ namespace Calamari.Tests.Fixtures.Util
     [TestFixture]
     class ScriptVariableEncryptorFixture
     {
-        [Test]
-        public void EncryptionIsSymmetrical()
+        [TestCase(128)]
+        [TestCase(256)]
+        public void EncryptionIsSymmetrical(int keySize)
         {
             var passphrase = "PurpleMonkeyDishwasher";
             var text = "Put It In H!";
 
-            var encryptor = new AesEncryption(passphrase);
+            var encryptor = new AesEncryption(passphrase, keySize);
             Assert.AreEqual(text, encryptor.Decrypt(encryptor.Encrypt(text)));
         }
     }

--- a/source/Calamari.Tests/Fixtures/Util/ScriptVariableEncryptorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/ScriptVariableEncryptorFixture.cs
@@ -7,14 +7,13 @@ namespace Calamari.Tests.Fixtures.Util
     [TestFixture]
     class ScriptVariableEncryptorFixture
     {
-        [TestCase(128)]
-        [TestCase(256)]
-        public void EncryptionIsSymmetrical(int keySize)
+        [Test]
+        public void EncryptionIsSymmetrical()
         {
             var passphrase = "PurpleMonkeyDishwasher";
             var text = "Put It In H!";
 
-            var encryptor = new AesEncryption(passphrase, keySize);
+            var encryptor = AesEncryption.ForScripts(passphrase);
             Assert.AreEqual(text, encryptor.Decrypt(encryptor.Encrypt(text)));
         }
     }

--- a/source/Calamari.Tests/Fixtures/Variables/VariableFactoryFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Variables/VariableFactoryFixture.cs
@@ -119,13 +119,13 @@ namespace Calamari.Tests.Fixtures.Variables
             {
                 {"firstSensitiveVariableName", "firstSensitiveVariableValue"}
             };
-            File.WriteAllBytes(firstSensitiveVariablesFileName, new AesEncryption(encryptionPassword, AesEncryption.VariablesFileKeySize).Encrypt(JsonConvert.SerializeObject(firstSensitiveVariablesSet)));
+            File.WriteAllBytes(firstSensitiveVariablesFileName, AesEncryption.ForServerVariables(encryptionPassword).Encrypt(JsonConvert.SerializeObject(firstSensitiveVariablesSet)));
 
             var secondSensitiveVariablesSet = new Dictionary<string, string>
             {
                 {"secondSensitiveVariableName", "secondSensitiveVariableValue"}
             };
-            File.WriteAllBytes(secondSensitiveVariablesFileName, new AesEncryption(encryptionPassword, AesEncryption.VariablesFileKeySize).Encrypt(JsonConvert.SerializeObject(secondSensitiveVariablesSet)));
+            File.WriteAllBytes(secondSensitiveVariablesFileName, AesEncryption.ForServerVariables(encryptionPassword).Encrypt(JsonConvert.SerializeObject(secondSensitiveVariablesSet)));
         }
 
         [Test]

--- a/source/Calamari.Tests/Fixtures/Variables/VariableFactoryFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Variables/VariableFactoryFixture.cs
@@ -119,13 +119,13 @@ namespace Calamari.Tests.Fixtures.Variables
             {
                 {"firstSensitiveVariableName", "firstSensitiveVariableValue"}
             };
-            File.WriteAllBytes(firstSensitiveVariablesFileName, new AesEncryption(encryptionPassword).Encrypt(JsonConvert.SerializeObject(firstSensitiveVariablesSet)));
+            File.WriteAllBytes(firstSensitiveVariablesFileName, new AesEncryption(encryptionPassword, AesEncryption.VariablesFileKeySize).Encrypt(JsonConvert.SerializeObject(firstSensitiveVariablesSet)));
 
             var secondSensitiveVariablesSet = new Dictionary<string, string>
             {
                 {"secondSensitiveVariableName", "secondSensitiveVariableValue"}
             };
-            File.WriteAllBytes(secondSensitiveVariablesFileName, new AesEncryption(encryptionPassword).Encrypt(JsonConvert.SerializeObject(secondSensitiveVariablesSet)));
+            File.WriteAllBytes(secondSensitiveVariablesFileName, new AesEncryption(encryptionPassword, AesEncryption.VariablesFileKeySize).Encrypt(JsonConvert.SerializeObject(secondSensitiveVariablesSet)));
         }
 
         [Test]

--- a/source/Calamari.Tests/VariableDictionaryExtensions.cs
+++ b/source/Calamari.Tests/VariableDictionaryExtensions.cs
@@ -9,7 +9,7 @@ namespace Calamari.Tests
     {
         public static void SaveEncrypted(this VariableDictionary variables, string key, string file)
         {
-            var encryptedContent = new AesEncryption(key).Encrypt(variables.SaveAsString());
+            var encryptedContent = new AesEncryption(key, AesEncryption.VariablesFileKeySize).Encrypt(variables.SaveAsString());
             File.WriteAllBytes(file, encryptedContent);
         }
     }

--- a/source/Calamari.Tests/VariableDictionaryExtensions.cs
+++ b/source/Calamari.Tests/VariableDictionaryExtensions.cs
@@ -9,7 +9,7 @@ namespace Calamari.Tests
     {
         public static void SaveEncrypted(this VariableDictionary variables, string key, string file)
         {
-            var encryptedContent = new AesEncryption(key, AesEncryption.VariablesFileKeySize).Encrypt(variables.SaveAsString());
+            var encryptedContent = AesEncryption.ForServerVariables(key).Encrypt(variables.SaveAsString());
             File.WriteAllBytes(file, encryptedContent);
         }
     }

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -40,7 +40,7 @@ namespace Calamari.LaunchTools
                 var jsonInputs = variables.GetRaw(instructions.InputsVariable) ?? string.Empty;
                 variables.Set(instructions.InputsVariable, InputSubstitution.SubstituteAndEscapeAllVariablesInJson(jsonInputs, variables, log));
                 var variablesAsJson = variables.CloneAndEvaluate().SaveAsString();
-                File.WriteAllBytes(variableFile.FilePath, new AesEncryption(options.InputVariables.SensitiveVariablesPassword, AesEncryption.StepPackageBootstrapKeySize).Encrypt(variablesAsJson));
+                File.WriteAllBytes(variableFile.FilePath, AesEncryption.ForStepPackages(options.InputVariables.SensitiveVariablesPassword).Encrypt(variablesAsJson));
                 var pathToNode = variables.Get(instructions.NodePathVariable);
                 var nodeExecutablePath = BuildNodePath(pathToNode);
                 var parameters = BuildParams(instructions, variableFile.FilePath);

--- a/source/Calamari/LaunchTools/NodeExecutor.cs
+++ b/source/Calamari/LaunchTools/NodeExecutor.cs
@@ -40,7 +40,7 @@ namespace Calamari.LaunchTools
                 var jsonInputs = variables.GetRaw(instructions.InputsVariable) ?? string.Empty;
                 variables.Set(instructions.InputsVariable, InputSubstitution.SubstituteAndEscapeAllVariablesInJson(jsonInputs, variables, log));
                 var variablesAsJson = variables.CloneAndEvaluate().SaveAsString();
-                File.WriteAllBytes(variableFile.FilePath, new AesEncryption(options.InputVariables.SensitiveVariablesPassword).Encrypt(variablesAsJson));
+                File.WriteAllBytes(variableFile.FilePath, new AesEncryption(options.InputVariables.SensitiveVariablesPassword, AesEncryption.StepPackageBootstrapKeySize).Encrypt(variablesAsJson));
                 var pathToNode = variables.Get(instructions.NodePathVariable);
                 var nodeExecutablePath = BuildNodePath(pathToNode);
                 var parameters = BuildParams(instructions, variableFile.FilePath);


### PR DESCRIPTION
[sc-98850]

Depends on https://github.com/OctopusDeploy/step-api/pull/569

Relates to: https://github.com/OctopusDeploy/Issues/issues/9183

This PR updates the variable encryption from 128 to 256bits for:
- script bootstrapping (encryption in c#, decryption in the bootstrap scripts)
- step packages (encryption in c#, decryption in [step-api](https://github.com/OctopusDeploy/step-api/pull/569))
