### PR TITLE
Fix warnings - remove unused exception vars

### DIFF
--- a/source/Calamari.Aws/Integration/CloudFormation/Templates/CloudFormationS3Template.cs
+++ b/source/Calamari.Aws/Integration/CloudFormation/Templates/CloudFormationS3Template.cs
@@ -111,7 +111,7 @@ namespace Calamari.Aws.Integration.CloudFormation.Templates
                     response.WriteResponseStreamToFileAsync(ParametersFile, false, new CancellationTokenSource().Token).GetAwaiter().GetResult();
                 }
             }
-            catch (UriFormatException ex)
+            catch (UriFormatException)
             {
                 log.Error($"The parameters URL of {templateParameterS3Url} is invalid");
                 throw;

--- a/source/Calamari.Aws/Kubernetes/Discovery/AwsKubernetesDiscoverer.cs
+++ b/source/Calamari.Aws/Kubernetes/Discovery/AwsKubernetesDiscoverer.cs
@@ -106,7 +106,7 @@ namespace Calamari.Aws.Kubernetes.Discovery
                     .GetValue("Type", StringComparison.OrdinalIgnoreCase).Value<string>() ?? throw new Exception("Credentials type is null");
                 return true;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Log.Warn("Could not read authentication method of target discovery context.");
                 credentialsType = null;

--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -122,7 +122,7 @@ namespace Calamari.Azure.Kubernetes.Discovery
                 accountType = targetDiscoveryContext?.Authentication?.AuthenticationMethod ?? throw new Exception("AuthenticationMethod is null");
                 return true;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Log.Warn("Could not read authentication method of target discovery context.");
                 accountType = null;


### PR DESCRIPTION
Fixing up some code warnings - `CS0168` - `Variable is declared but never used`.