### PR TITLE
Fix Calamari multi target build

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -117,7 +117,7 @@
     <Copy SourceFiles="@(FSharpFiles)" DestinationFolder="$(PublishDir)/FSharp/" />
     <Copy SourceFiles="@(ScriptCSFiles)" DestinationFolder="$(PublishDir)/ScriptCS/" />
   </Target>
-  <Target Name="CopyDotnetScriptFilesAfterBuild" AfterTargets="Build">
+  <Target Name="CopyDotnetScriptFilesAfterBuild" AfterTargets="Build" Condition="'$(IsCrossTargetingBuild)' == 'false'">
     <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(OutDir)/" />
   </Target>
   <Target Name="CopyDotnetScriptFilesAfterPublish" AfterTargets="Publish">


### PR DESCRIPTION
Only run the `CopyDotnetScriptFilesAfterBuild` target for non-cross-targeting builds (i.e. only run for each framework build).

See explanation here: https://octopusdeploy.slack.com/archives/C06FXB5PT/p1741672943262309

Also cleans up the build.cs file a bit.