### PR TITLE
Consolidate Azure testing processes

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -20,6 +20,7 @@ using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing;
+using Calamari.Testing.Azure;
 using Calamari.Testing.LogParser;
 using FluentAssertions;
 using NUnit.Framework;

--- a/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AzureAppServiceDeployContainerBehaviourFixture.cs
@@ -12,6 +12,7 @@ using Calamari.AzureAppService.Azure;
 using Calamari.AzureAppService.Behaviors;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.Testing.Azure;
 using Calamari.Testing.Helpers;
 using FluentAssertions;
 using NUnit.Framework;

--- a/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
@@ -205,8 +205,9 @@ az group list";
             //as we have a single resource group, we need to have unique web app name per test
             context.Variables.Add("WebSite", $"Calamari-{Guid.NewGuid():N}");
             context.Variables.Add("Location", resourceGroupResource.Data.Location);
-            //this is a storage account prefix, so just make it as random as possible. The first character must be a letter, so just set to c (for calamari).
-            context.Variables.Add("AccountPrefix", AzureTestResourceHelpers.RandomName("c", 5));
+            //this is a storage account prefix, so just make it as random as possible
+            //The names of the storage accounts are a max of 7 chars, so we generate a prefix of 17 chars (storage accounts have a max of 24)
+            context.Variables.Add("AccountPrefix", AzureTestResourceHelpers.RandomName(length: 17));
         }
 
         private static void AddTemplateFiles(CommandTestBuilderContext context, string template, string parameters)

--- a/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
@@ -205,8 +205,8 @@ az group list";
             //as we have a single resource group, we need to have unique web app name per test
             context.Variables.Add("WebSite", $"Calamari-${Guid.NewGuid():N}");
             context.Variables.Add("Location", resourceGroupResource.Data.Location);
-            //this is a storage account prefix, so just make it as random as possible
-            context.Variables.Add("AccountPrefix", Guid.NewGuid().ToString().Substring(0, 6));
+            //this is a storage account prefix, so just make it as random as possible. The first character must be a letter, so just set to c (for calamari).
+            context.Variables.Add("AccountPrefix", AzureTestResourceHelpers.RandomName("c", 5));
         }
 
         private static void AddTemplateFiles(CommandTestBuilderContext context, string template, string parameters)

--- a/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
@@ -203,7 +203,7 @@ az group list";
             context.Variables.Add("ResourceGroup", resourceGroupName);
             context.Variables.Add("SKU", "Shared");
             //as we have a single resource group, we need to have unique web app name per test
-            context.Variables.Add("WebSite", $"Calamari-${Guid.NewGuid():N}");
+            context.Variables.Add("WebSite", $"Calamari-{Guid.NewGuid():N}");
             context.Variables.Add("Location", resourceGroupResource.Data.Location);
             //this is a storage account prefix, so just make it as random as possible. The first character must be a letter, so just set to c (for calamari).
             context.Variables.Add("AccountPrefix", AzureTestResourceHelpers.RandomName("c", 5));

--- a/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupActionHandlerFixture.cs
@@ -1,17 +1,20 @@
+using System;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Core;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using Calamari.Azure;
+using Calamari.CloudAccounts;
 using Calamari.Common.Features.Deployment;
 using Calamari.Common.Features.Scripts;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing;
+using Calamari.Testing.Azure;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
-using Microsoft.Azure.Management.Fluent;
-using Microsoft.Azure.Management.ResourceManager.Fluent;
-using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -26,45 +29,71 @@ namespace Calamari.AzureResourceGroup.Tests
         string clientSecret;
         string tenantId;
         string subscriptionId;
-        IResourceGroup resourceGroup;
-        IAzure azure;
         static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
         readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
+
+        ArmClient armClient;
+        SubscriptionResource subscriptionResource;
+        ResourceGroupResource resourceGroupResource;
+        string resourceGroupName;
 
         [OneTimeSetUp]
         public async Task Setup()
         {
-            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken);
-            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken);
-            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken);
-            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
+            var resourceManagementEndpointBaseUri =
+                Environment.GetEnvironmentVariable(AccountVariables.ResourceManagementEndPoint) ?? DefaultVariables.ResourceManagementEndpoint;
+            var activeDirectoryEndpointBaseUri =
+                Environment.GetEnvironmentVariable(AccountVariables.ActiveDirectoryEndPoint) ?? DefaultVariables.ActiveDirectoryEndpoint;
 
