### PR TITLE
Don't run Helm manifest retrieval for older versions of Helm

### DIFF
--- a/source/Calamari.Common/Plumbing/Logging/ILog.cs
+++ b/source/Calamari.Common/Plumbing/Logging/ILog.cs
@@ -22,6 +22,7 @@ namespace Calamari.Common.Plumbing.Logging
         void DeltaVerification(string remotePath, string hash, long size);
         void DeltaVerificationError(string error);
         string FormatLink(string uri, string? description = null);
+        string FormatShortLink(string link, string? description = null);
         void WriteServiceMessage(ServiceMessage serviceMessage);
     }
 }

--- a/source/Calamari.Common/Plumbing/Logging/Log.cs
+++ b/source/Calamari.Common/Plumbing/Logging/Log.cs
@@ -226,6 +226,8 @@ namespace Calamari.Common.Plumbing.Logging
             return $"[{description ?? uri}]({uri})";
         }
 
+        public string FormatShortLink(string shortSlug, string? description = null) => FormatLink($"https://oc.to/{shortSlug}", description);
+
         public static string ConvertServiceMessageValue(string value)
         {
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(value));

--- a/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
@@ -102,7 +102,7 @@ namespace Calamari.Tests.KubernetesFixtures
 
                 Assert.AreEqual(ReleaseName.ToLower(), result.CapturedOutput.OutputVariables["ReleaseName"]);
 
-                result.AssertOutputMatches("Helm manifest retrieval requires Helm v3.13 or newer.");
+                result.AssertOutputMatches("Octopus needs Helm v3.13 or later to display object status and manifests.");
 
                 result.CapturedOutput.ServiceMessages
                       .Where(sm => sm.Name == SpecialVariables.ServiceMessages.ResourceStatus.Name)

--- a/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
@@ -1,13 +1,10 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
-using Calamari.Tests.Fixtures;
-using Calamari.Tests.Helpers;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -49,7 +46,7 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNon32BitWindows]
         [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
-        public void ReportsObjectStatus()
+        public void HelmVersionNewerThanMinimumVersion_ReportsObjectStatus()
         {
             Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
             Variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.KOSForHelm);
@@ -79,12 +76,39 @@ namespace Calamari.Tests.KubernetesFixtures
             result.CapturedOutput.ServiceMessages
                   .Where(sm => sm.Name == SpecialVariables.ServiceMessages.ResourceStatus.Name)
                   .Should()
-                  .Contain(sm => sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Name] == $"mychart-configmap-{ReleaseName}" && 
-                                 sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Namespace] == Namespace && 
-                                 sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Group] == "" &&
-                                 sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Version] == "v1" &&
-                                 sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Kind] == "ConfigMap" &&
-                                 sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Status] == Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful.ToString());
+                  .Contain(sm => sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Name] == $"mychart-configmap-{ReleaseName}" && sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Namespace] == Namespace && sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Group] == "" && sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Version] == "v1" && sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Kind] == "ConfigMap" && sm.Properties[SpecialVariables.ServiceMessages.ResourceStatus.Attributes.Status] == Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful.ToString());
+        }
+
+        [Test]
+        [RequiresNonFreeBSDPlatform]
+        [RequiresNon32BitWindows]
+        [RequiresNonMac]
+        [Category(TestCategory.PlatformAgnostic)]
+        public async Task HelmVersionOlderThanMinimumVersion_DoesNotRunObjectStatus()
+        {
+            //minimum version is helm 3.13
+            using (await UseCustomHelmExeInPackage("3.12.0"))
+            {
+                Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
+                Variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.KOSForHelm);
+                Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
+
+                var result = DeployPackage();
+
+                result.AssertSuccess();
+                result.AssertOutputMatches($"NAMESPACE: {Namespace}");
+                result.AssertOutputMatches("STATUS: deployed");
+                result.AssertOutputMatches($"release \"{ReleaseName}\" uninstalled");
+
+                Assert.AreEqual(ReleaseName.ToLower(), result.CapturedOutput.OutputVariables["ReleaseName"]);
+
+                result.AssertOutputMatches("Helm manifest retrieval requires Helm v3.13 or newer.");
+
+                result.CapturedOutput.ServiceMessages
+                      .Where(sm => sm.Name == SpecialVariables.ServiceMessages.ResourceStatus.Name)
+                      .Should()
+                      .BeEmpty();
+            }
         }
 
         protected override string ExplicitExeVersion => "3.16.2";

