### PR TITLE
Set tenanted deployment mode

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AzureWebAppTagHelperFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureWebAppTagHelperFixture.cs
@@ -21,6 +21,7 @@ namespace Calamari.AzureAppService.Tests
                 { "OctOpuS-ProJecT", "taggedProject" },
                 { "oCtoPus-sPacE", "taggedSpace" },
                 { "ocTopUs-teNanT", "taggedTenant" },
+                { "ocTopUs-TeNanTedDeployMentMode", "Tenanted"}, 
             };
 
             // Act
@@ -34,6 +35,7 @@ namespace Calamari.AzureAppService.Tests
                 foundTags.Project.Should().Be("taggedProject");
                 foundTags.Space.Should().Be("taggedSpace");
                 foundTags.Tenant.Should().Be("taggedTenant");
+                foundTags.TenantedDeploymentMode.Should().Be("Tenanted");
             }
         }
     }

--- a/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
@@ -28,6 +28,7 @@ namespace Calamari.AzureAppService.Tests
         private static readonly string AccountId = "Accounts-1";
         private static readonly string Role = "my-azure-app-role";
         private static readonly string EnvironmentName = "dev";
+        static readonly string TenantedDeploymentModeName = "TenantedOrUntenanted";
         private RetryPolicy retryPolicy;
 
         private AppServicePlanResource appServicePlanResource;
@@ -73,6 +74,7 @@ namespace Calamari.AzureAppService.Tests
             {
                 { TargetTags.EnvironmentTagName, EnvironmentName },
                 { TargetTags.RoleTagName, Role },
+                { TargetTags.TenantedDeploymentModeTagName, TenantedDeploymentModeName}
             };
 
             await CreateOrUpdateTestWebApp(tags);
@@ -90,7 +92,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                                            Role,
                                                                                                                                                            null,
                                                                                                                                                            null,
-                                                                                                                                                           "TenantedOrUntenanted");
+                                                                                                                                                           TenantedDeploymentModeName);
                                                   var serviceMessageString = serviceMessageToCreateWebAppTarget.ToString();
                                                   log.StandardOut.Should().Contain(serviceMessageString);
                                               },

--- a/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/TargetDiscoveryBehaviourIntegrationTestFixture.cs
@@ -89,7 +89,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                                            AccountId,
                                                                                                                                                            Role,
                                                                                                                                                            null,
-                                                                                                                                                           null);
+                                                                                                                                                           null,
+                                                                                                                                                           "TenantedOrUntenanted");
                                                   var serviceMessageString = serviceMessageToCreateWebAppTarget.ToString();
                                                   log.StandardOut.Should().Contain(serviceMessageString);
                                               },
@@ -125,6 +126,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                      AccountId,
                                                                                                                      "a-different-role",
                                                                                                                      null,
+                                                                                                                     null,
                                                                                                                      null);
             log.StandardOut.Should().NotContain(serviceMessageToCreateWebAppTarget.ToString(), "The web app target should not be created as the role tag did not match");
         }
@@ -159,6 +161,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                                            AccountId,
                                                                                                                                                            Role,
                                                                                                                                                            null,
+                                                                                                                                                           null,
                                                                                                                                                            null);
                                                   log.StandardOut.Should().NotContain(serviceMessageToCreateWebAppTarget.ToString(), "A target should not be created for the web app itself, only for slots within the web app");
 
@@ -170,7 +173,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                                                 AccountId,
                                                                                                                                                                 Role,
                                                                                                                                                                 null,
-                                                                                                                                                                slotName);
+                                                                                                                                                                slotName,
+                                                                                                                                                                null);
                                                       log.StandardOut.Should().Contain(serviceMessageToCreateTargetForSlot.ToString());
                                                   }
                                               },
@@ -209,6 +213,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                                            AccountId,
                                                                                                                                                            Role,
                                                                                                                                                            null,
+                                                                                                                                                           null,
                                                                                                                                                            null);
                                                   log.StandardOut.Should().Contain(serviceMessageToCreateWebAppTarget.ToString(), "A target should be created for the web app itself as well as for the slots");
 
@@ -220,7 +225,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                                                                 AccountId,
                                                                                                                                                                 Role,
                                                                                                                                                                 null,
