### PR TITLE
Fix fallback to AWS IAM auth when cluster URL is not valid

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
@@ -7,8 +7,7 @@
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using EKS cluster name my-eks-cluster
 [Verbose] Attempting to authenticate with aws-cli
-[Verbose] Unable to authenticate to <server> using the aws cli. Failed with error message: Could not parse eks token: '
-Provided region_name '<server>' doesn't match a supported format.'
+[Verbose] The EKS cluster Url specified should contain a valid aws region name
 [Verbose] Attempting to authenticate with aws-iam-authenticator
 [Verbose] "kubectl" config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1beta1 --exec-arg=token --exec-arg=-i --exec-arg=my-eks-cluster --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
@@ -19,10 +19,12 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
         private const string OlderAwsVersion = "aws-cli/1.16.155";
         private const string InvalidAwsVersion = "aws-cli/not-a-version";
 
-        private const string EksClusterName = "my-cool-eks-cluster-name";
+        private const string EksClusterName = "my-cool_eks-cluster-name";
         private const string AwsRegion = "southwest";
-        private const string AwsClusterUrl = "http://www." + AwsRegion + ".eks.amazonaws.com";
-        private const string InvalidAwsClusterUrl = "http://www." + AwsRegion + "..eks.amazonaws.com";
+        private const string AwsClusterUrl = "https://" + EksClusterName + "." + AwsRegion + ".eks.amazonaws.com";
+        private const string InvalidAwsClusterUrl = "https://www." + AwsRegion + "..eks.amazonaws.com";
+        private const string HttpAwsClusterUrl = "http://" + EksClusterName + "." + AwsRegion + ".eks.amazonaws.com";
+        private const string ClusterCname = "cluster.cname";
 
         [SetUp]
         public void Setup()
@@ -223,14 +225,17 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
         }
 
         [Test]
-        public void FallsBackToIamAuthenticatorWithoutRegion()
+        [TestCase(InvalidAwsClusterUrl)]
+        [TestCase(HttpAwsClusterUrl)]
+        [TestCase(ClusterCname)]
+        public void FallsBackToIamAuthenticatorWithoutRegion(string clusterUrl)
         {
-            variables.Set(SpecialVariables.ClusterUrl, InvalidAwsClusterUrl);
+            variables.Set(SpecialVariables.ClusterUrl, clusterUrl);
 
             AddLogForAwsEksGetToken();
             AddLogForWhichAws();
 
-            var expectedInvocations = SetupClusterContextInvocations(InvalidAwsClusterUrl);
+            var expectedInvocations = SetupClusterContextInvocations(clusterUrl);
             expectedInvocations.AddRange(AwsCliInvocations());
             expectedInvocations.AddRange(
                                          new List<(string, string)>
@@ -244,6 +249,7 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             result.VerifySuccess();
             AssertInvocations(expectedInvocations);
             log.Received().Verbose("The EKS cluster Url specified should contain a valid aws region name");
+            log.Received().Verbose("Attempting to authenticate with aws-iam-authenticator");
         }
 
         void AddLogForWhichAws()

--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
@@ -22,6 +22,7 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
         private const string EksClusterName = "my-cool_eks-cluster-name";
         private const string AwsRegion = "southwest";
         private const string AwsClusterUrl = "https://" + EksClusterName + "." + AwsRegion + ".eks.amazonaws.com";
+        private const string ExtendedAwsClusterUrl = "https://" + EksClusterName + ".gr7." + AwsRegion + ".eks.amazonaws.com";
         private const string InvalidAwsClusterUrl = "https://www." + AwsRegion + "..eks.amazonaws.com";
         private const string HttpAwsClusterUrl = "http://" + EksClusterName + "." + AwsRegion + ".eks.amazonaws.com";
         private const string ClusterCname = "cluster.cname";
@@ -51,14 +52,18 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
                                            environmentVars,
                                            workingDirectory);
 
+        [TestCase(AwsClusterUrl)]
+        [TestCase(ExtendedAwsClusterUrl)]
         [Test]
