### PR TITLE
Remove two fully enabled feature toggles

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceBehaviourFixture.cs
@@ -88,11 +88,7 @@ namespace Calamari.AzureAppService.Tests
                                                          AddVariables(context);
 
                                                          var existingFeatureToggles = context.Variables.GetStrings(KnownVariables.EnabledFeatureToggles);
-                                                         context.Variables.SetStrings(KnownVariables.EnabledFeatureToggles,
-                                                                                      existingFeatureToggles.Concat(new[]
-                                                                                      {
-                                                                                          FeatureToggle.AsynchronousAzureZipDeployFeatureToggle.ToString()
-                                                                                      }));
+                                                         context.Variables.SetStrings(KnownVariables.EnabledFeatureToggles, existingFeatureToggles);
                                                      })
                                         .Execute();
 
@@ -163,11 +159,7 @@ namespace Calamari.AzureAppService.Tests
                                                          AddVariables(context);
 
                                                          var existingFeatureToggles = context.Variables.GetStrings(KnownVariables.EnabledFeatureToggles);
-                                                         context.Variables.SetStrings(KnownVariables.EnabledFeatureToggles,
-                                                                                      existingFeatureToggles.Concat(new[]
-                                                                                      {
-                                                                                          FeatureToggle.AsynchronousAzureZipDeployFeatureToggle.ToString()
-                                                                                      }));
+                                                         context.Variables.SetStrings(KnownVariables.EnabledFeatureToggles, existingFeatureToggles);
                                                      })
                                         .Execute();
 
@@ -215,7 +207,7 @@ namespace Calamari.AzureAppService.Tests
                                                          context.Variables[PackageVariables.SubstituteInFilesTargets] = "test.jsp";
                                                      })
                                         .Execute();
-                
+
                 await DoWithRetries(3,
                                     async () =>
                                     {
@@ -223,7 +215,7 @@ namespace Calamari.AzureAppService.Tests
                                     },
                                     secondsBetweenRetries: 10);
             }
-            
+
             [Test]
             public async Task CanDeployJarPackage()
             {
@@ -253,16 +245,16 @@ namespace Calamari.AzureAppService.Tests
                 packageinfo.packageVersion = "1.0.0";
                 packageinfo.packageName = "sample4";
                 greeting = "java";
-                
+
                 var commandResult = await CommandTestBuilder.CreateAsync<DeployAzureAppServiceCommand, Program>()
-                                        .WithArrange(context =>
-                                                     {
-                                                         context.WithPackage(packageinfo.packagePath, packageinfo.packageName, packageinfo.packageVersion);
-                                                         AddVariables(context);
-                                                         context.Variables[SpecialVariables.Action.Azure.WebAppName] = javaSite.Value.Data.Name;
-                                                     })
-                                        .Execute();
-                
+                                                            .WithArrange(context =>
+                                                                         {
+                                                                             context.WithPackage(packageinfo.packagePath, packageinfo.packageName, packageinfo.packageVersion);
+                                                                             AddVariables(context);
+                                                                             context.Variables[SpecialVariables.Action.Azure.WebAppName] = javaSite.Value.Data.Name;
+                                                                         })
+                                                            .Execute();
+
                 commandResult.Outcome.Should().Be(TestExecutionOutcome.Successful);
             }
 
@@ -332,7 +324,6 @@ namespace Calamari.AzureAppService.Tests
                 return packageinfo;
             }
 
-
             async Task<(string packagePath, string packageName, string packageVersion)> PrepareNugetPackage()
             {
                 (string packagePath, string packageName, string packageVersion) packageinfo;
@@ -370,7 +361,6 @@ namespace Calamari.AzureAppService.Tests
                 return packageinfo;
             }
 
-
             private static (string packagePath, string packageName, string packageVersion) PrepareFunctionAppZipPackage()
             {
                 (string packagePath, string packageName, string packageVersion) packageInfo;
@@ -392,15 +382,15 @@ namespace Calamari.AzureAppService.Tests
                 context.Variables.Add(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.SubstituteInFiles);
                 context.Variables.Add(PackageVariables.SubstituteInFilesTargets, "index.html");
                 context.Variables.Add(SpecialVariables.Action.Azure.DeploymentType, "ZipDeploy");
-                
+
                 var settings = BuildAppSettingsJson(new[]
                 {
                     ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
                     ("WEBSITE_SCM_ALWAYS_ON_ENABLED", "true", false)
                 });
-                
-                context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;
-                context.Variables[SpecialVariables.Action.Azure.AsyncZipDeploymentTimeout] =  "3";
+
+                context.Variables[SpecialVariables.Action.Azure.AppSettings] = settings.json;
+                context.Variables[SpecialVariables.Action.Azure.AsyncZipDeploymentTimeout] = "3";
             }
         }
 
