### PR TITLE
Provide No-op CreatePr operation for ArgoCD Templating step

### DIFF
--- a/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/FeatureToggle.cs
@@ -11,7 +11,6 @@
         KubernetesLiveObjectStatusFeatureToggle,
         KubernetesAuthAwsCliWithExecFeatureToggle,
         ForceUtf8ZipFileDecodingFeatureToggle,
-        BashParametersArrayFeatureToggle,
-        ArgocdCreatePullRequestFeatureToggle,
+        BashParametersArrayFeatureToggle
     }
 }

--- a/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
@@ -8,10 +8,12 @@ namespace Calamari.Common.FeatureToggles
         {
             public const string KubernetesObjectManifestInspection = "kubernetes-object-manifest-inspection";
             public const string KOSForHelm = "kos-for-helm";
+            public const string ArgoCDCreatePullRequestFeatureToggle = "argocd-create-pull-request";
         };
 
         public static readonly OctopusFeatureToggle KubernetesObjectManifestInspectionFeatureToggle = new OctopusFeatureToggle(KnownSlugs.KubernetesObjectManifestInspection);
         public static readonly OctopusFeatureToggle KOSForHelmFeatureToggle = new OctopusFeatureToggle(KnownSlugs.KOSForHelm);
+        public static readonly OctopusFeatureToggle ArgoCDCreatePullRequestFeatureToggle = new OctopusFeatureToggle(KnownSlugs.ArgoCDCreatePullRequestFeatureToggle);
 
         public class OctopusFeatureToggle
         {

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateGitRepositoryInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateGitRepositoryInstallConventionTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Calamari.ArgoCD.Commands;
 using Calamari.ArgoCD.Conventions;
 using Calamari.ArgoCD.Git;
+using Calamari.ArgoCD.GitHub;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Deployment;
 using Calamari.Common.Plumbing.FileSystem;
@@ -13,6 +14,7 @@ using Calamari.Tests.ArgoCD.Git;
 using Calamari.Tests.Fixtures.Integration.FileSystem;
 using FluentAssertions;
 using LibGit2Sharp;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Calamari.Tests.ArgoCD.Commands.Conventions
@@ -79,7 +81,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             runningDeployment.CurrentDirectoryProvider = DeploymentWorkingDirectory.StagingDirectory;
             runningDeployment.StagingDirectory = WorkingDirectory;
             
-            var convention = new UpdateGitRepositoryInstallConvention(fileSystem, CommitToGitCommand.PackageDirectoryName, log);
+            var convention = new UpdateGitRepositoryInstallConvention(fileSystem, CommitToGitCommand.PackageDirectoryName, log, Substitute.For<IGitHubPullRequestCreator>());
             
             convention.Install(runningDeployment);
             

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
@@ -2,11 +2,13 @@ using System;
 using System.IO;
 using System.Text;
 using Calamari.ArgoCD.Git;
+using Calamari.ArgoCD.GitHub;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Fixtures.Integration.FileSystem;
 using FluentAssertions;
 using LibGit2Sharp;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Calamari.Tests.ArgoCD.Git
@@ -34,7 +36,7 @@ namespace Calamari.Tests.ArgoCD.Git
             bareOrigin = RepositoryHelpers.CreateBareRepository(OriginPath);
             RepositoryHelpers.CreateBranchIn(branchName, OriginPath);
 
-            repositoryFactory = new RepositoryFactory(log, tempDirectory);
+            repositoryFactory = new RepositoryFactory(log, tempDirectory, Substitute.For<IGitHubPullRequestCreator>());
         }
         
         [TearDown]

--- a/source/Calamari/ArgoCD/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/ArgoCD/Commands/CommitToGitCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Calamari.ArgoCD.Conventions;
+using Calamari.ArgoCD.GitHub;
 using Calamari.Commands;
 using Calamari.Commands.Support;
 using Calamari.Common.Commands;
@@ -29,6 +30,7 @@ namespace Calamari.ArgoCD.Commands
         readonly ICalamariFileSystem fileSystem;
         readonly IExtractPackage extractPackage;
         readonly INonSensitiveSubstituteInFiles substituteInFiles;
