### PR TITLE
Improve deployment status detection to handle progress deadline exceeded scenarios

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Calamari.Kubernetes.ResourceStatus;
 using Calamari.Kubernetes.ResourceStatus.Resources;
@@ -13,86 +14,174 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         public void ShouldCollectCorrectProperties()
         {
             var input = new DeploymentResponseBuilder()
-                .WithDesiredReplicas(3)
-                .WithTotalReplicas(4)
-                .WithAvailableReplicas(3)
-                .WithReadyReplicas(3)
-                .WithUpdatedReplicas(1)
-                .Build();
+                        .WithDesiredReplicas(3)
+                        .WithTotalReplicas(4)
+                        .WithAvailableReplicas(3)
+                        .WithReadyReplicas(3)
+                        .WithUpdatedReplicas(1)
+                        .Build();
             var deployment = ResourceFactory.FromJson(input, new Options());
-            
-            deployment.Should().BeEquivalentTo(new
-            {
-                GroupVersionKind = SupportedResourceGroupVersionKinds.DeploymentV1,
-                Name = "nginx",
-                Namespace = "default",
-                Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
-                UpToDate = 1,
-                Ready = "3/3",
-                Available = 3,
-                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
-            });
+
+            deployment.Should()
+                      .BeEquivalentTo(new
+                      {
+                          GroupVersionKind = SupportedResourceGroupVersionKinds.DeploymentV1,
+                          Name = "nginx",
+                          Namespace = "default",
+                          Uid = "01695a39-5865-4eea-b4bf-1a4783cbce62",
+                          UpToDate = 1,
+                          Ready = "3/3",
+                          Available = 3,
+                          ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
+                      });
         }
 
         [Test]
         public void ShouldNotBeSuccessfulIfSomeChildrenPodsAreStillRunning()
         {
             var input = new DeploymentResponseBuilder()
-                .WithDesiredReplicas(3)
-                .WithTotalReplicas(3)
-                .WithAvailableReplicas(3)
-                .WithReadyReplicas(3)
-                .WithUpdatedReplicas(3)
-                .Build();
+                        .WithDesiredReplicas(3)
+                        .WithTotalReplicas(3)
+                        .WithAvailableReplicas(3)
+                        .WithReadyReplicas(3)
+                        .WithUpdatedReplicas(3)
+                        .Build();
             var deployment = ResourceFactory.FromJson(input, new Options());
-            
+
             var pod = new PodResponseBuilder().Build();
             // More pods remaining than desired
-            var children = Enumerable.Range(0, 4) 
-                .Select(_ => ResourceFactory.FromJson(pod, new Options()));
+            var children = Enumerable.Range(0, 4)
+                                     .Select(_ => ResourceFactory.FromJson(pod, new Options()));
 
             var replicaSet = new Resource();
             replicaSet.UpdateChildren(children);
-            
-            deployment.UpdateChildren(new Resource[] { replicaSet });
+
+            deployment.UpdateChildren(new[] { replicaSet });
 
             deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
         }
-        
+
         [Test]
         public void ShouldBeSuccessfulIfOnlyDesiredPodsAreRunning()
         {
             var input = new DeploymentResponseBuilder()
-                .WithDesiredReplicas(3)
-                .WithTotalReplicas(3)
-                .WithAvailableReplicas(3)
-                .WithReadyReplicas(3)
-                .WithUpdatedReplicas(3)
-                .Build();
+                        .WithDesiredReplicas(3)
+                        .WithTotalReplicas(3)
+                        .WithAvailableReplicas(3)
+                        .WithReadyReplicas(3)
+                        .WithUpdatedReplicas(3)
+                        .Build();
             var deployment = ResourceFactory.FromJson(input, new Options());
-            
+
             var pod = new PodResponseBuilder().Build();
             var children = Enumerable.Range(0, 3)
-                .Select(_ => ResourceFactory.FromJson(pod, new Options()));
-            
+                                     .Select(_ => ResourceFactory.FromJson(pod, new Options()));
+
             var replicaSet = new Resource();
             replicaSet.UpdateChildren(children);
-            
-            deployment.UpdateChildren(new Resource[] { replicaSet });
+
+            deployment.UpdateChildren(new[] { replicaSet });
 
             deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
         }
