### PR TITLE
Support OIDC Auth for GCR Feeds

### DIFF
--- a/source/Calamari.CloudAccounts/GoogleAuthenticationProvider.cs
+++ b/source/Calamari.CloudAccounts/GoogleAuthenticationProvider.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Newtonsoft.Json;
+using NetWebRequest = System.Net.WebRequest;
+
+
+namespace Calamari.CloudAccounts
+{
+    public class GoogleAuthenticationProvider
+    {
+        readonly HttpClient httpClient;
+        const string StsEndpoint = "https://sts.googleapis.com/v1/token";
+        const string GcrScope = "https://www.googleapis.com/auth/devstorage.read_write";
+        const string OidcUsername = "oauth2accesstoken";
+        
+        public GoogleAuthenticationProvider()
+        {
+            httpClient = new HttpClient(new HttpClientHandler {Proxy = NetWebRequest.DefaultWebProxy});
+        }
+        
+        public (string Username, string Password, Uri RegistryUri) GetGcrUserNamePasswordCredentials(string username, string password, Uri registryUri)
+        {
+            return (username, password, registryUri);
+        }
+        
+        public async Task<(string Username, string Password, Uri RegistryUri)> GetGcrOidcCredentials(IVariables variables, Uri registryUri)
+        {
+            try
+            {
+                Log.Verbose("Starting GCR OIDC credential retrieval process");
+                var jwt = variables.Get(AuthenticationVariables.Jwt);
+                var audience = variables.Get(AuthenticationVariables.Google.Audience)?.Replace("https:", "");
+                var gcrToken = await ExchangeJwtForGcrToken(jwt, audience);
+                Log.Verbose($"Successfully retrieved credentials for {registryUri}");
+                return (OidcUsername, gcrToken, registryUri);
+            }
+            catch (Exception ex)
+            { 
+                throw new Exception($"GCR-LOGIN-ERROR: Failed to verify OIDC credentials. Error: {ex.Message}", ex);
+            }
+        }
+        
+        async Task<string> ExchangeJwtForGcrToken(string jwt, string audience)
+        {
+            
+            var requestContent = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+                { "audience", audience },
+                { "scope", GcrScope },
+                { "requested_token_type", "urn:ietf:params:oauth:token-type:access_token" },
+                { "subject_token", jwt },
+                { "subject_token_type", "urn:ietf:params:oauth:token-type:jwt" }
+            });
+    
+            var response = httpClient.PostAsync(StsEndpoint, requestContent, CancellationToken.None)
+                                     .GetAwaiter().GetResult();
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync();
+                throw new Exception($"Failed to exchange JWT for GCR token. Status: {response.StatusCode}, Error: {errorContent}");
+            }
+
+            var responseJson = await response.Content.ReadAsStringAsync();
+            var tokenResponse = JsonConvert.DeserializeObject<TokenResponse>(responseJson);
+    
+            if (string.IsNullOrEmpty(tokenResponse?.AccessToken))
+            {
+                throw new Exception("Access token was not present in the response");
+            }
+    
+            return tokenResponse.AccessToken;
+        }
+        
+        class TokenResponse
+        {
+            [JsonProperty("access_token")]
+            public string AccessToken { get; set; }
+    
+            [JsonProperty("token_type")]
+            public string TokenType { get; set; }
+    
+            [JsonProperty("expires_in")]
+            public int? ExpiresIn { get; set; }
+    
+            [JsonProperty("issued_token_type")]
+            public string IssuedTokenType { get; set; }
+        }
+    }
+}

--- a/source/Calamari.CloudAccounts/GoogleAuthenticationProvider.cs
+++ b/source/Calamari.CloudAccounts/GoogleAuthenticationProvider.cs
@@ -57,9 +57,8 @@ namespace Calamari.CloudAccounts
                 { "subject_token", jwt },
                 { "subject_token_type", "urn:ietf:params:oauth:token-type:jwt" }
             });
