### PR TITLE
Fix issue downloading tools for K8s tests

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -561,11 +561,16 @@ namespace Calamari.Tests.KubernetesFixtures
 
         HttpClient CreateHttpClient()
         {
+            //we are _totally_ Chrome :joy:
+            const string userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
 #if NETCORE
-            return httpClientFactory.CreateClient();
+            var httpClient = httpClientFactory.CreateClient();
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
 #else
-            return new HttpClient();
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
 #endif
+            return httpClient;
         }
     }
 }


### PR DESCRIPTION
It appears that Cloudfront, which sits in-front of the hashicorp checkpoint API (what we use to work out what version of Terraform to download), requires a user agent string in the HTTP call.

We are now Chrome
