### PR TITLE
Enable dotnetcore for framework

### DIFF
--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
@@ -84,9 +84,6 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
 
         public static string FindBundledExecutable()
         {
-            if (ScriptingEnvironment.IsNetFramework())
-                throw new CommandException("dotnet-script requires .NET Core 6 or later");
-
             var exeName = $"dotnet-script.{(CalamariEnvironment.IsRunningOnWindows ? "cmd" : "dll")}";
             var myPath = typeof(DotnetScriptExecutor).Assembly.Location;
             var parent = Path.GetDirectoryName(myPath);

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -106,7 +106,7 @@
     <ItemGroup>
       <FSharpFiles Include="$(FSharpCompilerTools)" />
       <ScriptCSFiles Include="$(ScriptCS)" />
-      <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip" Condition="'$(TargetFramework)' == 'net6.0'" />
+      <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip"/>
     </ItemGroup>
   </Target>
   <Target Name="CopyToolsAfterBuild" AfterTargets="Build" DependsOnTargets="GetToolFiles">


### PR DESCRIPTION
Avoid throwing an exception when attempting to run .NET scripts in the .NET Framework build of Calamari. This is for Pre-Deploy scripts on Deploy a Package as this step does not support .NET Core

[SC-99263]