### PR TITLE
Fix Helm variable substitution failure for JSON values with unescaped quotes

### DIFF
--- a/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
+++ b/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
@@ -22,7 +22,7 @@ namespace Calamari.Kubernetes.Helm
 
         public IEnumerable<string> ParseAndWriteTemplateValuesFilesFromAllSources(RunningDeployment deployment)
         {
-            var templateValueSources = deployment.Variables.Get(SpecialVariables.Helm.TemplateValuesSources);
+            var templateValueSources = deployment.Variables.GetRaw(SpecialVariables.Helm.TemplateValuesSources);
 
             if (string.IsNullOrWhiteSpace(templateValueSources))
                 return Enumerable.Empty<string>();
@@ -34,7 +34,7 @@ namespace Calamari.Kubernetes.Helm
 
         public IEnumerable<string> ParseTemplateValuesFilesFromDependencies(RunningDeployment deployment, bool logIncludedFiles = true)
         {
-            var templateValueSources = deployment.Variables.Get(SpecialVariables.Helm.TemplateValuesSources);
+            var templateValueSources = deployment.Variables.GetRaw(SpecialVariables.Helm.TemplateValuesSources);
 
             if (string.IsNullOrWhiteSpace(templateValueSources))
                 return Enumerable.Empty<string>();
@@ -115,7 +115,9 @@ namespace Calamari.Kubernetes.Helm
 
                     case TemplateValuesSourceType.InlineYaml:
                         var inlineYamlTvs = json.ToObject<InlineYamlTemplateValuesSource>();
-                        var inlineYamlFilename = InlineYamlValuesFileWriter.WriteToFile(deployment, fileSystem, inlineYamlTvs.Value, index);
+                        
+                        var val = deployment.Variables.Evaluate(inlineYamlTvs.Value);
+                        var inlineYamlFilename = InlineYamlValuesFileWriter.WriteToFile(deployment, fileSystem, val, index);
 
                         AddIfNotNull(filenames, inlineYamlFilename);
                         break;


### PR DESCRIPTION
## Background

Fixes https://github.com/OctopusDeploy/Issues/issues/9140

The Helm Upgrade command supports sourcing Helm values from various locations, such as packages, charts, and inline YAML. This data is stored as a JSON object in the `Octopus.Action.Helm.TemplateValuesSources` variable.

When using the inline YAML option, Octopus variables can be substituted during deployment. However, an issue arises if any of these variables contain unescaped quotes. This is particularly common when the variable includes JSON (as JSON is valid within YAML). Since the JSON **TemplateValuesSources** must be parsed, unescaped quotes are misinterpreted as delimiters, leading to JSON parsing errors.

However, we want to support the use of raw JSON in Octopus variables without requiring users to escape strings. Users should not need to adjust their input to accommodate the internal details of how the step is handled within Calamari.

original repro and poc fix https://github.com/OctopusDeploy/Calamari/pull/1390

[sc-101575]

## Result

Enables the use of raw JSON strings in variables utilized by the inline YAML option. This is accomplished by initially processing the **TemplateValuesSources** as raw JSON (without evaluating any variables) and then evaluating the values within the inner type.

## Breaking Change

Variable values (JSON or otherwise) that previously used escaped quotes will now be interpreted differently. Escaped string quotes will be preserved and passed through as-is, which may cause deployment issues.

For example, the string`\"foo\"` was previously passed to the YAML as `"foo"`, but it will now be passed directly as `\"foo\"`.

This change may require updates to variable values in cases where such usage occurs.