### PR TITLE
Fix variable substitution for Helm Template Value Source types

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesCreatorFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesCreatorFixture.cs
@@ -254,6 +254,11 @@ secondary.Development.yaml"
             // Assert
             using (var _ = new AssertionScope())
             {
+                // defined as verbatim text to avoid line ending issues when tests are run on both Windows & Linux
+                var expectedKeyValueContent = @"key-1: value-1
+KeyWithNumberValue: 3
+";
+                
                 var inlineTvsFilename = Path.Combine(RootDir, InlineYamlValuesFileWriter.GetFileName(0));
                 var chartTvsFilename = Path.Combine(RootDir, "values/dev.yaml");
                 var keyValuesTvsFilename = Path.Combine(RootDir, KeyValuesValuesFileWriter.GetFileName(2));
@@ -262,7 +267,7 @@ secondary.Development.yaml"
                 filenames.Should().BeEquivalentTo(inlineTvsFilename, chartTvsFilename, keyValuesTvsFilename, packageTvsFilename);
                 
                 fileSystem.Received().WriteAllText(inlineTvsFilename, @"colors: [""red"",""green"",""blue""]");
-                fileSystem.Received().WriteAllText(keyValuesTvsFilename, "key-1: value-1\nKeyWithNumberValue: 3\n");
+                fileSystem.Received().WriteAllText(keyValuesTvsFilename, expectedKeyValueContent);
             }
         }
 

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesCreatorFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesCreatorFixture.cs
@@ -208,6 +208,14 @@ secondary.Development.yaml"
                                                                             new HelmTemplateValueSourcesParser.ChartTemplateValuesSource
                                                                             {
                                                                                 ValuesFilePaths = "values/#{Octopus.Environment.Name | ToLower}.yaml"
+                                                                            },
+                                                                            new HelmTemplateValueSourcesParser.KeyValuesTemplateValuesSource
+                                                                            {
+                                                                                Value = new Dictionary<string, object>
+                                                                                {
+                                                                                    ["#{MyKey}"] = "#{MyValue}",
+                                                                                    ["KeyWithNumberValue"] = 3
+                                                                                }
                                                                             }
                                                                         },
                                                                         Formatting.None);
@@ -218,6 +226,8 @@ secondary.Development.yaml"
                 ["JsonArray"] = @"[""red"",""green"",""blue""]",
                 ["Service.HelmYaml"] = ExampleYaml,
                 ["Octopus.Environment.Name"] = "Dev",
+                ["MyKey"] = "key-1",
+                ["MyValue"] = "value-1",
                 [SpecialVariables.Helm.TemplateValuesSources] = templateValuesSourcesJson,
                 [KnownVariables.OriginalPackageDirectoryPath] = RootDir,
                 [ScriptVariables.ScriptSource] = ScriptVariables.ScriptSourceOptions.Package,
@@ -248,12 +258,14 @@ secondary.Development.yaml"
                 var inlineTvsFilename2 = Path.Combine(RootDir, InlineYamlValuesFileWriter.GetFileName(1));
                 var inlineTvsFilename3 = Path.Combine(RootDir, InlineYamlValuesFileWriter.GetFileName(2));
                 var chartTvsFilename = Path.Combine(RootDir, "values/dev.yaml");
+                var keyValuesTvsFilename = Path.Combine(RootDir, KeyValuesValuesFileWriter.GetFileName(4));
                 
-                filenames.Should().BeEquivalentTo(inlineTvsFilename1, inlineTvsFilename2, inlineTvsFilename3, chartTvsFilename);
+                filenames.Should().BeEquivalentTo(inlineTvsFilename1, inlineTvsFilename2, inlineTvsFilename3, chartTvsFilename, keyValuesTvsFilename);
                 
                 fileSystem.Received().WriteAllText(inlineTvsFilename1,ExampleJson);
                 fileSystem.Received().WriteAllText(inlineTvsFilename2, @"colors: [""red"",""green"",""blue""]");
                 fileSystem.Received().WriteAllText(inlineTvsFilename3, ExampleYaml);
+                fileSystem.Received().WriteAllText(keyValuesTvsFilename, "key-1: value-1\nKeyWithNumberValue: 3\n");
             }
         }
 

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
@@ -132,6 +132,34 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
             evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
         }
         
