### PR TITLE
Fix warnings & enable warnings as errors in Calamari.Testing

### DIFF
--- a/source/Calamari.Testing/Calamari.Testing.csproj
+++ b/source/Calamari.Testing/Calamari.Testing.csproj
@@ -6,6 +6,7 @@
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <LangVersion>default</LangVersion>
         <TargetFrameworks>net462;netstandard2.1</TargetFrameworks>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
         <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>

--- a/source/Calamari.Testing/CommandTestBuilder.cs
+++ b/source/Calamari.Testing/CommandTestBuilder.cs
@@ -226,7 +226,8 @@ namespace Calamari.Testing
 
                 if (!context.withStagedPackageArgument)
                 {
-                    var packageId = context.Variables.GetRaw("Octopus.Test.PackagePath");
+                    var variableName = "Octopus.Test.PackagePath";
+                    var packageId = context.Variables.GetRaw(variableName) ?? throw new Exception($"No packageId was specified in the '{variableName}' variable");
                     if (File.Exists(packageId))
                     {
                         var fileName = new FileInfo(packageId).Name;

--- a/source/Calamari.Testing/CommandTestBuilder.cs
+++ b/source/Calamari.Testing/CommandTestBuilder.cs
@@ -224,19 +224,22 @@ namespace Calamari.Testing
                     contents.CopyTo(fileStream);
                 }
 
-                if (!context.withStagedPackageArgument)
+                if (context.withStagedPackageArgument)
+                    return;
+                
+                var variableName = "Octopus.Test.PackagePath";
+                var packageId = context.Variables.GetRaw(variableName);
+                if (string.IsNullOrEmpty(packageId))
+                    return;
+                
+                if (File.Exists(packageId))
                 {
-                    var variableName = "Octopus.Test.PackagePath";
-                    var packageId = context.Variables.GetRaw(variableName) ?? throw new Exception($"No packageId was specified in the '{variableName}' variable");
-                    if (File.Exists(packageId))
-                    {
-                        var fileName = new FileInfo(packageId).Name;
-                        File.Copy(packageId, Path.Combine(workingPath, fileName));
-                    }
-                    else if (Directory.Exists(packageId))
-                    {
-                        Copy(packageId, workingPath);
-                    }
+                    var fileName = new FileInfo(packageId).Name;
+                    File.Copy(packageId, Path.Combine(workingPath, fileName));
+                }
+                else if (Directory.Exists(packageId))
+                {
+                    Copy(packageId!, workingPath);
                 }
             }
 

