### PR TITLE
Adjust ApiResources error log level to be Verbose

### DIFF
--- a/source/Calamari/Kubernetes/ApiResourceScopeLookup.cs
+++ b/source/Calamari/Kubernetes/ApiResourceScopeLookup.cs
@@ -41,7 +41,7 @@ namespace Calamari.Kubernetes
             }
             catch
             {
-                log.Warn("Unable to retrieve resource scoping using kubectl api-resources. Using default resource scopes.");
+                log.Verbose("Unable to retrieve resource scoping using kubectl api-resources. Using default resource scopes.");
                 return DefaultResourceScopeLookup;
             }
         }


### PR DESCRIPTION
We've had feedback from users that the `log.Warn` here is confusing.

It's not something the user can fix and isn't really a big issue as there is a default, so I'm comfortable changing this back to `Verbose`