-            var resourceGroupName = SdkContext.RandomResourceName(nameof(AzureResourceGroupActionHandlerFixture), 60);
+            clientId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionClientId, cancellationToken);
+            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionPassword, cancellationToken);
+            tenantId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionTenantId, cancellationToken);
+            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionId, cancellationToken);
 
-            var credentials = SdkContext.AzureCredentialsFactory.FromServicePrincipal(clientId,
-                                                                                      clientSecret,
-                                                                                      tenantId,
-                                                                                      AzureEnvironment.AzureGlobalCloud);
+            var resourceGroupLocation = Environment.GetEnvironmentVariable("AZURE_NEW_RESOURCE_REGION") ?? RandomAzureRegion.GetRandomRegionWithExclusions();
 
-            azure = Microsoft.Azure.Management.Fluent.Azure
-                             .Configure()
-                             .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
-                             .Authenticate(credentials)
-                             .WithSubscription(subscriptionId);
+            resourceGroupName = AzureTestResourceHelpers.GetResourceGroupName();
 
-            resourceGroup = await azure.ResourceGroups
-                                       .Define(resourceGroupName)
-                                       .WithRegion(Region.USWest)
-                                       .CreateAsync();
+            var servicePrincipalAccount = new AzureServicePrincipalAccount(subscriptionId,
+                                                                           clientId,
+                                                                           tenantId,
+                                                                           clientSecret,
+                                                                           "AzureGlobalCloud",
+                                                                           resourceManagementEndpointBaseUri,
+                                                                           activeDirectoryEndpointBaseUri);
+
+            armClient = servicePrincipalAccount.CreateArmClient(retryOptions =>
+                                                                {
+                                                                    retryOptions.MaxRetries = 5;
+                                                                    retryOptions.Mode = RetryMode.Exponential;
+                                                                    retryOptions.Delay = TimeSpan.FromSeconds(2);
+                                                                    retryOptions.NetworkTimeout = TimeSpan.FromSeconds(200);
+                                                                });
+
+            //create the resource group
+            subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscriptionId));
+
+            var response = await subscriptionResource
+                                 .GetResourceGroups()
+                                 .CreateOrUpdateAsync(WaitUntil.Completed,
+                                                      resourceGroupName,
+                                                      new ResourceGroupData(new AzureLocation(resourceGroupLocation))
+                                                      {
+                                                          Tags =
+                                                          {
+                                                              [AzureTestResourceHelpers.ResourceGroupTags.LifetimeInDaysKey] = AzureTestResourceHelpers.ResourceGroupTags.LifetimeInDaysValue,
+                                                              [AzureTestResourceHelpers.ResourceGroupTags.SourceKey] = AzureTestResourceHelpers.ResourceGroupTags.SourceValue
+                                                          }
+                                                      });
+
+            resourceGroupResource = response.Value;
         }
 
         [OneTimeTearDown]
         public async Task Cleanup()
         {
-            if (resourceGroup != null)
-            {
-                await azure.ResourceGroups.DeleteByNameAsync(resourceGroup.Name);
-            }
+            await armClient.GetResourceGroupResource(ResourceGroupResource.CreateResourceIdentifier(subscriptionId, resourceGroupName))
+                           .DeleteAsync(WaitUntil.Started);
         }
 
         [Test]
@@ -170,12 +199,14 @@ az group list";
             context.Variables.Add(AzureAccountVariables.TenantId, tenantId);
             context.Variables.Add(AzureAccountVariables.ClientId, clientId);
             context.Variables.Add(AzureAccountVariables.Password, clientSecret);
-            context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupName, resourceGroup.Name);
-            context.Variables.Add("ResourceGroup", resourceGroup.Name);
+            context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupName, resourceGroupName);
+            context.Variables.Add("ResourceGroup", resourceGroupName);
             context.Variables.Add("SKU", "Shared");
