### PR TITLE
Fix account priority in AWS script step

### DIFF
--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationFixtureHelpers.cs
@@ -136,6 +136,7 @@ namespace Calamari.Tests.AWS.CloudFormation
         public async Task DeployTemplate(string resourceName, string templateFilePath, IVariables variables)
         {
             var variablesFile = Path.GetTempFileName();
+            variables.Set("Octopus.Account.AccountType", "AmazonWebServicesAccount");
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
             variables.Set("AWSAccount.AccessKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, CancellationToken.None));
             variables.Set("AWSAccount.SecretKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, CancellationToken.None));
@@ -175,6 +176,7 @@ namespace Calamari.Tests.AWS.CloudFormation
         public async Task DeployTemplateS3(string resourceName, IVariables variables)
         {
             var variablesFile = Path.GetTempFileName();
+            variables.Set("Octopus.Account.AccountType", "AmazonWebServicesAccount");
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
             variables.Set("AWSAccount.AccessKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, CancellationToken.None));
             variables.Set("AWSAccount.SecretKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, CancellationToken.None));
@@ -226,6 +228,7 @@ namespace Calamari.Tests.AWS.CloudFormation
         {
             var variablesFile = Path.GetTempFileName();
             var variables = new CalamariVariables();
+            variables.Set("Octopus.Account.AccountType", "AmazonWebServicesAccount");
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
             variables.Set("AWSAccount.AccessKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, CancellationToken.None));
             variables.Set("AWSAccount.SecretKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, CancellationToken.None));

--- a/source/Calamari.Tests/AWS/S3Fixture.cs
+++ b/source/Calamari.Tests/AWS/S3Fixture.cs
@@ -662,6 +662,7 @@ namespace Calamari.Tests.AWS
             var variablesFile = Path.GetTempFileName();
 
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
+            variables.Set("Octopus.Account.AccountType", "AmazonWebServicesAccount");
             variables.Set("AWSAccount.AccessKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, cancellationToken));
             variables.Set("AWSAccount.SecretKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, cancellationToken));
             variables.Set("Octopus.Action.Aws.Region", region);


### PR DESCRIPTION
The AWS Script step ignores OIDC accounts when 2 accounts for a variable exist.

The script always chooses to authenticate using access keys even if the OIDC account is higher in priority according to the scoping rule. 

This PR will make Calamari select the authentication method based on the account type, which is selected by scoping priority rather than the presence of access key variables.

https://github.com/OctopusDeploy/Issues/issues/9120
[[sc-97348](https://app.shortcut.com/octopusdeploy/story/97348/sev-3-oidc-accounts-being-ignored-in-deployments-when-having-2-aws-accounts-in-a-variable-one-aws-account-unscoped-and-one)]