### PR TITLE
Run helm upgrade tests on mac

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
@@ -16,7 +16,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void Upgrade_Succeeds()
         {
@@ -34,7 +33,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public async Task CustomHelmExeInPackage_RelativePath()
         {
@@ -44,7 +42,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void HelmVersionNewerThanMinimumVersion_ReportsObjectStatus()
         {
@@ -82,7 +79,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public async Task HelmVersionOlderThanMinimumVersion_DoesNotRunObjectStatus()
         {
@@ -114,7 +110,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void HooksOnlyPackage_RetrievesEmptyManifestButDoesNotReportObjectStatus()
         {
@@ -144,7 +139,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void EmptyChart_RetrievesEmptyManifestButDoesNotReportObjectStatus()
         {

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -8,6 +8,7 @@ using Calamari.Common.Features.Deployment;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripts;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.FileSystem;
@@ -21,7 +22,6 @@ using Calamari.Tests.Helpers;
 using Calamari.Util;
 using FluentAssertions;
 using NUnit.Framework;
-using Octopus.Versioning.Semver;
 
 namespace Calamari.Tests.KubernetesFixtures
 {
@@ -40,7 +40,11 @@ namespace Calamari.Tests.KubernetesFixtures
 
         protected const string Namespace = "calamari-testing";
 
-        static string HelmOsPlatform => CalamariEnvironment.IsRunningOnWindows ? "windows-amd64" : "linux-amd64";
+        static string HelmOsPlatform => CalamariEnvironment.IsRunningOnWindows
+            ? "windows-amd64"
+            : CalamariEnvironment.IsRunningOnNix
+                ? "linux-amd64"
+                : "darwin-arm64";
 
         TemporaryDirectory explicitVersionTempDirectory;
 
@@ -121,7 +125,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void NoValues_EmbeddedValuesUsed()
         {
@@ -135,7 +138,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test(Description = "Test the case where the package ID does not match the directory inside the helm archive.")]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void MismatchPackageIDAndHelmArchivePathWorks()
         {
@@ -153,7 +155,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void ExplicitValues_NewValuesUsed()
         {
@@ -168,7 +169,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void ValuesFromPackage_NewValuesUsed()
         {
@@ -189,7 +189,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void ValuesFromChartPackage_NewValuesUsed()
         {
@@ -204,7 +203,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void ValuesFromChartPackage_GetSubstituted()
         {
@@ -219,7 +217,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void ValuesFromChartPackageWithoutSubDirectory_NewValuesUsed()
         {
@@ -234,7 +231,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void ValuesFromPackageAndExplicit_ExplicitTakesPrecedence()
         {
@@ -259,7 +255,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void ValuesFromRawYaml_ValuesAdded()
         {
@@ -286,7 +281,7 @@ namespace Calamari.Tests.KubernetesFixtures
         {
             var fileName = Path.Combine(Path.GetTempPath(), $"helm-v{version}-{HelmOsPlatform}.tgz");
             var tempFile = new TemporaryFile(fileName);
-            
+
             await DownloadHelmPackage(version, fileName);
 
             var customHelmExePackageId = Kubernetes.SpecialVariables.Helm.Packages.CustomHelmExePackageKey;
@@ -298,14 +293,13 @@ namespace Calamari.Tests.KubernetesFixtures
             // If package is provided then it should be treated as a relative path
             var customLocation = HelmOsPlatform + Path.DirectorySeparatorChar + "helm";
             Variables.Set(Kubernetes.SpecialVariables.Helm.CustomHelmExecutable, customLocation);
-            
+
             return tempFile;
         }
 
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void Namespace_Override_Used()
         {
@@ -321,7 +315,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void AdditionalArgumentsPassed()
         {
@@ -336,7 +329,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void WhenTheChartDirectoryVariableIsSet_TheChartAtThatLocationIsUsed()
         {
@@ -348,7 +340,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void WhenTheChartDirectoryVariableIsSet_AndTheChartDoesNotExist_AnErrorIsReturned()
         {
@@ -361,7 +352,6 @@ namespace Calamari.Tests.KubernetesFixtures
         [Test]
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
-        [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
         public void WhenChartIsInRootOfPackage_ShouldUseTheRootStagingDirectory()
         {
@@ -398,7 +388,7 @@ namespace Calamari.Tests.KubernetesFixtures
             Variables.Set(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.CustomScripts);
         }
 
-        static string DeleteCommand(string @namespace, string releaseName) 
+        static string DeleteCommand(string @namespace, string releaseName)
             => $"uninstall {releaseName} --namespace {@namespace}";
 
         protected CalamariResult DeployPackage(string packageName = null)
@@ -432,7 +422,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 }
             }
         }
-        
+
         static HelmVersion GetVersion()
         {
             StringBuilder stdout = new StringBuilder();

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -40,11 +40,23 @@ namespace Calamari.Tests.KubernetesFixtures
 
         protected const string Namespace = "calamari-testing";
 
-        static string HelmOsPlatform => CalamariEnvironment.IsRunningOnWindows
-            ? "windows-amd64"
-            : CalamariEnvironment.IsRunningOnNix
-                ? "linux-amd64"
-                : "darwin-arm64";
+        static string HelmOsPlatform
+        {
+            get
+            {
+                if (CalamariEnvironment.IsRunningOnWindows)
+                {
+                    return "windows-amd64";
+                }
+
+                if (CalamariEnvironment.IsRunningOnMac)
+                {
+                    return "darwin-arm64";
+                }
+
+                return "linux-amd64";
+            }
+        }
 
         TemporaryDirectory explicitVersionTempDirectory;
 
@@ -97,7 +109,7 @@ namespace Calamari.Tests.KubernetesFixtures
             FileSystem.PurgeDirectory(packageExtractionDirectory, FailureOptions.ThrowOnFailure);
 
             Environment.SetEnvironmentVariable("TentacleJournal",
-                                               Path.Combine(StagingDirectory, "DeploymentJournal.xml"));
+                Path.Combine(StagingDirectory, "DeploymentJournal.xml"));
 
             Variables = new VariablesFactory(FileSystem, new SilentLog()).Create(new CommonOptions("test"));
             Variables.Set(TentacleVariables.Agent.ApplicationDirectoryPath, StagingDirectory);
@@ -241,7 +253,7 @@ namespace Calamari.Tests.KubernetesFixtures
             Variables.Set(PackageVariables.IndexedPackageId("Pack-1"), "CustomValues");
             Variables.Set(PackageVariables.IndexedPackageVersion("Pack-1"), "2.0.0");
             Variables.Set(PackageVariables.IndexedOriginalPath("Pack-1"),
-                          GetFixtureResource("Charts", "CustomValues.2.0.0.zip"));
+                GetFixtureResource("Charts", "CustomValues.2.0.0.zip"));
             Variables.Set(Kubernetes.SpecialVariables.Helm.Packages.ValuesFilePath("Pack-1"), "values.yaml");
 
             //Variable that will replace packaged value in package
@@ -427,10 +439,10 @@ namespace Calamari.Tests.KubernetesFixtures
         {
             StringBuilder stdout = new StringBuilder();
             var result = SilentProcessRunner.ExecuteCommand("helm",
-                                                            "version --client --short",
-                                                            Environment.CurrentDirectory,
-                                                            output => stdout.AppendLine(output),
-                                                            error => { });
+                "version --client --short",
+                Environment.CurrentDirectory,
+                output => stdout.AppendLine(output),
+                error => { });
 
             result.ExitCode.Should().Be(0, $"Failed to retrieve version from Helm (Exit code {result.ExitCode}). Error output: \r\n{result.ErrorOutput}");
 

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -69,8 +69,6 @@ namespace Calamari.Kubernetes.Conventions
 
             var customHelmExecutable = CustomHelmExecutableFullPath(deployment.Variables, deployment.CurrentDirectory);
 
-            AssertHelmV3(customHelmExecutable);
-
             var sb = new StringBuilder();
 
             SetExecutable(sb, syntax, customHelmExecutable);

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeConvention.cs
@@ -74,6 +74,7 @@ namespace Calamari.Kubernetes.Conventions
             var sb = new StringBuilder();
 
             SetExecutable(sb, syntax, customHelmExecutable);
+            AssertHelmV3(customHelmExecutable);
             sb.Append($" upgrade --install");
             SetNamespaceParameter(deployment, sb);
             SetResetValuesParameter(deployment, sb);


### PR DESCRIPTION
Helm tests don't currently run on `darwin-arm64`, now they will.