### PR TITLE
Rework the Helm manifest polling cancellation logic

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
@@ -170,6 +170,34 @@ namespace Calamari.Tests.KubernetesFixtures
                   .Should()
                   .BeEmpty();
         }
+        
+        [Test]
+        [RequiresNonFreeBSDPlatform]
+        [RequiresNon32BitWindows]
+        [RequiresNonMac]
+        [Category(TestCategory.PlatformAgnostic)]
+        public void TargetingANamespaceThatDoesNotExistAbortsTheManifestSearchingLoop()
+        {
+            Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
+            Variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.KOSForHelm);
+            Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
+            Variables.Set(SpecialVariables.Helm.Namespace, "this-namespace-does-not-exist");
+
+            var result = DeployPackage();
+
+            result.AssertFailure();
+            result.AssertOutputMatches($"Retrieving manifest for {ReleaseName}");
+            result.AssertNoOutputMatches($"Retrieved manifest for {ReleaseName}");
+            
+            result.AssertOutputMatches("Helm Upgrade returned non-zero exit code: 1. Deployment terminated.");
+            result.AssertOutputMatches("Canceling manifest retrieval as Helm installation failed");
+
+            //we should not have received any KOS service messages
+            result.CapturedOutput.ServiceMessages
+                  .Where(sm => sm.Name == SpecialVariables.ServiceMessages.ResourceStatus.Name)
+                  .Should()
+                  .BeEmpty();
+        }
 
         protected override string ExplicitExeVersion => "3.16.2";
     }

--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
@@ -37,11 +37,11 @@ namespace Calamari.Kubernetes.Conventions.Helm
             this.helmCli = helmCli;
         }
 
-        public async Task StartBackgroundMonitoringAndReporting(
-            RunningDeployment deployment,
-            string releaseName,
-            int revisionNumber,
-            CancellationToken cancellationToken)
+        public async Task StartBackgroundMonitoringAndReporting(RunningDeployment deployment,
+                                                                string releaseName,
+                                                                int revisionNumber,
+                                                                CancellationToken helmInstallCompletedCancellationToken,
+                                                                CancellationToken helmInstallErrorCancellationToken)
         {
             await Task.Run(async () =>
                            {
@@ -58,7 +58,7 @@ namespace Calamari.Kubernetes.Conventions.Helm
                                        return;
                                    }
 
-                                   var manifest = await PollForManifest(deployment, releaseName, revisionNumber);
+                                   var manifest = await PollForManifest(deployment, releaseName, revisionNumber, helmInstallErrorCancellationToken);
 
                                    //it's possible that we have no manifest as charts with just hooks don't produce a manifest
                                    //in this case, there is nothing to do, so we are done :)
@@ -70,14 +70,17 @@ namespace Calamari.Kubernetes.Conventions.Helm
                                    //report the manifest has been applied
                                    manifestReporter.ReportManifestApplied(manifest);
 
+                                   //we want to cancel KOS if either token is cancelled
+                                   var kosKts = CancellationTokenSource.CreateLinkedTokenSource(helmInstallCompletedCancellationToken, helmInstallErrorCancellationToken);
+
                                    //if resource status (KOS) is enabled, parse the manifest and start monitoring the resources
                                    if (resourceStatusCheckIsEnabled)
                                    {
-                                       await ParseManifestAndMonitorResourceStatuses(deployment, manifest, cancellationToken);
+                                       await ParseManifestAndMonitorResourceStatuses(deployment, manifest, kosKts.Token);
                                    }
                                }
                            },
-                           cancellationToken);
+                           helmInstallCompletedCancellationToken);
         }
 
         static readonly SemanticVersion MinimumHelmVersion = new SemanticVersion(3, 13, 0);
@@ -98,19 +101,22 @@ namespace Calamari.Kubernetes.Conventions.Helm
 
         async Task<string> PollForManifest(RunningDeployment deployment,
                                            string releaseName,
-                                           int revisionNumber)
+                                           int revisionNumber,
+                                           CancellationToken helmInstallErrorCancellationToken)
         {
-            var ct = new CancellationTokenSource();
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(helmInstallErrorCancellationToken);
             var timeout = GoDurationParser.TryParseDuration(deployment.Variables.Get(SpecialVariables.Helm.Timeout), out var timespan) ? timespan : TimeSpan.FromMinutes(5);
-            ct.CancelAfter(timeout);
+            cts.CancelAfter(timeout);
             string manifest = null;
             log.Verbose($"Retrieving manifest for {releaseName}, revision {revisionNumber}.");
             var didSuccessfullyExecuteCliCall = false;
-            while (!ct.IsCancellationRequested)
+
+            while (!cts.IsCancellationRequested)
+            {
                 try
                 {
                     manifest = helmCli.GetManifest(releaseName, revisionNumber);
-                    
+
                     //flag if we successfully executed the get manifest call
                     //this is important because some helm charts just have hooks that don't have any manifests, so we receive null/empty string here
                     didSuccessfullyExecuteCliCall = true;
@@ -119,12 +125,29 @@ namespace Calamari.Kubernetes.Conventions.Helm
                 catch (CommandLineException)
                 {
                     log.Verbose($"Manifest could not be retrieved for {releaseName}, revision {revisionNumber}. Retrying in 1s.");
-                    await Task.Delay(TimeSpan.FromSeconds(1), ct.Token);
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        //We don't care if this is delayed
+                    }
                 }
+            }
 
-            //it's possible that some manifests doesn't
+            //if the helm install failed
+            if (helmInstallErrorCancellationToken.IsCancellationRequested)
+            {
+                log.Verbose("Canceling manifest retrieval as Helm installation failed");
+                return null;
+            }
+
+            //If we can't retrieve the manifest
             if (!didSuccessfullyExecuteCliCall)
-                throw new CommandException("Failed to retrieve helm manifest in a timely manner");
+            {
+                throw new CommandException("Failed to retrieve Helm manifest in a timely manner");
+            }
 
             //Log if we found a manifest, or not
             log.Verbose(string.IsNullOrWhiteSpace(manifest)

--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
@@ -131,7 +131,7 @@ namespace Calamari.Kubernetes.Conventions.Helm
                     }
                     catch (TaskCanceledException)
                     {
-                        //We don't care if this is delayed
+                        //We don't care if the delay was cancelled
                     }
                 }
             }


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

If the helm install command fails, we continue to attempt to retrieve the manifest until the configured timeout (or 5min) elapses.

This PR adds another CancellationTokenSource that tracks if the helm command fails. If the command fails, it cancels the manifest retrieval polling (if it's still running)