### PR TITLE
Add command for aws-create-s3-bucket to run as a conventional step

### DIFF
--- a/source/Calamari.Aws/Commands/CreateAwsS3Command.cs
+++ b/source/Calamari.Aws/Commands/CreateAwsS3Command.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using Calamari.Aws.Deployment;
+using Calamari.Aws.Deployment.Conventions;
+using Calamari.Aws.Integration.CloudFormation;
+using Calamari.Aws.Integration.CloudFormation.Templates;
+using Calamari.Aws.Util;
+using Calamari.CloudAccounts;
+using Calamari.Commands.Support;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Extensions;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Common.Util;
+using Calamari.Deployment;
+using Calamari.Deployment.Conventions;
+using Newtonsoft.Json;
+
+namespace Calamari.Aws.Commands
+{
+    [Command("create-aws-s3", Description = "Creates an AWS S3 bucket")]
+    public class CreateAwsS3Command : Command
+    {
+        readonly ILog log;
+        readonly IVariables variables;
+        string bucketName;
+        string stackName;
+        bool publicAccess;
+        bool objectWriterOwnership;
+
+        public CreateAwsS3Command(ILog log, IVariables variables)
+        {
+            this.log = log;
+            this.variables = variables;
+            Options.Add("bucketName=", "The name of the bucket to create", v => bucketName = v);
+            Options.Add("stackName=", "The name of the CloudFormation stack.", v => stackName = v);
+            Options.Add("publicAccess=",
+                        "True if the bucket should allow public access, and False otherwise.",
+                        v => publicAccess = bool.TrueString.Equals(v, StringComparison.OrdinalIgnoreCase)); // False by default
+            Options.Add("objectWriterOwnership=",
+                        "True if the account creating the object should own it, and False if the bucket should own the object.",
+                        v => objectWriterOwnership = bool.TrueString.Equals(v, StringComparison.OrdinalIgnoreCase)); // False by default
+        }
+
+        public override int Execute(string[] commandLineArguments)
+        {
+            Options.Parse(commandLineArguments);
+
+            var tags = JsonConvert.DeserializeObject<List<KeyValuePair<string, string>>>(variables.Get(AwsSpecialVariables.CloudFormation.Tags) ?? "[]");
+            ValidateTags(tags);
+            
+            var environment = AwsEnvironmentGeneration.Create(log, variables).GetAwaiter().GetResult();
+
+            IAmazonCloudFormation ClientFactory()
+            {
+                return ClientHelpers.CreateCloudFormationClient(environment);
+            }
+
+            StackArn StackProvider(RunningDeployment _) => new StackArn(stackName);
+
+            ICloudFormationRequestBuilder TemplateFactory()
+            {
+                return new CloudFormationTemplate(GetTemplateBody,
+                                                  new EmptyTemplateInputs<Parameter>(),
+                                                  stackName,
+                                                  new List<string>(),
+                                                  true,
+                                                  null,
+                                                  tags,
+                                                  new StackArn(stackName),
+                                                  ClientFactory,
+                                                  variables);
+            }
+
+            var stackEventLogger = new StackEventLogger(log);
+
+            var conventions = new List<IConvention>
+            {
+                new LogAwsUserInfoConvention(environment),
+                new DeployAwsCloudFormationConvention(
+                                                      ClientFactory,
+                                                      TemplateFactory,
+                                                      stackEventLogger,
+                                                      StackProvider,
+                                                      _ => null,
+                                                      true,
+                                                      stackName,
+                                                      environment)
+            };
+            
+            var conventionRunner = new ConventionProcessor(new RunningDeployment(variables), conventions, log);
+            conventionRunner.RunConventions();
+            return 0;
+
+            // if stack is in update progress, fail step -- we might not need it manually but let the AWS error message bubble up
+            // deploy stack with strategy: create or update or delete+recreate (for unrecoverable states)
+
+            // print output variables
+        }
+
+        void ValidateTags(List<KeyValuePair<string, string>> tags)
+        {
+            var errorLink = log.FormatShortLink("createAwsS3BucketValidationError", "S3-CreateBucket-ValidationError");
+            if (tags.Count > 20)
+                throw new CommandException($"{errorLink} Total number of tags must not be more than 20.");
+
+            var uniqueTagKeys = tags.Select(t => t.Key).Distinct();
+            if (uniqueTagKeys.Count() != tags.Count)
+                throw new CommandException($"{errorLink} Each tag key must be unique.");
+        }
+
+        string GetTemplateBody()
+        {
+            var template = new
+            {
+                AWSTemplateFormatVersion = "2010-09-09",
+                Resources = new Dictionary<string, object>
+                {
+                    [$"Bucket{bucketName.ToCamelCase()}"] = new
+                    {
+                        Type = "AWS::S3::Bucket",
+                        Properties = new
+                        {
+                            BucketName = bucketName,
+                            PublicAccessBlockConfiguration = new
+                            {
+                                BlockPublicAcls = !publicAccess,
+                                BlockPublicPolicy = !publicAccess,
+                                IgnorePublicAcls = !publicAccess,
+                                RestrictPublicBuckets = !publicAccess
+                            },
+                            OwnershipControls = new
+                            {
+                                Rules = new object []
+                                {
+                                    new
+                                    {
+                                        ObjectOwnership = objectWriterOwnership ? "ObjectWriter" : "BucketOwnerPreferred"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            return JsonConvert.SerializeObject(template);
+        }
+    }
+}

--- a/source/Calamari.Aws/Deployment/AwsSpecialVariables.cs
+++ b/source/Calamari.Aws/Deployment/AwsSpecialVariables.cs
@@ -12,6 +12,9 @@
 
         public static class S3
         {
+            public const string BucketName = "Octopus.Action.Aws.S3.BucketName";
+            public const string ObjectWriterOwnership = "Octopus.Action.Aws.S3.ObjectWriterOwnership";
+            public const string PublicAccess = "Octopus.Action.Aws.S3.PublicAccess";
             public const string FileSelections = "Octopus.Action.Aws.S3.FileSelections";
             public const string PackageOptions = "Octopus.Action.Aws.S3.PackageOptions";
         }

--- a/source/Calamari.Aws/Deployment/Conventions/DescribeAwsCloudFormationStackConvention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/DescribeAwsCloudFormationStackConvention.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using Calamari.Aws.Exceptions;
+using Calamari.Aws.Integration.CloudFormation;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Newtonsoft.Json;
+
+namespace Calamari.Aws.Deployment.Conventions
+{
+    public class DescribeAwsCloudFormationStackConvention : CloudFormationInstallationConventionBase
+    {
+        readonly Func<IAmazonCloudFormation> clientFactory;
+        readonly Func<RunningDeployment, StackArn> stackProvider;
+        readonly Func<List<StackResourceSummary>, List<KeyValuePair<string, string>>> customOutputPropertiesProvider;
+
+        public DescribeAwsCloudFormationStackConvention(
+            Func<IAmazonCloudFormation> clientFactory,
+            Func<RunningDeployment, StackArn> stackProvider,
+            Func<List<StackResourceSummary>, List<KeyValuePair<string, string>>> customOutputPropertiesProvider,
+            StackEventLogger logger) : base(logger)
+        {
+            this.clientFactory = clientFactory;
+            this.stackProvider = stackProvider;
+            this.customOutputPropertiesProvider = customOutputPropertiesProvider;
+        }
+
+        public override void Install(RunningDeployment deployment)
+        {
+            InstallAsync(deployment).GetAwaiter().GetResult();
+        }
+
+        Task InstallAsync(RunningDeployment deployment)
+        {
+            var stack = stackProvider(deployment);
+
+            return WithAmazonServiceExceptionHandling(async () =>
+                                                          await DescribeStack(stack, deployment.Variables)
+                                                     );
+        }
+
+        async Task DescribeStack(StackArn stack, IVariables variables)
+        {
+            Guard.NotNull(stack, "The provided stack identifier or name may not be null");
+            Guard.NotNull(variables, "The variable dictionary may not be null");
+
+            try
+            {
+                var stackResponse = await clientFactory.DescribeStackAsync(stack);
+                var resourceSummaries = await clientFactory.ListStackResourcesAsync(stack);
+
+                var outputs = BuildOutputVariables(stackResponse, resourceSummaries, variables);
+
+                Log.Verbose($"OUTPUTS: {JsonConvert.SerializeObject(outputs)}");
+                foreach (var output in outputs)
+                    Log.SetOutputVariable(output.Key, output.Value, variables);
+            }
+            catch (AmazonCloudFormationException ex) when (ex.ErrorCode == "AccessDenied")
+            {
+                throw new PermissionException(
+                                              "The AWS account used to perform the operation does not have the required permissions to describe the stack.\n" + "Please ensure the current account has permission to perform action 'cloudformation:DescribeStacks' and 'cloudformation:DescribeStackResources'." + ex.Message + "\n");
+            }
+            catch (AmazonCloudFormationException ex)
+            {
+                throw new UnknownException("An unrecognized exception was thrown while describing the CloudFormation stack.", ex);
+            }
+        }
+
+        Dictionary<string, string> BuildOutputVariables(Stack stack, List<StackResourceSummary> stackResourceSummaries, IVariables variables)
+        {
+            var outputs = new Dictionary<string, string>
+            {
+                ["StackName"] = stack.StackName,
+                ["StackId"] = stack.StackId,
+                ["Region"] = variables.Get("Octopus.Action.Aws.Region")?.Trim()
+            };
+
+            var customOutputProperties = customOutputPropertiesProvider(stackResourceSummaries);
+            foreach (var kvp in customOutputProperties)
+                outputs.Add(kvp.Key, kvp.Value);
+
+            return outputs;
+        }
+    }
+}

--- a/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
@@ -222,6 +222,18 @@ namespace Calamari.Aws.Integration.CloudFormation
             var response = await clientFactory().DescribeStacksAsync(new DescribeStacksRequest { StackName = stack.Value });
             return response.Stacks.FirstOrDefault();
         }
+        
+        /// <summary>
+        /// Lists the stack resources
+        /// </summary>
+        /// <param name="clientFactory"></param>
+        /// <param name="stack"></param>
+        /// <returns></returns>
+        public static async Task<List<StackResourceSummary>> ListStackResourcesAsync(this Func<IAmazonCloudFormation> clientFactory, StackArn stack)
+        {
+            var response = await clientFactory().ListStackResourcesAsync(new ListStackResourcesRequest { StackName = stack.Value });
+            return response.StackResourceSummaries;
+        }
 
 
         /// <summary>

--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -369,10 +369,13 @@ namespace Calamari.CloudAccounts
 
         public AssumeRoleRequest GetAssumeRoleRequest()
         {
+            // RoleSessionName is required in .NET; if not provided, generate a random one like the JavaScript SDK.
+            var roleSessionName = String.IsNullOrEmpty(assumeRoleSession) ? $"aws-sdk-dotnet-{Guid.NewGuid()}" : assumeRoleSession;
+            
             var request = new AssumeRoleRequest
             {
                 RoleArn = assumeRoleArn,
-                RoleSessionName = assumeRoleSession,
+                RoleSessionName = roleSessionName,
                 ExternalId = string.IsNullOrWhiteSpace(assumeRoleExternalId) ? null : assumeRoleExternalId
             };
             if (int.TryParse(assumeRoleDurationSeconds, out var durationSeconds))

--- a/source/Calamari.Common/Plumbing/Extensions/StringExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/StringExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -74,6 +75,17 @@ namespace Calamari.Common.Plumbing.Extensions
                                   .FirstOrDefault()
                                   ?.Key
                    ?? LineEnding.Dos;
+        }
+        
+        public static string ToCamelCase(this string text)
+        {
+            var sanitizedText = Regex.Replace(text, @"[^a-zA-Z0-9\s]", " ");
+            
+            var textInfo = CultureInfo.CurrentCulture.TextInfo;
+            var camelCase = textInfo.ToTitleCase(sanitizedText).Replace(" ","").ToCharArray();
+            camelCase[0] = char.ToLower(camelCase[0]);
+            
+            return new string(camelCase);
         }
     }
 }

--- a/source/Calamari.Common/Util/ITemplate.cs
+++ b/source/Calamari.Common/Util/ITemplate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Calamari.Common.Util
 {
@@ -11,6 +12,11 @@ namespace Calamari.Common.Util
     public interface ITemplateInputs<TInput>
     {
         IEnumerable<TInput> Inputs { get; }
+    }
+    
+    public class EmptyTemplateInputs<TInput> : ITemplateInputs<TInput>
+    {
+        public IEnumerable<TInput> Inputs => Enumerable.Empty<TInput>();
     }
 
     public interface ITemplateOutputs<TOutput>

--- a/source/Calamari.Tests/AWS/CreateAwsS3CommandFixture.cs
+++ b/source/Calamari.Tests/AWS/CreateAwsS3CommandFixture.cs
@@ -1,13 +1,25 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
 using Calamari.Aws.Commands;
 using Calamari.Aws.Deployment;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.Deployment;
+using Calamari.Testing;
 using Calamari.Testing.Helpers;
 using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using Tag = Amazon.S3.Model.Tag;
 
 namespace Calamari.Tests.AWS
 {
@@ -15,6 +27,47 @@ namespace Calamari.Tests.AWS
     [Category(TestCategory.RunOnceOnWindowsAndLinux)]
     public class CreateAwsS3CommandFixture
     {
+        const string Region = "ap-southeast-2";
+        readonly CancellationToken cancellationToken;
+        readonly string stackName;
+        readonly string bucketName;
+        readonly CalamariVariables variables;
+
+        public CreateAwsS3CommandFixture()
+        {
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+            cancellationToken = cancellationTokenSource.Token;
+            stackName = $"calamari-create-s3-stack-{Guid.NewGuid()}";
+            bucketName = $"calamari-create-s3-bucket-{Guid.NewGuid()}";
+            variables = new CalamariVariables();
+        }
+
+        [SetUp]
+        public async Task Setup()
+        {
+            variables.Set(AwsSpecialVariables.Authentication.AwsAccountVariable, "AWSAccount");
+            variables.Set(SpecialVariables.Account.AccountType, "AmazonWebServicesAccount");
+            variables.Set("Octopus.Action.Aws.Region", Region);
+            variables.Set("AWSAccount.AccessKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, cancellationToken));
+            variables.Set("AWSAccount.SecretKey", await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, cancellationToken));
+        }
+
+        [TearDown]
+        public async Task TearDownInfrastructure()
+        {
+            await ExecuteAwsClient(async (s3Client, cfClient) =>
+                           {
+                               var response = await s3Client.ListObjectsAsync(bucketName, cancellationToken);
+                               foreach (var s3Object in response.S3Objects)
+                                   await s3Client.DeleteObjectAsync(bucketName, s3Object.Key, cancellationToken);
+                               await cfClient.DeleteStackAsync(new DeleteStackRequest
+                                                               {
+                                                                   StackName = stackName
+                                                               },
+                                                               cancellationToken);
+                           });
+        }
+
         [Test]
         public void NonUniqueTags_ShouldThrow()
         {
@@ -23,16 +76,78 @@ namespace Calamari.Tests.AWS
                 new KeyValuePair<string, string>("key1", "value1"),
                 new KeyValuePair<string, string>("key1", "value2")
             };
-            var variables = new CalamariVariables();
             variables.Set(AwsSpecialVariables.CloudFormation.Tags, JsonConvert.SerializeObject(tags));
-            
+
             var command = new CreateAwsS3Command(new InMemoryLog(), variables);
             Action act = () => command.Execute(new[]
             {
-                "--bucket", "test-bucket",
+                "--bucket", bucketName
             });
 
             act.Should().Throw<CommandException>().WithMessage("*Each tag key must be unique.");
+        }
+
+        [Test]
+        public async Task BucketShouldBeCreated()
+        {
+            // Arrange
+            var tags = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("key1", "value1"),
+                new KeyValuePair<string, string>("key2", "value2")
+            };
+            variables.Set(AwsSpecialVariables.CloudFormation.Tags, JsonConvert.SerializeObject(tags));
+
+            var log = new InMemoryLog();
+            var command = new CreateAwsS3Command(log, variables);
+
+            // Act
+            var result = command.Execute(new[]
+            {
+                "--bucketName", bucketName,
+                "--stackName", stackName,
+                "--objectWriterOwnership", "False"
+            });
+
+            // Assert
+            result.Should().Be(0);
+            await ExecuteAwsClient(async (s3Client, _) =>
+                           {
+                               var bucketTagsResponse = await s3Client.GetBucketTaggingAsync(new GetBucketTaggingRequest
+                                                                                             {
+                                                                                                 BucketName = bucketName
+                                                                                             },
+                                                                                             cancellationToken);
+                               var tagList = tags.Select(t => new Tag { Key = t.Key, Value = t.Value }).ToList();
+                               bucketTagsResponse.TagSet.Where(t => tagList.Exists(x => x.Key == t.Key)).Should().BeEquivalentTo(tagList);
+
+                               var bucketOwnershipControlsResponse = await s3Client.GetBucketOwnershipControlsAsync(new GetBucketOwnershipControlsRequest
+                                                                                                                    {
+                                                                                                                        BucketName = bucketName
+                                                                                                                    },
+                                                                                                                    cancellationToken);
+                               bucketOwnershipControlsResponse.OwnershipControls.Rules.Should()
+                                                              .BeEquivalentTo(new OwnershipControlsRule
+                                                              {
+                                                                  ObjectOwnership = ObjectOwnership.BucketOwnerPreferred
+                                                              });
+                           });
+        }
+
+        async Task ExecuteAwsClient(Func<AmazonS3Client, AmazonCloudFormationClient, Task> execute)
+        {
+            var credentials = new BasicAWSCredentials(
+                                                      await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, cancellationToken),
+                                                      await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, cancellationToken));
+
+            var s3Config = new AmazonS3Config { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.GetBySystemName(Region), LogResponse = true };
+            var cfConfig = new AmazonCloudFormationConfig { AllowAutoRedirect = true, RegionEndpoint = RegionEndpoint.GetBySystemName(Region), LogResponse = true };
+
+            using (var cfClient = new AmazonCloudFormationClient(credentials, cfConfig))
+            using (var s3Client = new AmazonS3Client(credentials, s3Config))
+            {
+                await execute(s3Client, cfClient);
+            }
         }
     }
 }

--- a/source/Calamari.Tests/AWS/CreateAwsS3CommandFixture.cs
+++ b/source/Calamari.Tests/AWS/CreateAwsS3CommandFixture.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using Calamari.Aws.Commands;
+using Calamari.Aws.Deployment;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Calamari.Tests.AWS
+{
+    [TestFixture]
+    [Category(TestCategory.RunOnceOnWindowsAndLinux)]
+    public class CreateAwsS3CommandFixture
+    {
+        [Test]
+        public void NonUniqueTags_ShouldThrow()
+        {
+            var tags = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("key1", "value1"),
+                new KeyValuePair<string, string>("key1", "value2")
+            };
+            var variables = new CalamariVariables();
+            variables.Set(AwsSpecialVariables.CloudFormation.Tags, JsonConvert.SerializeObject(tags));
+            
+            var command = new CreateAwsS3Command(new InMemoryLog(), variables);
+            Action act = () => command.Execute(new[]
+            {
+                "--bucket", "test-bucket",
+            });
+
+            act.Should().Throw<CommandException>().WithMessage("*Each tag key must be unique.");
+        }
+    }
+}

