### PR TITLE
Add EKS Pod Identity Support

### DIFF
--- a/source/Calamari.Aws/Calamari.Aws.csproj
+++ b/source/Calamari.Aws/Calamari.Aws.csproj
@@ -24,10 +24,10 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.EKS" Version="3.7.13.24" />
     <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.9.14" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.11.1" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.400.62" />
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.116" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.8.8" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.128" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.401.11" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
+++ b/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
@@ -15,8 +15,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.Core" Version="3.3.104.14" />
-      <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.34" />
+      <PackageReference Include="AWSSDK.Core" Version="3.7.400.62" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.401.11" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
       <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -45,7 +45,7 @@
         <PackageReference Include="Octostache" Version="3.7.0" />
         <PackageReference Include="Polly" Version="8.3.1" />
         <PackageReference Include="SharpCompress" Version="0.37.2" />
-        <PackageReference Include="XPath2" Version="1.0.12" />
+        <PackageReference Include="XPath2" Version="1.1.5" />
         <PackageReference Include="YamlDotNet" Version="8.1.2" />
         <PackageReference Include="System.ValueTuple" Version="4.5.0" />
         <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />

--- a/source/Calamari.Terraform/Calamari.Terraform.csproj
+++ b/source/Calamari.Terraform/Calamari.Terraform.csproj
@@ -10,7 +10,7 @@
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.34" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.401.11" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
+++ b/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
@@ -1,9 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
 using Calamari.CloudAccounts;
+using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
+using WireMock.Matchers;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
 
 namespace Calamari.Tests.AWS
 {
@@ -27,6 +37,58 @@ namespace Calamari.Tests.AWS
             request.RoleArn.Should().Be(arn);
             request.RoleSessionName.Should().Be(sessionName);
             request.DurationSeconds.Should().Be(expectedDuration);
+        }
+
+        [Test]
+        public async Task UsesGenericContainerCredentialsWhenAvailable()
+        {
+            IVariables variables = new CalamariVariables();
+            var server = WireMockServer.Start();
+            
+            // Generate data - Keeping as close as possible to AWS
+            var authToken = Randomizer.CreateRandomizer().GetString(1120, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
+            var accessKeyId = Randomizer.CreateRandomizer().GetString(20, "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+            var secretAccessKey = Randomizer.CreateRandomizer().GetString(40, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+");
+            var sessionToken = Randomizer.CreateRandomizer().GetString(1120, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
+            var accountId = Randomizer.CreateRandomizer().GetString(12, "0123456789");
+            
+            var jsonResponse = $@"
+            {{
+                ""AccessKeyId"": ""{accessKeyId}"",
+                ""SecretAccessKey"": ""{secretAccessKey}"",
+                ""Token"": ""{sessionToken}"",
+                ""AccountId"": ""{accountId}"",
+                ""Expiration"": ""{DateTime.UtcNow.AddHours(12):yyyy-MM-ddTHH:mm:ssZ}""
+            }}";
+            
+            server
+                .Given(
+                       Request.Create()
+                              // This is the normal path for EKS Pod Identity Server
+                              .WithPath("/v1/credentials")
+                              // Match the auth token provided to the pod credentials
+                              .WithHeader("Authorization", authToken, MatchBehaviour.AcceptOnMatch)
+                              .UsingGet()
+                      )
+                .RespondWith(
+                             Response.Create()
+                                     .WithStatusCode(200)
+                                     .WithHeader("Content-Type", "application/json")
+                                     .WithBody(jsonResponse)
+                            );
+            
+            AwsEnvironmentGeneration awsEnvironmentGenerator;
+            using (var tokenPath = new TemporaryFile(Path.Combine(Path.GetTempPath(),Guid.NewGuid().ToString())))
+            {
+                File.WriteAllText(tokenPath.FilePath, authToken);
+                Environment.SetEnvironmentVariable("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", tokenPath.FilePath);
+                Environment.SetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_FULL_URI", $"http://127.0.0.1:{server.Port}/v1/credentials");
+                awsEnvironmentGenerator = await AwsEnvironmentGeneration.Create(Substitute.For<ILog>(), variables);
+            }
+            
+            awsEnvironmentGenerator.EnvironmentVars.Should().Contain(new KeyValuePair<string, string>("AWS_ACCESS_KEY_ID", accessKeyId));
+            awsEnvironmentGenerator.EnvironmentVars.Should().Contain(new KeyValuePair<string, string>("AWS_SECRET_ACCESS_KEY", secretAccessKey));
+            awsEnvironmentGenerator.EnvironmentVars.Should().Contain(new KeyValuePair<string, string>("AWS_SESSION_TOKEN", sessionToken));
         }
     }
 }

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -20,7 +20,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.7.0" />
-    <PackageReference Include="XPath2" Version="1.0.12" />
+    <PackageReference Include="WireMock.Net" Version="1.6.9" />
+    <PackageReference Include="XPath2" Version="1.1.5" />
     <ProjectReference Include="..\Calamari.Testing\Calamari.Testing.csproj" />
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />


### PR DESCRIPTION
This PR enables EKS Pod Identity Support to Calamari. This is done by leveraging the `GenericContainerCredentials` type in the AWS SDK, which does all the work for us.

This has been smoke tested using the `S3 Upload to S3 step` and the `AWS CLI Step` on the Kubernetes Worker, set to use the pod role assigned. This worked perfectly:
![CleanShot 2024-12-13 at 16 42 34@2x](https://github.com/user-attachments/assets/51d9dd79-6104-43f8-91b7-5ad2734946bd)

Because of the way that the EKS pod identity manager binds to a virtual IP, it's not feasible for us to use `kubectl port-forward` to test this, and there aren't any alternatives for good tests yet. As such, the tests currently use WireMock to mock out a fake EKS Pod Identity service, so that we can test that our code returns the correct authentication details when the response on the wire is well-known. 

**Note:** This will _not_ fix the error when trying to download packages from the S3 feed with machine credentials