### PR TITLE
Don't report helm manifests when dry run is enabled

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
@@ -1,7 +1,5 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
-using Calamari.Common.FeatureToggles;
-using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
@@ -49,7 +47,6 @@ namespace Calamari.Tests.KubernetesFixtures
         public void HelmVersionNewerThanMinimumVersion_ReportsObjectStatus()
         {
             Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
-            Variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.KOSForHelm);
             Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
             var result = DeployPackage();
@@ -90,7 +87,6 @@ namespace Calamari.Tests.KubernetesFixtures
             using (await UseCustomHelmExeInPackage("3.12.0"))
             {
                 Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
-                Variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.KOSForHelm);
                 Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
                 var result = DeployPackage();
@@ -119,7 +115,6 @@ namespace Calamari.Tests.KubernetesFixtures
         public void HooksOnlyPackage_RetrievesEmptyManifestButDoesNotReportObjectStatus()
         {
             Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
-            Variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.KOSForHelm);
             Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
             var result = DeployPackage("hooks-only-1.0.0.tgz");
@@ -149,7 +144,6 @@ namespace Calamari.Tests.KubernetesFixtures
         public void EmptyChart_RetrievesEmptyManifestButDoesNotReportObjectStatus()
         {
             Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
-            Variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.KOSForHelm);
             Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
             var result = DeployPackage("empty-chart-1.0.0.tgz");

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -8,6 +8,7 @@ using Calamari.Common.Features.Deployment;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripts;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.FileSystem;
@@ -21,7 +22,6 @@ using Calamari.Tests.Helpers;
 using Calamari.Util;
 using FluentAssertions;
 using NUnit.Framework;
-using Octopus.Versioning.Semver;
 
 namespace Calamari.Tests.KubernetesFixtures
 {

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -112,6 +112,9 @@ namespace Calamari.Tests.KubernetesFixtures
             Variables.Set(SpecialVariables.Account.AccountType, "Token");
             Variables.Set(SpecialVariables.Account.Token, ClusterToken);
 
+            // KOSForHelm is on by default
+            Variables.Set(KnownVariables.EnabledFeatureToggles, Variables.Get(KnownVariables.EnabledFeatureToggles) + "," + OctopusFeatureToggles.KnownSlugs.KOSForHelm);
+
             if (ExplicitExeVersion != null)
                 Variables.Set(Kubernetes.SpecialVariables.Helm.CustomHelmExecutable, HelmExePath);
 
@@ -331,6 +334,23 @@ namespace Calamari.Tests.KubernetesFixtures
             var result = DeployPackage();
             result.AssertSuccess();
             result.AssertOutputMatches("[helm|\\\\helm\"] upgrade (.*) --dry-run");
+        }
+
+        [Test]
+        [RequiresNonFreeBSDPlatform]
+        [RequiresNon32BitWindows]
+        [RequiresNonMac]
+        [Category(TestCategory.PlatformAgnostic)]
+        public void DoesNotReportManifestsWhenDryRunIsSet()
+        {
+            Variables.Set(Kubernetes.SpecialVariables.Helm.AdditionalArguments, "--dry-run");
+            Variables.Set(Kubernetes.SpecialVariables.ResourceStatusCheck, "true");
+            AddPostDeployMessageCheckAndCleanup(explicitNamespace: null, dryRun: true);
+
+            var result = DeployPackage();
+            result.AssertSuccess();
+            result.AssertOutputMatches("[helm|\\\\helm\"] upgrade (.*) --dry-run");
+            result.AssertOutputContains("Helm --dry-run is enabled, no object statuses will be reported");
         }
 
         [Test]

--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
@@ -58,7 +58,7 @@ namespace Calamari.Kubernetes.Conventions.Helm
                                        return;
                                    }
 
-                                   if (DeploymentSupportsManifestReporting(deployment, out var reason))
+                                   if (!DeploymentSupportsManifestReporting(deployment, out var reason))
                                    {
                                        log.Verbose(reason);
                                        return;


### PR DESCRIPTION
[sc-115648]

When Helm dry run is enabled, we never make a real update to the cluster. This ends up having Calamari attempting to fetch an updated revision that doesn't exist - eventually timing out because it will never be created.

If users are validating their Helm applications with dry run, then the features we have created that leverage the reported manifests aren't super useful.
There is a case to be made that they may want to see the (soon to be) applied manifests, however I think we are safe to wait for customer feedback on this as the number of customers using dry run must be low since this is the first time we've heard about this issue.

I've tried to write this in a way that could be built upon if there are other reasons we want to skip the manifest reporting. I considered moving the `--dry-run` flag to be a configurable option in the step, however, again, it seems like no one is really asking for that. Instead we're left with checking for the existance of `--dry-run` in the additional args.

Part of the reason this got through is becuase we are still testing a lot without KOS for helm enabled - I've just enabled it for all tests now since we default the feature toggle to on.