### PR TITLE
Wrap paths in quotes

### DIFF
--- a/source/Calamari.Common/Plumbing/Extensions/StringExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/StringExtensions.cs
@@ -82,10 +82,14 @@ namespace Calamari.Common.Plumbing.Extensions
             var sanitizedText = Regex.Replace(text, @"[^a-zA-Z0-9\s]", " ");
             
             var textInfo = CultureInfo.CurrentCulture.TextInfo;
-            var camelCase = textInfo.ToTitleCase(sanitizedText).Replace(" ","").ToCharArray();
+            var camelCase = textInfo.ToTitleCase(sanitizedText).Replace(" ", string.Empty).ToCharArray();
             camelCase[0] = char.ToLower(camelCase[0]);
             
             return new string(camelCase);
         }
+
+        public static string EnsureDoubleQuoteIfContainsSpaces(this string text) => EnsureDoubleQuote(text, t => t.Contains(" "));
+        public static string EnsureDoubleQuote(this string text) => EnsureDoubleQuote(text, t => !t.EndsWith("\"") && !t.StartsWith("\""));
+        public static string EnsureDoubleQuote(this string text, Predicate<string> shouldQuote) => shouldQuote(text) ? $"\"{text}\"" : text;
     }
 }

--- a/source/Calamari.GoogleCloudAccounts/GoogleCloudAccountExtensions.cs
+++ b/source/Calamari.GoogleCloudAccounts/GoogleCloudAccountExtensions.cs
@@ -261,10 +261,10 @@ namespace Calamari.GoogleCloudAccounts
                                                         "--service-account-token-lifetime-seconds=3600",
                                                         "--subject-token-type=urn:ietf:params:oauth:token-type:jwt",
                                                         "--credential-source-type=text",
-                                                        $"--credential-source-file={jwtFilePath}",
+                                                        $"--credential-source-file=\"{jwtFilePath}\"",
                                                         "--app-id-uri",
                                                         serverUri,
-                                                        $"--output-file={jsonAuthFilePath}");
+                                                        $"--output-file=\"{jsonAuthFilePath}\"");
                 if (createConfigResult.ExitCode != 0)
                 {
                     log.Error("Failed to create credential config with gcloud.");
@@ -273,7 +273,7 @@ namespace Calamari.GoogleCloudAccounts
 
                 if (ExecuteCommand("auth",
                                    "login",
-                                   $"--cred-file={jsonAuthFilePath}")
+                                   $"--cred-file=\"{jsonAuthFilePath}\"")
                         .ExitCode
                     != 0)
                 {

--- a/source/Calamari.GoogleCloudAccounts/GoogleCloudAccountExtensions.cs
+++ b/source/Calamari.GoogleCloudAccounts/GoogleCloudAccountExtensions.cs
@@ -4,14 +4,12 @@ using System.IO;
 using System.Linq;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
-using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Proxies;
 using Calamari.Common.Plumbing.Variables;
-using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.GoogleCloudAccounts
 {
@@ -216,7 +214,7 @@ namespace Calamari.GoogleCloudAccounts
                 using (var keyFile = new TemporaryFile(Path.Combine(workingDirectory, Path.GetRandomFileName())))
                 {
                     File.WriteAllBytes(keyFile.FilePath, bytes);
-                    if (ExecuteCommand("auth", "activate-service-account", $"--key-file=\"{keyFile.FilePath}\"")
+                    if (ExecuteCommand("auth", "activate-service-account", $"--key-file={keyFile.FilePath.EnsureDoubleQuoteIfContainsSpaces()}")
                             .ExitCode
                         != 0)
                     {
@@ -261,10 +259,10 @@ namespace Calamari.GoogleCloudAccounts
                                                         "--service-account-token-lifetime-seconds=3600",
                                                         "--subject-token-type=urn:ietf:params:oauth:token-type:jwt",
                                                         "--credential-source-type=text",
-                                                        $"--credential-source-file=\"{jwtFilePath}\"",
+                                                        $"--credential-source-file={jwtFilePath.EnsureDoubleQuoteIfContainsSpaces()}",
                                                         "--app-id-uri",
                                                         serverUri,
-                                                        $"--output-file=\"{jsonAuthFilePath}\"");
+                                                        $"--output-file={jsonAuthFilePath.EnsureDoubleQuoteIfContainsSpaces()}");
                 if (createConfigResult.ExitCode != 0)
                 {
                     log.Error("Failed to create credential config with gcloud.");
@@ -273,7 +271,7 @@ namespace Calamari.GoogleCloudAccounts
 
                 if (ExecuteCommand("auth",
                                    "login",
-                                   $"--cred-file=\"{jsonAuthFilePath}\"")
+                                   $"--cred-file={jsonAuthFilePath.EnsureDoubleQuoteIfContainsSpaces()}")
                         .ExitCode
                     != 0)
                 {

--- a/source/Calamari.GoogleCloudScripting/GoogleCloudContextScriptWrapper.cs
+++ b/source/Calamari.GoogleCloudScripting/GoogleCloudContextScriptWrapper.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.Scripts;
-using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.GoogleCloudAccounts;

--- a/source/Calamari.Tests/Common/Plumbing/Extensions/StringExtensionsTests.cs
+++ b/source/Calamari.Tests/Common/Plumbing/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,27 @@
+using Calamari.Common.Plumbing.Extensions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Common.Plumbing.Extensions
+{
+    public class StringExtensionsTests
+    {
+        [Test]
+        public void DoubleQuote() => "blah".EnsureDoubleQuote().Should().Be("\"blah\"");
+        
+        [Test]
+        public void DoubleQuote_AlreadyQuoted() => "\"blah\"".EnsureDoubleQuote().Should().Be("\"blah\"");
+
+        [Test]
+        public void DoubleQuote_PredicateFalse() => "blah".EnsureDoubleQuote(s => false).Should().Be("blah");
+        
+        [Test]
+        public void DoubleQuote_PredicateTrue() => "blah".EnsureDoubleQuote(s => true).Should().Be("\"blah\"");
+        
+        [Test]
+        public void DoubleQuoteIfContainsSpaces() => "blah blah".EnsureDoubleQuoteIfContainsSpaces().Should().Be("\"blah blah\"");
+        
+        [Test]
+        public void DoubleQuoteIfContainsSpaces_NoSpaces() => "blah".EnsureDoubleQuoteIfContainsSpaces().Should().Be("blah");
+    }
+}


### PR DESCRIPTION
[sc-119773]

For script steps, where the customers script is sourced from a subdirectory containing a space, the files written to support the gcloud auth are inside the subdirectory. 
This PR ensures that these paths are quoted to avoid errors with paths containing spaces.

Relates to https://github.com/OctopusDeploy/issues/issues/9581