@@ -409,7 +399,7 @@ namespace Calamari.AzureAppService.Tests
         {
             // For some reason we are having issues creating these linux resources on Standard in EastUS
             protected override string DefaultResourceGroupLocation => RandomAzureRegion.GetRandomRegionWithExclusions("eastus");
-            
+
             static readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
             readonly CancellationToken cancellationToken = CancellationTokenSource.Token;
             AppServicePlanResource appServicePlanResource;
@@ -471,13 +461,13 @@ namespace Calamari.AzureAppService.Tests
                                                                                                new AppServiceNameValuePair { Name = "FUNCTIONS_EXTENSION_VERSION", Value = "~4" },
                                                                                                new AppServiceNameValuePair { Name = "AzureWebJobsStorage", Value = $"DefaultEndpointsProtocol=https;AccountName={storageAccountName};AccountKey={keys.First().Value};EndpointSuffix=core.windows.net" },
                                                                                                new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" },
-                                                                                               new AppServiceNameValuePair { Name = "WEBSITE_SCM_ALWAYS_ON_ENABLED", Value = "true"}
+                                                                                               new AppServiceNameValuePair { Name = "WEBSITE_SCM_ALWAYS_ON_ENABLED", Value = "true" }
                                                                                            }
                                                                                        }
                                                                                    });
 
                 await linuxWebSiteResponse.WaitForCompletionAsync(cancellationToken);
-                
+
                 WebSiteResource = linuxWebSiteResponse.Value;
             }
 
@@ -537,7 +527,6 @@ namespace Calamari.AzureAppService.Tests
                                     secondsBetweenRetries: 10);
             }
 
-
             [Test]
             public async Task CanDeployZip_ToLinuxFunctionApp_WithAsyncDeploymentAndPolling()
             {
@@ -552,11 +541,7 @@ namespace Calamari.AzureAppService.Tests
                                                          AddVariables(context);
 
                                                          var existingFeatureToggles = context.Variables.GetStrings(KnownVariables.EnabledFeatureToggles);
-                                                         context.Variables.SetStrings(KnownVariables.EnabledFeatureToggles,
-                                                                                      existingFeatureToggles.Concat(new[]
-                                                                                      {
-                                                                                          FeatureToggle.AsynchronousAzureZipDeployFeatureToggle.ToString()
-                                                                                      }));
+                                                         context.Variables.SetStrings(KnownVariables.EnabledFeatureToggles, existingFeatureToggles);
                                                      })
                                         .Execute();
 
@@ -570,7 +555,7 @@ namespace Calamari.AzureAppService.Tests
                                     },
                                     secondsBetweenRetries: 10);
             }
-            
+
             [Test]
             public async Task CanDeployJarPackage()
             {
@@ -589,7 +574,7 @@ namespace Calamari.AzureAppService.Tests
                                                                                        AppSettings = new List<AppServiceNameValuePair>
                                                                                        {
                                                                                            new AppServiceNameValuePair { Name = "WEBSITES_CONTAINER_START_TIME_LIMIT", Value = "460" },
-                                                                                           new AppServiceNameValuePair { Name = "WEBSITE_SCM_ALWAYS_ON_ENABLED", Value = "true"}
+                                                                                           new AppServiceNameValuePair { Name = "WEBSITE_SCM_ALWAYS_ON_ENABLED", Value = "true" }
                                                                                        }
                                                                                    }
                                                                                });
@@ -600,16 +585,16 @@ namespace Calamari.AzureAppService.Tests
                 packageinfo.packageVersion = "1.0.0";
                 packageinfo.packageName = "sample4";
                 greeting = "java";
-                
+
                 var commandResult = await CommandTestBuilder.CreateAsync<DeployAzureAppServiceCommand, Program>()
-                                        .WithArrange(context =>
-                                                     {
-                                                         context.WithPackage(packageinfo.packagePath, packageinfo.packageName, packageinfo.packageVersion);
-                                                         AddVariables(context);
-                                                         context.Variables[SpecialVariables.Action.Azure.WebAppName] = javaSite.Value.Data.Name;
-                                                     })
-                                        .Execute();
-                
+                                                            .WithArrange(context =>
+                                                                         {
+                                                                             context.WithPackage(packageinfo.packagePath, packageinfo.packageName, packageinfo.packageVersion);
+                                                                             AddVariables(context);
+                                                                             context.Variables[SpecialVariables.Action.Azure.WebAppName] = javaSite.Value.Data.Name;
+                                                                         })
+                                                            .Execute();
+
                 commandResult.Outcome.Should().Be(TestExecutionOutcome.Successful);
             }
 