+        [Test]
+        public void FromJTokenWithEvaluation_GitRepositoryTvs_VariablesAreEvaluated()
+        {
+            // Arrange
+            var keyValuesTvs = new HelmTemplateValueSourcesParser.GitRepositoryTemplateValuesSource()
+            {
+                GitDependencyName = "#{MyGitDependency}",
+                ValuesFilePaths = "values/#{Octopus.Environment.Name | ToLower}.yaml"
+            };
+            var variables = new CalamariVariables
+            {
+                ["MyGitDependency"] = "helm-git-repository",
+                ["Octopus.Environment.Name"] = "Dev"
+            };
+
+            var expectedTvs = new HelmTemplateValueSourcesParser.GitRepositoryTemplateValuesSource
+            {
+                GitDependencyName = "helm-git-repository",
+                ValuesFilePaths = "values/dev.yaml"
+            };
+
+            // Act
+            var evaluatedTvs = HelmTemplateValueSourcesParser.GitRepositoryTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(keyValuesTvs), variables);
+
+            // Assert
+            evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
+        }
+        
         static JObject ConvertToJObject(object value)
         {
             return JObject.Parse(JsonConvert.SerializeObject(value));

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
@@ -63,7 +63,8 @@ config:
                 {
                     { "#{MyKey1}", "#{MyValue1}" },
                     { "#{MyKey2}", "environments/#{MyValue2}" },
-                    { "non-string-value", 42 }
+                    { "non-string-value", 42 },
+                    { "jsonBlob", "#{JsonBlob}" },
                 }
             };
             var variables = new CalamariVariables
@@ -72,7 +73,8 @@ config:
                 ["MyValue1"] = "octopus",
                 ["MyKey2"] = "env",
                 ["MyValue2"] = "#{Environment}",
-                ["Environment"] = "dev"
+                ["Environment"] = "dev",
+                ["JsonBlob"] = ExampleJson
             };
 
             var expectedTvs = new HelmTemplateValueSourcesParser.KeyValuesTemplateValuesSource
@@ -81,7 +83,8 @@ config:
                 {
                     { "name", "octopus" },
                     { "env", "environments/dev" },
-                    { "non-string-value", 42 }
+                    { "non-string-value", 42 },
+                    { "jsonBlob", ExampleJson },
                 }
             };
 

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes.Helm;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.Helm
+{
+    [TestFixture]
+    public class HelmTemplateValueSourcesFixture
+    {
+        [Test]
+        public void FromJTokenWithEvaluation_KeyValuesTvs_VariablesAreEvaluated()
+        {
+            // Arrange
+            var keyValuesTvs = new HelmTemplateValueSourcesParser.KeyValuesTemplateValuesSource
+            {
+                Value = new Dictionary<string, object>
+                {
+                    { "#{MyKey1}", "#{MyValue1}" },
+                    { "#{MyKey2}", "environments/#{MyValue2}" },
+                    { "non-string-value", 42 },
+                }
+            };
+            var variables = new CalamariVariables
+            {
+                ["MyKey1"] = "name",
+                ["MyValue1"] = "octopus",
+                ["MyKey2"] = "env",
+                ["MyValue2"] = "#{Environment}",
+                ["Environment"] = "dev"
+            };
+
+            var expectedTvs = new HelmTemplateValueSourcesParser.KeyValuesTemplateValuesSource
+            {
+                Value = new Dictionary<string, object>
+                {
+                    { "name", "octopus" },
+                    { "env", "environments/dev" },
+                    { "non-string-value", 42 },
+                }
+            };
+
+            // Act
+            var evaluatedTvs = HelmTemplateValueSourcesParser.KeyValuesTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(keyValuesTvs), variables);
+            
+            // Assert
+            evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
+        }
+        
+        static JObject ConvertToJObject(object value) => JObject.Parse(JsonConvert.SerializeObject(value));
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
@@ -75,6 +75,31 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
             // Assert
             evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
         }