--- a/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
+++ b/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
@@ -37,7 +37,7 @@ namespace Calamari.Tests.AWS
 {
     [TestFixture]
     [Category(TestCategory.RunOnceOnWindowsAndLinux)]
-    public class S3FixtureForExistingBucket : S3Fixture
+    public class UploadAwsS3FixtureForExistingBucket : UploadAwsS3CommandFixture
     {
         // S3 Bucket operations are only eventually consistent (https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html#ConsistencyModel),
         // For this fixture, we pre-create the bucket to avoid any timing issues where we get told "Bucket does not exist" when trying to validate
@@ -520,7 +520,7 @@ namespace Calamari.Tests.AWS
 
     [TestFixture]
     [Category(TestCategory.RunOnceOnWindowsAndLinux)]
-    public class S3FixtureForNewBucket : S3Fixture
+    public class UploadAwsS3FixtureForNewBucket : UploadAwsS3CommandFixture
     {
         [Test]
         public async Task UploadPackage1()
@@ -580,14 +580,14 @@ namespace Calamari.Tests.AWS
         }
     }
 
-    public abstract class S3Fixture
+    public abstract class UploadAwsS3CommandFixture
     {
         protected string region;
         protected string bucketName;
         static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
         readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
 
-        public S3Fixture()
+        public UploadAwsS3CommandFixture()
         {
             region = RegionRandomiser.GetARegion();
             bucketName = $"calamari-s3fixture-{Guid.NewGuid():N}";

--- a/source/Calamari.Tests/Fixtures/Util/StringExtensionsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/StringExtensionsFixture.cs
@@ -43,5 +43,14 @@ namespace Calamari.Tests.Fixtures.Util
         {
             Assert.AreEqual(expected, source.AsRelativePathFrom(baseDirectory));
         }
+
+        [TestCase("to_camel_case_function", "toCamelCaseFunction")]
+        [TestCase("My S3 Bucket", "myS3Bucket")]
+        [TestCase("-only-$AlphaNUMERIC-characters%^",  "onlyAlphanumericCharacters")]
+        [Test]
+        public void ToCamelCase_ReturnsCorrectCamelCase(string input, string expected)
+        {
+            input.ToCamelCase().Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
## Background
We plan to deprecate the Step Package Framework — details in this [doc](https://docs.google.com/document/d/1tjRNW_Nf0jWOGYAsDwOaTLoeVovuBqNdGSFrVROE40o/edit?tab=t.0)

As part of this process, we will be converting all Step Package steps (implemented as Nodejs scripts) into conventional commands in Calamari.

[sc-105200]

## Result
Introduces a new `CreateAwsS3Command` that is functionally equivalent to the [current step package](https://github.com/OctopusDeploy/step-package-aws-s3) version.