### PR TITLE
Add retry for failed Kubernetes status check 

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Amazon.IdentityManagement.Model;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Kubernetes.Integration;
@@ -54,12 +55,13 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
             kubectlGet.SetAllResources("Pod", pod1, pod2);
 
 
-            var got = resourceRetriever.GetAllOwnedResources(
+            var result = resourceRetriever.GetAllOwnedResources(
                 new List<ResourceIdentifier>
                 {
                     new ResourceIdentifier(SupportedResourceGroupVersionKinds.DeploymentV1, "nginx", "octopus")
                 },
                 null, new Options());
+            var got = result.Select(r => r.Value);
 
             got.Should().BeEquivalentTo(new object[]
             {
@@ -122,13 +124,14 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
             kubectlGet.SetAllResources("ReplicaSet", replicaSet1, replicaSet2);
             kubectlGet.SetAllResources("Pod");
 
-            var got = resourceRetriever.GetAllOwnedResources(
+            var result = resourceRetriever.GetAllOwnedResources(
                 new List<ResourceIdentifier>
                 {
                     new ResourceIdentifier(SupportedResourceGroupVersionKinds.DeploymentV1, "deployment-1", "octopus"),
                     new ResourceIdentifier(SupportedResourceGroupVersionKinds.DeploymentV1, "deployment-2", "octopus")
                 },
                 null, new Options());
+            var got = result.Select(r => r.Value);
 
             got.Should().BeEquivalentTo(new object[]
             {
@@ -190,12 +193,13 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
             kubectlGet.SetAllResources("Pod", childPod, irrelevantPod);
 
 
-            var got = resourceRetriever.GetAllOwnedResources(
+            var result = resourceRetriever.GetAllOwnedResources(
                 new List<ResourceIdentifier>
                 {
                     new ResourceIdentifier(SupportedResourceGroupVersionKinds.ReplicaSetV1, "rs", "octopus"),
                 },
                 null, new Options());
+            var got = result.Select(r => r.Value);
 
             got.Should().BeEquivalentTo(new object[]
             {

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/RunningResourceStatusCheckTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/RunningResourceStatusCheckTests.cs
@@ -187,20 +187,20 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
 
     public class TestRetriever : IResourceRetriever
     {
-        private readonly List<List<Resource>> responses = new List<List<Resource>>();
+        private readonly List<List<ResourceRetrieverResult>> responses = new List<List<ResourceRetrieverResult>>();
         private int current;
 
-        public IEnumerable<Resource> GetAllOwnedResources(
+        public IEnumerable<ResourceRetrieverResult> GetAllOwnedResources(
             IEnumerable<ResourceIdentifier> resourceIdentifiers,
             IKubectl kubectl,
             Options options)
         {
-            return current >= responses.Count ? new List<Resource>() : responses[current++];
+            return current >= responses.Count ? new List<ResourceRetrieverResult>() : responses[current++];
         }
 
         public void SetResponses(params List<Resource>[] responses)
         {
-            this.responses.AddRange(responses);
+            this.responses.AddRange(responses.Select(r => r.Select(ResourceRetrieverResult.Success).ToList()));
         }
     }
 

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
@@ -98,7 +98,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             
             var resources = parseResult.Value;
             var children = resources
-                           .Where(resource => resource.GroupVersionKind.Equals(childGvk))
+                           .Where(resource => resource.OwnerUids.Contains(parentResource.Uid))
                            .Select(child =>FetchChildrenAndUpdateResource(child, kubectl, options))
                            .ToList();
             parentResource.UpdateChildren(children);

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusCheckTask.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusCheckTask.cs
@@ -46,7 +46,7 @@ namespace Calamari.Kubernetes.ResourceStatus
 
             var definedResources = resources.ToArray();
             var checkCount = 0;
-            var taskResult = await Task.Run(async () =>
+            return await Task.Run(async () =>
             {
                 timer.Start();
                 var result = new Result();
@@ -71,7 +71,7 @@ namespace Calamari.Kubernetes.ResourceStatus
                                           .ToList();
                     if (statusCheckFailures.Any())
                     {
-                        log.Verbose("Resource Status Check: Failed to retrieve 1 or more resources status.");
+                        log.Verbose("Resource Status Check: Failed to update status for one or more resources:");
                         statusCheckFailures.ForEach(log.Verbose);
                     }
                     var definedResourceStatuses = resourceStatusResults.Where(r => r.IsSuccess).Select(r => r.Value).ToArray();
@@ -88,8 +88,7 @@ namespace Calamari.Kubernetes.ResourceStatus
                         deploymentStatus,
                         definedResources,
                         definedResourceStatuses,
-                        resourceStatuses,
-                        statusCheckFailures.ToArray()
+                        resourceStatuses
                     );
 
                     //if we have been asked to stop, jump out after the last check
@@ -104,16 +103,6 @@ namespace Calamari.Kubernetes.ResourceStatus
 
                 return result;
             }, cancellationToken);
-            
-            if (taskResult.Warnings.Length <= 0)
-                return taskResult;
-            
-            log.Warn("Resource Status Check completed with issues:");
-            foreach (var warning in taskResult.Warnings)
-            {
-                log.Warn(warning);
-            }
-            return taskResult;
         }
 
         /// <summary>
@@ -165,8 +154,7 @@ namespace Calamari.Kubernetes.ResourceStatus
                     deploymentStatus,
                     Array.Empty<ResourceIdentifier>(),
                     Array.Empty<Resource>(),
-                    new Dictionary<string, Resource>(),
-                    Array.Empty<string>()
+                    new Dictionary<string, Resource>()
                     )
             {
             }
@@ -175,21 +163,18 @@ namespace Calamari.Kubernetes.ResourceStatus
                 DeploymentStatus deploymentStatus,
                 ResourceIdentifier[] definedResources,
                 Resource[] definedResourceStatuses,
-                Dictionary<string, Resource> resourceStatuses,
-                string[] warnings)
+                Dictionary<string, Resource> resourceStatuses)
             {
                 DefiniedResources = definedResources;
                 DefinedResourceStatuses = definedResourceStatuses;
                 ResourceStatuses = resourceStatuses;
                 DeploymentStatus = deploymentStatus;
-                Warnings = warnings;
             }
 
             public ResourceIdentifier[] DefiniedResources { get; }
             public Resource[] DefinedResourceStatuses { get; }
             public Dictionary<string, Resource> ResourceStatuses { get; }
             public DeploymentStatus DeploymentStatus { get; }
-            public string[] Warnings { get; }
         }
     }
 }


### PR DESCRIPTION
# Background
After a deployment to a Kubernetes cluster, we poll the Kubernetes control plane using the kubectl CLI. The response from the CLI is used to update the state. 

Currently, there is no error handling if any of the responses from the CLI cannot be parsed. This will result in the deployment failing, even though the deployment task might succeed.

This is especially the case for the first status check, where the resource might not be created yet, and the CLI command will return an error. 
# Results
This PR adds better error handling for failed CLI commands and parsing. Instead of throwing immediately, the error is returned as a result. 

The deployment will only fail if all retries of the status check for a resource fail to verify that the resource was updated successfully. 

Fixes: https://github.com/OctopusDeploy/Issues/issues/9360
[sc-107940]