--- a/source/Calamari.Testing/EnvironmentVariables.cs
+++ b/source/Calamari.Testing/EnvironmentVariables.cs
@@ -115,7 +115,7 @@ namespace Calamari.Testing
         {
             var missingVariables = Enum.GetValues(typeof(ExternalVariable))
                                        .Cast<ExternalVariable>()
-                                       .Select(prop => EnvironmentVariableAttribute.Get(prop))
+                                       .Select(prop => EnvironmentVariableAttribute.Get(prop) ?? throw new Exception($"`{prop}` does not include a {nameof(EnvironmentVariableAttribute)}."))
                                        .Where(attr => Environment.GetEnvironmentVariable(attr.Name) == null)
                                        .ToList();
 
@@ -143,10 +143,10 @@ namespace Calamari.Testing
             {
                 var valueFromSecretManager = string.IsNullOrEmpty(attr.SecretReference)
                     ? null
-                    : await SecretManagerClient.Value.GetSecret(attr.SecretReference, cancellationToken, throwOnNotFound: false);
+                    : await SecretManagerClient.Value.GetSecret(attr.SecretReference!, cancellationToken, throwOnNotFound: false);
                 if (!string.IsNullOrEmpty(valueFromSecretManager))
                 {
-                    return valueFromSecretManager;
+                    return valueFromSecretManager!;
                 }
 
                 return attr.DefaultValue ?? 

--- a/source/Calamari.Testing/Helpers/CalamariResult.cs
+++ b/source/Calamari.Testing/Helpers/CalamariResult.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Calamari.Common.Plumbing.Extensions;
-using Calamari.Common.Plumbing.ServiceMessages;
 using FluentAssertions;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
 
@@ -59,70 +56,28 @@ namespace Calamari.Testing.Helpers
             Assert.That(variable, resolveConstraint);
         }
 
-        public void AssertServiceMessage(string name, IResolveConstraint? resolveConstraint = null, Dictionary<string, object>? properties = null, string message = "", params object[] args)
+        public void AssertPackageDeltaVerificationServiceMessage(string message = "")
         {
-            switch (name)
+            if (!string.IsNullOrWhiteSpace(message))
             {
-                case ServiceMessageNames.CalamariFoundPackage.Name:
-                    Assert.That(captured.CalamariFoundPackage, resolveConstraint, message, args);
-                    break;
-                case ServiceMessageNames.FoundPackage.Name:
-                    Assert.That(captured.FoundPackage, Is.Not.Null);
-                    if (properties != null)
-                    {
-                        Assert.That(resolveConstraint, Is.Not.Null, "Resolve constraint was not provided");
-                        foreach (var property in properties)
-                        {
-                            var fp = JObject.FromObject(captured.FoundPackage);
-                            string value;
-                            if (property.Key.Contains("."))
-                            {
-                                var props = property.Key.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries);
-                                value = fp[props[0]][props[1]].ToString();
-                            }
-                            else
-                            {
-                                value = fp[property.Key].ToString();
-                            }
-
-                            AssertServiceMessageValue(property.Key, property.Value, value, resolveConstraint);
-                        }
-                    }
-
-                    break;
-                case ServiceMessageNames.PackageDeltaVerification.Name:
-                    if (!string.IsNullOrWhiteSpace(message))
-                    {
-                        Assert.That(captured?.DeltaError?.Replace("\r\n", "\n"), Is.EqualTo(message));
-                        break;
-                    }
-
-                    Assert.That(captured.DeltaVerification, Is.Not.Null);
-                    if (properties != null)
-                    {
-                        foreach (var property in properties)
-                        {
-                            var dv = JObject.FromObject(captured.DeltaVerification);
-                            string value;
-                            if (property.Key.Contains("."))
-                            {
-                                var props = property.Key.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries);
-                                value = dv[props[0]][props[1]].ToString();
-                            }
-                            else
-                            {
-                                value = dv[property.Key].ToString();
-                            }
-
-                            AssertServiceMessageValue(property.Key, property.Value, value, resolveConstraint);
-                        }
-                    }
-
-                    break;
+                Assert.That(captured?.DeltaError?.Replace("\r\n", "\n"), Is.EqualTo(message));
+                return;
             }
+
+            Assert.That(captured.DeltaVerification, Is.Not.Null);
+        }
+        
+        public void AssertCalamariFoundPackageServiceMessage(IResolveConstraint resolveConstraint, string message = "", params object[] args)
+        {
+            Assert.That(captured.CalamariFoundPackage, resolveConstraint, message, args);
+        }
+        
+        public void AssertFoundPackageServiceMessage()
+        {
+            Assert.That(captured.FoundPackage, Is.Not.Null);
         }
 