-            context.Variables.Add("WebSite", SdkContext.RandomResourceName(string.Empty, 12));
-            context.Variables.Add("Location", resourceGroup.RegionName);
-            context.Variables.Add("AccountPrefix", SdkContext.RandomResourceName(string.Empty, 6));
+            //as we have a single resource group, we need to have unique web app name per test
+            context.Variables.Add("WebSite", $"Calamari-${Guid.NewGuid():N}");
+            context.Variables.Add("Location", resourceGroupResource.Data.Location);
+            //this is a storage account prefix, so just make it as random as possible
+            context.Variables.Add("AccountPrefix", Guid.NewGuid().ToString().Substring(0, 6));
         }
 
         private static void AddTemplateFiles(CommandTestBuilderContext context, string template, string parameters)

--- a/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
+++ b/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
@@ -7,8 +7,6 @@
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.38.1" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />

--- a/source/Calamari.AzureResourceGroup.Tests/DeployAzureBicepTemplateCommandFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/DeployAzureBicepTemplateCommandFixture.cs
@@ -3,10 +3,13 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
-using Azure.Identity;
+using Azure.Core;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
+using Calamari.Azure;
+using Calamari.CloudAccounts;
 using Calamari.Testing;
+using Calamari.Testing.Azure;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Tools;
 using NUnit.Framework;
@@ -27,33 +30,65 @@ namespace Calamari.AzureResourceGroup.Tests
         static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(5));
         readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
         readonly string packagePath = TestEnvironment.GetTestPath("Packages", "Bicep");
+        SubscriptionResource subscriptionResource;
 
         static IDeploymentTool AzureCLI = new InPathDeploymentTool("Octopus.Dependencies.AzureCLI", "AzureCLI\\wbin");
 
         [OneTimeSetUp]
         public async Task Setup()
         {
-            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken);
-            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken);
-            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken);
-            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
-            
-            resourceGroupName = $"calamari-deploy-bicep-fixture-{Guid.NewGuid().ToString("N").Substring(0, 8)}";
-            resourceGroupLocation = "australiasoutheast";
-            
-            armClient = new ArmClient(new ClientSecretCredential(tenantId, clientId, clientSecret), subscriptionId);
+            var resourceManagementEndpointBaseUri =
+                Environment.GetEnvironmentVariable(AccountVariables.ResourceManagementEndPoint) ?? DefaultVariables.ResourceManagementEndpoint;
+            var activeDirectoryEndpointBaseUri =
+                Environment.GetEnvironmentVariable(AccountVariables.ActiveDirectoryEndPoint) ?? DefaultVariables.ActiveDirectoryEndpoint;
+
+            clientId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionClientId, cancellationToken);
+            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionPassword, cancellationToken);
+            tenantId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionTenantId, cancellationToken);
+            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionId, cancellationToken);
+
+            resourceGroupName = AzureTestResourceHelpers.GetResourceGroupName();
+
+            resourceGroupLocation = Environment.GetEnvironmentVariable("AZURE_NEW_RESOURCE_REGION") ?? RandomAzureRegion.GetRandomRegionWithExclusions();
+
+            var servicePrincipalAccount = new AzureServicePrincipalAccount(subscriptionId,
+                                                                           clientId,
+                                                                           tenantId,
+                                                                           clientSecret,
+                                                                           "AzureGlobalCloud",
+                                                                           resourceManagementEndpointBaseUri,
+                                                                           activeDirectoryEndpointBaseUri);
+
+            armClient = servicePrincipalAccount.CreateArmClient(retryOptions =>
+                                                                {
+                                                                    retryOptions.MaxRetries = 5;
+                                                                    retryOptions.Mode = RetryMode.Exponential;
+                                                                    retryOptions.Delay = TimeSpan.FromSeconds(2);
+                                                                    retryOptions.NetworkTimeout = TimeSpan.FromSeconds(200);
+                                                                });
+
+            //create the resource group
+            subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscriptionId));
+
+            await subscriptionResource
+                                 .GetResourceGroups()
+                                 .CreateOrUpdateAsync(WaitUntil.Completed,
+                                                      resourceGroupName,
+                                                      new ResourceGroupData(new AzureLocation(resourceGroupLocation))
+                                                      {
+                                                          Tags =
+                                                          {
+                                                              [AzureTestResourceHelpers.ResourceGroupTags.LifetimeInDaysKey] = AzureTestResourceHelpers.ResourceGroupTags.LifetimeInDaysValue,
+                                                              [AzureTestResourceHelpers.ResourceGroupTags.SourceKey] = AzureTestResourceHelpers.ResourceGroupTags.SourceValue
+                                                          }
+                                                      });
         }