-        public void AuthenticatesWithAwsCli()
+        public void AuthenticatesWithAwsCli(string clusterUrl)
         {
+            variables.Set(SpecialVariables.ClusterUrl, clusterUrl);
+
             AddLogForAwsEksGetToken();
             AddLogForWhichAws();
             AddLogForAwsVersion(CurrentAwsVersion);
 
-            var expectedInvocations = SetupClusterContextInvocations(AwsClusterUrl);
+            var expectedInvocations = SetupClusterContextInvocations(clusterUrl);
             expectedInvocations.AddRange(AwsCliInvocations());
             expectedInvocations.AddRange(
                                          new List<(string, string)>

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -1,17 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Text.RegularExpressions;
 using Calamari.CloudAccounts;
 using Calamari.Common.FeatureToggles;
-using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.Integration;
-using Newtonsoft.Json.Linq;
 using Octopus.CoreUtilities;
 using Octopus.CoreUtilities.Extensions;
 using Octopus.Versioning.Semver;
-using InvalidOperationException = Amazon.CloudFormation.Model.InvalidOperationException;
 
 namespace Calamari.Kubernetes.Authentication
 {
@@ -132,7 +129,11 @@ namespace Calamari.Kubernetes.Authentication
             }
         }
 
-        static string GetEksClusterRegion(string clusterUrl) => clusterUrl.Replace(".eks.amazonaws.com", "").Split('.').Last();
+        static string GetEksClusterRegion(string clusterUrl)
+        {
+            var match = Regex.Match(clusterUrl, @"^https:\/\/[^.]+\.([a-z0-9-]+)\.eks\.amazonaws\.com$");
+            return match.Success ? match.Groups[1].Value : null;
+        }
 
         void SetKubeConfigAuthenticationToAwsCliUsingToken(string user, string clusterName, string region)
         {

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -81,6 +81,8 @@ namespace Calamari.Kubernetes.Authentication
                     }
 
                     log.Verbose("The EKS cluster Url specified should contain a valid aws region name");
+
+                    return false;
                 }
 
                 log.Verbose(

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -131,7 +131,7 @@ namespace Calamari.Kubernetes.Authentication
 
         static string GetEksClusterRegion(string clusterUrl)
         {
-            var match = Regex.Match(clusterUrl, @"^https:\/\/[^.]+\.([a-z0-9-]+)\.eks\.amazonaws\.com$");
+            var match = Regex.Match(clusterUrl, @"^https:\/\/[^.]+(?:\.[^.]+)?\.([a-z0-9-]+)\.eks\.amazonaws\.com$");
             return match.Success ? match.Groups[1].Value : null;
         }
 


### PR DESCRIPTION
[SC-59943]

Fixes: https://github.com/OctopusDeploy/Issues/issues/8346

Requires: https://github.com/OctopusDeploy/Calamari/pull/1504

When a CNAME is used instead of an AWS EKS cluster URL for for configuring an EKS deployment target, health checks fail. The current implementation attempts to use part or all of the CNAME as the region, even if this value is not a valid AWS region. When this value is used by the AWS CLI to retrieve a token, the region is not validated and a token is returned successfully, however because the token's region is not valid for the cluster, kubectl fails to authenticate.

## Results

The original intention was to fall back to use `aws-iam-authenticator` instead of the AWS CLI if the region or URL was invalid. This PR resolves the issue by enforcing fallback when the URL is not formatted correctly.

The URL regex is based on the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#cluster-endpoint-ipv4) here, however I found some newer endpoints had an extra segment before the region which isn't included in the documentation.

Before (with extra logging added locally):
```
Info          Creating kubectl context to https://eks.first/ (namespace default) using EKS cluster name scrumptious-dubstep-mountain
Verbose       Attempting to authenticate with aws-cli
Verbose       Received cluster URL: https://eks.first/
Verbose       Found region: first
Verbose       Found token: k8s-aws-*****
Verbose       "C:\ProgramData\chocolatey\bin\kubectl.exe" config set-credentials octouser --token=<token> --request-timeout=1m
Verbose       User "octouser" set.
Verbose       "C:\ProgramData\chocolatey\bin\kubectl.exe" get namespace default --request-timeout=1m
Verbose       error: You must be logged in to the server (Unauthorized)
```

After:
```
Info          Creating kubectl context to https://eks.first/ (namespace default) using EKS cluster name scrumptious-dubstep-mountain
Verbose       Attempting to authenticate with aws-cli
Verbose       The EKS cluster Url specified should contain a valid aws region name
Verbose       Attempting to authenticate with aws-iam-authenticator
Verbose       "C:\ProgramData\chocolatey\bin\kubectl.exe" config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1beta1 --exec-arg=token --exec-arg=-i --exec-arg=scrumptious-dubstep-mountain --request-timeout=1m
Verbose       User "octouser" set.
Verbose       "C:\ProgramData\chocolatey\bin\kubectl.exe" get namespace default --request-timeout=1m
Verbose       NAME      STATUS   AGE
Verbose       default   Active   3d21h
```

