### PR TITLE
Fix warnings & enable warnings as errors in Calamari.Azure

### DIFF
--- a/source/Calamari.Azure/AppServices/AzureTargetSite.cs
+++ b/source/Calamari.Azure/AppServices/AzureTargetSite.cs
@@ -91,7 +91,7 @@ namespace Calamari.Azure.AppServices
                              ? "No Deployment Slot specified"
                              : $"Using Deployment Slot '{slotName}'");
 
-            return new AzureTargetSite(account.SubscriptionNumber, resourceGroupName, webAppName, slotName);
+            return new AzureTargetSite(account.SubscriptionNumber, resourceGroupName!, webAppName!, slotName);
         }
     }
 }

--- a/source/Calamari.Azure/AzureKnownEnvironment.cs
+++ b/source/Calamari.Azure/AzureKnownEnvironment.cs
@@ -51,7 +51,9 @@ namespace Calamari.Azure
         {
             "AzureGlobalCloud" => AzureAuthorityHosts.AzurePublicCloud,
             "AzureChinaCloud" => AzureAuthorityHosts.AzureChina,
+#pragma warning disable CS0618 // Type or member is obsolete - Microsoft Cloud Germany was closed on October 29th, 2021.
             "AzureGermanCloud" => AzureAuthorityHosts.AzureGermany,
+#pragma warning restore CS0618 // Type or member is obsolete
             "AzureUSGovernment" => AzureAuthorityHosts.AzureGovernment,
             _ => throw new InvalidOperationException($"ARM Environment {name} is not a known Azure Environment name.")
         };

--- a/source/Calamari.Azure/Calamari.Azure.csproj
+++ b/source/Calamari.Azure/Calamari.Azure.csproj
@@ -8,6 +8,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <LangVersion>8.0</LangVersion>
         <TargetFrameworks>net462;net6.0</TargetFrameworks>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Azure.Identity" Version="1.13.1" />


### PR DESCRIPTION
Fixes up some warnings in Calamari.Azure, which in turn allows us to enable TreatWarningsAsErrors, which will help remove noise and distractions for engineers.