-                                                                                                                                                                slotName);
+                                                                                                                                                                slotName,
+                                                                                                                                                                null);
                                                       log.StandardOut.Should().Contain(serviceMessageToCreateTargetForSlot.ToString());
                                                   }
                                               },
@@ -264,6 +270,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                       AccountId,
                                                                                                                       Role,
                                                                                                                       null,
+                                                                                                                      null,
                                                                                                                       null);
                                                   log.StandardOut.Should()
                                                      .NotContain(serviceMessageToCreateWebAppTarget.ToString(),
@@ -278,7 +285,8 @@ namespace Calamari.AzureAppService.Tests
                                                                                                                           AccountId,
                                                                                                                           Role,
                                                                                                                           null,
-                                                                                                                          slotName);
+                                                                                                                          slotName,
+                                                                                                                          null);
                                                       log.StandardOut.Should()
                                                          .NotContain(serviceMessageToCreateTargetForSlot.ToString(),
                                                                      "A target should not be created for the web app slot as the tags directly on the slot do not match, even though when combined with the web app tags they do");

--- a/source/Calamari.AzureAppService/Azure/AzureWebAppTagHelper.cs
+++ b/source/Calamari.AzureAppService/Azure/AzureWebAppTagHelper.cs
@@ -16,12 +16,15 @@ namespace Calamari.AzureAppService.Azure
             caseInsensitiveTagDictionary.TryGetValue(TargetTags.ProjectTagName, out string? project);
             caseInsensitiveTagDictionary.TryGetValue(TargetTags.SpaceTagName, out string? space);
             caseInsensitiveTagDictionary.TryGetValue(TargetTags.TenantTagName, out string? tenant);
+            caseInsensitiveTagDictionary.TryGetValue(TargetTags.TenantedDeploymentModeTagName, out string? tenantedDeploymentMode);
+
             return new TargetTags(
                 environment: environment,
                 role: role,
                 project: project,
                 space: space,
-                tenant: tenant);
+                tenant: tenant,
+                tenantedDeploymentMode: tenantedDeploymentMode);
         }
     }
 }

--- a/source/Calamari.AzureAppService/Behaviors/TargetDiscoveryBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/TargetDiscoveryBehaviour.cs
@@ -159,7 +159,8 @@ namespace Calamari.AzureAppService.Behaviors
                     context.Authentication!.AccountId,
                     matchResult.Role,
                     context.Scope!.WorkerPoolId,
-                    slotName));
+                    slotName,
+                    matchResult.TenantedDeploymentMode));
         }
 
         private TargetDiscoveryContext<AccountAuthenticationDetails<IAzureAccount>>? GetTargetDiscoveryContext<T>(
@@ -190,7 +191,7 @@ namespace Calamari.AzureAppService.Behaviors
 
     public static class TargetDiscoveryHelpers
     {
-        public static ServiceMessage CreateWebAppTargetCreationServiceMessage(string? resourceGroupName, string webAppName, string accountId, string role, string? workerPoolId, string? slotName)
+        public static ServiceMessage CreateWebAppTargetCreationServiceMessage(string? resourceGroupName, string webAppName, string accountId, string role, string? workerPoolId, string? slotName, string? tenantedMode)
         {
             var parameters = new Dictionary<string, string?> {
                     { "azureWebApp", webAppName },
@@ -201,7 +202,8 @@ namespace Calamari.AzureAppService.Behaviors
                     { "octopusRoles", role },
                     { "updateIfExisting", "True" },
                     { "octopusDefaultWorkerPoolIdOrName", workerPoolId },
-                    { "isDynamic", "True" }
+                    { "isDynamic", "True" },
+                    { "tenantedDeploymentParticipation", tenantedMode },
                 };
 
             return new ServiceMessage(

--- a/source/Calamari.Common/Features/Discovery/TargetDiscoveryScope.cs
+++ b/source/Calamari.Common/Features/Discovery/TargetDiscoveryScope.cs
@@ -74,10 +74,10 @@ namespace Calamari.Common.Features.Discovery
                 failureReasons.Add(
                     $"Mismatched tenant tag. Optional '{TargetTags.TenantTagName}' tag must match '{TenantName}' if present, but is '{tags.Tenant}'.");
             }
-
+            
             return failureReasons.Any()
                 ? TargetMatchResult.Failure(failureReasons)
-                : TargetMatchResult.Success(this.Roles.First(r => r.Equals(tags.Role, StringComparison.OrdinalIgnoreCase)));
+                : TargetMatchResult.Success(this.Roles.First(r => r.Equals(tags.Role, StringComparison.OrdinalIgnoreCase)), tags.TenantedDeploymentMode);
         }
     }
 

--- a/source/Calamari.Common/Features/Discovery/TargetMatchResult.cs
+++ b/source/Calamari.Common/Features/Discovery/TargetMatchResult.cs
@@ -10,11 +10,13 @@ namespace Calamari.Common.Features.Discovery
     public class TargetMatchResult
     {
         private readonly string? role;
+        private readonly string? tenantedDeploymentMode;
         private readonly IEnumerable<string> failureReasons;
 
-        private TargetMatchResult(string role)
+        private TargetMatchResult(string role, string? tenantedDeploymentMode = null)
         {
             this.role = role;
+            this.tenantedDeploymentMode = tenantedDeploymentMode;
             this.failureReasons = Enumerable.Empty<string>();
         }
 
@@ -24,12 +26,13 @@ namespace Calamari.Common.Features.Discovery
         }
 
         public string Role => this.role ?? throw new InvalidOperationException("Cannot get Role from failed target match result.");
+        public string? TenantedDeploymentMode => this.tenantedDeploymentMode;
         
         public IEnumerable<string> FailureReasons => this.failureReasons;
 
         public bool IsSuccess => this.role != null;
 
-        public static TargetMatchResult Success(string role) => new TargetMatchResult(role);
+        public static TargetMatchResult Success(string role, string? tenantedDeploymentMode) => new TargetMatchResult(role, tenantedDeploymentMode);
 
         public static TargetMatchResult Failure(IEnumerable<string> failureReasons) => new TargetMatchResult(failureReasons);
     }

