### PR TITLE
Bash variable name iteration

### DIFF
--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -15,6 +15,7 @@
         KubernetesLiveObjectStatusFeatureToggle,
         KubernetesAuthAwsCliWithExecFeatureToggle,
         ForceUtf8ZipFileDecodingFeatureToggle,
-        DisableFSharpScriptExecutionFeatureToggle
+        DisableFSharpScriptExecutionFeatureToggle,
+        BashParametersArrayFeatureToggle
     }
 }

--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -60,8 +60,8 @@ namespace Calamari.Common.Features.Scripting.Bash
         {
             return variables.Select(variable =>
                                     {
-                                        var variableValue = $@"decrypt_variable ""{variable.EncryptedValue}"" ""{variable.Iv}""";
-                                        return $"[\"{variable}\"]={variableValue}";
+                                        var variableValue = $@"$(decrypt_variable ""{variable.EncryptedValue}"" ""{variable.Iv}"")";
+                                        return $"[{variable.Name}]={variableValue}";
                                     });
         }
 

--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -77,8 +77,7 @@ namespace Calamari.Common.Features.Scripting.Bash
             var sb = new StringBuilder();
             foreach (var variable in variables.Where(v => !ScriptVariables.IsLibraryScriptModule(v.Key)))
             {
-                var value = variable.Value ?? "nul";
-                sb.Append($"{EncodeAsHex(variable.Key)}").Append("$").AppendLine(EncodeAsHex(value));
+                sb.AppendLine(EncodeAsHex(variable.Key));
             }
 
             var encrypted = VariableEncryptor.Encrypt(sb.ToString());

--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -43,7 +43,7 @@ namespace Calamari.Common.Features.Scripting.Bash
             var builder = new StringBuilder(BootstrapScriptTemplate);
             var encryptedVariables = EncryptVariables(variables);
             builder.Replace("#### VariableDeclarations ####", string.Join(LinuxNewLine, GetVariableSwitchConditions(encryptedVariables)));
-            builder.Replace("#### VariableNamesArrayDeclarations ####", string.Join(", ", GetVariableNameAndValueDeclaration(encryptedVariables)));
+            builder.Replace("#### VariableNamesArrayDeclarations ####", string.Join(" ", GetVariableNameAndValueDeclaration(encryptedVariables)));
 
             using (var file = new FileStream(configurationFile, FileMode.CreateNew, FileAccess.Write))
             using (var writer = new StreamWriter(file, Encoding.ASCII))

--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -43,6 +43,7 @@ namespace Calamari.Common.Features.Scripting.Bash
             var builder = new StringBuilder(BootstrapScriptTemplate);
             var encryptedVariables = EncryptVariables(variables);
             builder.Replace("#### VariableDeclarations ####", string.Join(LinuxNewLine, GetVariableSwitchConditions(encryptedVariables)));
+            builder.Replace("#### VariableNamesArrayDeclarations ####", string.Join(", ", GetVariableNameAndValueDeclaration(encryptedVariables)));
 
             using (var file = new FileStream(configurationFile, FileMode.CreateNew, FileAccess.Write))
             using (var writer = new StreamWriter(file, Encoding.ASCII))
@@ -53,6 +54,15 @@ namespace Calamari.Common.Features.Scripting.Bash
 
             File.SetAttributes(configurationFile, FileAttributes.Hidden);
             return configurationFile;
+        }
+
+        static IEnumerable<string> GetVariableNameAndValueDeclaration(IEnumerable<EncryptedVariable> variables)
+        {
+            return variables.Select(variable =>
+                                    {
+                                        var variableValue = $@"decrypt_variable ""{variable.EncryptedValue}"" ""{variable.Iv}""";
+                                        return $"[\"{variable}\"]={variableValue}";
+                                    });
         }
 
         static IList<EncryptedVariable> EncryptVariables(IVariables variables)

--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -63,9 +63,14 @@ namespace Calamari.Common.Features.Scripting.Bash
         {
             return variables.Select(variable =>
                                     {
-                                        var variableValue = $@"$(get_octopusvariable ""{variable.Name.Replace("\"", "\\\"")}"")";
-                                        return $"[\"{variable.Name.Replace("\"", "\\\"")}\"]=\"{variableValue}\"";
+                                        var variableValue = $@"$(get_octopusvariable ""{EscapeNixCharacter(variable.Name)}"")";
+                                        return $"[\"{EscapeNixCharacter(variable.Name)}\"]=\"{variableValue}\"";
                                     });
+        }
+
+        private static string EscapeNixCharacter(string stringToEscape)
+        {
+            return stringToEscape.Replace("\"", "\\\"").Replace("`", "\\`");
         }
 
         static IList<EncryptedVariable> EncryptVariables(IVariables variables)

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -266,7 +266,7 @@ function log_environment_information
 log_environment_information
 
 if (( ${BASH_VERSINFO[0]} > 4 || (${BASH_VERSINFO[0]} == 4 && ${BASH_VERSINFO[1]} > 2) )); then
