### PR TITLE
Bump System.IO.FileSystem.AccessControl to 5.0.0

### DIFF
--- a/source/Calamari.AzureScripting/Calamari.AzureScripting.csproj
+++ b/source/Calamari.AzureScripting/Calamari.AzureScripting.csproj
@@ -17,8 +17,8 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
-        <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
+        <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
+        <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -19,8 +19,8 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
         <PackageReference Include="NuGet.Commands" Version="5.11.5" />
-        <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.3.0" />
         <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
+        <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
         <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
     </ItemGroup>

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -61,10 +61,10 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="NuGet.Commands" Version="5.11.5" />
     <PackageReference Include="Markdown" Version="2.1.0" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.IO.Packaging" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />


### PR DESCRIPTION
Bump `System.IO.FileSystem.AccessControl` and `System.Security.Principal.Windows` to 5.0.0 to fix compilation warning:

```
MSB3277: Found conflicts between different versions of "System.Security.Principal.Windows" that could not be resolved. [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277: There was a conflict between "System.Security.Principal.Windows, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:     "System.Security.Principal.Windows, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was chosen because it was primary and "System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was not. [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:     References which depend on "System.Security.Principal.Windows, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [C:\Users\ContainerAdministrator\.nuget\packages\system.security.principal.windows\4.3.0\ref\netstandard1.3\System.Security.Principal.Windows.dll]. [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:         C:\Users\ContainerAdministrator\.nuget\packages\system.security.principal.windows\4.3.0\ref\netstandard1.3\System.Security.Principal.Windows.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:           Project file item includes which caused reference "C:\Users\ContainerAdministrator\.nuget\packages\system.security.principal.windows\4.3.0\ref\netstandard1.3\System.Security.Principal.Windows.dll". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\Users\ContainerAdministrator\.nuget\packages\system.security.principal.windows\4.3.0\ref\netstandard1.3\System.Security.Principal.Windows.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:     References which depend on "System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" []. [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:         C:\BuildAgent\work\62728692c7c35200\source\Calamari.Common\bin\Release\netstandard2.1\Calamari.Common.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:           Project file item includes which caused reference "C:\BuildAgent\work\62728692c7c35200\source\Calamari.Common\bin\Release\netstandard2.1\Calamari.Common.dll". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\BuildAgent\work\62728692c7c35200\source\Calamari.Common\bin\Release\netstandard2.1\Calamari.Common.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\BuildAgent\work\62728692c7c35200\source\Calamari.CloudAccounts\bin\Release\netstandard2.1\Calamari.CloudAccounts.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:         C:\Users\ContainerAdministrator\.nuget\packages\system.io.filesystem.accesscontrol\4.3.0\ref\netstandard1.3\System.IO.FileSystem.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:           Project file item includes which caused reference "C:\Users\ContainerAdministrator\.nuget\packages\system.io.filesystem.accesscontrol\4.3.0\ref\netstandard1.3\System.IO.FileSystem.AccessControl.dll". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\Users\ContainerAdministrator\.nuget\packages\system.io.filesystem.accesscontrol\4.3.0\ref\netstandard1.3\System.IO.FileSystem.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:         C:\Users\ContainerAdministrator\.nuget\packages\system.security.accesscontrol\4.3.0\ref\netstandard1.3\System.Security.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:           Project file item includes which caused reference "C:\Users\ContainerAdministrator\.nuget\packages\system.security.accesscontrol\4.3.0\ref\netstandard1.3\System.Security.AccessControl.dll". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\Users\ContainerAdministrator\.nuget\packages\system.security.accesscontrol\4.3.0\ref\netstandard1.3\System.Security.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:         C:\Users\ContainerAdministrator\.nuget\packages\system.threading.accesscontrol\4.3.0\ref\netstandard1.3\System.Threading.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:           Project file item includes which caused reference "C:\Users\ContainerAdministrator\.nuget\packages\system.threading.accesscontrol\4.3.0\ref\netstandard1.3\System.Threading.AccessControl.dll". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\Users\ContainerAdministrator\.nuget\packages\system.threading.accesscontrol\4.3.0\ref\netstandard1.3\System.Threading.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\BuildAgent\work\62728692c7c35200\source\Calamari.Common\bin\Release\netstandard2.1\Calamari.Common.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\BuildAgent\work\62728692c7c35200\source\Calamari.CloudAccounts\bin\Release\netstandard2.1\Calamari.CloudAccounts.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:         C:\Program Files\dotnet\packs\NETStandard.Library.Ref\2.1.0\ref\netstandard2.1\mscorlib.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:           Project file item includes which caused reference "C:\Program Files\dotnet\packs\NETStandard.Library.Ref\2.1.0\ref\netstandard2.1\mscorlib.dll". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\Program Files\dotnet\packs\NETStandard.Library.Ref\2.1.0\ref\netstandard2.1\mscorlib.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
```