--- a/source/Calamari.Common/Features/Discovery/TargetTags.cs
+++ b/source/Calamari.Common/Features/Discovery/TargetTags.cs
@@ -13,19 +13,22 @@ namespace Calamari.Common.Features.Discovery
         public const string ProjectTagName = "octopus-project";
         public const string SpaceTagName = "octopus-space";
         public const string TenantTagName = "octopus-tenant";
+        public const string TenantedDeploymentModeTagName = "octopus-tenantedDeploymentMode";
 
         public TargetTags(
             string? environment,
             string? role,
             string? project,
             string? space,
-            string? tenant)
+            string? tenant,
+            string? tenantedDeploymentMode)
         {
             this.Environment = environment;
             this.Role = role;
             this.Project = project;
             this.Space = space;
             this.Tenant = tenant;
+            this.TenantedDeploymentMode = tenantedDeploymentMode;
         }
 
         public string? Environment { get; }
@@ -33,5 +36,6 @@ namespace Calamari.Common.Features.Discovery
         public string? Project { get; }
         public string? Space { get; }
         public string? Tenant { get; }
+        public string? TenantedDeploymentMode { get; }
     }
 }

--- a/source/Calamari.Common/Features/Discovery/TargetTagsExtensions.cs
+++ b/source/Calamari.Common/Features/Discovery/TargetTagsExtensions.cs
@@ -14,12 +14,14 @@ namespace Calamari.Common.Features.Discovery
             caseInsensitiveTagDictionary.TryGetValue(TargetTags.ProjectTagName, out var project);
             caseInsensitiveTagDictionary.TryGetValue(TargetTags.SpaceTagName, out var space);
             caseInsensitiveTagDictionary.TryGetValue(TargetTags.TenantTagName, out var tenant);
+            caseInsensitiveTagDictionary.TryGetValue(TargetTags.TenantedDeploymentModeTagName, out var tenantedDeploymentMode);
             return new TargetTags(
                 environment: environment,
                 role: role,
                 project: project,
                 space: space,
-                tenant: tenant);
+                tenant: tenant,
+                tenantedDeploymentMode: tenantedDeploymentMode);
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Discovery/TargetDiscoveryScopeFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Discovery/TargetDiscoveryScopeFixture.cs
@@ -14,6 +14,7 @@ namespace Calamari.Tests.Fixtures.Discovery
         private const string scopeEnvironment = "scope-environment";
         private const string scopeRole1 = "scope-role-1";
         private const string scopeRole2 = "scope-role-2";
