### PR TITLE
K8s: An unparsable ApiVersion string now throws, rather than returning "null, null"

### DIFF
--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceGroupVersionKindExtensionMethods.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceGroupVersionKindExtensionMethods.cs
@@ -40,7 +40,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                 case 2:
                     return (apiVersionParts[0], apiVersionParts[1]);
                 default:
-                    return (null, null);
+                    throw new InvalidOperationException($"Invalid API Version: {apiVersion}, must conform to <group>/<version> naming convention.");
             }
         } 
         


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
