### PR TITLE
Update LibGit2Sharp to fix ssl library loading issue with Dynamic/K8s Workers

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateGitRepositoryInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateGitRepositoryInstallConventionTests.cs
@@ -1,3 +1,4 @@
+#if NET
 using System;
 using System.IO;
 using Calamari.ArgoCD.Commands;
@@ -144,3 +145,4 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
         }
     }
 }
+#endif 

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
@@ -1,3 +1,4 @@
+#if NET
 using System;
 using System.IO;
 using System.Text;
@@ -99,3 +100,4 @@ namespace Calamari.Tests.ArgoCD.Git
         }
     }
 }
+#endif

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryHelpers.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryHelpers.cs
@@ -1,3 +1,4 @@
+#if NET
 using System;
 using System.IO;
 using Calamari.ArgoCD.Git;
@@ -39,3 +40,4 @@ namespace Calamari.Tests.ArgoCD.Git
         }
     }
 }
+#endif

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
@@ -1,3 +1,4 @@
+#if NET
 using System;
 using System.IO;
 using System.Threading;
@@ -124,3 +125,4 @@ namespace Calamari.Tests.ArgoCD.Git
         }
     }
 }
+#endif

--- a/source/Calamari/ArgoCD/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/ArgoCD/Commands/CommitToGitCommand.cs
@@ -1,3 +1,4 @@
+#if NET
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -85,3 +86,4 @@ namespace Calamari.ArgoCD.Commands
         }
     }
 }
+#endif

--- a/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
@@ -1,3 +1,4 @@
+#if NET
 #nullable enable
 using System;
 using System.Collections.Generic;
@@ -130,3 +131,4 @@ namespace Calamari.ArgoCD.Conventions
         }
     }
 }
+#endif

--- a/source/Calamari/ArgoCD/Git/RepositoryExtensionMethods.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryExtensionMethods.cs
@@ -1,3 +1,4 @@
+#if NET
 using LibGit2Sharp;
 
 namespace Calamari.ArgoCD.Git
@@ -17,3 +18,4 @@ namespace Calamari.ArgoCD.Git
         }
     }
 }
+#endif

--- a/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
@@ -44,7 +44,7 @@ namespace Calamari.ArgoCD.Git
             var options = new CloneOptions();
             if (gitConnection.Username != null && gitConnection.Password != null)
             {
-                options.CredentialsProvider = (url, usernameFromUrl, types) => new UsernamePasswordCredentials
+                options.FetchOptions.CredentialsProvider = (url, usernameFromUrl, types) => new UsernamePasswordCredentials
                     {
                         Username = gitConnection.Username!,
                         Password = gitConnection.Password!

--- a/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
@@ -1,3 +1,4 @@
+#if NET
 using System;
 using System.IO;
 using Calamari.ArgoCD.Conventions;
@@ -71,3 +72,4 @@ namespace Calamari.ArgoCD.Git
         }
     }
 }
+#endif

--- a/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
@@ -1,3 +1,4 @@
+#if NET
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -104,3 +105,4 @@ namespace Calamari.ArgoCD.Git
         }
     }
 }
+#endif

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -18,7 +18,7 @@
     <Product>Calamari</Product>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
     <ApplicationManifest>Calamari.exe.manifest</ApplicationManifest>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
@@ -57,7 +57,6 @@
     <PackageReference Include="SharpCompress" Version="0.37.2" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Octopus.LibGit2Sharp" Version="0.26.353-octopus-master" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -88,6 +87,9 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="ArgoCD\Http\" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
   </ItemGroup>
   <!--
     In netcore 2.1.3, the framework stopped calculating package definitions automatically "for perf"

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -18,7 +18,7 @@
     <Product>Calamari</Product>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
     <ApplicationManifest>Calamari.exe.manifest</ApplicationManifest>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">


### PR DESCRIPTION
[sc-120294]

The ArgoCD commit to Git steps [don't work on our K8s or Dynamic workers](https://github.com/libgit2/libgit2sharp.nativebinaries/issues/151) due to us referencing an old version of LibGit2Sharp in our fork.

<img width="2746" height="808" alt="CleanShot 2025-09-04 at 17 07 37@2x" src="https://github.com/user-attachments/assets/b1cbb86a-458c-4d8b-ab3d-f51f1850c363" />

This PR makes a targeted change to make Calamari update to reference v0.3 of LibGit2Sharp directly.

ArgoCD steps will not work on netFX (which is fine because we are deprecating netFX)