### PR TITLE
Fix job status reporting when backoff limit is 0 and wait for jobs is enabled

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
@@ -48,12 +48,15 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         }
         
         [Test]
-        public void WhenWaitForJobsIsEnabled_ShouldHaveStatusOfFailedIfBackOffLimitHasBeenReached()
+        [TestCase(0,1)]
+        [TestCase(1,1)]
+        [TestCase(1,2)]
+        public void WhenWaitForJobsIsEnabled_ShouldHaveStatusOfFailedIfBackOffLimitHasBeenReached(int backoffLimit, int failures)
         {
             var jobResponse = new JobResponseBuilder()
-                .WithCompletions(3)
-                .WithBackoffLimit(4)
-                .WithFailed(4)
+                .WithCompletions(1)
+                .WithBackoffLimit(backoffLimit)
+                .WithFailed(failures)
                 .Build();
 
             var job = ResourceFactory.FromJson(jobResponse, new Options() { WaitForJobs = true });

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
@@ -70,6 +70,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
             var jobResponse = new JobResponseBuilder()
                 .WithCompletions(3)
                 .WithSucceeded(3)
+                .WithBackoffLimit(3)
                 .WithFailed(1)
                 .Build();
 
@@ -84,6 +85,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
             var jobResponse = new JobResponseBuilder()
                 .WithCompletions(3)
                 .WithSucceeded(2)
+                .WithBackoffLimit(3)
                 .WithFailed(1)
                 .Build();
 

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
@@ -21,15 +21,17 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             Duration = $"{completionTime - startTime:c}";
 
             var backoffLimit = FieldOrDefault("$.spec.backoffLimit", 0);
-            var failed = FieldOrDefault("$.status.failed", 0);
+
+            // Using a default value of -1 rather than 0 as a job can be created with a backoffLimit of 0 and we don't want to immediately mark the job as failed
+            var failed = FieldOrDefault("$.status.failed", -1);
 
             if (!options.WaitForJobs)
             {
                 ResourceStatus = ResourceStatus.Successful;
                 return;
             }
-            
-            if (backoffLimit != 0 && failed == backoffLimit)
+
+            if (failed >= backoffLimit)
             {
                 ResourceStatus = ResourceStatus.Failed;
             } 


### PR DESCRIPTION
# Background
Kubernetes Job's can have a backoff limit of zero and the checks we currently make to see if the Job has failed explicitly skips over the failure reporting if the backoff limit is set to 0 regardless of how many failures have occurred 

[SC-91594]

fixes: https://github.com/OctopusDeploy/Issues/issues/9371

# Results
- Change check for job failures to account for a backoff limit of 0
- Set default value for failures to be -1 
- Added more test cases for failed status to account for edge cases