+        const string tenantedDeploymentMode = "Tenanted";
         private static readonly string[] scopeRoles = new string[] { scopeRole1, scopeRole2 };
         private TargetDiscoveryScope sut = new TargetDiscoveryScope(
             scopeSpace, scopeEnvironment, scopeProject, scopeTenant, scopeRoles, "WorkerPool-1", null);
@@ -27,7 +28,8 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: scopeRole1,
                 project: null,
                 space: null,
-                tenant: null);
+                tenant: null,
+                tenantedDeploymentMode: null);
 
             // Act
             var result = sut.Match(foundTags);
@@ -50,7 +52,8 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: scopeRole1,
                 project: null,
                 space: null,
-                tenant: null);
+                tenant: null,
+                tenantedDeploymentMode: null);
 
             // Act
             var result = sut.Match(foundTags);
@@ -73,7 +76,8 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: null,
                 project: null,
                 space: null,
-                tenant: null);
+                tenant: null,
+                tenantedDeploymentMode: null);
 
             // Act
             var result = sut.Match(foundTags);
@@ -96,7 +100,8 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: "wrong-role",
                 project: null,
                 space: null,
-                tenant: null);
+                tenant: null,
+                tenantedDeploymentMode: null);
 
             // Act
             var result = sut.Match(foundTags);
@@ -119,7 +124,8 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: scopeRole1,
                 project: null,
                 space: null,
-                tenant: null);
+                tenant: null,
+                tenantedDeploymentMode: null);
 
             // Act
             var result = sut.Match(foundTags);
@@ -137,7 +143,8 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: scopeRole2,
                 project: null,
                 space: null,
-                tenant: null);
+                tenant: null,
+                tenantedDeploymentMode: null);
 
             // Act
             var result = sut.Match(foundTags);
@@ -155,7 +162,8 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: scopeRole1,
                 project: "wrong-project",
                 space: null,
-                tenant: null);
+                tenant: null,
+                tenantedDeploymentMode: null);
 
             // Act
             var result = sut.Match(foundTags);
@@ -178,7 +186,8 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: scopeRole1,
                 project: null,
                 space: "wrong-space",
-                tenant: null);
+                tenant: null,
+                tenantedDeploymentMode: null);
 
             // Act
             var result = sut.Match(foundTags);
@@ -201,7 +210,8 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: scopeRole1,
                 project: null,
                 space: null,
-                tenant: "wrong-tenant");
+                tenant: "wrong-tenant",
+                tenantedDeploymentMode: null);
 
             // Act
             var result = sut.Match(foundTags);
@@ -224,10 +234,12 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: scopeRole1,
                 project: scopeProject,
                 space: scopeSpace,
-                tenant: scopeTenant);
+                tenant: scopeTenant,
+                tenantedDeploymentMode: tenantedDeploymentMode);
 
             // Act
             var result = sut.Match(foundTags);
+            result.TenantedDeploymentMode.Should().BeEquivalentTo(tenantedDeploymentMode);
 
             // Assert
             result.IsSuccess.Should().BeTrue();
@@ -236,16 +248,19 @@ namespace Calamari.Tests.Fixtures.Discovery
         [Test]
         public void Match_ShouldMakeOrdinalCaseInsenitiveComparisons()
         {
+            var tenantedDeploymentModeTag = "TaG-tenAntedDeploymentMode";
             // Arrange
             var foundTags = new TargetTags(
                 environment: "sCoPe-eNvIrOnMeNt",
                 role: "sCoPe-rOlE-1",
                 project: "sCoPe-pRoJeCt",
                 space: "sCoPe-sPaCe",
-                tenant: "sCoPe-tEnAnT");
+                tenant: "sCoPe-tEnAnT",
+                tenantedDeploymentMode: tenantedDeploymentModeTag);
 
             // Act
             var result = sut.Match(foundTags);
+            result.TenantedDeploymentMode.Should().BeEquivalentTo(tenantedDeploymentModeTag);
 
             // Assert
             result.IsSuccess.Should().BeTrue();
@@ -260,7 +275,8 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: "sCoPe-rOlE-1",
                 project: null,
                 space: null,
-                tenant: null);
+                tenant: null,
+                tenantedDeploymentMode: null);
 
             // Act
             var result = sut.Match(foundTags);