-  declare -grA example_array=(#### VariableNamesArrayDeclarations ####)
+  declare -grA octopus_parameters=(#### VariableNamesArrayDeclarations ####)
 else
   echo "Bash version 4.2 or later is required to use octopus_parameters"
 fi

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -66,16 +66,6 @@ function get_octopusvariable
     esac
 }
 
-# -----------------------------------------------------------------------------
-# Function to base64 decode an octopus variable name
-#		Accepts 1 argument:
-#			string: the value to decode
-# -----------------------------------------------------------------------------
-function decode_octopusvariablename
-{
-	echo -n "$1" | openssl enc -base64 -A -d
-}
-
 #	---------------------------------------------------------------------------
 # Function for failing a step with an optional message
 #   Accepts 1 argument:

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -265,7 +265,8 @@ function log_environment_information
 
 log_environment_information
 
-#	---------------------------------------------------------------------------
-# Function for declaring array of octopus variable names
-#	---------------------------------------------------------------------------
-declare -rA octopus_parameters=(#### VariableNamesArrayDeclarations ####)
+if (( ${BASH_VERSINFO[0]} > 4 || (${BASH_VERSINFO[0]} == 4 && ${BASH_VERSINFO[1]} > 2) )); then
+  declare -grA example_array=(#### VariableNamesArrayDeclarations ####)
+else
+  echo "Bash version 4.2 or later is required to use octopus_parameters"
+fi

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -265,8 +265,13 @@ function log_environment_information
 
 log_environment_information
 
-if (( ${BASH_VERSINFO[0]} > 4 || (${BASH_VERSINFO[0]} == 4 && ${BASH_VERSINFO[1]} > 2) )); then
-  declare -grA octopus_parameters=(#### VariableNamesArrayDeclarations ####)
-else
-  echo "Bash version 4.2 or later is required to use octopus_parameters"
+bashParametersArrayFeatureToggle=#### BashParametersArrayFeatureToggle ####
+
+if [ "$bashParametersArrayFeatureToggle" = true ]; then
+    if (( ${BASH_VERSINFO[0]} > 4 || (${BASH_VERSINFO[0]} == 4 && ${BASH_VERSINFO[1]} > 2) )); then
+      declare -grA octopus_parameters=(#### VariableNamesArrayDeclarations ####)
+    else
+      echo "Bash version 4.2 or later is required to use octopus_parameters"
+    fi
 fi
+

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -66,6 +66,24 @@ function get_octopusvariable
     esac
 }
 
+# -----------------------------------------------------------------------------
+# Function to base64 decode an octopus variable name
+#		Accepts 1 argument:
+#			string: the value to decode
+# -----------------------------------------------------------------------------
+function decode_octopusvariablename
+{
+	echo -n "$1" | openssl enc -base64 -A -d
+}
+
+#	---------------------------------------------------------------------------
+# Function for declaring array of octopus variable names
+#	---------------------------------------------------------------------------
+function declare_variablenames
+{
+  export declare -rA octopus_parameters=(#### VariableNamesArrayDeclarations ####)
+}
+
 #	---------------------------------------------------------------------------
 # Function for failing a step with an optional message
 #   Accepts 1 argument:
@@ -264,3 +282,5 @@ function log_environment_information
 }
 
 log_environment_information
+
+declare_variablenames

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -281,7 +281,7 @@ function decrypt_and_parse_variables {
         key_byte_lengths+=("$key_byte_len")
         concatenated_hex+="${hex_key}"
     done <<< "$decrypted"
-    decoded_output=$(hex_to_ascii "$concatenated_hex")
+    decoded_output=$(hex_to_string "$concatenated_hex")
     
     section_end=$(date +%s%3N)
 
@@ -308,7 +308,7 @@ function decrypt_and_parse_variables {
     done
 }
 
-hex_to_ascii() {
+hex_to_string() {
     local hex_string="$1"
     hex_string="${hex_string//[$'\t\r\n ']/}"
     if (( ${#hex_string} % 2 )); then

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -265,13 +265,101 @@ function log_environment_information
 
 log_environment_information
 
+function decrypt_and_parse_variables {
+    local encrypted="$1"
+    local iv="$2"
+
+    local decrypted
+    decrypted=$(decrypt_variable "$encrypted" "$iv")
+    declare -gA octopus_parameters=()
+
+    key_byte_lengths=()
+    value_byte_lengths=()
+    concatenated_hex=""
+    while IFS='$' read -r hex_key hex_value; do
+        hex_value="${hex_value//$'\n'/}"
+        key_byte_len=$(( ${#hex_key} / 2 ))
+        value_byte_len=$(( ${#hex_value} / 2 ))
+        key_byte_lengths+=("$key_byte_len")
+        value_byte_lengths+=("$value_byte_len")
+        concatenated_hex+="${hex_key}${hex_value}"
+    done <<< "$decrypted"
+    decoded_output=$(hex_to_ascii "$concatenated_hex")
+    
+    section_end=$(date +%s%3N)
+
+    section_start=$(date +%s%3N)
+    decoded_keys=()
+    decoded_values=()
+
+    # Use a temporary file to avoid subshell issues 
+    tmp_file=$(mktemp)
+    
+    printf "%s" "$decoded_output" > "$tmp_file"
+    exec 3<"$tmp_file"
+
+    for idx in "${!key_byte_lengths[@]}"; do
+        key_byte_len="${key_byte_lengths[idx]}"
+        value_byte_len="${value_byte_lengths[idx]}"
+
+        read -r -N "$key_byte_len" decoded_key <&3
+        read -r -N "$value_byte_len" decoded_value <&3
+
+        [[ "$decoded_value" == "nul" ]] && decoded_value=""
+        decoded_keys+=("$decoded_key")
+        decoded_values+=("$decoded_value")
+    done
+
+    exec 3<&-
+    rm -f "$tmp_file"
+
+    for i in "${!decoded_keys[@]}"; do
+        octopus_parameters["${decoded_keys[$i]}"]="${decoded_values[$i]}"
+    done
+}
+
+hex_to_ascii() {
+    local hex_string="$1"
+    hex_string="${hex_string//[$'\t\r\n ']/}"
+    # If the length is odd, pad with a leading zero
+    if (( ${#hex_string} % 2 )); then
+        hex_string="0$hex_string"
+    fi
+    echo "$hex_string" | awk '
+    BEGIN {
+      # Build a lookup table for hex digits
+      hexmap["0"] = 0; hexmap["1"] = 1; hexmap["2"] = 2; hexmap["3"] = 3;
+      hexmap["4"] = 4; hexmap["5"] = 5; hexmap["6"] = 6; hexmap["7"] = 7;
+      hexmap["8"] = 8; hexmap["9"] = 9; hexmap["A"] = 10; hexmap["B"] = 11;
+      hexmap["C"] = 12; hexmap["D"] = 13; hexmap["E"] = 14; hexmap["F"] = 15;
+      hexmap["a"] = 10; hexmap["b"] = 11; hexmap["c"] = 12; hexmap["d"] = 13;
+      hexmap["e"] = 14; hexmap["f"] = 15;
+    }
+    # Define a generic function to convert a hex string to decimal
+    function hex2dec(hex,    i, n, d) {
+      n = 0;
+      for (i = 1; i <= length(hex); i++) {
+         d = substr(hex, i, 1);
+         n = n * 16 + hexmap[d];
+      }
+      return n;
+    }
+    {
+      # Process the input string two characters at a time
+      for (i = 1; i <= length($0); i += 2)
+        printf "%c", hex2dec(substr($0, i, 2));
+    }'
+}
+
 bashParametersArrayFeatureToggle=#### BashParametersArrayFeatureToggle ####
 
 if [ "$bashParametersArrayFeatureToggle" = true ]; then
-    if (( ${BASH_VERSINFO[0]} > 4 || (${BASH_VERSINFO[0]} == 4 && ${BASH_VERSINFO[1]} > 2) )); then
-      declare -grA octopus_parameters=(#### VariableNamesArrayDeclarations ####)
+    if (( ${BASH_VERSINFO[0]:-0} > 4 || (${BASH_VERSINFO[0]:-0} == 4 && ${BASH_VERSINFO[1]:-0} > 2) )); then
+        decrypt_and_parse_variables "#### VARIABLESTRING.ENCRYPTED ####" "#### VARIABLESTRING.IV ####"
     else
-      echo "Bash version 4.2 or later is required to use octopus_parameters"
+        echo "Bash version 4.2 or later is required to use octopus_parameters"
     fi
 fi
+
+
 

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -77,14 +77,6 @@ function decode_octopusvariablename
 }
 
 #	---------------------------------------------------------------------------
-# Function for declaring array of octopus variable names
-#	---------------------------------------------------------------------------
-function declare_variablenames
-{
-  export declare -rA octopus_parameters=(#### VariableNamesArrayDeclarations ####)
-}
-
-#	---------------------------------------------------------------------------
 # Function for failing a step with an optional message
 #   Accepts 1 argument:
 #     string: reason for failing
@@ -283,4 +275,7 @@ function log_environment_information
 
 log_environment_information
 
-declare_variablenames
+#	---------------------------------------------------------------------------
+# Function for declaring array of octopus variable names
+#	---------------------------------------------------------------------------
+declare -rA octopus_parameters=(#### VariableNamesArrayDeclarations ####)

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -205,7 +205,8 @@ namespace Calamari.Tests.Fixtures.Bash
                 ["VariableName, {8}"] = "Value {8}",
                 ["VariableName\t9"] = "Value\t9",
                 ["VariableName 10 !@#$%^&*()_+1234567890-="] = "Value 10 !@#$%^&*()_+1234567890-=",
-                ["VariableName, \n 11"] = "Value \n 11",
+                ["VariableName \n 11"] = "Value \n 11",
+                ["VariableName.prop.anotherprop 12"] = "Value.prop.11",
             });
 
             output.AssertSuccess();
@@ -220,6 +221,7 @@ namespace Calamari.Tests.Fixtures.Bash
             output.AssertOutput(@"Key: VariableName\t9, Value: Value\t9");
             output.AssertOutput(@"Key: VariableName 10 !@#$%^&*()_+1234567890-=, Value: Value 10 !@#$%^&*()_+1234567890-=");
             output.AssertOutput("Key: VariableName \n 11, Value: Value \n 11");
+            output.AssertOutput("Key: VariableName.prop.anotherprop 12, Value: Value.prop.11");
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -264,19 +264,19 @@ namespace Calamari.Tests.Fixtures.Bash
                     return;
                 }
 
-                output.AssertOutput(@"Key: VariableName1, Value: Value 1");
-                output.AssertOutput(@"Key: VariableName 2, Value: Value 2");
-                output.AssertOutput(@"Key: VariableName3, Value: Value 3");
-                output.AssertOutput(@"Key: VariableName '4', Value: Value '4'");
-                output.AssertOutput("Key: VariableName \"5\", Value: Value \"5\"");
-                output.AssertOutput(@"Key: VariableName, 6, Value: Value, 6");
-                output.AssertOutput(@"Key: VariableName [7], Value: Value [7]");
-                output.AssertOutput(@"Key: VariableName {8}, Value: Value {8}");
-                output.AssertOutput("Key: VariableName\t9, Value: Value\t9");
-                output.AssertOutput(@"Key: VariableName 10 !@#$%^&*()_+1234567890-=, Value: Value 10 !@#$%^&*()_+1234567890-=");
-                output.AssertOutput("Key: VariableName \n 11, Value: Value \n 11");
-                output.AssertOutput("Key: VariableName.prop.anotherprop 12, Value: Value.prop.12");
-                output.AssertOutput("Key: VariableName`prop`anotherprop` 13, Value: Value`prop`13");
+                output.AssertOutput(@"Key: VariableName1, Value: ");
+                output.AssertOutput(@"Key: VariableName 2, Value: ");
+                output.AssertOutput(@"Key: VariableName3, Value: ");
+                output.AssertOutput(@"Key: VariableName '4', Value: ");
+                output.AssertOutput("Key: VariableName \"5\", Value: ");
+                output.AssertOutput(@"Key: VariableName, 6, Value: ");
+                output.AssertOutput(@"Key: VariableName [7], Value: ");
+                output.AssertOutput(@"Key: VariableName {8}, Value: ");
+                output.AssertOutput("Key: VariableName\t9, Value: ");
+                output.AssertOutput(@"Key: VariableName 10 !@#$%^&*()_+1234567890-=, Value: ");
+                output.AssertOutput("Key: VariableName \n 11, Value: ");
+                output.AssertOutput("Key: VariableName.prop.anotherprop 12, Value: ");
+                output.AssertOutput("Key: VariableName`prop`anotherprop` 13, Value: ");
                 output.AssertOutput($"Key: {specialCharacters}, Value: {specialCharacters}");
             }
         }

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using Calamari.Common.FeatureToggles;
+using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment;
 using Calamari.Testing.Requirements;
 using Calamari.Tests.Helpers;
@@ -9,205 +11,243 @@ namespace Calamari.Tests.Fixtures.Bash
     [TestFixture]
     public class BashFixture : CalamariFixture
     {
-        [Test]
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldPrintEncodedVariable()
+        public void ShouldPrintEncodedVariable(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("print-encoded-variable.sh");
+            var (output, _) = RunScript("print-encoded-variable.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertOutput("##octopus[setVariable name='U3VwZXI=' value='TWFyaW8gQnJvcw==']");
-            });
-        }
-        
-        [Test]
-        [RequiresBashDotExeIfOnWindows]
-        public void ShouldPrintSensitiveVariable()
-        {
-            var (output, _) = RunScript("print-sensitive-variable.sh");
-
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertOutput("##octopus[setVariable name='UGFzc3dvcmQ=' value='Y29ycmVjdCBob3JzZSBiYXR0ZXJ5IHN0YXBsZQ==' sensitive='VHJ1ZQ==']");
-            });
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("##octopus[setVariable name='U3VwZXI=' value='TWFyaW8gQnJvcw==']");
+                            });
         }
 
-        [Test]
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldCreateArtifact()
+        public void ShouldPrintSensitiveVariable(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("create-artifact.sh");
+            var (output, _) = RunScript("print-sensitive-variable.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertOutput("##octopus[createArtifact path='Li9zdWJkaXIvYW5vdGhlcmRpci9teWZpbGU=' name='bXlmaWxl' length='MA==']");
-            });
-        }
-        
-        [Test]
-        [RequiresBashDotExeIfOnWindows]
-        public void ShouldUpdateProgress()
-        {
-            var (output, _) = RunScript("update-progress.sh");
-
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertOutput("##octopus[progress percentage='NTA=' message='SGFsZiBXYXk=']");
-            });
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("##octopus[setVariable name='UGFzc3dvcmQ=' value='Y29ycmVjdCBob3JzZSBiYXR0ZXJ5IHN0YXBsZQ==' sensitive='VHJ1ZQ==']");
+                            });
         }
 
-        [Test]
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldConsumeParametersWithQuotes()
+        public void ShouldCreateArtifact(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("parameters.sh", new Dictionary<string, string>()
-                { [SpecialVariables.Action.Script.ScriptParameters] = "\"Para meter0\" 'Para meter1'" });
+            var (output, _) = RunScript("create-artifact.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertOutput("Parameters ($1='Para meter0' $2='Para meter1'");
-            });
-        }
-        
-        [Test]
-        [RequiresBashDotExeIfOnWindows]
-        public void ShouldNotReceiveParametersIfNoneProvided()
-        {
-            var (output, _) = RunScript("parameters.sh", sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
-
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertOutput("Parameters ($1='' $2='')");
-            });
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("##octopus[createArtifact path='Li9zdWJkaXIvYW5vdGhlcmRpci9teWZpbGU=' name='bXlmaWxl' length='MA==']");
+                            });
         }
 
-        [Test]
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldCallHello()
+        public void ShouldUpdateProgress(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("hello.sh", new Dictionary<string, string>()
-            {
-                ["Name"] = "Paul",
-                ["Variable2"] = "DEF",
-                ["Variable3"] = "GHI",
-                ["Foo_bar"] = "Hello",
-                ["Host"] = "Never",
-            });
+            var (output, _) = RunScript("update-progress.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertOutput("Hello Paul");
-            });
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("##octopus[progress percentage='NTA=' message='SGFsZiBXYXk=']");
+                            });
         }
 
-
-        [Test]
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldCallHelloWithSensitiveVariable()
+        public void ShouldConsumeParametersWithQuotes(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("hello.sh", new Dictionary<string, string>()
-                { ["Name"] = "NameToEncrypt" }, sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
+            var (output, _) = RunScript("parameters.sh",
+                                        new Dictionary<string, string>()
+                                            { [SpecialVariables.Action.Script.ScriptParameters] = "\"Para meter0\" 'Para meter1'" }.AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertOutput("Hello NameToEncrypt");
-            });
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("Parameters ($1='Para meter0' $2='Para meter1'");
+                            });
         }
 
