### PR TITLE
Update target framework from net40 to net462

### DIFF
--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/DumpArgs/DumpArgs.csproj
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/DumpArgs/DumpArgs.csproj
@@ -4,7 +4,7 @@
     <Description>A sample project containing a Windows service.</Description>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>ACME Corporation</Authors>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <AssemblyName>DumpArgs</AssemblyName>
     <PackageId>DumpArgs</PackageId>
     <NuspecFile>DumpArgs.nuspec</NuspecFile>


### PR DESCRIPTION
Updates a test project that was referencing `net4.0` to `net462` to make it use a supported framework.