### PR TITLE
Allow new Helm upgrade command to be executed via script

### DIFF
--- a/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
@@ -8,11 +8,13 @@ namespace Calamari.Common.FeatureToggles
         {
             public const string KubernetesObjectManifestInspection = "kubernetes-object-manifest-inspection";
             public const string KOSForHelm = "kos-for-helm";
+            public const string ExecuteHelmUpgradeCommandViaShellScript = "execute-helm-upgrade-command-via-shell-script";
         };
 
         public static readonly OctopusFeatureToggle NonPrimaryGitDependencySupportFeatureToggle = new OctopusFeatureToggle("non-primary-git-dependency-support");
         public static readonly OctopusFeatureToggle KubernetesObjectManifestInspectionFeatureToggle = new OctopusFeatureToggle(KnownSlugs.KubernetesObjectManifestInspection);
         public static readonly OctopusFeatureToggle KOSForHelmFeatureToggle = new OctopusFeatureToggle(KnownSlugs.KOSForHelm);
+        public static readonly OctopusFeatureToggle ExecuteHelmUpgradeCommandViaShellScriptFeatureToggle = new OctopusFeatureToggle(KnownSlugs.ExecuteHelmUpgradeCommandViaShellScript);
 
         public class OctopusFeatureToggle
         {

--- a/source/Calamari.Tests/KubernetesFixtures/Integration/HelmCliTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Integration/HelmCliTests.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.IO;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes;
 using Calamari.Kubernetes.Integration;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
+using Calamari.Tests.Fixtures.Integration.FileSystem;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using NSubstitute;
@@ -19,6 +21,9 @@ namespace Calamari.Tests.KubernetesFixtures.Integration
     [TestFixture]
     public class HelmCliTests
     {
+        const string BashScriptFilename = "Calamari.HelmUpgrade.sh";
+        readonly CalamariVariables executeViaScriptFeatureToggle = new CalamariVariables { [KnownVariables.EnabledFeatureToggles] = OctopusFeatureToggles.KnownSlugs.ExecuteHelmUpgradeCommandViaShellScript };
+        
         [Test]
         public void ExecutesWithDefaultExecutable()
         {
@@ -77,7 +82,6 @@ namespace Calamari.Tests.KubernetesFixtures.Integration
 
             var (helm, commandLineRunner, workingDirectory, _) = GetHelmCli(expectedExecutable, new CalamariVariables
             {
-                [SpecialVariables.Helm.Packages.CustomHelmExePackageKey] = expectedPackageKey,
                 [$"{PackageVariables.PackageCollection}[{expectedPackageKey}]"] = SpecialVariables.Helm.Packages.CustomHelmExePackageKey
             });
             
@@ -99,7 +103,6 @@ namespace Calamari.Tests.KubernetesFixtures.Integration
             
             var (helm, commandLineRunner, _, _) = GetHelmCli(expectedExecutable, new CalamariVariables
             {
-                { SpecialVariables.Helm.Packages.CustomHelmExePackageKey, expectedPackageKey },
                 { $"{PackageVariables.PackageCollection}[{expectedPackageKey}]", SpecialVariables.Helm.Packages.CustomHelmExePackageKey }
             });
             
@@ -110,6 +113,134 @@ namespace Calamari.Tests.KubernetesFixtures.Integration
 
             actual.Executable.Should().BeEquivalentTo(expectedExecutable);
         }
+        
+        [Test]
+        [NonWindowsTest]
+        public void ExecuteViaScript_ExecutesWithDefaultExecutable()
+        {
+            var (helm, commandLineRunner, workingDirectory, _) = GetHelmCli(additionalVariables: executeViaScriptFeatureToggle);
+            CommandLineInvocation actual = null;
+            string scriptContents = null;
+            commandLineRunner
+                .When(x => x.Execute(Arg.Any<CommandLineInvocation>()))
+                .Do(x =>
+                    {
+                        actual = x.Arg<CommandLineInvocation>();
+                        scriptContents = File.ReadAllText(Path.Combine(workingDirectory.DirectoryPath, BashScriptFilename));
+                    });
+
+            helm.Upgrade("myReleaseName", "myPackagePath", new []{"--reset-values", "--set something='SomeValue'"});
+
+            using (var _ = new AssertionScope())
+            {
+                actual.Executable.Should().BeEquivalentTo("bash");
+                actual.Arguments.Should().Contain(BashScriptFilename);
+            }
+
+            scriptContents.Should().Be("helm upgrade --install --reset-values --set something='SomeValue' myReleaseName myPackagePath");
+        }
+        
+        [Test]
+        [NonWindowsTest]
+        public void ExecuteViaScript_UsesCustomHelmExecutable()
+        {
+            const string expectedExecutable = "my-custom-exe";
+            
+            var (helm, commandLineRunner, workingDirectory, _) = GetHelmCli(customHelmExe: expectedExecutable, additionalVariables: executeViaScriptFeatureToggle);
+            CommandLineInvocation actual = null;
+            string scriptContents = null;
+            commandLineRunner
+                .When(x => x.Execute(Arg.Any<CommandLineInvocation>()))
+                .Do(x =>
+                    {
+                        actual = x.Arg<CommandLineInvocation>();
+                        scriptContents = File.ReadAllText(Path.Combine(workingDirectory.DirectoryPath, BashScriptFilename));
+                    });
+
+            helm.Upgrade("myReleaseName", "myPackagePath", new []{"--reset-values", "--set something='SomeValue'"});
+
+            using (var _ = new AssertionScope())
+            {
+                actual.Executable.Should().BeEquivalentTo("bash");
+                actual.Arguments.Should().Contain(BashScriptFilename);
+            }
+
+            scriptContents.Should().Be($"chmod +x \"{expectedExecutable}\"; {expectedExecutable} upgrade --install --reset-values --set something='SomeValue' myReleaseName myPackagePath");
+        }
+        
+        [Test]
+        [NonWindowsTest]
+        public void ExecuteViaScript_UsesCustomHelmExecutableFromPackage()
+        {
+            const string expectedExecutable = "my-custom-exe";
+            const string expectedPackageKey = "helm-exe-package";
+
+            var variables = new CalamariVariables
+            {
+                [$"{PackageVariables.PackageCollection}[{expectedPackageKey}]"] = SpecialVariables.Helm.Packages.CustomHelmExePackageKey
+            };
+            variables.Merge(executeViaScriptFeatureToggle);
+
+            var (helm, commandLineRunner, workingDirectory, _) = GetHelmCli(customHelmExe: expectedExecutable, additionalVariables: variables);
+            
+            CommandLineInvocation actual = null;
+            string scriptContents = null;
+            commandLineRunner
+                .When(x => x.Execute(Arg.Any<CommandLineInvocation>()))
+                .Do(x =>
+                    {
+                        actual = x.Arg<CommandLineInvocation>();
+                        scriptContents = File.ReadAllText(Path.Combine(workingDirectory.DirectoryPath, BashScriptFilename));
+                    });
+
+            helm.Upgrade("myReleaseName", "myPackagePath", new []{"--reset-values", "--set something='SomeValue'"});
+
+            using (var _ = new AssertionScope())
+            {
+                actual.Executable.Should().BeEquivalentTo("bash");
+                actual.Arguments.Should().Contain(BashScriptFilename);
+            }
+            
+            var expectedExecutablePath = Path.Combine(workingDirectory.DirectoryPath, SpecialVariables.Helm.Packages.CustomHelmExePackageKey, expectedExecutable);
+
+            scriptContents.Should().Be($"chmod +x \"{expectedExecutablePath}\"; {expectedExecutablePath} upgrade --install --reset-values --set something='SomeValue' myReleaseName myPackagePath");
+        }
+        
+        [Test]
+        [NonWindowsTest]
+        public void ExecuteViaScript_AlwaysUsesCustomHelmExecutableWhenRooted()
+        {
+            const string expectedExecutable = "/my-custom-exe";
+            const string expectedPackageKey = "helm-exe-package";
+
+            var variables = new CalamariVariables
+            {
+                [$"{PackageVariables.PackageCollection}[{expectedPackageKey}]"] = SpecialVariables.Helm.Packages.CustomHelmExePackageKey
+            };
+            variables.Merge(executeViaScriptFeatureToggle);
+
+            var (helm, commandLineRunner, workingDirectory, _) = GetHelmCli(customHelmExe: expectedExecutable, additionalVariables: variables);
+            
+            CommandLineInvocation actual = null;
+            string scriptContents = null;
+            commandLineRunner
+                .When(x => x.Execute(Arg.Any<CommandLineInvocation>()))
+                .Do(x =>
+                    {
+                        actual = x.Arg<CommandLineInvocation>();
+                        scriptContents = File.ReadAllText(Path.Combine(workingDirectory.DirectoryPath, BashScriptFilename));
+                    });
+
+            helm.Upgrade("myReleaseName", "myPackagePath", new []{"--reset-values", "--set something='SomeValue'"});
+
+            using (var _ = new AssertionScope())
+            {
+                actual.Executable.Should().BeEquivalentTo("bash");
+                actual.Arguments.Should().Contain(BashScriptFilename);
+            }
+            
+            scriptContents.Should().Be($"chmod +x \"{expectedExecutable}\"; {expectedExecutable} upgrade --install --reset-values --set something='SomeValue' myReleaseName myPackagePath");
+        }
 
         static (HelmCli, ICommandLineRunner, TemporaryDirectory, RunningDeployment) GetHelmCli(string customHelmExe = null, CalamariVariables additionalVariables = null)
         {
@@ -117,6 +248,7 @@ namespace Calamari.Tests.KubernetesFixtures.Integration
             var commandLineRunner = Substitute.For<ICommandLineRunner>();
             var workingDirectory = TemporaryDirectory.Create();
             var variables = new CalamariVariables();
+            var fileSystem = new TestCalamariPhysicalFileSystem();
 
             commandLineRunner.Execute(Arg.Any<CommandLineInvocation>())
                              .Returns(ci => new CommandResult(ci.ArgAt<CommandLineInvocation>(0).ToString(), 0));
@@ -136,7 +268,7 @@ namespace Calamari.Tests.KubernetesFixtures.Integration
                 StagingDirectory = workingDirectory.DirectoryPath
             };
 
-            var helm = new HelmCli(memoryLog, commandLineRunner, runningDeployment);
+            var helm = new HelmCli(memoryLog, commandLineRunner, runningDeployment, fileSystem);
 
             return (helm, commandLineRunner, workingDirectory, runningDeployment);
         }

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeWithKOSConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeWithKOSConvention.cs
@@ -46,7 +46,7 @@ namespace Calamari.Kubernetes.Conventions
         {
             var releaseName = GetReleaseName(deployment.Variables);
 
-            var helmCli = new HelmCli(log, commandLineRunner, deployment);
+            var helmCli = new HelmCli(log, commandLineRunner, deployment, fileSystem);
 
             kubectl.SetKubectl();
 

--- a/source/Calamari/Kubernetes/Integration/HelmCli.cs
+++ b/source/Calamari/Kubernetes/Integration/HelmCli.cs
@@ -114,7 +114,7 @@ namespace Calamari.Kubernetes.Integration
 
             if (OctopusFeatureToggles.ExecuteHelmUpgradeCommandViaShellScriptFeatureToggle.IsEnabled(variables))
             {
-                log.Warn("Backwards compatibility for Helm command execution via bash scripts is temporary and will be removed in a future release. Provide arguments compatible with direct Helm invocation, avoiding bash-specific formatting.");
+                log.Warn("Backwards compatibility for Helm command execution via shell scripts is temporary and will be removed in a future release. Provide arguments compatible with direct Helm invocation, avoiding shell-specific formatting.");
                 return ExecuteCommandViaScript(buildArgs);
             }
 

--- a/source/Calamari/Kubernetes/Integration/HelmCli.cs
+++ b/source/Calamari/Kubernetes/Integration/HelmCli.cs
@@ -114,7 +114,7 @@ namespace Calamari.Kubernetes.Integration
 
             if (OctopusFeatureToggles.ExecuteHelmUpgradeCommandViaShellScriptFeatureToggle.IsEnabled(variables))
             {
-                log.Warn("Backwards compatibility for Helm command execution via shell scripts is temporary and will be removed in a future release. Provide arguments compatible with direct Helm invocation, avoiding shell-specific formatting.");
+                log.Warn("The current workaround for backwards compatibility with Helm command execution via shell scripts is temporary and will be removed in Octopus version 2025.3. To ensure continued compatibility, please update your step to provide arguments directly compatible with Helm, avoiding shell-specific formatting");
                 return ExecuteCommandViaScript(buildArgs);
             }
 


### PR DESCRIPTION
Part of https://github.com/OctopusDeploy/Issues/issues/9168

The new Helm Upgrade command (introduced as part of the KOS for Helm feature) changed the way Helm was being executed. It was previously being executed via a Bash (or Powershell) script, whereas now the Helm command is being invoked directly with the arguments.

Customers who were using Bash-specific formatting in their arguments, e.g. quotes around literals, have experienced errors in their Helm step as these arguments are no longer being processed by Bash.

This PR introduces a feature-flagged workaround that enables affected customers to continue deploying using the new Helm command by reverting to the script-based deployment method.

[sc-99264]