-
-        [Test]
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldCallHelloWithNullVariable()
+        public void ShouldNotReceiveParametersIfNoneProvided(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("hello.sh", new Dictionary<string, string>()
-                {["Name"] = null});
+            var (output, _) = RunScript("parameters.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }), sensitiveVariablesPassword:
+            "5XETGOgqYR2bRhlfhDruEg==");
 
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertOutput("Hello");
-            });
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("Parameters ($1='' $2='')");
+                            });
         }
 
-        [Test]
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldCallHelloWithNullSensitiveVariable()
+        public void ShouldCallHello(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("hello.sh", new Dictionary<string, string>()
-                { ["Name"] = null }, sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
+            var (output, _) = RunScript("hello.sh",
+                                        new Dictionary<string, string>()
+                                        {
+                                            ["Name"] = "Paul",
+                                            ["Variable2"] = "DEF",
+                                            ["Variable3"] = "GHI",
+                                            ["Foo_bar"] = "Hello",
+                                            ["Host"] = "Never",
+                                        }.AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertOutput("Hello");
-            });
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("Hello Paul");
+                            });
         }
 
-        [Test]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldNotFailOnStdErr()
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
+        public void ShouldCallHelloWithSensitiveVariable(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("stderr.sh");
-            
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertErrorOutput("hello");
-            });
+            var (output, _) = RunScript("hello.sh",
+                                        new Dictionary<string, string>()
+                                            { ["Name"] = "NameToEncrypt" }.AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }), sensitiveVariablesPassword:
+            "5XETGOgqYR2bRhlfhDruEg==");
+
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("Hello NameToEncrypt");
+                            });
         }
 