+
+        [Test]
+        public void ShouldBeFailedWhenProgressDeadlineExceeded()
+        {
+            var input = new DeploymentResponseBuilder()
+                        .WithDesiredReplicas(3)
+                        .WithTotalReplicas(1)
+                        .WithAvailableReplicas(1)
+                        .WithReadyReplicas(1)
+                        .WithUpdatedReplicas(1)
+                        .WithGeneration(2)
+                        .WithObservedGeneration(2)
+                        .WithProgressDeadlineExceeded()
+                        .Build();
+            var deployment = ResourceFactory.FromJson(input, new Options());
+
+            deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Failed);
+        }
+
+        [Test]
+        public void ShouldBeInProgressWhenGenerationIsGreaterThanObservedGeneration()
+        {
+            var input = new DeploymentResponseBuilder()
+                        .WithDesiredReplicas(3)
+                        .WithTotalReplicas(3)
+                        .WithAvailableReplicas(3)
+                        .WithReadyReplicas(3)
+                        .WithUpdatedReplicas(3)
+                        .WithGeneration(3)
+                        .WithObservedGeneration(2)
+                        .Build();
+            var deployment = ResourceFactory.FromJson(input, new Options());
+
+            deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+
+        [Test]
+        public void ShouldBeInProgressWhenUpToDateIsLessThanDesired()
+        {
+            var input = new DeploymentResponseBuilder()
+                        .WithDesiredReplicas(3)
+                        .WithTotalReplicas(3)
+                        .WithAvailableReplicas(3)
+                        .WithReadyReplicas(3)
+                        .WithUpdatedReplicas(2)
+                        .WithGeneration(1)
+                        .WithObservedGeneration(1)
+                        .Build();
+            var deployment = ResourceFactory.FromJson(input, new Options());
+
+            deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+
+        [Test]
+        public void ShouldBeInProgressWhenTotalReplicasIsGreaterThanUpToDate()
+        {
+            var input = new DeploymentResponseBuilder()
+                        .WithDesiredReplicas(3)
+                        .WithTotalReplicas(4)
+                        .WithAvailableReplicas(3)
+                        .WithReadyReplicas(3)
+                        .WithUpdatedReplicas(3)
+                        .WithGeneration(1)
+                        .WithObservedGeneration(1)
+                        .Build();
+            var deployment = ResourceFactory.FromJson(input, new Options());
+
+            deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+
+        [Test]
+        public void ShouldBeInProgressWhenAvailableIsLessThanUpToDate()
+        {
+            var input = new DeploymentResponseBuilder()
+                        .WithDesiredReplicas(3)
+                        .WithTotalReplicas(3)
+                        .WithAvailableReplicas(2)
+                        .WithReadyReplicas(3)
+                        .WithUpdatedReplicas(3)
+                        .WithGeneration(1)
+                        .WithObservedGeneration(1)
+                        .Build();
+            var deployment = ResourceFactory.FromJson(input, new Options());
+
+            deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
     }
 
-    internal class DeploymentResponseBuilder
+    class DeploymentResponseBuilder
     {
-        private const string Template = @"{{
+        const string Template = @"{{
     ""apiVersion"": ""apps/v1"",
     ""kind"": ""Deployment"",
     ""metadata"": {{
         ""name"": ""nginx"",
         ""namespace"": ""default"",
-        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62"",
+        ""generation"": {5}
     }},
     ""spec"": {{
         ""replicas"": {0}
@@ -101,55 +190,88 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         ""replicas"": {1},
         ""availableReplicas"": {2},
         ""readyReplicas"": {3},
-        ""updatedReplicas"": {4}
+        ""updatedReplicas"": {4},
+        ""observedGeneration"": {6}{7}
     }}
 }}";
 
-        private int DesiredReplicas { get; set; }
-        private int TotalReplicas { get; set; }
-        private int AvailableReplicas { get; set; }
-        private int ReadyReplicas { get; set; }
-        private int UpdatedReplicas { get; set; }
+        int DesiredReplicas { get; set; }
+        int TotalReplicas { get; set; }
+        int AvailableReplicas { get; set; }
+        int ReadyReplicas { get; set; }
+        int UpdatedReplicas { get; set; }
+        int Generation { get; set; } = 1;
+        int ObservedGeneration { get; set; } = 1;
+        string Conditions { get; set; } = "";
 
         public DeploymentResponseBuilder WithDesiredReplicas(int replicas)
         {
             DesiredReplicas = replicas;
             return this;
         }
-        
+
         public DeploymentResponseBuilder WithTotalReplicas(int replicas)
         {
             TotalReplicas = replicas;
             return this;
         }
-        
+
         public DeploymentResponseBuilder WithAvailableReplicas(int replicas)
         {
             AvailableReplicas = replicas;
             return this;
         }
-        
+
         public DeploymentResponseBuilder WithReadyReplicas(int replicas)
         {
             ReadyReplicas = replicas;
             return this;
         }
-        
+
         public DeploymentResponseBuilder WithUpdatedReplicas(int replicas)
         {
             UpdatedReplicas = replicas;
             return this;
         }
-        
+
+        public DeploymentResponseBuilder WithGeneration(int generation)
+        {
+            Generation = generation;
+            return this;
+        }
+
+        public DeploymentResponseBuilder WithObservedGeneration(int observedGeneration)
+        {
+            ObservedGeneration = observedGeneration;
+            return this;
+        }
+
+        public DeploymentResponseBuilder WithProgressDeadlineExceeded()
+        {
+            Conditions = @",
+        ""conditions"": [
+            {
+                ""type"": ""Progressing"",
+                ""status"": ""False"",
+                ""reason"": ""ProgressDeadlineExceeded"",
+                ""message"": ""ReplicaSet has timed out progressing.""
+            }
+        ]";
+            return this;
+        }
+
         public string Build()
         {
             return string.Format(
-                Template, 
-                DesiredReplicas, 
-                TotalReplicas, 
-                AvailableReplicas, 
-                ReadyReplicas,
-                UpdatedReplicas);
+                                 Template,
+                                 DesiredReplicas,
+                                 TotalReplicas,
+                                 AvailableReplicas,
+                                 ReadyReplicas,
+                                 UpdatedReplicas,
+                                 Generation,
+                                 ObservedGeneration,
+                                 Conditions);
         }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
@@ -175,25 +175,25 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
     class DeploymentResponseBuilder
     {
         const string Template = @"{{
-    ""apiVersion"": ""apps/v1"",
-    ""kind"": ""Deployment"",
-    ""metadata"": {{
-        ""name"": ""nginx"",
-        ""namespace"": ""default"",
-        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62"",
-        ""generation"": {5}
-    }},
-    ""spec"": {{
-        ""replicas"": {0}
-    }},
-    ""status"": {{
-        ""replicas"": {1},
-        ""availableReplicas"": {2},
-        ""readyReplicas"": {3},
-        ""updatedReplicas"": {4},
-        ""observedGeneration"": {6}{7}
-    }}
-}}";
+            ""apiVersion"": ""apps/v1"",
+            ""kind"": ""Deployment"",
+            ""metadata"": {{
+                ""name"": ""nginx"",
+                ""namespace"": ""default"",
+                ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62"",
+                ""generation"": {5}
+            }},
+            ""spec"": {{
+                ""replicas"": {0}
+            }},
+            ""status"": {{
+                ""replicas"": {1},
+                ""availableReplicas"": {2},
+                ""readyReplicas"": {3},
+                ""updatedReplicas"": {4},
+                ""observedGeneration"": {6}{7}
+            }}
+        }}";
 
         int DesiredReplicas { get; set; }
         int TotalReplicas { get; set; }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