-        static void AssertServiceMessageValue(string property, object expected, string actual, IResolveConstraint? resolveConstraint)
+        static void AssertServiceMessageValue(string property, object expected, string actual, IResolveConstraint resolveConstraint)
         {
             Assert.That(actual, Is.Not.Null);
             Assert.That(actual, Is.Not.Empty);

--- a/source/Calamari.Testing/Helpers/CaptureCommandInvocationOutputSink.cs
+++ b/source/Calamari.Testing/Helpers/CaptureCommandInvocationOutputSink.cs
@@ -66,7 +66,7 @@ namespace Calamari.Testing.Helpers
                     var variableValue = message.GetValue(ServiceMessageNames.SetVariable.ValueAttribute);
 
                     if (!string.IsNullOrWhiteSpace(variableName))
-                        outputVariables.Set(variableName, variableValue);
+                        outputVariables.Set(variableName!, variableValue);
                     break;
                 case ServiceMessageNames.CalamariFoundPackage.Name:
                     CalamariFoundPackage = true;

--- a/source/Calamari.Testing/Requirements/RequiresNonFreeBSDPlatformAttribute.cs
+++ b/source/Calamari.Testing/Requirements/RequiresNonFreeBSDPlatformAttribute.cs
@@ -8,7 +8,7 @@ namespace Calamari.Testing.Requirements
 {
     public class RequiresNonFreeBSDPlatformAttribute : NUnitAttribute, IApplyToTest
     {
-        readonly string reason;
+        readonly string? reason;
 
         public RequiresNonFreeBSDPlatformAttribute()
         {

--- a/source/Calamari.Tests/Fixtures/ApplyDelta/ApplyDeltaFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ApplyDelta/ApplyDeltaFixture.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Text.RegularExpressions;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
-using Calamari.Common.Plumbing.ServiceMessages;
 using Calamari.Integration.FileSystem;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Fixtures.Deployment.Packages;
@@ -101,7 +100,7 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
                     var patchResult = ApplyDelta(basisFile.FilePath, basisFile.Hash, deltaFile.FilePath, NewFileName);
                     patchResult.AssertSuccess();
 
-                    patchResult.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name);
+                    patchResult.AssertPackageDeltaVerificationServiceMessage();
                     patchResult.AssertOutput("Applying delta to {0} with hash {1} and storing as {2}", basisFile.FilePath,
                         basisFile.Hash, patchResult.CapturedOutput.DeltaVerification.FullPathOnRemoteMachine);
                     Assert.AreEqual(newFile.Hash, patchResult.CapturedOutput.DeltaVerification.Hash);
@@ -116,7 +115,7 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
             var result = ApplyDelta("", "Hash", "Delta", "New");
 
             result.AssertSuccess();
-            result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: "No basis file was specified. Please pass --basisFileName MyPackage.1.0.0.0.nupkg");
+            result.AssertPackageDeltaVerificationServiceMessage(message: "No basis file was specified. Please pass --basisFileName MyPackage.1.0.0.0.nupkg");
         }
 
         [Test]
@@ -125,7 +124,7 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
             var result = ApplyDelta("Basis", "", "Delta", "New");
 
             result.AssertSuccess();
-            result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: "No file hash was specified. Please pass --fileHash MyFileHash");
+            result.AssertPackageDeltaVerificationServiceMessage(message: "No file hash was specified. Please pass --fileHash MyFileHash");
         }
         [Test]
         public void ShouldWriteErrorWhenNoDeltaFileIsSpecified()
@@ -133,7 +132,7 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
             var result = ApplyDelta("Basis", "Hash", "", "New");
 
             result.AssertSuccess();
-            result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: $"No delta file was specified. Please pass --deltaFileName MyPackage.1.0.0.0_to_1.0.0.1.octodelta");
+            result.AssertPackageDeltaVerificationServiceMessage(message: $"No delta file was specified. Please pass --deltaFileName MyPackage.1.0.0.0_to_1.0.0.1.octodelta");
         }
 
         [Test]
@@ -142,7 +141,7 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
             var result = ApplyDelta("Basis", "Hash", "Delta", "");
 
             result.AssertSuccess();
-            result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: "No new file name was specified. Please pass --newFileName MyPackage.1.0.0.1.nupkg");
+            result.AssertPackageDeltaVerificationServiceMessage(message: "No new file name was specified. Please pass --newFileName MyPackage.1.0.0.1.nupkg");
         }
 
         [Test]
@@ -152,7 +151,7 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
             var result = ApplyDelta(basisFile, "Hash", "Delta", "New");
 
             result.AssertSuccess();
-            result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: "Could not find basis file: " + basisFile);
+            result.AssertPackageDeltaVerificationServiceMessage(message: "Could not find basis file: " + basisFile);
         }
 
         [Test]
@@ -164,7 +163,7 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
                 var result = ApplyDelta(basisFile.FilePath, basisFile.Hash, deltaFilePath, "New");
 
                 result.AssertSuccess();
-                result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: "Could not find delta file: " + deltaFilePath);
+                result.AssertPackageDeltaVerificationServiceMessage(message: "Could not find delta file: " + deltaFilePath);
             }
         }
 
@@ -185,7 +184,7 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
                 var result = ApplyDelta(basisFile.FilePath, otherBasisFileHash, deltaFilePath, NewFileName, messageOnError: true);
 
                 result.AssertSuccess();
-                result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: $"Basis file hash `{basisFile.Hash}` does not match the file hash specified `{otherBasisFileHash}`");
+                result.AssertPackageDeltaVerificationServiceMessage(message: $"Basis file hash `{basisFile.Hash}` does not match the file hash specified `{otherBasisFileHash}`");
             }
         }
 
@@ -208,7 +207,7 @@ namespace Calamari.Tests.Fixtures.ApplyDelta
                 result.AssertOutputMatches(
                     $".*\nApplying delta to {Regex.Escape(basisFile.FilePath)} with hash {basisFile.Hash} and storing as {Regex.Escape(DownloadPath)}.*");
                 result.AssertOutput("The delta file appears to be corrupt.");
