### PR TITLE
Ignore the proxy tests on .NET Core

### DIFF
--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
@@ -1,18 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Proxies;
 using Calamari.Testing.Helpers;
-using Calamari.Tests.Helpers;
+using Calamari.Testing.Requirements;
 using FluentAssertions;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace Calamari.Tests.Fixtures.Integration.Proxies
 {
     [TestFixture]
+    // These tests currently only work in .NET Framework due to an issue with the .NET Core and proxy caching
+    // See https://github.com/OctopusDeploy/Calamari/pull/1504 for more information
+    [RequiresDotNetFramework]
     public class ProxyEnvironmentVariablesGeneratorFixture
     {
         const string BadproxyUrl = "http://proxy-initializer-fixture-bad-proxy:1234";

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/WebProxyInitializerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/WebProxyInitializerFixture.cs
@@ -4,7 +4,6 @@ using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Proxies;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
-using Calamari.Tests.Helpers;
 using FluentAssertions;
 using NUnit.Framework;
 


### PR DESCRIPTION
Due to continued issues with the Proxy tests affecting other tests, this PR disables the proxy tests on .NET Core.

See https://github.com/OctopusDeploy/Calamari/pull/1504 for more context on issues with .NET Core and proxies