-        
+
         [OneTimeTearDown]
         public async Task Cleanup()
         {
-            var subscription = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscriptionId));
-            var resourceGroups = subscription.GetResourceGroups();
-            var existing = await resourceGroups.GetIfExistsAsync(resourceGroupName, CancellationToken.None);
-            if (existing.HasValue && existing.Value != null)
-            {
-                await existing.Value.DeleteAsync(WaitUntil.Started, cancellationToken: CancellationToken.None);
-            }
+            await armClient.GetResourceGroupResource(ResourceGroupResource.CreateResourceIdentifier(subscriptionId, resourceGroupName))
+                           .DeleteAsync(WaitUntil.Started);
         }
 
         [Test]
@@ -79,12 +114,12 @@ namespace Calamari.AzureResourceGroup.Tests
             // different.
             await CommandTestBuilder.CreateAsync<DeployAzureBicepTemplateCommand, Program>()
                                     .WithArrange(context =>
-                                    {
-                                        AddDefaults(context);
-                                        context.Variables.Add(SpecialVariables.Action.Azure.TemplateSource, "GitRepository");
-                                        context.Variables.Add(SpecialVariables.Action.Azure.BicepTemplate, "azure_website_template.bicep");
-                                        context.WithFilesToCopy(packagePath);
-                                    })
+                                                 {
+                                                     AddDefaults(context);
+                                                     context.Variables.Add(SpecialVariables.Action.Azure.TemplateSource, "GitRepository");
+                                                     context.Variables.Add(SpecialVariables.Action.Azure.BicepTemplate, "azure_website_template.bicep");
+                                                     context.WithFilesToCopy(packagePath);
+                                                 })
                                     .Execute();
         }
 
@@ -96,12 +131,12 @@ namespace Calamari.AzureResourceGroup.Tests
 
             await CommandTestBuilder.CreateAsync<DeployAzureBicepTemplateCommand, Program>()
                                     .WithArrange(context =>
-                                    {
-                                        AddDefaults(context);
-                                        context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupDeploymentMode, "Complete");
-                                        context.Variables.Add(SpecialVariables.Action.Azure.TemplateSource, "Inline");
-                                        AddTemplateFiles(context, templateFileContent, paramsFileContent);
-                                    })
+                                                 {
+                                                     AddDefaults(context);
+                                                     context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupDeploymentMode, "Complete");
+                                                     context.Variables.Add(SpecialVariables.Action.Azure.TemplateSource, "Inline");
+                                                     AddTemplateFiles(context, templateFileContent, paramsFileContent);
+                                                 })
                                     .Execute();
         }
 

--- a/source/Calamari.AzureResourceGroup.Tests/DeployAzureBicepTemplateCommandFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/DeployAzureBicepTemplateCommandFixture.cs
@@ -156,7 +156,8 @@ namespace Calamari.AzureResourceGroup.Tests
 
             context.Variables.Add("SKU", "Standard_LRS");
             context.Variables.Add("Location", resourceGroupLocation);
-            context.Variables.Add("StorageAccountName", "calamari" + Guid.NewGuid().ToString("N").Substring(0, 7));
+            //storage accounts can be 24 chars long
+            context.Variables.Add("StorageAccountName", AzureTestResourceHelpers.RandomName(length: 24));
         }
 
         static void AddTemplateFiles(CommandTestBuilderContext context, string template, string parameters)

--- a/source/Calamari.AzureScripting.Tests/AzurePowershellCommandFixture.cs
+++ b/source/Calamari.AzureScripting.Tests/AzurePowershellCommandFixture.cs
@@ -33,10 +33,10 @@ namespace Calamari.AzureScripting.Tests
         [OneTimeSetUp]
         public async Task Setup()
         {
-            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken);
-            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken);
-            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken);
-            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
+            clientId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionClientId, cancellationToken);
+            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionPassword, cancellationToken);
+            tenantId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionTenantId, cancellationToken);
+            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionId, cancellationToken);
         }
 
         [Test]

--- a/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
+++ b/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
@@ -8,6 +8,7 @@ using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Testing;
+using Calamari.Testing.Azure;
 using Calamari.Testing.Helpers;
 using FluentAssertions;
 using Microsoft.Azure.Management.AppService.Fluent;