-        [Test]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldFailOnStdErrWithTreatScriptWarningsAsErrors()
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
+        public void ShouldCallHelloWithNullVariable(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("stderr.sh", new Dictionary<string, string>()
-                {[SpecialVariables.Action.FailScriptOnErrorOutput] = "True"});
+            var (output, _) = RunScript("hello.sh",
+                                        new Dictionary<string, string>()
+                                            { ["Name"] = null }.AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
-            Assert.Multiple(() => {
-                output.AssertFailure();
-                output.AssertErrorOutput("hello");
-            });
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("Hello");
+                            });
         }
 
-        [Test]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldNotFailOnStdErrFromServiceMessagesWithTreatScriptWarningsAsErrors()
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
+        public void ShouldCallHelloWithNullSensitiveVariable(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("hello.sh", new Dictionary<string, string>()
-            {[SpecialVariables.Action.FailScriptOnErrorOutput] = "True"});
+            var (output, _) = RunScript("hello.sh",
+                                        new Dictionary<string, string>()
+                                            { ["Name"] = null }.AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }), sensitiveVariablesPassword:
+            "5XETGOgqYR2bRhlfhDruEg==");
+
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("Hello");
+                            });
+        }
+
+        [RequiresBashDotExeIfOnWindows]
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
+        public void ShouldNotFailOnStdErr(FeatureToggle? featureToggle)
+        {
+            var (output, _) = RunScript("stderr.sh",
+                                        new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
+
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertErrorOutput("hello");
+                            });
+        }
+
+        [RequiresBashDotExeIfOnWindows]
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
+        public void ShouldFailOnStdErrWithTreatScriptWarningsAsErrors(FeatureToggle? featureToggle)
+        {
+            var (output, _) = RunScript("stderr.sh",
+                                        new Dictionary<string, string>()
+                                            { [SpecialVariables.Action.FailScriptOnErrorOutput] = "True" }.AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
+
+            Assert.Multiple(() =>
+                            {
+                                output.AssertFailure();
+                                output.AssertErrorOutput("hello");
+                            });
+        }
+
+        [RequiresBashDotExeIfOnWindows]
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
+        public void ShouldNotFailOnStdErrFromServiceMessagesWithTreatScriptWarningsAsErrors(FeatureToggle? featureToggle)
+        {
+            var (output, _) = RunScript("hello.sh",
+                                        new Dictionary<string, string>()
+                                            { [SpecialVariables.Action.FailScriptOnErrorOutput] = "True" }.AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
             output.AssertSuccess();
         }
 
-        [Test]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldSupportStrictVariableUnset()
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
+        public void ShouldSupportStrictVariableUnset(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("strict-mode.sh");
+            var (output, _) = RunScript("strict-mode.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
-            Assert.Multiple(() => {
-                output.AssertSuccess();
-                output.AssertOutput("##octopus[setVariable name='UGFzc3dvcmQ=' value='Y29ycmVjdCBob3JzZSBiYXR0ZXJ5IHN0YXBsZQ==']");
-            });
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("##octopus[setVariable name='UGFzc3dvcmQ=' value='Y29ycmVjdCBob3JzZSBiYXR0ZXJ5IHN0YXBsZQ==']");
+                            });
         }
 
-        [Test]
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
-        public void ShouldBeAbleToEnumerateVariableValues()
+        public void ShouldBeAbleToEnumerateVariableValues(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("enumerate-variables.sh", new Dictionary<string, string>()
-            {
-                ["VariableName1"] = "Value 1",
-                ["VariableName 2"] = "Value 2",
-                ["VariableName3"] = "Value 3",
-                ["VariableName '4'"] = "Value '4'",
-                ["VariableName \"5\""] = "Value \"5\"",
-                ["VariableName, 6"] = "Value, 6",
-                ["VariableName, [7]"] = "Value [7]",
-                ["VariableName, {8}"] = "Value {8}",
-                ["VariableName\t9"] = "Value\t9",
-                ["VariableName 10 !@#$%^&*()_+1234567890-="] = "Value 10 !@#$%^&*()_+1234567890-=",
-                ["VariableName \n 11"] = "Value \n 11",
-                ["VariableName.prop.anotherprop 12"] = "Value.prop.11",
-            });
+            var (output, _) = RunScript("enumerate-variables.sh",
+                                        new Dictionary<string, string>()
+                                        {
+                                            ["VariableName1"] = "Value 1",
+                                            ["VariableName 2"] = "Value 2",
+                                            ["VariableName3"] = "Value 3",
+                                            ["VariableName '4'"] = "Value '4'",
+                                            ["VariableName \"5\""] = "Value \"5\"",
+                                            ["VariableName, 6"] = "Value, 6",
+                                            ["VariableName, [7]"] = "Value [7]",
+                                            ["VariableName, {8}"] = "Value {8}",
+                                            ["VariableName\t9"] = "Value\t9",
+                                            ["VariableName 10 !@#$%^&*()_+1234567890-="] = "Value 10 !@#$%^&*()_+1234567890-=",
+                                            ["VariableName \n 11"] = "Value \n 11",
+                                            ["VariableName.prop.anotherprop 12"] = "Value.prop.11",
+                                        }.AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
             output.AssertSuccess();
             output.AssertOutput(@"Key: VariableName1, Value: Value 1");
@@ -222,6 +262,15 @@ namespace Calamari.Tests.Fixtures.Bash
             output.AssertOutput(@"Key: VariableName 10 !@#$%^&*()_+1234567890-=, Value: Value 10 !@#$%^&*()_+1234567890-=");
             output.AssertOutput("Key: VariableName \n 11, Value: Value \n 11");
             output.AssertOutput("Key: VariableName.prop.anotherprop 12, Value: Value.prop.11");
+        }
+    }
+
+    public static class AdditionalVariablesExtensions
+    {
+        public static Dictionary<string, string> AddFeatureToggleToDictionary(this Dictionary<string, string> variables, List<FeatureToggle?> featureToggles)
+        {
+            variables.Add(KnownVariables.EnabledFeatureToggles, string.Join(", ", featureToggles));
+            return variables;
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -188,5 +188,24 @@ namespace Calamari.Tests.Fixtures.Bash
                 output.AssertOutput("##octopus[setVariable name='UGFzc3dvcmQ=' value='Y29ycmVjdCBob3JzZSBiYXR0ZXJ5IHN0YXBsZQ==']");
             });
         }