@@ -278,7 +294,8 @@ namespace Calamari.Tests.Fixtures.Discovery
                 role: "wrong-role",
                 project: "wrong-project",
                 space: "wrong-space",
-                tenant: "wrong-tenant");
+                tenant: "wrong-tenant",
+                tenantedDeploymentMode: null);
 
             // Act
             var result = sut.Match(foundTags);

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAks.cs
@@ -211,7 +211,8 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "updateIfExisting", bool.TrueString },
                 { "isDynamic", bool.TrueString },
                 { "awsUseWorkerCredentials", bool.FalseString },
-                { "awsAssumeRole", bool.FalseString }
+                { "awsAssumeRole", bool.FalseString },
+                { "tenantedDeploymentParticipation", "TenantedOrUntenanted" },
             };
 
             if (scope.HealthCheckContainer != null)

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAksLocalAccessDisabled.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureAksLocalAccessDisabled.cs
@@ -132,7 +132,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "updateIfExisting", bool.TrueString },
                 { "isDynamic", bool.TrueString },
                 { "awsUseWorkerCredentials", bool.FalseString },
-                { "awsAssumeRole", bool.FalseString }
+                { "awsAssumeRole", bool.FalseString },
             };
 
             if (scope.HealthCheckContainer != null)

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -396,8 +396,7 @@ namespace Calamari.Tests.KubernetesFixtures
                         { "isDynamic", bool.TrueString },
                         { "awsUseWorkerCredentials", bool.TrueString },
                         { "awsAssumeRole", bool.TrueString },
-                        { "awsAssumeRoleArn", eksIamRolArn },
-                        { "tenantedDeploymentParticipation", "TenantedOrUntenanted" },
+                        { "awsAssumeRoleArn", eksIamRolArn }
                     };
 
                 DoDiscoveryAndAssertReceivedServiceMessageWithMatchingProperties(authenticationDetails,
@@ -442,8 +441,7 @@ namespace Calamari.Tests.KubernetesFixtures
                         { "updateIfExisting", bool.TrueString },
                         { "isDynamic", bool.TrueString },
                         { "awsUseWorkerCredentials", bool.TrueString },
-                        { "awsAssumeRole", bool.FalseString },
-                        { "tenantedDeploymentParticipation", "TenantedOrUntenanted" },
+                        { "awsAssumeRole", bool.FalseString }
                     };
 
                 DoDiscoveryAndAssertReceivedServiceMessageWithMatchingProperties(authenticationDetails,
@@ -537,7 +535,6 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "awsAssumeRoleArn", eksIamRolArn },
                 { "awsAssumeRoleSession", "ThisIsASessionName" },
                 { "awsAssumeRoleSessionDurationSeconds", sessionDuration.ToString() },
-                { "tenantedDeploymentParticipation", "TenantedOrUntenanted" },
             };
 
             DoDiscoveryAndAssertReceivedServiceMessageWithMatchingProperties(authenticationDetails, serviceMessageProperties);

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -397,6 +397,7 @@ namespace Calamari.Tests.KubernetesFixtures
                         { "awsUseWorkerCredentials", bool.TrueString },
                         { "awsAssumeRole", bool.TrueString },
                         { "awsAssumeRoleArn", eksIamRolArn },
+                        { "tenantedDeploymentParticipation", "TenantedOrUntenanted" },
                     };
 
                 DoDiscoveryAndAssertReceivedServiceMessageWithMatchingProperties(authenticationDetails,
@@ -441,7 +442,8 @@ namespace Calamari.Tests.KubernetesFixtures
                         { "updateIfExisting", bool.TrueString },
                         { "isDynamic", bool.TrueString },
                         { "awsUseWorkerCredentials", bool.TrueString },
-                        { "awsAssumeRole", bool.FalseString }
+                        { "awsAssumeRole", bool.FalseString },
+                        { "tenantedDeploymentParticipation", "TenantedOrUntenanted" },
                     };
 
                 DoDiscoveryAndAssertReceivedServiceMessageWithMatchingProperties(authenticationDetails,
@@ -486,7 +488,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "updateIfExisting", bool.TrueString },
                 { "isDynamic", bool.TrueString },
                 { "awsUseWorkerCredentials", bool.FalseString },