-    
-            var response = httpClient.PostAsync(StsEndpoint, requestContent, CancellationToken.None)
-                                     .GetAwaiter().GetResult();
+
+            var response = await httpClient.PostAsync(StsEndpoint, requestContent, CancellationToken.None);
             if (!response.IsSuccessStatusCode)
             {
                 var errorContent = await response.Content.ReadAsStringAsync();

--- a/source/Calamari.CloudAccounts/GoogleAuthenticationProvider.cs
+++ b/source/Calamari.CloudAccounts/GoogleAuthenticationProvider.cs
@@ -8,7 +8,6 @@ using Calamari.Common.Plumbing.Variables;
 using Newtonsoft.Json;
 using NetWebRequest = System.Net.WebRequest;
 
-
 namespace Calamari.CloudAccounts
 {
     public class GoogleAuthenticationProvider
@@ -34,7 +33,10 @@ namespace Calamari.CloudAccounts
             {
                 Log.Verbose("Starting GCR OIDC credential retrieval process");
                 var jwt = variables.Get(AuthenticationVariables.Jwt);
-                var audience = variables.Get(AuthenticationVariables.Google.Audience)?.Replace("https:", "");
+                var rawAudience = variables.Get(AuthenticationVariables.Google.Audience);
+                var audience = Uri.TryCreate(rawAudience, UriKind.Absolute, out var uri)
+                    ? $"//{uri.Host}{uri.AbsolutePath}"
+                    : rawAudience;
                 var gcrToken = await ExchangeJwtForGcrToken(jwt, audience);
                 Log.Verbose($"Successfully retrieved credentials for {registryUri}");
                 return (OidcUsername, gcrToken, registryUri);

--- a/source/Calamari.Common/Plumbing/Variables/AuthenticationVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/AuthenticationVariables.cs
@@ -17,5 +17,10 @@ namespace Calamari.Common.Plumbing.Variables
             public static readonly string TenantId = "TenantId";
             public static readonly string ClientId = "ClientId";
         }
+        
+        public static class Google
+        {
+            public static readonly string Audience = "Audience";
+        }
     }
 }

--- a/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
@@ -75,7 +75,8 @@ namespace Calamari.Integration.Packages.Download
         {
             var feedType = variables.Get(AuthenticationVariables.FeedType);
             if (feedType == FeedType.AwsElasticContainerRegistry.ToString()
-                || feedType == FeedType.AzureContainerRegistry.ToString())
+                || feedType == FeedType.AzureContainerRegistry.ToString()
+                || feedType == FeedType.GoogleContainerRegistry.ToString())
             {
                 var loginDetails = GetContainerRegistryLoginDetails(feedType, username, password, feedUri);
                 username = loginDetails.Username;

--- a/source/Calamari.Shared/Integration/Packages/Download/GcrFeedLoginDetailsProvider.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/GcrFeedLoginDetailsProvider.cs
@@ -12,8 +12,13 @@ namespace Calamari.Integration.Packages.Download
         { 
             var gcrAuth = new GoogleAuthenticationProvider();
             var usingOidc = !string.IsNullOrWhiteSpace(variables.Get(AuthenticationVariables.Jwt));
-            Log.Verbose(usingOidc ? "Gcr Feed - OIDC token detected - using token-based authentication flow." : "Gcr Feed - Using json key authentication flow.");
-            return usingOidc ? (await gcrAuth.GetGcrOidcCredentials(variables, feedUri)) : ( await Task.FromResult(gcrAuth.GetGcrUserNamePasswordCredentials(username, password, feedUri)));
+            if (usingOidc) {
+                Log.Verbose("Gcr Feed - OIDC token detected - using token-based authentication flow.");
+                return await gcrAuth.GetGcrOidcCredentials(variables, feedUri);
+            } 
+            
+            Log.Verbose("Gcr Feed - Using json key authentication flow.");
+            return await Task.FromResult(gcrAuth.GetGcrUserNamePasswordCredentials(username, password, feedUri));
         }
     }
 }

--- a/source/Calamari.Shared/Integration/Packages/Download/GcrFeedLoginDetailsProvider.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/GcrFeedLoginDetailsProvider.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+using Calamari.CloudAccounts;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Integration.Packages.Download
+{
+    public class GcrFeedLoginDetailsProvider : IFeedLoginDetailsProvider
+    {
+        public async Task<(string Username, string Password, Uri FeedUri)> GetFeedLoginDetails(IVariables variables, string? username, string? password, Uri feedUri)
+        { 
+            var gcrAuth = new GoogleAuthenticationProvider();
+            var usingOidc = !string.IsNullOrWhiteSpace(variables.Get(AuthenticationVariables.Jwt));
+            Log.Verbose(usingOidc ? "Gcr Feed - OIDC token detected - using token-based authentication flow." : "Gcr Feed - Using json key authentication flow.");
+            return usingOidc ? (await gcrAuth.GetGcrOidcCredentials(variables, feedUri)) : ( await Task.FromResult(gcrAuth.GetGcrUserNamePasswordCredentials(username, password, feedUri)));
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/Packages/Download/IFeedLoginDetailsProviderFactory.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/IFeedLoginDetailsProviderFactory.cs
@@ -18,6 +18,8 @@ namespace Calamari.Integration.Packages.Download
                     return new EcrFeedLoginDetailsProvider();
                 case FeedType.AzureContainerRegistry:
                     return new AcrFeedLoginDetailsProvider();
+                case FeedType.GoogleContainerRegistry:
+                    return new GcrFeedLoginDetailsProvider();
                 default:
                     throw new NotImplementedException($"No login provider implementation for feed type `{feedType}`.");
             }


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

Updates Calamari to take contributed JWT and Audience variables to do an OIDC auth exchange for Google Container Registry Feeds.

Part of [#project-oidc-external-feeds](https://octopusdeploy.slack.com/archives/C08GX2ANBRP)

[sc-107861]