+
+        [Test]
+        [RequiresBashDotExeIfOnWindows]
+        public void ShouldBeAbleToEnumerateVariableValues()
+        {
+            var (output, _) = RunScript("enumerate-variables.sh", new Dictionary<string, string>()
+            {
+                ["VariableName1"] = "Value 1",
+                ["VariableName 2"] = "Value 2",
+                ["VariableName3"] = "Value 3",
+                ["VariableName '4'"] = "Value 4"
+            });
+
+            output.AssertSuccess();
+            output.AssertOutput(@"Key: VariableName1, Value: Value 1");
+            output.AssertOutput(@"Key: VariableName 2, Value: Value 2");
+            output.AssertOutput(@"Key: VariableName3, Value: Value 3");
+            output.AssertOutput(@"Key: VariableName '4', Value: Value 4");
+        }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -241,8 +241,8 @@ namespace Calamari.Tests.Fixtures.Bash
                                             ["VariableName '4'"] = "Value '4'",
                                             ["VariableName \"5\""] = "Value \"5\"",
                                             ["VariableName, 6"] = "Value, 6",
-                                            ["VariableName, [7]"] = "Value [7]",
-                                            ["VariableName, {8}"] = "Value {8}",
+                                            ["VariableName [7]"] = "Value [7]",
+                                            ["VariableName {8}"] = "Value {8}",
                                             ["VariableName\t9"] = "Value\t9",
                                             ["VariableName 10 !@#$%^&*()_+1234567890-="] = "Value 10 !@#$%^&*()_+1234567890-=",
                                             ["VariableName \n 11"] = "Value \n 11",