+        
+        [Test]
+        public void FromJTokenWithEvaluation_ChartTvs_VariablesAreEvaluated()
+        {
+            // Arrange
+            var keyValuesTvs = new HelmTemplateValueSourcesParser.ChartTemplateValuesSource
+            {
+                ValuesFilePaths = "values/#{Octopus.Environment.Name | ToLower}.yaml"
+            };
+            var variables = new CalamariVariables
+            {
+                ["Octopus.Environment.Name"] = "Dev"
+            };
+
+            var expectedTvs = new HelmTemplateValueSourcesParser.ChartTemplateValuesSource
+            {
+                ValuesFilePaths = "values/dev.yaml"
+            };
+
+            // Act
+            var evaluatedTvs = HelmTemplateValueSourcesParser.ChartTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(keyValuesTvs), variables);
+
+            // Assert
+            evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
+        }
 
         static JObject ConvertToJObject(object value)
         {

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
@@ -22,7 +22,7 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
                 {
                     { "#{MyKey1}", "#{MyValue1}" },
                     { "#{MyKey2}", "environments/#{MyValue2}" },
-                    { "non-string-value", 42 },
+                    { "non-string-value", 42 }
                 }
             };
             var variables = new CalamariVariables
@@ -40,17 +40,45 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
                 {
                     { "name", "octopus" },
                     { "env", "environments/dev" },
-                    { "non-string-value", 42 },
+                    { "non-string-value", 42 }
                 }
             };
 
             // Act
             var evaluatedTvs = HelmTemplateValueSourcesParser.KeyValuesTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(keyValuesTvs), variables);
-            
+
             // Assert
             evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
         }
-        
-        static JObject ConvertToJObject(object value) => JObject.Parse(JsonConvert.SerializeObject(value));
+
+        [Test]
+        public void FromJTokenWithEvaluation_InlineYamlTvs_VariablesAreEvaluated()
+        {
+            // Arrange
+            var keyValuesTvs = new HelmTemplateValueSourcesParser.InlineYamlTemplateValuesSource
+            {
+                Value = "colors: #{JsonArray}"
+            };
+            var variables = new CalamariVariables
+            {
+                ["JsonArray"] = @"[""red"",""green"",""blue""]"
+            };
+
+            var expectedTvs = new HelmTemplateValueSourcesParser.InlineYamlTemplateValuesSource
+            {
+                Value = @"colors: [""red"",""green"",""blue""]"
+            };
+
+            // Act
+            var evaluatedTvs = HelmTemplateValueSourcesParser.InlineYamlTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(keyValuesTvs), variables);
+
+            // Assert
+            evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
+        }
+
+        static JObject ConvertToJObject(object value)
+        {
+            return JObject.Parse(JsonConvert.SerializeObject(value));
+        }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
@@ -97,7 +97,7 @@ config:
         public void FromJTokenWithEvaluation_InlineYamlTvs_VariablesAreEvaluated(string value, IVariables variables, string expectedValue)
         {
             // Arrange
-            var keyValuesTvs = new HelmTemplateValueSourcesParser.InlineYamlTemplateValuesSource
+            var inlineYamlTvs = new HelmTemplateValueSourcesParser.InlineYamlTemplateValuesSource
             {
                 Value = value
             };
@@ -108,7 +108,7 @@ config:
             };
 
             // Act
-            var evaluatedTvs = HelmTemplateValueSourcesParser.InlineYamlTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(keyValuesTvs), variables);
+            var evaluatedTvs = HelmTemplateValueSourcesParser.InlineYamlTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(inlineYamlTvs), variables);
 
             // Assert
             evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
@@ -118,7 +118,7 @@ config:
         public void FromJTokenWithEvaluation_ChartTvs_VariablesAreEvaluated()
         {
             // Arrange
-            var keyValuesTvs = new HelmTemplateValueSourcesParser.ChartTemplateValuesSource
+            var chartTvs = new HelmTemplateValueSourcesParser.ChartTemplateValuesSource
             {
                 ValuesFilePaths = "values/#{Octopus.Environment.Name | ToLower}.yaml"
             };
@@ -133,7 +133,7 @@ config:
             };
 
             // Act
-            var evaluatedTvs = HelmTemplateValueSourcesParser.ChartTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(keyValuesTvs), variables);
+            var evaluatedTvs = HelmTemplateValueSourcesParser.ChartTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(chartTvs), variables);
 
             // Assert
             evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