--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
@@ -52,7 +52,7 @@ namespace Calamari.Kubernetes.Conventions.Helm
                                {
                                    if (!DoesHelmCliSupportManifestRetrieval(out var helmVersion))
                                    {
-                                       log.Warn($"Helm manifest retrieval requires Helm v3.13 or later. Your current version is {helmVersion}. Please update your Helm executable or container.");
+                                       log.Warn($"Octopus needs Helm v3.13 or later to display object status and manifests. Your current version is {helmVersion}. Please update your Helm executable or container to enable our new Kubernetes capabilities. Learn more in our {log.FormatShortLink("KOS", "documentation")}.");
                                        return;
                                    }
                                    

--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
@@ -11,6 +11,8 @@ using Calamari.Kubernetes.Integration;
 using Calamari.Kubernetes.ResourceStatus;
 using Calamari.Kubernetes.ResourceStatus.Resources;
 using Calamari.Util;
+using Octopus.Versioning;
+using Octopus.Versioning.Semver;
 using YamlDotNet.RepresentationModel;
 
 namespace Calamari.Kubernetes.Conventions.Helm
@@ -39,15 +41,22 @@ namespace Calamari.Kubernetes.Conventions.Helm
             int revisionNumber,
             CancellationToken cancellationToken)
         {
+            if (!DoesHelmCliSupportManifestRetrieval(out var helmVersion))
+            {
+                log.Warn($"Helm manifest retrieval requires Helm v3.13 or newer. The current version {helmVersion} does not support the required commands. Please update your Helm executable or execution container.");
+                return;
+            }
+            
             await Task.Run(async () =>
                            {
                                var resourceStatusCheckIsEnabled = deployment.Variables.GetFlag(SpecialVariables.ResourceStatusCheck);
-                               
-                               if (resourceStatusCheckIsEnabled
+                      
+                               if (
+                                   resourceStatusCheckIsEnabled
                                    || FeatureToggle.KubernetesLiveObjectStatusFeatureToggle.IsEnabled(deployment.Variables)
                                    || OctopusFeatureToggles.KubernetesObjectManifestInspectionFeatureToggle.IsEnabled(deployment.Variables))
                                {
-                                   var manifest = await PollForManifest(deployment, helmCli, releaseName, revisionNumber);
+                                   var manifest = await PollForManifest(deployment, releaseName, revisionNumber);
 
                                    //report the manifest has been applied
                                    manifestReporter.ReportManifestApplied(manifest);
@@ -62,8 +71,22 @@ namespace Calamari.Kubernetes.Conventions.Helm
                            cancellationToken);
         }
 
+        static readonly SemanticVersion MinimumHelmVersion = new SemanticVersion(3, 13, 0);
+        bool DoesHelmCliSupportManifestRetrieval(out string helmVersion)
+        {
+            var parsedExecutableVersion = helmCli.GetParsedExecutableVersion();
+
+            if (parsedExecutableVersion == null)
+            {
+                helmVersion = "UNKNOWN";
+                return false;
+            }
+
+            helmVersion = parsedExecutableVersion.Version.ToString();
+            return parsedExecutableVersion >= MinimumHelmVersion;
+        }
+
         async Task<string> PollForManifest(RunningDeployment deployment,
-                                           HelmCli helmCli,
                                            string releaseName,
                                            int revisionNumber)
         {

--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
@@ -41,12 +41,6 @@ namespace Calamari.Kubernetes.Conventions.Helm
             int revisionNumber,
             CancellationToken cancellationToken)
         {
-            if (!DoesHelmCliSupportManifestRetrieval(out var helmVersion))
-            {
-                log.Warn($"Helm manifest retrieval requires Helm v3.13 or newer. The current version {helmVersion} does not support the required commands. Please update your Helm executable or execution container.");
-                return;
-            }
-            
             await Task.Run(async () =>
                            {
                                var resourceStatusCheckIsEnabled = deployment.Variables.GetFlag(SpecialVariables.ResourceStatusCheck);
@@ -56,6 +50,12 @@ namespace Calamari.Kubernetes.Conventions.Helm
                                    || FeatureToggle.KubernetesLiveObjectStatusFeatureToggle.IsEnabled(deployment.Variables)
                                    || OctopusFeatureToggles.KubernetesObjectManifestInspectionFeatureToggle.IsEnabled(deployment.Variables))
                                {
+                                   if (!DoesHelmCliSupportManifestRetrieval(out var helmVersion))
+                                   {
+                                       log.Warn($"Helm manifest retrieval requires Helm v3.13 or later. Your current version is {helmVersion}. Please update your Helm executable or container.");
+                                       return;
+                                   }
+                                   
                                    var manifest = await PollForManifest(deployment, releaseName, revisionNumber);
 
                                    //report the manifest has been applied

--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
@@ -103,7 +103,11 @@ namespace Calamari.Kubernetes.Conventions.Helm
                 {
                     if (!(document.RootNode is YamlMappingNode rootNode))
                     {
-                        log.Warn("Could not parse manifest, resources will not be added to kubernetes object status");
+                        if (document.RootNode.Tag != null)
+                        {
+                            log.Verbose("Could not parse manifest, resources will not be added to Kubernetes Object Status");
+                        }
+                        
                         continue;
                     }
 


### PR DESCRIPTION
Helm versions less than 3.13.0 did not have the `get metadata` command, this would result in an error, this giving a current revision of `1`.

This causes an issue in two ways:

1. If revision `1` exists, then we are returning an old manifest
2. Revision `1` might have been removed due to the `--history-max` `upgrade` flag defaulting to `10`, so it would fail to find a revision.

This change now checks the version of Helm and verifies it's greater than `3.13`. If the version of helm is < `3.13`, we warn the user and _disable_ the manifest retrieval. This will mean KOS and LOS won't run, but I think that's acceptable as we aren't using KOS data to determine success or failure of the step.

There is also a second big fix which is that a helm manifest may include empty documents due to helm templating generating an empty file. In these cases, they have no root node and we _were_ warning them. An empty document receives a `null` `rootNode.Tag`, so now, in the cases where the rootNode _has_ a tag, then we log a verbose message. 