@@ -250,18 +250,21 @@ namespace Calamari.Tests.Fixtures.Bash
                                         }.AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
             output.AssertSuccess();
-            output.AssertOutput(@"Key: VariableName1, Value: Value 1");
-            output.AssertOutput(@"Key: VariableName 2, Value: Value 2");
-            output.AssertOutput(@"Key: VariableName3, Value: Value 3");
-            output.AssertOutput(@"Key: VariableName '4', Value: Value '4'");
-            output.AssertOutput("Key: VariableName \"5\", Value: Value \"5\"");
-            output.AssertOutput(@"Key: VariableName, 6, Value: Value, 6");
-            output.AssertOutput(@"Key: VariableName [7], Value: Value [7]");
-            output.AssertOutput(@"Key: VariableName {8}, Value: Value {8}");
-            output.AssertOutput(@"Key: VariableName\t9, Value: Value\t9");
-            output.AssertOutput(@"Key: VariableName 10 !@#$%^&*()_+1234567890-=, Value: Value 10 !@#$%^&*()_+1234567890-=");
-            output.AssertOutput("Key: VariableName \n 11, Value: Value \n 11");
-            output.AssertOutput("Key: VariableName.prop.anotherprop 12, Value: Value.prop.11");
+            if (featureToggle == FeatureToggle.BashParametersArrayFeatureToggle)
+            {
+                output.AssertOutput(@"Key: VariableName1, Value: Value 1");
+                output.AssertOutput(@"Key: VariableName 2, Value: Value 2");
+                output.AssertOutput(@"Key: VariableName3, Value: Value 3");
+                output.AssertOutput(@"Key: VariableName '4', Value: Value '4'");
+                output.AssertOutput("Key: VariableName \"5\", Value: Value \"5\"");
+                output.AssertOutput(@"Key: VariableName, 6, Value: Value, 6");
+                output.AssertOutput(@"Key: VariableName [7], Value: Value [7]");
+                output.AssertOutput(@"Key: VariableName {8}, Value: Value {8}");
+                output.AssertOutput("Key: VariableName\t9, Value: Value\t9");
+                output.AssertOutput(@"Key: VariableName 10 !@#$%^&*()_+1234567890-=, Value: Value 10 !@#$%^&*()_+1234567890-=");
+                output.AssertOutput("Key: VariableName \n 11, Value: Value \n 11");
+                output.AssertOutput("Key: VariableName.prop.anotherprop 12, Value: Value.prop.11");
+            }
         }
     }
 

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment;
@@ -246,12 +247,20 @@ namespace Calamari.Tests.Fixtures.Bash
                                             ["VariableName\t9"] = "Value\t9",
                                             ["VariableName 10 !@#$%^&*()_+1234567890-="] = "Value 10 !@#$%^&*()_+1234567890-=",
                                             ["VariableName \n 11"] = "Value \n 11",
