### PR TITLE
Argo Manifests: Support Purge output

### DIFF
--- a/source/Calamari/ArgoCD/Conventions/ArgoCommitToGitConfig.cs
+++ b/source/Calamari/ArgoCD/Conventions/ArgoCommitToGitConfig.cs
@@ -5,11 +5,12 @@ namespace Calamari.ArgoCD.Conventions
 {
     public class ArgoCommitToGitConfig
     {
-        public ArgoCommitToGitConfig(string workingDirectory, string inputSubPath, bool recurseInputPath, GitCommitParameters commitParameters)
+        public ArgoCommitToGitConfig(string workingDirectory, string inputSubPath, bool recurseInputPath, bool purgeOutputDirectory, GitCommitParameters commitParameters)
         {
             WorkingDirectory = workingDirectory;
             InputSubPath = inputSubPath;
             RecurseInputPath = recurseInputPath;
+            PurgeOutputDirectory = purgeOutputDirectory;
             CommitParameters = commitParameters;
         }
         
@@ -19,6 +20,7 @@ namespace Calamari.ArgoCD.Conventions
         
         public string InputSubPath { get; }
         public bool RecurseInputPath { get; }
+        public bool PurgeOutputDirectory { get; }
         public GitCommitParameters CommitParameters { get; }
     }
 }

--- a/source/Calamari/ArgoCD/Conventions/DeploymentConfigFactory.cs
+++ b/source/Calamari/ArgoCD/Conventions/DeploymentConfigFactory.cs
@@ -24,11 +24,13 @@ namespace Calamari.ArgoCD.Conventions
             var commitParameters = CommitParameters(deployment);
             var inputPath = deployment.Variables.Get(SpecialVariables.Git.InputPath, string.Empty);
             var recursive = deployment.Variables.GetFlag(SpecialVariables.Git.Recursive, false);
+            var purgeOutput = deployment.Variables.GetFlag(SpecialVariables.Git.PurgeOutput, false);
             
             return new ArgoCommitToGitConfig(
                                            deployment.CurrentDirectory,
                                            inputPath,
                                            recursive,
+                                           purgeOutput,
                                            commitParameters);
         }
 

--- a/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
@@ -65,6 +65,10 @@ namespace Calamari.ArgoCD.Conventions
                 var applicationFromYaml = argoCdApplicationManifestParser.ParseManifest(application.Manifest);
                 foreach (var applicationSource in applicationFromYaml.Spec.Sources.OfType<BasicSource>())
                 {
+                if (spec.PurgeOutputDirectory)
+                {
+                    repository.StageFilesForRemoval(argoSource.SubFolder, spec.RecurseInputPath);
+                }
                     Log.Info($"Writing files to repository '{applicationSource.RepoUrl}' for '{application.Name}'");
                     
                     var gitCredential = gitCredentials[applicationSource.RepoUrl.AbsoluteUri];

--- a/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
@@ -65,10 +65,6 @@ namespace Calamari.ArgoCD.Conventions
                 var applicationFromYaml = argoCdApplicationManifestParser.ParseManifest(application.Manifest);
                 foreach (var applicationSource in applicationFromYaml.Spec.Sources.OfType<BasicSource>())
                 {
-                if (spec.PurgeOutputDirectory)
-                {
-                    repository.StageFilesForRemoval(argoSource.SubFolder, spec.RecurseInputPath);
-                }
                     Log.Info($"Writing files to repository '{applicationSource.RepoUrl}' for '{application.Name}'");
                     
                     var gitCredential = gitCredentials[applicationSource.RepoUrl.AbsoluteUri];
@@ -78,6 +74,11 @@ namespace Calamari.ArgoCD.Conventions
                     Log.Info($"Copying files into repository {applicationSource.RepoUrl}");
                     var subFolder = applicationSource.Path ?? String.Empty;
                     Log.VerboseFormat("Copying files into subfolder '{0}'", subFolder);
+                    
+                    if (deploymentConfig.PurgeOutputDirectory)
+                    {
+                        repository.StageFilesForRemoval(subFolder, deploymentConfig.RecurseInputPath);
+                    }
 
                     var repositoryFiles = packageFiles.Select(f => new FileCopySpecification(f, repository.WorkingDirectory, subFolder)).ToList();
                     Log.VerboseFormat("Copying files into subfolder '{0}'", applicationSource.Path!);

--- a/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
@@ -43,6 +43,38 @@ namespace Calamari.ArgoCD.Git
                 return false;
             }
         }