-                { "awsAssumeRole", bool.FalseString }
+                { "awsAssumeRole", bool.FalseString },
             };
 
             DoDiscoveryAndAssertReceivedServiceMessageWithMatchingProperties(authenticationDetails, serviceMessageProperties);
@@ -534,7 +536,8 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "awsAssumeRole", bool.TrueString },
                 { "awsAssumeRoleArn", eksIamRolArn },
                 { "awsAssumeRoleSession", "ThisIsASessionName" },
-                { "awsAssumeRoleSessionDurationSeconds", sessionDuration.ToString() }
+                { "awsAssumeRoleSessionDurationSeconds", sessionDuration.ToString() },
+                { "tenantedDeploymentParticipation", "TenantedOrUntenanted" },
             };
 
             DoDiscoveryAndAssertReceivedServiceMessageWithMatchingProperties(authenticationDetails, serviceMessageProperties);

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
@@ -85,7 +85,6 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "awsUseWorkerCredentials", bool.TrueString },
                 { "awsAssumeRole", bool.TrueString },
                 { "awsAssumeRoleArn", eksIamRolArn },
-                { "tenantedDeploymentParticipation", "TenantedOrUntenanted" },
             };
 
             DoDiscoveryAndAssertReceivedServiceMessageWithMatchingProperties(authenticationDetails,
@@ -115,7 +114,6 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "isDynamic", bool.TrueString },
                 { "awsUseWorkerCredentials", bool.TrueString },
                 { "awsAssumeRole", bool.FalseString },
-                { "tenantedDeploymentParticipation", "TenantedOrUntenanted" },
             };
 
             DoDiscoveryAndAssertReceivedServiceMessageWithMatchingProperties(authenticationDetails,

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureForEc2Instance.cs
@@ -85,6 +85,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "awsUseWorkerCredentials", bool.TrueString },
                 { "awsAssumeRole", bool.TrueString },
                 { "awsAssumeRoleArn", eksIamRolArn },
+                { "tenantedDeploymentParticipation", "TenantedOrUntenanted" },
             };
 
             DoDiscoveryAndAssertReceivedServiceMessageWithMatchingProperties(authenticationDetails,
@@ -113,7 +114,8 @@ namespace Calamari.Tests.KubernetesFixtures
                 { "updateIfExisting", bool.TrueString },
                 { "isDynamic", bool.TrueString },
                 { "awsUseWorkerCredentials", bool.TrueString },
-                { "awsAssumeRole", bool.FalseString }
+                { "awsAssumeRole", bool.FalseString },
+                { "tenantedDeploymentParticipation", "TenantedOrUntenanted" },
             };
 
             DoDiscoveryAndAssertReceivedServiceMessageWithMatchingProperties(authenticationDetails,

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.tf
@@ -13,6 +13,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   tags = {
     octopus-environment = "Staging"
     octopus-role = "discovery-role"
+    octopus-tenantedDeploymentMode = "TenantedOrUntenanted"
     source       = "calamari-e2e-tests"
   }
 

--- a/source/Calamari/Kubernetes/Commands/KubernetesDiscoveryCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesDiscoveryCommand.cs
@@ -127,7 +127,8 @@ namespace Calamari.Kubernetes.Commands
                 { "awsAssumeRoleArn", cluster.AwsAssumeRole?.Arn },
                 { "awsAssumeRoleSession", cluster.AwsAssumeRole?.Session },
                 { "awsAssumeRoleSessionDurationSeconds", cluster.AwsAssumeRole?.SessionDuration?.ToString() },
-                { "awsAssumeRoleExternalId", cluster.AwsAssumeRole?.ExternalId }
+                { "awsAssumeRoleExternalId", cluster.AwsAssumeRole?.ExternalId },
+                { "tenantedDeploymentParticipation", matchResult.TenantedDeploymentMode },
             };
 
             var serviceMessage = new ServiceMessage(


### PR DESCRIPTION
This change adds support for a new tag `octopus-tenantedDeploymentMode` that can be set to `Untenanted`, `TenantedOrUntenanted` or `Tenanted`. When omitted targets will default to `Untenanted` unless they include the tenanted tag which will default to `TenantedOrUntenanted`. This change adds a service message `TenantedDeploymentParticipationAttribute` which is consumed in Server and adds the property see - https://github.com/OctopusDeploy/OctopusDeploy/pull/30649/files.