### PR TITLE
Update default region for s3 bucket to the AWS global endpoint region

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
@@ -19,6 +19,7 @@ namespace Calamari.Integration.Packages.Download
     public class S3PackageDownloader : IPackageDownloader
     {
         const string Extension = ".zip";
+        const string DefaultRegion = "us-east-1";
 
         // first item will be used as the default extension before checking for others
         static string[] knownFileExtensions =
@@ -135,7 +136,7 @@ namespace Calamari.Integration.Packages.Download
             throw new CommandException($"Failed to download package {packageId} {version}. Attempted {retry} times.");
         }
 
-        static AmazonS3Client GetS3Client(string? feedUsername, string? feedPassword, string endpoint = "us-west-1")
+        static AmazonS3Client GetS3Client(string? feedUsername, string? feedPassword, string endpoint = DefaultRegion)
         {
             var config = new AmazonS3Config
             {
@@ -171,7 +172,7 @@ namespace Calamari.Integration.Packages.Download
                 // If the bucket is in the us-east-1 region, then the region name is not included in the response.
                 if (string.IsNullOrEmpty(regionString))
                 {
-                    regionString = "us-east-1";
+                    regionString = DefaultRegion;
                 }
                 else if (regionString.Equals("EU", StringComparison.OrdinalIgnoreCase))
                 {

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS-local-access-disabled/aks.tf
@@ -8,7 +8,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   resource_group_name = azurerm_resource_group.default.name
   location            = "Australia East"
   dns_prefix          = "${random_pet.prefix.id}-k8s"
-  kubernetes_version  = "1.28"
+  kubernetes_version  = "1.29"
   
   tags = {
     octopus-environment = "Staging"

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/Clusters/AKS/aks.tf
@@ -8,7 +8,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   resource_group_name = azurerm_resource_group.default.name
   location            = "Australia East"
   dns_prefix          = "${random_pet.prefix.id}-k8s"
-  kubernetes_version  = "1.28"
+  kubernetes_version  = "1.29"
   
   tags = {
     octopus-environment = "Staging"


### PR DESCRIPTION
The default region for S3 buckets, according to AWS, is `us-east-1` so this PR updates the region we use by default from `us-west-1` to `us-east-1`.

[sc-107220]

Relates to OctopusDeploy/Issues#9338