-                                            ["VariableName.prop.anotherprop 12"] = "Value.prop.11",
+                                            ["VariableName.prop.anotherprop 12"] = "Value.prop.12",
+                                            ["VariableName`prop`anotherprop` 13"] = "Value`prop`13"
                                         }.AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
             output.AssertSuccess();
             if (featureToggle == FeatureToggle.BashParametersArrayFeatureToggle)
             {
+                var fullOutput = string.Join(Environment.NewLine, output.CapturedOutput.Infos);
+                if (fullOutput.Contains("Bash version 4.2 or later is required to use octopus_parameters"))
+                {
+                    output.AssertOutput("Still ran this script");
+                    return;
+                }
+
                 output.AssertOutput(@"Key: VariableName1, Value: Value 1");
                 output.AssertOutput(@"Key: VariableName 2, Value: Value 2");
                 output.AssertOutput(@"Key: VariableName3, Value: Value 3");
@@ -263,7 +272,8 @@ namespace Calamari.Tests.Fixtures.Bash
                 output.AssertOutput("Key: VariableName\t9, Value: Value\t9");
                 output.AssertOutput(@"Key: VariableName 10 !@#$%^&*()_+1234567890-=, Value: Value 10 !@#$%^&*()_+1234567890-=");
                 output.AssertOutput("Key: VariableName \n 11, Value: Value \n 11");
-                output.AssertOutput("Key: VariableName.prop.anotherprop 12, Value: Value.prop.11");
+                output.AssertOutput("Key: VariableName.prop.anotherprop 12, Value: Value.prop.12");
+                output.AssertOutput("Key: VariableName`prop`anotherprop` 13, Value: Value`prop`13");
             }
         }
     }

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -198,14 +198,28 @@ namespace Calamari.Tests.Fixtures.Bash
                 ["VariableName1"] = "Value 1",
                 ["VariableName 2"] = "Value 2",
                 ["VariableName3"] = "Value 3",
-                ["VariableName '4'"] = "Value 4"
+                ["VariableName '4'"] = "Value '4'",
+                ["VariableName \"5\""] = "Value \"5\"",
+                ["VariableName, 6"] = "Value, 6",
+                ["VariableName, [7]"] = "Value [7]",
+                ["VariableName, {8}"] = "Value {8}",
+                ["VariableName\t9"] = "Value\t9",
+                ["VariableName 10 !@#$%^&*()_+1234567890-="] = "Value 10 !@#$%^&*()_+1234567890-=",
+                ["VariableName, \n 11"] = "Value \n 11",
             });
 
             output.AssertSuccess();
             output.AssertOutput(@"Key: VariableName1, Value: Value 1");
             output.AssertOutput(@"Key: VariableName 2, Value: Value 2");
             output.AssertOutput(@"Key: VariableName3, Value: Value 3");
