### PR TITLE
Don't report helm manifests when dry run is enabled

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
@@ -1,7 +1,5 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
-using Calamari.Common.FeatureToggles;
-using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
@@ -49,7 +47,6 @@ namespace Calamari.Tests.KubernetesFixtures
         public void HelmVersionNewerThanMinimumVersion_ReportsObjectStatus()
         {
             Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
-            Variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.KOSForHelm);
             Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
             var result = DeployPackage();
@@ -90,7 +87,6 @@ namespace Calamari.Tests.KubernetesFixtures
             using (await UseCustomHelmExeInPackage("3.12.0"))
             {
                 Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
-                Variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.KOSForHelm);
                 Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
                 var result = DeployPackage();
@@ -119,7 +115,6 @@ namespace Calamari.Tests.KubernetesFixtures
         public void HooksOnlyPackage_RetrievesEmptyManifestButDoesNotReportObjectStatus()
         {
             Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
-            Variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.KOSForHelm);
             Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
             var result = DeployPackage("hooks-only-1.0.0.tgz");
@@ -149,7 +144,6 @@ namespace Calamari.Tests.KubernetesFixtures
         public void EmptyChart_RetrievesEmptyManifestButDoesNotReportObjectStatus()
         {
             Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
-            Variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.KOSForHelm);
             Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
             var result = DeployPackage("empty-chart-1.0.0.tgz");

--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
@@ -52,15 +52,15 @@ namespace Calamari.Kubernetes.Conventions.Helm
                                    || FeatureToggle.KubernetesLiveObjectStatusFeatureToggle.IsEnabled(deployment.Variables)
                                    || OctopusFeatureToggles.KubernetesObjectManifestInspectionFeatureToggle.IsEnabled(deployment.Variables))
                                {
-                                   if (!DoesHelmCliSupportManifestRetrieval(out var helmVersion))
-                                   {
-                                       log.Warn($"Octopus needs Helm v3.13 or later to display object status and manifests. Your current version is {helmVersion}. Please update your Helm executable or container to enable our new Kubernetes capabilities. Learn more in our {log.FormatShortLink("KOS", "documentation")}.");
-                                       return;
-                                   }
-
                                    if (!DeploymentSupportsManifestReporting(deployment, out var reason))
                                    {
                                        log.Verbose(reason);
+                                       return;
+                                   }
+
+                                   if (!DoesHelmCliSupportManifestRetrieval(out var helmVersion))
+                                   {
+                                       log.Warn($"Octopus needs Helm v3.13 or later to display object status and manifests. Your current version is {helmVersion}. Please update your Helm executable or container to enable our new Kubernetes capabilities. Learn more in our {log.FormatShortLink("KOS", "documentation")}.");
                                        return;
                                    }
 

--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmManifestAndStatusReporter.cs
@@ -58,6 +58,12 @@ namespace Calamari.Kubernetes.Conventions.Helm
                                        return;
                                    }
 
+                                   if (!DeploymentSupportsManifestReporting(deployment, out var reason))
+                                   {
+                                       log.Verbose(reason);
+                                       return;
+                                   }
+
                                    var manifest = await PollForManifest(deployment, releaseName, revisionNumber);
 
                                    //it's possible that we have no manifest as charts with just hooks don't produce a manifest
@@ -96,6 +102,19 @@ namespace Calamari.Kubernetes.Conventions.Helm
             return parsedExecutableVersion >= MinimumHelmVersion;
         }
 
+        static bool DeploymentSupportsManifestReporting(RunningDeployment deployment, out string reason)
+        {
+            var additionalArguments = deployment.Variables.Get(SpecialVariables.Helm.AdditionalArguments);
+            if (additionalArguments?.Contains("--dry-run") ?? false)
+            {
+                reason = "Helm --dry-run is enabled, no object statuses will be reported";
+                return false;
+            }
+
+            reason = "";
+            return true;
+        }
+
         async Task<string> PollForManifest(RunningDeployment deployment,
                                            string releaseName,
                                            int revisionNumber)
@@ -110,7 +129,7 @@ namespace Calamari.Kubernetes.Conventions.Helm
                 try
                 {
                     manifest = helmCli.GetManifest(releaseName, revisionNumber);
-                    
+
                     //flag if we successfully executed the get manifest call
                     //this is important because some helm charts just have hooks that don't have any manifests, so we receive null/empty string here
                     didSuccessfullyExecuteCliCall = true;


### PR DESCRIPTION
[sc-115648]

When Helm dry run is enabled, we never make a real update to the cluster. This ends up having Calamari attempting to fetch an updated revision that doesn't exist - eventually timing out because it will never be created.

If users are validating their Helm applications with dry run, then the features we have created that leverage the reported manifests aren't super useful.
There is a case to be made that they may want to see the (soon to be) applied manifests, however I think we are safe to wait for customer feedback on this as the number of customers using dry run must be low since this is the first time we've heard about this issue.

I've tried to write this in a way that could be built upon if there are other reasons we want to skip the manifest reporting. I considered moving the `--dry-run` flag to be a configurable option in the step, however, again, it seems like no one is really asking for that. Instead we're left with checking for the existance of `--dry-run` in the additional args.

Part of the reason this got through is becuase we are still testing a lot without KOS for helm enabled - I've just enabled it for all tests now since we default the feature toggle to on.