### PR TITLE
Use region endpoint for assume role

### DIFF
--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -358,7 +358,7 @@ namespace Calamari.CloudAccounts
         {
             if ("True".Equals(assumeRole, StringComparison.OrdinalIgnoreCase))
             {
-                var client = new AmazonSecurityTokenServiceClient(AwsCredentials, AwsRegion);
+                var client = string.IsNullOrWhiteSpace(region) ? new AmazonSecurityTokenServiceClient(AwsCredentials) : new AmazonSecurityTokenServiceClient(AwsCredentials, AwsRegion);
                 var credentials = (await client.AssumeRoleAsync(GetAssumeRoleRequest())).Credentials;
 
                 EnvironmentVars["AWS_ACCESS_KEY_ID"] = credentials.AccessKeyId;

--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -358,7 +358,7 @@ namespace Calamari.CloudAccounts
         {
             if ("True".Equals(assumeRole, StringComparison.OrdinalIgnoreCase))
             {
-                var client = new AmazonSecurityTokenServiceClient(AwsCredentials);
+                var client = new AmazonSecurityTokenServiceClient(AwsCredentials, AwsRegion);
                 var credentials = (await client.AssumeRoleAsync(GetAssumeRoleRequest())).Credentials;
 
                 EnvironmentVars["AWS_ACCESS_KEY_ID"] = credentials.AccessKeyId;


### PR DESCRIPTION
[SC-101215]

When attempting to run a `Run an AWS CLI Script` or `Plan to apply a Terraform template` step with `Assume a different AWS service role` enabled, the AWS global STS endpoint is used. This endpoint is not supported by AWS `opt-in` regions, resulting in an AuthFailure when attempting to run the step. This PR ensures that the region endpoint is used for the region specified within the step process.

Fixes: https://github.com/OctopusDeploy/Issues/issues/9216