+        readonly IGitHubPullRequestCreator pullRequestCreator;
         PathToPackage pathToPackage;
 
         public CommitToGitCommand(
@@ -36,13 +38,15 @@ namespace Calamari.ArgoCD.Commands
             IVariables variables,
             ICalamariFileSystem fileSystem,
             IExtractPackage extractPackage,
-            INonSensitiveSubstituteInFiles substituteInFiles)
+            INonSensitiveSubstituteInFiles substituteInFiles,
+            IGitHubPullRequestCreator pullRequestCreator)
         {
             this.log = log;
             this.variables = variables;
             this.fileSystem = fileSystem;
             this.extractPackage = extractPackage;
             this.substituteInFiles = substituteInFiles;
+            this.pullRequestCreator = pullRequestCreator;
 
             Options.Add("package=",
                         "Path to the NuGet package to install.",
@@ -66,7 +70,7 @@ namespace Calamari.ArgoCD.Commands
                                                   d.CurrentDirectoryProvider = DeploymentWorkingDirectory.StagingDirectory;
                                               }),
                 new SubstituteInFilesConvention(new NonSensitiveSubstituteInFilesBehaviour(substituteInFiles, PackageDirectoryName)),
-                new UpdateGitRepositoryInstallConvention(fileSystem, PackageDirectoryName, log),
+                new UpdateGitRepositoryInstallConvention(fileSystem, PackageDirectoryName, log, pullRequestCreator),
             };
 
             var runningDeployment = new RunningDeployment(pathToPackage, variables);

--- a/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
@@ -75,7 +75,7 @@ namespace Calamari.ArgoCD.Conventions
 
         bool RequiresPullRequest(RunningDeployment deployment)
         {
-            return deployment.Variables.Get(SpecialVariables.Git.CommitMethod) == SpecialVariables.Git.GitCommitMethods.PullRequest;
+            return OctopusFeatureToggles.ArgoCDCreatePullRequestFeatureToggle.IsEnabled(deployment.Variables) && deployment.Variables.Get(SpecialVariables.Git.CommitMethod) == SpecialVariables.Git.GitCommitMethods.PullRequest;
 
         }
 

--- a/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
@@ -11,7 +11,6 @@ using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
-using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment.Conventions;
 using Calamari.Kubernetes;
 

--- a/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
@@ -3,7 +3,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Calamari.ArgoCD.Git;
+using Calamari.ArgoCD.GitHub;
 using Calamari.Common.Commands;
 using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Extensions;
@@ -20,11 +22,13 @@ namespace Calamari.ArgoCD.Conventions
         readonly ICalamariFileSystem fileSystem;
         readonly ILog log;
         readonly string packageSubfolder;
+        readonly IGitHubPullRequestCreator pullRequestCreator;
 
-        public UpdateGitRepositoryInstallConvention(ICalamariFileSystem fileSystem, string packageSubfolder, ILog log)
+        public UpdateGitRepositoryInstallConvention(ICalamariFileSystem fileSystem, string packageSubfolder, ILog log, IGitHubPullRequestCreator pullRequestCreator)
         {
             this.fileSystem = fileSystem;
             this.log = log;
+            this.pullRequestCreator = pullRequestCreator;
             this.packageSubfolder = packageSubfolder;
         }
         
@@ -36,7 +40,7 @@ namespace Calamari.ArgoCD.Conventions
             var requiresPullRequest = RequiresPullRequest(deployment);
             var commitMessage = GenerateCommitMessage(deployment);
             
-            var repositoryFactory = new RepositoryFactory(log, deployment.CurrentDirectory);
+            var repositoryFactory = new RepositoryFactory(log, deployment.CurrentDirectory, pullRequestCreator);
             var repositoryIndexes = deployment.Variables.GetIndexes(SpecialVariables.Git.Index);
             log.Info($"Found the following repository indicies '{repositoryIndexes.Join(",")}'");
             foreach (var repositoryIndex in repositoryIndexes)
