### PR TITLE
Quote helm package path and release name

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Integration/HelmCliTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Integration/HelmCliTests.cs
@@ -137,7 +137,7 @@ namespace Calamari.Tests.KubernetesFixtures.Integration
                 actual.Arguments.Should().Contain(BashScriptFilename);
             }
 
-            scriptContents.Should().Be("helm upgrade --install --reset-values --set something='SomeValue' myReleaseName myPackagePath");
+            scriptContents.Should().Be("helm upgrade --install --reset-values --set something='SomeValue' \"myReleaseName\" \"myPackagePath\"");
         }
         
         [Test]
@@ -165,7 +165,7 @@ namespace Calamari.Tests.KubernetesFixtures.Integration
                 actual.Arguments.Should().Contain(BashScriptFilename);
             }
 
-            scriptContents.Should().Be($"chmod +x \"{expectedExecutable}\"; {expectedExecutable} upgrade --install --reset-values --set something='SomeValue' myReleaseName myPackagePath");
+            scriptContents.Should().Be($"chmod +x \"{expectedExecutable}\"; {expectedExecutable} upgrade --install --reset-values --set something='SomeValue' \"myReleaseName\" \"myPackagePath\"");
         }
         
         [Test]
@@ -203,7 +203,7 @@ namespace Calamari.Tests.KubernetesFixtures.Integration
             
             var expectedExecutablePath = Path.Combine(workingDirectory.DirectoryPath, SpecialVariables.Helm.Packages.CustomHelmExePackageKey, expectedExecutable);
 
-            scriptContents.Should().Be($"chmod +x \"{expectedExecutablePath}\"; {expectedExecutablePath} upgrade --install --reset-values --set something='SomeValue' myReleaseName myPackagePath");
+            scriptContents.Should().Be($"chmod +x \"{expectedExecutablePath}\"; {expectedExecutablePath} upgrade --install --reset-values --set something='SomeValue' \"myReleaseName\" \"myPackagePath\"");
         }
         
         [Test]
@@ -239,7 +239,7 @@ namespace Calamari.Tests.KubernetesFixtures.Integration
                 actual.Arguments.Should().Contain(BashScriptFilename);
             }
             
-            scriptContents.Should().Be($"chmod +x \"{expectedExecutable}\"; {expectedExecutable} upgrade --install --reset-values --set something='SomeValue' myReleaseName myPackagePath");
+            scriptContents.Should().Be($"chmod +x \"{expectedExecutable}\"; {expectedExecutable} upgrade --install --reset-values --set something='SomeValue' \"myReleaseName\" \"myPackagePath\"");
         }
 
         static (HelmCli, ICommandLineRunner, TemporaryDirectory, RunningDeployment) GetHelmCli(string customHelmExe = null, CalamariVariables additionalVariables = null)

--- a/source/Calamari/Kubernetes/Integration/HelmCli.cs
+++ b/source/Calamari/Kubernetes/Integration/HelmCli.cs
@@ -127,8 +127,9 @@ namespace Calamari.Kubernetes.Integration
 
             buildArgs.AddRange(upgradeArgs);
             buildArgs.Add(NamespaceArg());
-            buildArgs.Add(releaseName);
-            buildArgs.Add(packagePath);
+            //properly quote the release name and package path (consistent with previous code)
+            buildArgs.Add($"\"{releaseName}\"");
+            buildArgs.Add($"\"{packagePath}\"");
 
             if (OctopusFeatureToggles.ExecuteHelmUpgradeCommandViaShellScriptFeatureToggle.IsEnabled(variables))
             {


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

We need to quote the package path to handle paths with spaces in them.
I'm quoting the release name as well as that's consistent with the previous behaviour

https://github.com/OctopusDeploy/Calamari/blob/main/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs#L83