--- a/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
+++ b/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
@@ -45,11 +45,12 @@ namespace Calamari.AzureWebApp.Tests
             azureConfigPath = TemporaryDirectory.Create();
             Environment.SetEnvironmentVariable("AZURE_CONFIG_DIR", azureConfigPath.DirectoryPath);
             
-            clientId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken);
-            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken);
-            tenantId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId, cancellationToken);
-            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureSubscriptionId, cancellationToken);
-            var resourceGroupName = SdkContext.RandomResourceName(nameof(DeployAzureWebCommandFixture), 60);
+            clientId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionClientId, cancellationToken);
+            clientSecret = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionPassword, cancellationToken);
+            tenantId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionTenantId, cancellationToken);
+            subscriptionId = await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionId, cancellationToken);
+
+            var resourceGroupName = AzureTestResourceHelpers.GetResourceGroupName();
 
             var credentials = SdkContext.AzureCredentialsFactory.FromServicePrincipal(clientId, clientSecret, tenantId,
                 AzureEnvironment.AzureGlobalCloud);
@@ -63,6 +64,7 @@ namespace Calamari.AzureWebApp.Tests
             resourceGroup = await azure.ResourceGroups
                 .Define(resourceGroupName)
                 .WithRegion(Region.USWest)
+                .WithTags(AzureTestResourceHelpers.ResourceGroupTags.ToDictionary())
                 .CreateAsync();
 
             appServicePlan = await azure.AppServices.AppServicePlans

--- a/source/Calamari.Terraform.Tests/Azure/example.tf
+++ b/source/Calamari.Terraform.Tests/Azure/example.tf
@@ -6,11 +6,24 @@ variable "app_name" {
   description = "The name of the app"
 }
 