@@ -32,6 +32,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             var generation = FieldOrDefault("$.metadata.generation", 0);
             var observedGeneration = FieldOrDefault("$.status.observedGeneration", 0);
             
+            // Note that deployment status logic aligns with ArgoCD's gitops-engine, which is also used in the Kubernetes Monitor
             if (generation <= observedGeneration)
             {
                 var conditions = json.SelectToken("$.status.conditions") as JArray;

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
@@ -29,12 +29,39 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             Available = FieldOrDefault("$.status.availableReplicas", 0);
             UpToDate = FieldOrDefault("$.status.updatedReplicas", 0);
             
-            ResourceStatus = TotalReplicas == Desired
-                             && UpToDate == Desired
-                             && Available == Desired 
-                             && ReadyReplicas == Desired
-                ? ResourceStatus.Successful 
-                : ResourceStatus.InProgress;
+            var generation = FieldOrDefault("$.metadata.generation", 0);
+            var observedGeneration = FieldOrDefault("$.status.observedGeneration", 0);
+            
+            if (generation <= observedGeneration)
+            {
+                var conditions = json.SelectToken("$.status.conditions") as JArray;
+                var progressingCondition = conditions?.FirstOrDefault(c => c["type"]?.ToString() == "Progressing");
+                
+                if (progressingCondition != null && progressingCondition["reason"]?.ToString() == "ProgressDeadlineExceeded")
+                {
+                    ResourceStatus = ResourceStatus.Failed;
+                }
+                else if (Desired > 0 && UpToDate < Desired)
+                {
+                    ResourceStatus = ResourceStatus.InProgress;
+                }
+                else if (TotalReplicas > UpToDate)
+                {
+                    ResourceStatus = ResourceStatus.InProgress;
+                }
+                else if (Available < UpToDate)
+                {
+                    ResourceStatus = ResourceStatus.InProgress;
+                }
+                else
+                {
+                    ResourceStatus = ResourceStatus.Successful;
+                }
+            }
+            else
+            {
+                ResourceStatus = ResourceStatus.InProgress;
+            }
         }
 
         public override void UpdateChildren(IEnumerable<Resource> children)


