### PR TITLE
Fix import error for `ConfigurationManager`

### DIFF
--- a/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
+++ b/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="Octopus.Dependencies.AzureCLI" Version="2.41.0" GeneratePathProperty="true" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
   <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">
     <ItemGroup>

--- a/source/Calamari.AzureResourceGroup.Tests/Packages/AzureResourceGroup/Default.aspx
+++ b/source/Calamari.AzureResourceGroup.Tests/Packages/AzureResourceGroup/Default.aspx
@@ -1,4 +1,5 @@
 ﻿<%@ Page Language="C#" AutoEventWireup="true" %>
+<%@ Import Namespace="System.Configuration" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
@@ -31,6 +32,7 @@
       <%
         } 
       %>
+      </table>
     </div>
     </form>
 </body>


### PR DESCRIPTION
I was getting IDE errors in `Calamari.AzureResourceGroup.Tests/Packages/AzureResourceGroup/Default.aspx`:

<img width="820" height="716" alt="image" src="https://github.com/user-attachments/assets/31768601-4767-4598-8114-b4c4425100dd" />

Fixing this up so we can focus on real errors while coding, not false positives.