@@ -143,7 +143,7 @@ config:
         public void FromJTokenWithEvaluation_PackageTvs_VariablesAreEvaluated()
         {
             // Arrange
-            var keyValuesTvs = new HelmTemplateValueSourcesParser.PackageTemplateValuesSource
+            var packageTvs = new HelmTemplateValueSourcesParser.PackageTemplateValuesSource
             {
                 PackageId = "#{Package.Id}",
                 PackageName = "#{Package.Name}",
@@ -164,7 +164,7 @@ config:
             };
 
             // Act
-            var evaluatedTvs = HelmTemplateValueSourcesParser.PackageTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(keyValuesTvs), variables);
+            var evaluatedTvs = HelmTemplateValueSourcesParser.PackageTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(packageTvs), variables);
 
             // Assert
             evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
@@ -174,7 +174,7 @@ config:
         public void FromJTokenWithEvaluation_GitRepositoryTvs_VariablesAreEvaluated()
         {
             // Arrange
-            var keyValuesTvs = new HelmTemplateValueSourcesParser.GitRepositoryTemplateValuesSource
+            var gitRepoTvs = new HelmTemplateValueSourcesParser.GitRepositoryTemplateValuesSource
             {
                 GitDependencyName = "#{MyGitDependency}",
                 ValuesFilePaths = "values/#{Octopus.Environment.Name | ToLower}.yaml"
@@ -192,7 +192,7 @@ config:
             };
 
             // Act
-            var evaluatedTvs = HelmTemplateValueSourcesParser.GitRepositoryTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(keyValuesTvs), variables);
+            var evaluatedTvs = HelmTemplateValueSourcesParser.GitRepositoryTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(gitRepoTvs), variables);
 
             // Assert
             evaluatedTvs.Should().BeEquivalentTo(expectedTvs);

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesFixture.cs
@@ -101,6 +101,37 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
             evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
         }
 
+        [Test]
+        public void FromJTokenWithEvaluation_PackageTvs_VariablesAreEvaluated()
+        {
+            // Arrange
+            var keyValuesTvs = new HelmTemplateValueSourcesParser.PackageTemplateValuesSource
+            {
+                PackageId = "#{Package.Id}",
+                PackageName = "#{Package.Name}",
+                ValuesFilePaths = "values/#{Octopus.Environment.Name | ToLower}.yaml"
+            };
+            var variables = new CalamariVariables
+            {
+                ["Package.Id"] = "0a5c0b5d70e6",
+                ["Package.Name"] = "my-helm-package",
+                ["Octopus.Environment.Name"] = "Dev"
+            };
+
+            var expectedTvs = new HelmTemplateValueSourcesParser.PackageTemplateValuesSource
+            {
+                PackageId = "0a5c0b5d70e6",
+                PackageName = "my-helm-package",
+                ValuesFilePaths = "values/dev.yaml"
+            };
+
+            // Act
+            var evaluatedTvs = HelmTemplateValueSourcesParser.PackageTemplateValuesSource.FromJTokenWithEvaluation(ConvertToJObject(keyValuesTvs), variables);
+
+            // Assert
+            evaluatedTvs.Should().BeEquivalentTo(expectedTvs);
+        }
+        
         static JObject ConvertToJObject(object value)
         {
             return JObject.Parse(JsonConvert.SerializeObject(value));

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesParserFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesParserFixture.cs
@@ -245,6 +245,10 @@ secondary.Development.yaml"
             // Assert
             using (var _ = new AssertionScope())
             {
+                var expectedKeyValueContent = @"key-1: value-1
+KeyWithNumberValue: 3
+".ReplaceLineEndings();
+                
                 var inlineTvsFilename = Path.Combine(RootDir, InlineYamlValuesFileWriter.GetFileName(0));
                 var chartTvsFilename = Path.Combine(RootDir, "values/dev.yaml");
                 var keyValuesTvsFilename = Path.Combine(RootDir, KeyValuesValuesFileWriter.GetFileName(2));
@@ -253,7 +257,7 @@ secondary.Development.yaml"
                 filenames.Should().BeEquivalentTo(inlineTvsFilename, chartTvsFilename, keyValuesTvsFilename, packageTvsFilename);
                 
                 fileSystem.Received().WriteAllText(inlineTvsFilename, @"colors: [""red"",""green"",""blue""]");
-                fileSystem.Received().WriteAllText(keyValuesTvsFilename, "key-1: value-1\nKeyWithNumberValue: 3\n".ReplaceLineEndings());
+                fileSystem.Received().WriteAllText(keyValuesTvsFilename, expectedKeyValueContent);
             }
         }
 

