### PR TITLE
Run dotnet-script on netfx builds

### DIFF
--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
@@ -84,9 +84,6 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
 
         public static string FindBundledExecutable()
         {
-            if (ScriptingEnvironment.IsNetFramework())
-                throw new CommandException("dotnet-script requires .NET Core 6 or later");
-
             var exeName = $"dotnet-script.{(CalamariEnvironment.IsRunningOnWindows ? "cmd" : "dll")}";
             var myPath = typeof(DotnetScriptExecutor).Assembly.Location;
             var parent = Path.GetDirectoryName(myPath);

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -106,7 +106,7 @@
     <ItemGroup>
       <FSharpFiles Include="$(FSharpCompilerTools)" />
       <ScriptCSFiles Include="$(ScriptCS)" />
-      <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip" Condition="'$(TargetFramework)' == 'net6.0'" />
+      <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip"/>
     </ItemGroup>
   </Target>
   <Target Name="CopyToolsAfterBuild" AfterTargets="Build" DependsOnTargets="GetToolFiles">


### PR DESCRIPTION
Avoid throwing an exception when attempting to run .NET scripts in the .NET Framework build of Calamari. This is for Pre-Deploy scripts on Deploy a Package as this step does not support .NET Core. This will need to be backported with https://github.com/OctopusDeploy/Calamari/pull/1406.

Before:
<img width="1584" alt="image" src="https://github.com/user-attachments/assets/12980725-e71c-4120-a082-f7ba1e89b8bf" />


After:
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/1e8523fb-272d-4d7e-8454-23240dd0d533" />


[sc-99263]