### PR TITLE
Fix warnings & enable warnings as errors in Calamari.AzureAppService.Tests

### DIFF
--- a/source/Calamari.AzureAppService.Tests/AppServiceSettingsBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceSettingsBehaviourFixture.cs
@@ -21,7 +21,7 @@ namespace Calamari.AzureAppService.Tests
     [TestFixture]
     public class AppServiceSettingsBehaviorFixture : AppServiceIntegrationTest
     {
-        string? slotName;
+        string slotName;
         AppServiceConfigurationDictionary existingSettings;
         ConnectionStringDictionary existingConnectionStrings;
 
@@ -152,7 +152,7 @@ namespace Calamari.AzureAppService.Tests
             await AssertAppSettings(settings.setting, connectionStrings.connStrings);
         }
 
-        private (string json, IEnumerable<AppSetting> setting) BuildAppSettingsJson(IEnumerable<(string name, string value, bool isSlotSetting)> settings)
+        private new (string json, IEnumerable<AppSetting> setting) BuildAppSettingsJson(IEnumerable<(string name, string value, bool isSlotSetting)> settings)
         {
             var appSettings = settings.Select(setting => new AppSetting
                                                   { Name = setting.name, Value = setting.value, SlotSetting = setting.isSlotSetting });

--- a/source/Calamari.AzureAppService.Tests/AppServiceSettingsBehaviourFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/AppServiceSettingsBehaviourFixture.cs
@@ -152,14 +152,6 @@ namespace Calamari.AzureAppService.Tests
             await AssertAppSettings(settings.setting, connectionStrings.connStrings);
         }
 
-        private new (string json, IEnumerable<AppSetting> setting) BuildAppSettingsJson(IEnumerable<(string name, string value, bool isSlotSetting)> settings)
-        {
-            var appSettings = settings.Select(setting => new AppSetting
-                                                  { Name = setting.name, Value = setting.value, SlotSetting = setting.isSlotSetting });
-
-            return (JsonConvert.SerializeObject(appSettings), appSettings);
-        }
-
         private (string json, ConnectionStringDictionary connStrings) BuildConnectionStringJson(
             IEnumerable<(string name, string value, ConnectionStringType type, bool isSlotSetting)> connStrings)
         {

--- a/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
+++ b/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
@@ -7,6 +7,7 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
     <LangVersion>8.0</LangVersion>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes up some warnings in Calamari.AzureAppService.Tests, which in turn allows us to enable `TreatWarningsAsErrors`, which will help remove noise and distractions for engineers.