### PR TITLE
Fully qualify bash artifact path

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -135,8 +135,16 @@ function new_octopusartifact
 
 	if [ -z "$ofn" ]
 	then
-	    ofn=`basename "$pth"`
+	    ofn=$(basename "$pth")
 	fi
+	
+	# Fully qualify the path (also check if realpath exists)
+	if [ -x "$(command -v realpath)" ];
+  then
+	    pth="$(realpath "$pth")" 
+  else 
+      pth="$(cd "$(dirname -- "$pth")" >/dev/null; pwd -P)/$(basename -- "$pth")"
+  fi	
 
 	echo "##octopus[stdout-verbose]"
 	echo "Artifact $ofn will be collected from $pth after this step completes"

--- a/source/Calamari.Tests/Fixtures/Bash/Scripts/create-artifact.sh
+++ b/source/Calamari.Tests/Fixtures/Bash/Scripts/create-artifact.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-rm -fr ./subdir
-mkdir -p ./subdir/anotherdir
-touch ./subdir/anotherdir/myfile
+artifactPath=$(get_octopusvariable "BashFixture.ShouldCreateArtifact.Path")
 
-new_octopusartifact "./subdir/anotherdir/myfile"
+new_octopusartifact "$artifactPath"


### PR DESCRIPTION
Bash artifacts were not having their path fully qualified before passing back to server.