### PR TITLE
Update server variable key size to 256 bits

### DIFF
--- a/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
@@ -13,7 +13,7 @@ namespace Calamari.Common.Plumbing.Extensions
         const int ScriptBootstrapKeySize = 256;
         
         //Key size used to decrypt the variables file sent by Octopus Server
-        const int ServerVariablesKeySize = 128;
+        const int ServerVariablesKeySize = 256;
         
         //Key size used to encrypt variables for step packages (`step-bootstrapper` package referenced by Server)
         //The variables are decrypted in the step package bootstrapper


### PR DESCRIPTION
[SC-100872]

Relates to: https://github.com/OctopusDeploy/Issues/issues/9184

This PR updates the variable encryption from 128 to 256bits for:

- Sensitive variable encryption (encryption in c#, decryption in Calamari)