-            output.AssertOutput(@"Key: VariableName '4', Value: Value 4");
+            output.AssertOutput(@"Key: VariableName '4', Value: Value '4'");
+            output.AssertOutput("Key: VariableName \"5\", Value: Value \"5\"");
+            output.AssertOutput(@"Key: VariableName, 6, Value: Value, 6");
+            output.AssertOutput(@"Key: VariableName [7], Value: Value [7]");
+            output.AssertOutput(@"Key: VariableName {8}, Value: Value {8}");
+            output.AssertOutput(@"Key: VariableName\t9, Value: Value\t9");
+            output.AssertOutput(@"Key: VariableName 10 !@#$%^&*()_+1234567890-=, Value: Value 10 !@#$%^&*()_+1234567890-=");
+            output.AssertOutput("Key: VariableName \n 11, Value: Value \n 11");
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -228,6 +228,8 @@ namespace Calamari.Tests.Fixtures.Bash
                             });
         }
 
+        static string specialCharacters => "! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~  \n\u00b1 \u00d7 \u00f7 \u2211 \u220f \u2202 \u221e \u222b \u2248 \u2260 \u2264 \u2265 \u221a \u221b \u2206 \u2207 \u221d  \n$ \u00a2 \u00a3 \u00a5 \u20ac \u20b9 \u20a9 \u20b1 \u20aa \u20bf  \n• ‣ … ′ ″ ‘ ’ “ ” ‽ ¡ ¿ – — ―  \n( ) [ ] { } ⟨ ⟩ « » ‘ ’ “ ”  \n\u2190 \u2191 \u2192 \u2193 \u2194 \u2195 \u2196 \u2197 \u2198 \u2199 \u2b05 \u2b06 \u2b07 \u27a1 \u27f3  \nα β γ δ ε ζ η θ ι κ λ μ ν ξ ο π ρ σ τ υ φ χ ψ ω  \n\u00a9 \u00ae \u2122 § ¶ † ‡ µ #\n";
+
         [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
         [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
@@ -248,7 +250,8 @@ namespace Calamari.Tests.Fixtures.Bash
                                             ["VariableName 10 !@#$%^&*()_+1234567890-="] = "Value 10 !@#$%^&*()_+1234567890-=",
                                             ["VariableName \n 11"] = "Value \n 11",
                                             ["VariableName.prop.anotherprop 12"] = "Value.prop.12",
-                                            ["VariableName`prop`anotherprop` 13"] = "Value`prop`13"
+                                            ["VariableName`prop`anotherprop` 13"] = "Value`prop`13",
+                                            [specialCharacters] = specialCharacters
                                         }.AddFeatureToggleToDictionary(new List<FeatureToggle?>{ featureToggle }));
 
             output.AssertSuccess();
@@ -274,6 +277,7 @@ namespace Calamari.Tests.Fixtures.Bash
                 output.AssertOutput("Key: VariableName \n 11, Value: Value \n 11");
                 output.AssertOutput("Key: VariableName.prop.anotherprop 12, Value: Value.prop.12");
                 output.AssertOutput("Key: VariableName`prop`anotherprop` 13, Value: Value`prop`13");
+                output.AssertOutput($"Key: {specialCharacters}, Value: {specialCharacters}");
             }
         }
     }

--- a/source/Calamari.Tests/Fixtures/Bash/Scripts/enumerate-variables.sh
+++ b/source/Calamari.Tests/Fixtures/Bash/Scripts/enumerate-variables.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for key in "${!octopus_parameters[@]}"; do
+    value="${octopus_parameters[$key]}"
+    echo "Key: $key, Value: $value"
+done

--- a/source/Calamari.Tests/Fixtures/Bash/Scripts/enumerate-variables.sh
+++ b/source/Calamari.Tests/Fixtures/Bash/Scripts/enumerate-variables.sh
@@ -4,3 +4,5 @@ for key in "${!octopus_parameters[@]}"; do
     value="${octopus_parameters[$key]}"
     echo "Key: $key, Value: $value"
 done
+
+echo "Still ran this script"


### PR DESCRIPTION
This is an alternative to #1441 If we can use the cli command `xxd` this is not an issue and simplifies the implementation significantly.

This change adds the ability to iterate variable names in base. The implementation for this is based off of the PowerShell implementation of OctopusParameters `Decrypt-Variables`. 

For PowerShell we do the following in **C#**
* Base 64 encode the variable name and value with a `$` delimiter between them. (This is to make sure all special characters are removed)
* Encrypt the combined string of all variables (We can a base string and IV)
* Base64 encode the base string and convert the IV to hex.

These are then string replaced in the PowerShell bootstrap.ps1 script.

The PowerShell bootstrap script does the following:
* Decodes the IV and Hex
* Decrypts the whole string
* Decodes one by one the variable name and values

This works well in Powershell ~3000 variables takes about 1 second in this process.
In base we use Openssl to decode base64 strings, this spins up a process and overall repeating this same process for ~3000 variables takes ~60 seconds.

To work around this I've settled on Hex encoding the variable names, unlike base64 hex encoded strings can be concatenated and decrypted all at once, this also doesn't depend on the openssl process being invoked. We have to handle the hex to string ourselves, we could use [strtonum](https://stackoverflow.com/questions/8199934/strtonum-in-os-x-not-found) but it's not available everywhere. 

![image](https://github.com/user-attachments/assets/ef8987c7-d234-4b74-8a6f-56912ab5d2ae)


Accessing keys

```
echo ${!example_array[@]}
```