+
+        public void StageFilesForRemoval(string subPath, bool recursive)
+        {
+            var cleansedSubPath = subPath;
+            if (cleansedSubPath.StartsWith("./"))
+            {
+                cleansedSubPath = cleansedSubPath.Substring(2);
+            }
+
+            List<IndexEntry> filesToRemove = new List<IndexEntry>();
+            if (recursive)
+            {
+                Log.Verbose("Removing files recursively...");
+                repository.Index.ForEach(i => log.Info($"{i.Path} {i.Mode} {i.StageLevel} )"));
+                //Log.Verbose($"Identified Files = {repository.Index.Select(i => $"{i.Path}")}");
+                Log.Info($"cleansedSubPath = {cleansedSubPath}");
+                filesToRemove.AddRange(repository.Index.Where(i => i.Path.StartsWith(cleansedSubPath)).ToArray());
+            }
+            else
+            {
+                Log.Info($"Removing files which match {cleansedSubPath}");
+                // not sure how to handle platform-specific paths.
+                filesToRemove.AddRange(repository.Index.Where(i => i.Path.StartsWith(cleansedSubPath)
+                                                                   && (i.Path.EndsWith("yaml") || i.Path.EndsWith("yml"))
+                                                                   && !i.Path.Substring(cleansedSubPath.Length).Contains("/")
+                                                                   && i.Mode != Mode.Directory)
+                                                 .ToArray());
+            }
+            Log.Info($"Removing {filesToRemove.Select(i => i.Path).Join(",")}");
+            Log.Info($"Removing {filesToRemove.Count()} files from {subPath}");
+            filesToRemove.ForEach(i => repository.Index.Remove(i.Path));
+        }
         
         public void StageFiles(string[] filesToStage)
         {

--- a/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
@@ -1,10 +1,14 @@
 #if NET
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Calamari.ArgoCD.GitHub;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using LibGit2Sharp;
+using SharpCompress;
 
 namespace Calamari.ArgoCD.Git
 {
@@ -55,10 +59,8 @@ namespace Calamari.ArgoCD.Git
             List<IndexEntry> filesToRemove = new List<IndexEntry>();
             if (recursive)
             {
-                Log.Verbose("Removing files recursively...");
-                repository.Index.ForEach(i => log.Info($"{i.Path} {i.Mode} {i.StageLevel} )"));
-                //Log.Verbose($"Identified Files = {repository.Index.Select(i => $"{i.Path}")}");
-                Log.Info($"cleansedSubPath = {cleansedSubPath}");
+                Log.Verbose("Removing files recursively.");
+                repository.Index.ForEach(i => log.Info($" - {i.Path}"));
                 filesToRemove.AddRange(repository.Index.Where(i => i.Path.StartsWith(cleansedSubPath)).ToArray());
             }
             else
@@ -71,8 +73,6 @@ namespace Calamari.ArgoCD.Git
                                                                    && i.Mode != Mode.Directory)
                                                  .ToArray());
             }
-            Log.Info($"Removing {filesToRemove.Select(i => i.Path).Join(",")}");
-            Log.Info($"Removing {filesToRemove.Count()} files from {subPath}");
             filesToRemove.ForEach(i => repository.Index.Remove(i.Path));
         }
         

--- a/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
@@ -50,11 +50,7 @@ namespace Calamari.ArgoCD.Git
 
         public void StageFilesForRemoval(string subPath, bool recursive)
         {
-            var cleansedSubPath = subPath;
-            if (cleansedSubPath.StartsWith("./"))
-            {
-                cleansedSubPath = cleansedSubPath.Substring(2);
-            }
+            var cleansedSubPath = subPath.StartsWith("./") ? subPath.Substring(2) : subPath;
 
             List<IndexEntry> filesToRemove = new List<IndexEntry>();
             if (recursive)

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -73,6 +73,8 @@ namespace Calamari.Kubernetes
             public static readonly string InputPath = "Octopus.Action.ArgoCD.InputPath";
             
             public static readonly string Recursive = "Octopus.Action.ArgoCD.RecursiveResourceDetection";
+
+            public static readonly string PurgeOutput = "Octopus.Action.ArgoCD.PurgeOutputFolder";
             
             public static class PullRequest
             {


### PR DESCRIPTION
There is a variable on the Argo Manifest step which is responsible for removing files from the output directory prior to updating it.

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
