### PR TITLE
Removes the last usage of the old Azure service principal creds

### DIFF
--- a/source/Calamari.Testing/EnvironmentVariables.cs
+++ b/source/Calamari.Testing/EnvironmentVariables.cs
@@ -11,22 +11,6 @@ namespace Calamari.Testing
 {
     public enum ExternalVariable
     {
-        
-        [EnvironmentVariable("Azure_OctopusAPITester_SubscriptionId", "op://Calamari Secrets for Tests/Azure - OctopusApiTester/subscription id")]
-        AzureSubscriptionId,
-
-        [EnvironmentVariable("Azure_OctopusAPITester_TenantId", "op://Calamari Secrets for Tests/Azure - OctopusApiTester/tenant id")]
-        AzureSubscriptionTenantId,
-
-        [EnvironmentVariable("Azure_OctopusAPITester_Password", "op://Calamari Secrets for Tests/Azure - OctopusApiTester/password")]
-        AzureSubscriptionPassword,
-
-        [EnvironmentVariable("Azure_OctopusAPITester_ClientId", "op://Calamari Secrets for Tests/Azure - OctopusApiTester/client application id")]
-        AzureSubscriptionClientId,
-
-        [EnvironmentVariable("Azure_OctopusAPITester_Certificate", "op://Calamari Secrets for Tests/Azure - OctopusApiTester/thumbprint")]
-        AzureSubscriptionCertificate,
-
         //This is correctly configured in TeamCity. ALl azure tests _should_ use these secrets going forward.
         [EnvironmentVariable("AzureAks_OctopusAPITester_SubscriptionId", "op://Calamari Secrets for Tests/Azure - OctopusApiTester/subscription id")]
         AzureAksSubscriptionId,

--- a/source/Calamari.Tests/Fixtures/Commands/CommandFromModuleTest.cs
+++ b/source/Calamari.Tests/Fixtures/Commands/CommandFromModuleTest.cs
@@ -41,8 +41,8 @@ namespace Calamari.Tests.Fixtures.Commands
             variables.Set("Octopus.Action.Aws.AssumedRoleSession", "");
             variables.Set("Octopus.Account.AccountType", "AzureServicePrincipal");
             variables.Set("Octopus.Action.Azure.TenantId", "2a881dca-3230-4e01-abcb-a1fd235c0981");
-            variables.Set("Octopus.Action.Azure.ClientId", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId, cancellationToken));
-            variables.Set("Octopus.Action.Azure.Password", await ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword, cancellationToken));
+            variables.Set("Octopus.Action.Azure.ClientId", await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionClientId, cancellationToken));
+            variables.Set("Octopus.Action.Azure.Password", await ExternalVariables.Get(ExternalVariable.AzureAksSubscriptionPassword, cancellationToken));
             variables.Set("Octopus.Action.Azure.SubscriptionId", "cf21dc34-73dc-4d7d-bd86-041884e0bc75");
 
             return variables;


### PR DESCRIPTION
These credentials are different in TeamCity to 1Password, so we are consolidating on the AKS creds to be consistent.

A future PR will sync the credentials to be the same