@@ -638,14 +623,14 @@ namespace Calamari.AzureAppService.Tests
             {
                 AddAzureVariables(context);
                 context.Variables.Add(SpecialVariables.Action.Azure.DeploymentType, "ZipDeploy");
-                
+
                 var settings = BuildAppSettingsJson(new[]
                 {
                     ("WEBSITES_CONTAINER_START_TIME_LIMIT", "460", false),
                     ("WEBSITE_SCM_ALWAYS_ON_ENABLED", "true", false)
                 });
-                
-                context.Variables[SpecialVariables.Action.Azure.AppSettings] =  settings.json;
+
+                context.Variables[SpecialVariables.Action.Azure.AppSettings] = settings.json;
             }
         }
     }

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -158,7 +158,7 @@ namespace Calamari.AzureAppService.Behaviors
                 //Need to check if site turn off 
                 var scmPublishEnabled = await armClient.IsScmPublishEnabled(targetSite);
                 
-                if (packageProvider.SupportsAsynchronousDeployment && FeatureToggle.AsynchronousAzureZipDeployFeatureToggle.IsEnabled(context.Variables))
+                if (packageProvider.SupportsAsynchronousDeployment)
                 {
                     await UploadZipAndPollAsync(account, publishingProfile, scmPublishEnabled, uploadPath, targetSite.ScmSiteAndSlot, packageProvider, pollingTimeout, asyncZipDeployTimeoutPolicy);
                 }

--- a/source/Calamari.AzureScripting/AzureContextScriptWrapper.cs
+++ b/source/Calamari.AzureScripting/AzureContextScriptWrapper.cs
@@ -50,7 +50,6 @@ namespace Calamari.AzureScripting
             var workingDirectory = Path.GetDirectoryName(script.File)!;
             variables.Set("OctopusAzureTargetScript", script.File);
             variables.Set("OctopusAzureTargetScriptParameters", script.Parameters);
-            variables.Set("OctopusAzureRmIsDeprecated", FeatureToggle.AzureRMDeprecationFeatureToggle.IsEnabled(variables).ToString());
 
             SetOutputVariable("OctopusAzureSubscriptionId", variables.Get(SpecialVariables.Action.Azure.SubscriptionId)!);
             SetOutputVariable("OctopusAzureStorageAccountName", variables.Get(SpecialVariables.Action.Azure.StorageAccountName)!);

--- a/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
+++ b/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
@@ -18,7 +18,6 @@
 ##   $OctopusDisableAzureCLI = "..."
 ##   $OctopusAzureExtensionsDirectory = "..." 
 ##   $OctopusOpenIdJwt = "..."
-##   $OctopusAzureRmIsDeprecated = "..."
 
 $ErrorActionPreference = "Stop"
 
@@ -185,14 +184,8 @@ Execute-WithRetry{
                     Initialize-AzContext
                 }
                 elseif (Get-AzureRmModuleInstalled) {
-                    if($OctopusAzureRmIsDeprecated -like [Boolean]::TrueString) {
-                        Write-Error "Azure Resource Manager modules are no longer available for authenticating with Azure, you are required to move to Azure CLI or the Az powershell modules."
-                        exit 2
-                    }
-                    else {
-                        Write-Warning "Azure Resource Manager powershell module has reached end-of-life; please authenticate using Azure CLI or the Az module, Octopus will prevent usage of the AzureRM module in 2024.3."
-                        Initialize-AzureRmContext    
-                    }
+                    Write-Error "Azure Resource Manager modules are no longer available for authenticating with Azure, you are required to move to Azure CLI or the Az powershell modules."
+                    exit 2
                 }
             }
             

--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -8,7 +8,6 @@
     public enum FeatureToggle {
         SkunkworksFeatureToggle,
         OidcAccountsFeatureToggle,
-        AsynchronousAzureZipDeployFeatureToggle,
         AzureRMDeprecationFeatureToggle,
         KubernetesLiveObjectStatusFeatureToggle,
         KubernetesAuthAwsCliWithExecFeatureToggle,

--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -8,7 +8,6 @@
     public enum FeatureToggle {
         SkunkworksFeatureToggle,
         OidcAccountsFeatureToggle,
-        AzureRMDeprecationFeatureToggle,
         KubernetesLiveObjectStatusFeatureToggle,
         KubernetesAuthAwsCliWithExecFeatureToggle,
         ForceUtf8ZipFileDecodingFeatureToggle,


### PR DESCRIPTION
Both the `AsynchronousAzureZipDeployFeatureToggle` and `AzureRMDeprecationFeatureToggle` have been enabled in cloud at 100% for ages as well as enabled by default for ages.

We can now remove them and their usages