### PR DESCRIPTION
### Context

https://app.shortcut.com/octopusdeploy/story/104135/kos-doesn-t-correctly-mark-a-deployment-resource-as-failed-when-the-progress-deadline-expires

The current deployment status logic uses a simple comparison of replica counts to determine if a deployment is successful or in progress. This approach fails to detect when a Kubernetes deployment has exceeded its progress deadline and is stuck in a failed state.
When a deployment encounters issues (e.g., image pull failures, resource constraints, or other blocking conditions), it may remain indefinitely in a state where the replica counts don't match the desired state, but the deployment is marked as "Progressing" with reason "ProgressDeadlineExceeded". The original logic would incorrectly report this as InProgress rather than Failed.

### Solution

Enhanced the deployment status detection logic to:

1. Check generation vs observedGeneration: Only evaluate status when the deployment controller has observed the current generation, ensuring we're not checking stale status information.
2. Detect progress deadline exceeded: Explicitly check for the "Progressing" condition with reason "ProgressDeadlineExceeded" and mark the deployment as Failed when this occurs.
3. Improved progress detection: More granular checks for in-progress states:

When desired replicas > 0 but not all replicas are up-to-date
When total replicas exceed up-to-date replicas (rollback/scaling scenarios)
When available replicas are less than up-to-date replicas (readiness issues)


4. Fallback for ongoing updates: Mark as InProgress when the deployment controller hasn't yet observed the current generation.

### Testing evidence

**Setup**

- Progression Deadline in seconds set to 1
- Kubernetes Object Status Check set to `Check that Kubernetes objects are running successfully
`
- Deploying an nginx container with version `doesnotexist` to intentionally trigger a failure when the pod attempts to pull it


**Before**

Even though the Progress Deadline of 1 second has been exceeded, Calamari still hangs since the it still thinks that the Deployment is still "Progressing"

https://github.com/user-attachments/assets/bbda6f0f-f564-458b-a2fd-97c87e5e3fcd
![Screenshot 2025-07-09 at 11 21 57 am](https://github.com/user-attachments/assets/10b9c4b1-10c6-479d-a0b3-8b652b516416)




**After**

Once the Progress Deadline of 1 second has been exceeded, Calamari fails the deployment because it can now correctly identify that the Deployment should be failed.

https://github.com/user-attachments/assets/b8271382-4eb5-44be-8776-8177adae4785

