### PR TITLE
Update Image Update step to show rich warnings for missing annotations

### DIFF
--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
@@ -294,7 +294,7 @@ namespace Calamari.ArgoCD.Conventions
 
         void GenerateHelmAnnotationLogMessages(Application app, BasicSource source)
         {
-            var docsURL = "https://octopus.com/docs";
+            var docsURL = "https://oc.to/argo-cd-helm-image-annotations";
             log.WarnFormat("Argo CD Application '{0}' contains a helm chart ({1}), however the application is missing Octopus-specific annotations required for image-tag updating in Helm.",
                            app.Metadata.Name, Path.Combine(source.Path, ArgoCDConstants.HelmChartFileName));
             log.WarnFormat("Annotation creation documentation can be found {0}.", log.FormatLink(docsURL, "here"));

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
@@ -275,8 +275,8 @@ namespace Calamari.ArgoCD.Conventions
             var docsURL = "https://octopus.com/docs";
             log.WarnFormat("Argo CD Application '{0}' contains a helm chart ({1}), however the application is missing Octopus-specific annotations required for image-tag updating in Helm.",
                            app.Metadata.Name, Path.Combine(source.Path, ArgoCDConstants.HelmChartFileName));
-            log.WarnFormat("Required annotations can be found at '{0}'.", log.FormatLink(urlForArgoInstance));
-            log.WarnFormat("Further documentation can be found in '{0}'.", log.FormatLink(docsURL));
+            log.WarnFormat("Required annotations can be found at {0}.", log.FormatLink(urlForArgoInstance));
+            log.WarnFormat("Further documentation can be found in {0}.", log.FormatLink(docsURL));
             
         }
 

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
@@ -294,7 +294,6 @@ namespace Calamari.ArgoCD.Conventions
 
         void GenerateHelmAnnotationLogMessages(Application app, BasicSource source)
         {
-            var docsURL = "https://oc.to/argo-cd-helm-image-annotations";
             log.WarnFormat("Argo CD Application '{0}' contains a helm chart ({1}), however the application is missing Octopus-specific annotations required for image-tag updating in Helm.",
                            app.Metadata.Name, Path.Combine(source.Path, ArgoCDConstants.HelmChartFileName));
             log.WarnFormat("Annotation creation documentation can be found {0}.", log.FormatShortLink("argo-cd-helm-image-annotations", "here"));

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
@@ -297,7 +297,7 @@ namespace Calamari.ArgoCD.Conventions
             var docsURL = "https://oc.to/argo-cd-helm-image-annotations";
             log.WarnFormat("Argo CD Application '{0}' contains a helm chart ({1}), however the application is missing Octopus-specific annotations required for image-tag updating in Helm.",
                            app.Metadata.Name, Path.Combine(source.Path, ArgoCDConstants.HelmChartFileName));
-            log.WarnFormat("Annotation creation documentation can be found {0}.", log.FormatLink(docsURL, "here"));
+            log.WarnFormat("Annotation creation documentation can be found {0}.", log.FormatShortLink("argo-cd-helm-image-annotations", "here"));
             
         }
 

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
@@ -167,7 +167,7 @@ namespace Calamari.ArgoCD.Conventions
                                                                  .ToList();
             if (imageReplacePathAnnotations.IsNullOrEmpty())
             {
-                GenerateHelmAnnotationLogMessages(application, applicationFromYaml, applicationSource,deployment);
+                GenerateHelmAnnotationLogMessages(applicationFromYaml, applicationSource);
             }
             else
             {
@@ -292,14 +292,12 @@ namespace Calamari.ArgoCD.Conventions
             }
         }
 
-        void GenerateHelmAnnotationLogMessages(ArgoCDApplicationDto appDto, Application app, BasicSource source, RunningDeployment deployment)
+        void GenerateHelmAnnotationLogMessages(Application app, BasicSource source)
         {
-            var urlForArgoInstance = $"{deployment.Variables.Get("Octopus.Web.BaseUrl")}/app#/{deployment.Variables.Get("Octopus.Space.Id")}/infrastructure/argocdinstances/{appDto.GatewayId}/applications";
             var docsURL = "https://octopus.com/docs";
             log.WarnFormat("Argo CD Application '{0}' contains a helm chart ({1}), however the application is missing Octopus-specific annotations required for image-tag updating in Helm.",
                            app.Metadata.Name, Path.Combine(source.Path, ArgoCDConstants.HelmChartFileName));
-            log.WarnFormat("Required annotations can be found at {0}.", log.FormatLink(urlForArgoInstance));
-            log.WarnFormat("Further documentation can be found in {0}.", log.FormatLink(docsURL));
+            log.WarnFormat("Annotation creation documentation can be found {0}.", log.FormatLink(docsURL, "here"));
             
         }
 

--- a/source/Calamari/ArgoCD/Domain/Sources.cs
+++ b/source/Calamari/ArgoCD/Domain/Sources.cs
@@ -7,7 +7,7 @@ namespace Calamari.ArgoCD.Domain
     [JsonDerivedType(typeof(BasicSource), "basic")]
     [JsonDerivedType(typeof(HelmSource), "helm")]
     [JsonDerivedType(typeof(ReferenceSource), "reference")]
-    public abstract class SourceBase
+    public class SourceBase
     {
         [JsonPropertyName("repoURL")]
         public Uri RepoUrl { get; set; } = new Uri("about:blank");


### PR DESCRIPTION
It is possible that an Argo CD application has a 'Basic Source' (as identified by its yaml) - which actually contains a helm chart (based on the content of the repo it references).

Octopus _can_ update such a situation, but only if the appropriate annotations have been added to the application.

This PR tries to put in a valuable log message to aid the users to self-serve a solution.

In retrospect, linking to our Argo Applications page is _not_ great - as we won't necessarily be showing the "Generate Helm Annotations" button...

<img width="2495" height="432" alt="image" src="https://github.com/user-attachments/assets/50a7cf2a-dcf7-42ec-b16a-10ba55ec8e6f" />


:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
