### PR TITLE
Catch failure-to-push to a git repository

### DIFF
--- a/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
@@ -3,9 +3,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Calamari.ArgoCD.GitHub;
+using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Logging;
 using LibGit2Sharp;
-using NuGet.Commands;
 
 namespace Calamari.ArgoCD.Git
 {


### PR DESCRIPTION
It was found during testing that Calamari would fail silently when attempting to push to a protected branch on git hub.

This change introduces error status reporting in the push operation.

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