@@ -60,7 +64,7 @@ namespace Calamari.ArgoCD.Conventions
                 if (repository.CommitChanges(commitMessage))
                 {
                     Log.Info("Changes were commited, pushing to remote");
-                    repository.PushChanges(requiresPullRequest, gitConnection.BranchName);    
+                    repository.PushChanges(requiresPullRequest, gitConnection.BranchName, CancellationToken.None).GetAwaiter().GetResult();    
                 }
                 else
                 {
@@ -71,7 +75,7 @@ namespace Calamari.ArgoCD.Conventions
 
         bool RequiresPullRequest(RunningDeployment deployment)
         {
-            return FeatureToggle.ArgocdCreatePullRequestFeatureToggle.IsEnabled(deployment.Variables) && deployment.Variables.Get(SpecialVariables.Git.CommitMethod) == SpecialVariables.Git.GitCommitMethods.PullRequest;
+            return deployment.Variables.Get(SpecialVariables.Git.CommitMethod) == SpecialVariables.Git.GitCommitMethods.PullRequest;
 
         }
 

--- a/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using Calamari.ArgoCD.Conventions;
+using Calamari.ArgoCD.GitHub;
 using Calamari.Common.Plumbing.Logging;
 using LibGit2Sharp;
 
@@ -15,11 +16,13 @@ namespace Calamari.ArgoCD.Git
     {
         readonly ILog log;
         readonly string repositoryParentDirectory;
+        readonly IGitHubPullRequestCreator pullRequestCreator;
 
-        public RepositoryFactory(ILog log, string repositoryParentDirectory)
+        public RepositoryFactory(ILog log, string repositoryParentDirectory, IGitHubPullRequestCreator gitHubPullRequestCreator)
         {
             this.log = log;
             this.repositoryParentDirectory = repositoryParentDirectory;
+            this.pullRequestCreator = gitHubPullRequestCreator;
         }
 
         public RepositoryWrapper CloneRepository(string repositoryName, IGitConnection gitConnection)
@@ -67,7 +70,7 @@ namespace Calamari.ArgoCD.Git
             }
             LibGit2Sharp.Commands.Checkout(repo, branchToCheckout);
 
-            return new RepositoryWrapper(repo, log, gitConnection);
+            return new RepositoryWrapper(repo, log, gitConnection, pullRequestCreator);
         }
     }
 }

--- a/source/Calamari/ArgoCD/GitHub/GithubPullRequestCreator.cs
+++ b/source/Calamari/ArgoCD/GitHub/GithubPullRequestCreator.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Calamari.ArgoCD.Git;
+using Calamari.Common.Plumbing.Logging;
+
+namespace Calamari.ArgoCD.GitHub
+{
+    public interface IGitHubPullRequestCreator
+    {
+        Task<(int PullRequestNumber, string PullRequestUrl)> CreatePullRequest(ILog log,
+                                                                               IGitConnection gitConnection,
+                                                                               string prTitle, string body,
+                                                                               GitBranchName sourceBranch,
+                                                                               GitBranchName destinationBranch,
+                                                                               CancellationToken cancellationToken);
+    }
+
+    public class GitHubPullRequestCreator : IGitHubPullRequestCreator
+    {
+
+       public async Task<(int PullRequestNumber, string PullRequestUrl)> CreatePullRequest(ILog log,
+                                                                                           IGitConnection gitConnection,
+                                                                                           string prTitle,
+                                                                                           string body,
+                                                                                           GitBranchName sourceBranch,
+                                                                                           GitBranchName destinationBranch,
+                                                                                           CancellationToken cancellationToken)
+       {
+           await Task.CompletedTask;
+            log.Verbose("Attempting to use Git Credentials to talk to GitHub...");
+            log.Warn("This is currently a NO-OP operations");
+            return (-1, "not_a_real_url");
+       }
+    }
+}


### PR DESCRIPTION
This introduces the interface(s) required for creating a Github pull request - but does not actually pull in the backing http logic (which will come in a subsequent PR, and will largely be taken from the octopusServer repository).

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