--- a/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesParserFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm/HelmTemplateValueSourcesParserFixture.cs
@@ -19,7 +19,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.KubernetesFixtures.Helm
 {
     [TestFixture]
-    public class HelmTemplateValueSourcesCreatorFixture
+    public class HelmTemplateValueSourcesParserFixture
     {
         static readonly string RootDir = Path.Combine("root", "staging");
         
@@ -27,15 +27,6 @@ namespace Calamari.Tests.KubernetesFixtures.Helm
   ""name"": ""Test User"",
   ""id"": 1
 }";
-
-        const string ExampleYaml = @"replicas: 3
-config:
-  'min-replicas-to-write': 1
-  ""string-quoted-key"": ""string-quoted-value""
-  numbers:
-   - 42
-   - 3
-";
 
         [Test]
         public void ParseTemplateValuesFilesFromAllSources_ChartSourceButIncorrectScriptSource_ShouldThrowArgumentException()
@@ -254,11 +245,6 @@ secondary.Development.yaml"
             // Assert
             using (var _ = new AssertionScope())
             {
-                // defined as verbatim text to avoid line ending issues when tests are run on both Windows & Linux
-                var expectedKeyValueContent = @"key-1: value-1
-KeyWithNumberValue: 3
-";
-                
                 var inlineTvsFilename = Path.Combine(RootDir, InlineYamlValuesFileWriter.GetFileName(0));
                 var chartTvsFilename = Path.Combine(RootDir, "values/dev.yaml");
                 var keyValuesTvsFilename = Path.Combine(RootDir, KeyValuesValuesFileWriter.GetFileName(2));
@@ -267,7 +253,7 @@ KeyWithNumberValue: 3
                 filenames.Should().BeEquivalentTo(inlineTvsFilename, chartTvsFilename, keyValuesTvsFilename, packageTvsFilename);
                 
                 fileSystem.Received().WriteAllText(inlineTvsFilename, @"colors: [""red"",""green"",""blue""]");
-                fileSystem.Received().WriteAllText(keyValuesTvsFilename, expectedKeyValueContent);
+                fileSystem.Received().WriteAllText(keyValuesTvsFilename, "key-1: value-1\nKeyWithNumberValue: 3\n".ReplaceLineEndings());
             }
         }
 