and 

```
MSB3277:     "System.Security.AccessControl, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was chosen because it was primary and "System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was not. [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:     References which depend on "System.Security.AccessControl, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [C:\Users\ContainerAdministrator\.nuget\packages\system.security.accesscontrol\4.3.0\ref\netstandard1.3\System.Security.AccessControl.dll]. [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:         C:\Users\ContainerAdministrator\.nuget\packages\system.security.accesscontrol\4.3.0\ref\netstandard1.3\System.Security.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:           Project file item includes which caused reference "C:\Users\ContainerAdministrator\.nuget\packages\system.security.accesscontrol\4.3.0\ref\netstandard1.3\System.Security.AccessControl.dll". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\Users\ContainerAdministrator\.nuget\packages\system.security.accesscontrol\4.3.0\ref\netstandard1.3\System.Security.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:     References which depend on "System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" []. [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:         C:\BuildAgent\work\62728692c7c35200\source\Calamari.Common\bin\Release\netstandard2.1\Calamari.Common.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:           Project file item includes which caused reference "C:\BuildAgent\work\62728692c7c35200\source\Calamari.Common\bin\Release\netstandard2.1\Calamari.Common.dll". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\BuildAgent\work\62728692c7c35200\source\Calamari.Common\bin\Release\netstandard2.1\Calamari.Common.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\BuildAgent\work\62728692c7c35200\source\Calamari.CloudAccounts\bin\Release\netstandard2.1\Calamari.CloudAccounts.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:         C:\Users\ContainerAdministrator\.nuget\packages\system.io.filesystem.accesscontrol\4.3.0\ref\netstandard1.3\System.IO.FileSystem.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:           Project file item includes which caused reference "C:\Users\ContainerAdministrator\.nuget\packages\system.io.filesystem.accesscontrol\4.3.0\ref\netstandard1.3\System.IO.FileSystem.AccessControl.dll". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\Users\ContainerAdministrator\.nuget\packages\system.io.filesystem.accesscontrol\4.3.0\ref\netstandard1.3\System.IO.FileSystem.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:         C:\Users\ContainerAdministrator\.nuget\packages\system.threading.accesscontrol\4.3.0\ref\netstandard1.3\System.Threading.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:           Project file item includes which caused reference "C:\Users\ContainerAdministrator\.nuget\packages\system.threading.accesscontrol\4.3.0\ref\netstandard1.3\System.Threading.AccessControl.dll". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\Users\ContainerAdministrator\.nuget\packages\system.threading.accesscontrol\4.3.0\ref\netstandard1.3\System.Threading.AccessControl.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\BuildAgent\work\62728692c7c35200\source\Calamari.Common\bin\Release\netstandard2.1\Calamari.Common.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\BuildAgent\work\62728692c7c35200\source\Calamari.CloudAccounts\bin\Release\netstandard2.1\Calamari.CloudAccounts.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:         C:\Program Files\dotnet\packs\NETStandard.Library.Ref\2.1.0\ref\netstandard2.1\mscorlib.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:           Project file item includes which caused reference "C:\Program Files\dotnet\packs\NETStandard.Library.Ref\2.1.0\ref\netstandard2.1\mscorlib.dll". [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
MSB3277:             C:\Program Files\dotnet\packs\NETStandard.Library.Ref\2.1.0\ref\netstandard2.1\mscorlib.dll [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Shared\Calamari.Shared.csproj]
```