### PR TITLE
Create octoversion.json

### DIFF
--- a/octoversion.json
+++ b/octoversion.json
@@ -1,0 +1,3 @@
+{
+  "NonPreReleaseTagsRegex": "^refs/heads/(main|master|release/.*)$"
+}


### PR DESCRIPTION
Should mean the LTS branches build with knowing that `release/*` is a non-reprerelease tag