--- a/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
+++ b/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
@@ -177,12 +177,6 @@ namespace Calamari.Kubernetes.Helm
 
             public static ChartTemplateValuesSource FromJTokenWithEvaluation(JToken jToken, IVariables variables)
             {
-                var tvs = jToken.ToObject<TemplateValuesSource>();
-                if (tvs.Type != TemplateValuesSourceType.Chart)
-                {
-                    throw new Exception($"Expected {TemplateValuesSourceType.Chart}, but got {tvs.Type}");
-                }
-                
                 var chartTvs = jToken.ToObject<ChartTemplateValuesSource>();
 
                 return new ChartTemplateValuesSource
@@ -203,12 +197,6 @@ namespace Calamari.Kubernetes.Helm
 
             public static InlineYamlTemplateValuesSource FromJTokenWithEvaluation(JToken jToken, IVariables variables)
             {
-                var tvs = jToken.ToObject<TemplateValuesSource>();
-                if (tvs.Type != TemplateValuesSourceType.InlineYaml)
-                {
-                    throw new Exception($"Expected {TemplateValuesSourceType.InlineYaml}, but got {tvs.Type}");
-                }
-                
                 var inlineYamlTvs = jToken.ToObject<InlineYamlTemplateValuesSource>();
 
                 return new InlineYamlTemplateValuesSource
@@ -231,12 +219,6 @@ namespace Calamari.Kubernetes.Helm
 
             public static PackageTemplateValuesSource FromJTokenWithEvaluation(JToken jToken, IVariables variables)
             {
-                var tvs = jToken.ToObject<TemplateValuesSource>();
-                if (tvs.Type != TemplateValuesSourceType.Package)
-                {
-                    throw new Exception($"Expected {TemplateValuesSourceType.Package}, but got {tvs.Type}");
-                }
-                
                 var packageTvs = jToken.ToObject<PackageTemplateValuesSource>();
 
                 return new PackageTemplateValuesSource
@@ -260,12 +242,6 @@ namespace Calamari.Kubernetes.Helm
 
             public static GitRepositoryTemplateValuesSource FromJTokenWithEvaluation(JToken jToken, IVariables variables)
             {
-                var tvs = jToken.ToObject<TemplateValuesSource>();
-                if (tvs.Type != TemplateValuesSourceType.GitRepository)
-                {
-                    throw new Exception($"Expected {TemplateValuesSourceType.GitRepository}, but got {tvs.Type}");
-                }
-                
                 var gitRepositoryTvs = jToken.ToObject<GitRepositoryTemplateValuesSource>();
 
                 return new GitRepositoryTemplateValuesSource
@@ -287,12 +263,6 @@ namespace Calamari.Kubernetes.Helm
             
             public static KeyValuesTemplateValuesSource FromJTokenWithEvaluation(JToken jToken, IVariables variables)
             {
-                var tvs = jToken.ToObject<TemplateValuesSource>();
-                if (tvs.Type != TemplateValuesSourceType.KeyValues)
-                {
-                    throw new Exception($"Expected {TemplateValuesSourceType.KeyValues}, but got {tvs.Type}");
-                }
-                
                 var keyValuesTvs = jToken.ToObject<KeyValuesTemplateValuesSource>();
                 
                 var evaluatedKeyValues = new Dictionary<string, object>();

--- a/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
+++ b/source/Calamari/Kubernetes/Helm/HelmTemplateValueSourcesParser.cs
@@ -64,16 +64,17 @@ namespace Calamari.Kubernetes.Helm
                 {
                     case TemplateValuesSourceType.Chart:
                         var chartTvs = json.ToObject<ChartTemplateValuesSource>();
+                        var evaluatedChartTvsValueFilePaths = deployment.Variables.Evaluate(chartTvs.ValuesFilePaths);
 
                         IEnumerable<string> chartFilenames;
                         var scriptSource = deployment.Variables.Get(ScriptVariables.ScriptSource);
                         switch (scriptSource)
                         {
                             case ScriptVariables.ScriptSourceOptions.Package:
-                                chartFilenames = PackageValuesFileWriter.FindChartValuesFiles(deployment, fileSystem, log, chartTvs.ValuesFilePaths, logIncludedFiles);
+                                chartFilenames = PackageValuesFileWriter.FindChartValuesFiles(deployment, fileSystem, log, evaluatedChartTvsValueFilePaths, logIncludedFiles);
                                 break;
                             case ScriptVariables.ScriptSourceOptions.GitRepository:
-                                chartFilenames = GitRepositoryValuesFileWriter.FindChartValuesFiles(deployment, fileSystem, log, chartTvs.ValuesFilePaths, logIncludedFiles);
+                                chartFilenames = GitRepositoryValuesFileWriter.FindChartValuesFiles(deployment, fileSystem, log, evaluatedChartTvsValueFilePaths, logIncludedFiles);
                                 break;
                             default:
                                 if (scriptSource is null)
@@ -116,8 +117,8 @@ namespace Calamari.Kubernetes.Helm
                     case TemplateValuesSourceType.InlineYaml:
                         var inlineYamlTvs = json.ToObject<InlineYamlTemplateValuesSource>();
                         
-                        var val = deployment.Variables.Evaluate(inlineYamlTvs.Value);
-                        var inlineYamlFilename = InlineYamlValuesFileWriter.WriteToFile(deployment, fileSystem, val, index);
+                        var evaluatedInlineYamlTvsValue = deployment.Variables.Evaluate(inlineYamlTvs.Value);
+                        var inlineYamlFilename = InlineYamlValuesFileWriter.WriteToFile(deployment, fileSystem, evaluatedInlineYamlTvsValue, index);
 
                         AddIfNotNull(filenames, inlineYamlFilename);
                         break;


### PR DESCRIPTION
## Background

Part of https://github.com/OctopusDeploy/Issues/issues/9224

A previous [update](https://github.com/OctopusDeploy/Calamari/pull/1426) to fix an issue with unescaped quotes in `InlineYamlTemplateValuesSource` introduced a bug where Octopus variables in other TemplateValuesSource types are not being evaluated.

## Result

- Perform variable evaluation on the properties of all the TemplateValuesSource class types
- Refactored the code to make testing this a bit easier