### PR TITLE
Removed unneeded reference to `Octopus.Data`

### DIFF
--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -25,11 +25,6 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Octopus.Data">
-      <Version>6.0.0</Version>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari.CloudAccounts\Calamari.CloudAccounts.csproj" />
     <ProjectReference Include="..\Calamari.Azure\Calamari.Azure.csproj" />


### PR DESCRIPTION
This seems like some detritus copied over when this was merged together. Likely the reference was added by accident. That it's only for one of the two frameworks also points to it being an accident.

`Octopus.Data` contains `Result` and storage interfaces, plus a reference to `Octopus.Server.MessageContracts`. Nothing that indicates some kind of hidden usage in AzureAppService.

This is one of the last usages of `Octopus.Data`, which would allow us to axe that project.