+variable "resource_group_name" {
+  type = string
+}
+
+variable "resource_group_location" {
+  type = string
+}
+
 resource "random_pet" "prefix" {}
 
 resource "azurerm_resource_group" "resgrp" {
-  name     = "${random_pet.prefix.id}-rg"
-  location = "Australia East"
+  name     = var.resource_group_name
+  location = var.resource_group_location
+  
+  tags = {
+    LifetimeInDays = 1
+    source = "calamari-e2e-tests"
+  }
 }
 
 resource "azurerm_app_service_plan" "service_plan" {

--- a/source/Calamari.Terraform.Tests/Azure/example.tfvars
+++ b/source/Calamari.Terraform.Tests/Azure/example.tfvars
@@ -1,1 +1,3 @@
 app_name = "#{app_name}"
+resource_group_name = "#{resource_group_name}"
+resource_group_location = "#{resource_group_location}"

--- a/source/Calamari.Testing/Azure/AzureTestResourceHelpers.cs
+++ b/source/Calamari.Testing/Azure/AzureTestResourceHelpers.cs
@@ -7,11 +7,12 @@ public static class AzureTestResourceHelpers
 {
     const string ValidNameChars = "abcdefghijklmnopqrstuvwxyz0123456789";
 
-    static readonly Random Random = new Random();
+    static readonly Random Random = new();
 
     public static string GetResourceGroupName()
     {
-        return $"calamari-e2e-{DateTime.UtcNow:yyyyMMdd}-{Guid.NewGuid():N}";
+        //surely the changes of hitting 8 random chars on the same day at the same time are unique
+        return RandomName($"calamari-e2e-{DateTime.UtcNow:yyyyMMdd}-", 8);
     }
 
     public static string RandomName(string? prefix = null, int length = 32)

--- a/source/Calamari.Testing/Azure/AzureTestResourceHelpers.cs
+++ b/source/Calamari.Testing/Azure/AzureTestResourceHelpers.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Calamari.Testing;
+
+public static class AzureTestResourceHelpers
+{
+    public static string GetResourceGroupName()
+    {
+        return $"Calamari-E2E-{DateTime.UtcNow:yyyyMMdd}-{Guid.NewGuid():N}";
+    }
+
+    public static class ResourceGroupTags
+    {
+        public const string LifetimeInDaysKey = "LifetimeInDays";
+        public const string LifetimeInDaysValue = "1";
+
+        public const string SourceKey = "source";
+        public const string SourceValue = "calamari-e2e-tests";
+
+        public static Dictionary<string, string> ToDictionary()
+        {
+            
+            return new Dictionary<string, string>
+            {
+                [LifetimeInDaysKey] = LifetimeInDaysValue,
+                [SourceKey] = SourceValue
+            };
+        }
+    }
+}

--- a/source/Calamari.Testing/Azure/AzureTestResourceHelpers.cs
+++ b/source/Calamari.Testing/Azure/AzureTestResourceHelpers.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Calamari.Testing;
+namespace Calamari.Testing.Azure;
 
 public static class AzureTestResourceHelpers
 {
@@ -16,13 +16,13 @@ public static class AzureTestResourceHelpers
 
     public static string RandomName(string? prefix = null, int length = 32)
     {
-        var result = new char[32];
-        for (var i = 0; i < 2; i++)
+        var result = new char[length];
+        for (var i = 0; i < length; i++)
         {
             result[i] = ValidNameChars[Random.Next(ValidNameChars.Length)];
         }
 
-        return new string(result);
+        return $"{prefix}{new string(result)}";
     }
 
     public static class ResourceGroupTags

--- a/source/Calamari.Testing/Azure/AzureTestResourceHelpers.cs
+++ b/source/Calamari.Testing/Azure/AzureTestResourceHelpers.cs
@@ -5,9 +5,24 @@ namespace Calamari.Testing;
 
 public static class AzureTestResourceHelpers
 {
+    const string ValidNameChars = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+    static readonly Random Random = new Random();
+
     public static string GetResourceGroupName()
     {
         return $"Calamari-E2E-{DateTime.UtcNow:yyyyMMdd}-{Guid.NewGuid():N}";
+    }
+
+    public static string RandomName(string? prefix = null, int length = 32)
+    {
+        var result = new char[32];
+        for (var i = 0; i < 2; i++)
+        {
+            result[i] = ValidNameChars[Random.Next(ValidNameChars.Length)];
+        }
+
+        return new string(result);
     }
 
     public static class ResourceGroupTags
@@ -20,7 +35,6 @@ public static class AzureTestResourceHelpers
 
         public static Dictionary<string, string> ToDictionary()
         {
-            
             return new Dictionary<string, string>
             {
                 [LifetimeInDaysKey] = LifetimeInDaysValue,

--- a/source/Calamari.Testing/Azure/AzureTestResourceHelpers.cs
+++ b/source/Calamari.Testing/Azure/AzureTestResourceHelpers.cs
@@ -11,7 +11,7 @@ public static class AzureTestResourceHelpers
 
     public static string GetResourceGroupName()
     {
-        return $"Calamari-E2E-{DateTime.UtcNow:yyyyMMdd}-{Guid.NewGuid():N}";
+        return $"calamari-e2e-{DateTime.UtcNow:yyyyMMdd}-{Guid.NewGuid():N}";
     }
 
     public static string RandomName(string? prefix = null, int length = 32)

--- a/source/Calamari.Testing/Azure/RandomAzureRegion.cs
+++ b/source/Calamari.Testing/Azure/RandomAzureRegion.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-namespace Calamari.AzureAppService.Tests
+namespace Calamari.Testing.Azure
 {
     public static class RandomAzureRegion
     {

--- a/source/Calamari.Testing/EnvironmentVariables.cs
+++ b/source/Calamari.Testing/EnvironmentVariables.cs
@@ -27,7 +27,7 @@ namespace Calamari.Testing
         [EnvironmentVariable("Azure_OctopusAPITester_Certificate", "op://Calamari Secrets for Tests/Azure - OctopusApiTester/thumbprint")]
         AzureSubscriptionCertificate,
 
-        //These are specifically for the AKS tests against the static Instances
+        //This is correctly configured in TeamCity. ALl azure tests _should_ use these secrets going forward.
         [EnvironmentVariable("AzureAks_OctopusAPITester_SubscriptionId", "op://Calamari Secrets for Tests/Azure - OctopusApiTester/subscription id")]
         AzureAksSubscriptionId,
 


### PR DESCRIPTION
The PR consolidates a lot of the Azure testing processes where resource groups are created.

There is now a standard resource group naming structure `Calamari-{Date}-{Guid}`.
Also we have two standard tags, `LifetimeInDays` = `1` and `source` = `calamari-e2e-tests`.

This will allow for a cleanup script to remove resource groups that are not correctly cleaned up.

I also moved all of the tests to use the "Aks" credentials... If these work, I'll change them to not be "Aks" specific.