### PR TITLE
Fix warnings & enable warnings as errors in Calamari.Common

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -5,6 +5,7 @@
         <LangVersion>8</LangVersion>
         <Nullable>enable</Nullable>
         <PlatformTarget>anycpu</PlatformTarget>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
         <DefineConstants>$(DefineConstants);USE_ALPHAFS_FOR_LONG_FILE_PATH_SUPPORT;HAS_SSL3</DefineConstants>

--- a/source/Calamari.Common/Features/Deployment/Journal/DeployedPackage.cs
+++ b/source/Calamari.Common/Features/Deployment/Journal/DeployedPackage.cs
@@ -14,8 +14,8 @@ namespace Calamari.Common.Features.Deployment.Journal
         {
             Guard.NotNullOrWhiteSpace(packageId, "Deployed package must have an Id");
             Guard.NotNullOrWhiteSpace(packageVersion, "Deployed package must have a version");
-            PackageId = packageId;
-            PackageVersion = packageVersion;
+            PackageId = packageId!;
+            PackageVersion = packageVersion!;
             DeployedFrom = deployedFrom;
         }
 

--- a/source/Calamari.Common/Features/Discovery/TargetDiscoveryContext.cs
+++ b/source/Calamari.Common/Features/Discovery/TargetDiscoveryContext.cs
@@ -8,7 +8,7 @@ namespace Calamari.Common.Features.Discovery
 {
     public interface ITargetDiscoveryContext
     {
-        public TargetDiscoveryScope Scope { get; }
+        public TargetDiscoveryScope? Scope { get; }
     }
 
     /// <summary>

--- a/source/Calamari.Common/Features/Packages/NuGet/LocalNuGetPackage.cs
+++ b/source/Calamari.Common/Features/Packages/NuGet/LocalNuGetPackage.cs
@@ -43,6 +43,9 @@ namespace Calamari.Common.Features.Packages.NuGet
             {
                 foreach (var entry in archive.Entries)
                 {
+                    if (entry.Key == null)
+                        continue;
+                    
                     if (entry.IsDirectory || !IsManifest(entry.Key))
                         continue;
 

--- a/source/Calamari.Common/Features/Packages/NuGet/NupkgExtractor.cs
+++ b/source/Calamari.Common/Features/Packages/NuGet/NupkgExtractor.cs
@@ -44,12 +44,15 @@ namespace Calamari.Common.Features.Packages.NuGet
             {
                 foreach (var entry in archive.Entries)
                 {
+                    if (entry.Key == null)
+                        continue;
+                    
                     var unescapedKey = UnescapePath(entry.Key);
 
                     if (IsExcludedPath(unescapedKey))
                         continue;
 
-                    var targetDirectory = Path.Combine(directory, Path.GetDirectoryName(unescapedKey));
+                    var targetDirectory = Path.Combine(directory, Path.GetDirectoryName(unescapedKey) ?? string.Empty);
 
                     if (!Directory.Exists(targetDirectory))
                         Directory.CreateDirectory(targetDirectory);

--- a/source/Calamari.Common/Features/Processes/CommandLine.cs
+++ b/source/Calamari.Common/Features/Processes/CommandLine.cs
@@ -14,7 +14,7 @@ namespace Calamari.Common.Features.Processes
         bool useDotnet;
         private Dictionary<string,string>? environmentVariables = null;
         private bool outputToLog = true;
-        private string workingDirectory;
+        private string? workingDirectory;
 
         public CommandLine(Func<string[], int> func)
         {
@@ -104,7 +104,7 @@ namespace Calamari.Common.Features.Processes
             {
                 EnvironmentVars = environmentVariables,
                 OutputToLog = outputToLog,
-                WorkingDirectory = workingDirectory
+                WorkingDirectory = workingDirectory!
             };
         }
 

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptBootstrapper.cs
@@ -47,7 +47,7 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
             foreach (var executableName in executableNames)
             {
                 var (_, commandOutput) = ExecuteCommandAndReturnOutput(commandLineRunner,
-                                                                       environmentVars,
+                                                                       environmentVars ?? new Dictionary<string, string>(),
                                                                        CalamariEnvironment.IsRunningOnWindows ? "where" : "which",
                                                                        executableName);
                 

--- a/source/Calamari.Common/Features/Scripting/Script.cs
+++ b/source/Calamari.Common/Features/Scripting/Script.cs
@@ -4,7 +4,7 @@ namespace Calamari.Common.Features.Scripting
 {
     public class Script
     {
-        public Script(string? file, string? parameters = null)
+        public Script(string file, string? parameters = null)
         {
             if (string.IsNullOrEmpty(file))
                 throw new InvalidScriptException("File can not be null or empty.");

--- a/source/Calamari.Common/Plumbing/Extensions/LogExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/LogExtensions.cs
@@ -14,12 +14,12 @@ namespace Calamari.Common.Plumbing.Extensions
 
         public static void LogMetric(this ILog log, string metricName, object metricValue, string? operationId = null)
         {
-            var serviceMessageParameters = new Dictionary<string, string>
-            {
-                { ServiceMessageNames.CalamariDeploymentMetric.OperationIdAttribute, operationId },
-                { ServiceMessageNames.CalamariDeploymentMetric.MetricAttribute, metricName },
-                { ServiceMessageNames.CalamariDeploymentMetric.ValueAttribute, metricValue.ToString() },
-            };
+            var serviceMessageParameters = new Dictionary<string, string>();
+            if (operationId != null)
+                serviceMessageParameters.Add(ServiceMessageNames.CalamariDeploymentMetric.OperationIdAttribute, operationId);
+            
+            serviceMessageParameters.Add(ServiceMessageNames.CalamariDeploymentMetric.MetricAttribute, metricName);
+            serviceMessageParameters.Add(ServiceMessageNames.CalamariDeploymentMetric.ValueAttribute, metricValue.ToString());
 
             log.WriteServiceMessage(new ServiceMessage(ServiceMessageNames.CalamariDeploymentMetric.Name, serviceMessageParameters));
         }

--- a/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
@@ -502,7 +502,10 @@ namespace Calamari.Common.Plumbing.FileSystem
                     try
                     {
                         Log.VerboseFormat("Attempting to access with OpenOrCreate file mode, Read/Write Access and No file share {0}", filePath);
+#pragma warning disable CS0642  // Possible mistaken empty statement (it's deliberate here)
                         using (File.Open(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None));
+#pragma warning restore CS0642  // Possible mistaken empty statement
+
                         Log.VerboseFormat("Succeeded accessing {0}", filePath);
                     }
                     catch (Exception fileAccessException)


### PR DESCRIPTION
Fixes up some warnings in Calamari.Common, which in turn allows us to enable `TreatWarningsAsErrors`, which will help remove noise and distractions for engineers.