-                result.AssertServiceMessage(ServiceMessageNames.PackageDeltaVerification.Name, message: "The following command: OctoDiff\nFailed with exit code: 2\n");
+                result.AssertPackageDeltaVerificationServiceMessage(message: "The following command: OctoDiff\nFailed with exit code: 2\n");
             }
         }
     }

--- a/source/Calamari.Tests/Fixtures/FindPackage/FindPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/FindPackage/FindPackageFixture.cs
@@ -125,7 +125,7 @@ namespace Calamari.Tests.Fixtures.FindPackage
                     result.AssertOutput("Found 1 earlier version of {0} on this Tentacle", packageId);
                     result.AssertOutput("  - {0}: {1}", packageVersion, destinationFilePath);
 
-                    result.AssertServiceMessage(ServiceMessageNames.FoundPackage.Name, Is.True);
+                    result.AssertFoundPackageServiceMessage();
                     var foundPackage = result.CapturedOutput.FoundPackage;
                     Assert.AreEqual(VersionFactory.CreateSemanticVersion(packageVersion), foundPackage.Version);
                     Assert.AreEqual(acmeWeb.Hash, foundPackage.Hash);
@@ -206,7 +206,7 @@ namespace Calamari.Tests.Fixtures.FindPackage
                     result.AssertOutput("Found 1 earlier version of {0} on this Tentacle", packageId);
                     result.AssertOutput("  - {0}: {1}", packageVersion, destinationFilePath);
 
-                    result.AssertServiceMessage(ServiceMessageNames.FoundPackage.Name, Is.True);
+                    result.AssertFoundPackageServiceMessage();
                     var foundPackage = result.CapturedOutput.FoundPackage;
                     Assert.AreEqual(VersionFactory.CreateSemanticVersion(packageVersion), foundPackage.Version);
                     Assert.AreEqual(acmeWeb.Hash, foundPackage.Hash);
@@ -237,7 +237,7 @@ namespace Calamari.Tests.Fixtures.FindPackage
             result.AssertOutput("Found 1 earlier version of {0} on this Tentacle", mavenPackageId);
             result.AssertOutput("  - {0}: {1}", packageVersion, destinationFilePath);
 
-            result.AssertServiceMessage(ServiceMessageNames.FoundPackage.Name, Is.True);
+            result.AssertFoundPackageServiceMessage();
             var foundPackage = result.CapturedOutput.FoundPackage;
             Assert.AreEqual(VersionFactory.CreateMavenVersion(packageVersion), foundPackage.Version);
             Assert.AreEqual(mavenPackageHash, foundPackage.Hash);
@@ -257,16 +257,14 @@ namespace Calamari.Tests.Fixtures.FindPackage
                 var result = FindPackages(packageId, packageVersion, acmeWeb.Hash);
 
                 result.AssertSuccess();
-                result.AssertServiceMessage(
-                    ServiceMessageNames.CalamariFoundPackage.Name,
-                    Is.True,
+                result.AssertCalamariFoundPackageServiceMessage(Is.True,
                     message: "Expected service message '{0}' to be True",
                     args: ServiceMessageNames.CalamariFoundPackage.Name);
 
                 result.AssertOutput("Package {0} {1} hash {2} has already been uploaded", packageId, packageVersion,
                     acmeWeb.Hash);
 
-                result.AssertServiceMessage(ServiceMessageNames.FoundPackage.Name, Is.True);
+                result.AssertFoundPackageServiceMessage();
                 var foundPackage = result.CapturedOutput.FoundPackage;
                 Assert.AreEqual(VersionFactory.CreateSemanticVersion(packageVersion), foundPackage.Version);
                 Assert.AreEqual(acmeWeb.Hash, foundPackage.Hash);
@@ -285,9 +283,7 @@ namespace Calamari.Tests.Fixtures.FindPackage
             var result = FindPackages(mavenPackageId, packageVersion, mavenPackageHash, VersionFormat.Maven);
 
             result.AssertSuccess();
-            result.AssertServiceMessage(
-                ServiceMessageNames.CalamariFoundPackage.Name,
-                Is.True,
+            result.AssertCalamariFoundPackageServiceMessage(Is.True,
                 message: "Expected service message '{0}' to be True",
                 args: ServiceMessageNames.CalamariFoundPackage.Name);
 


### PR DESCRIPTION
Fixes up some warnings in Calamari.Testing, which in turn allows us to enable `TreatWarningsAsErrors`, which will help remove noise and distractions for engineers.