### PR TITLE
Identify when dotnet-scripts failed to compile and log a warning

### DIFF
--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -13,6 +13,7 @@ using Calamari.Common.Features.FunctionScriptContributions;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
+using Calamari.Common.Features.Scripting.DotnetScript;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing;
@@ -122,6 +123,8 @@ namespace Calamari.Common
             var assemblies = GetAllAssembliesToRegister().ToArray();
 
             builder.RegisterAssemblyTypes(assemblies).AssignableTo<ICodeGenFunctions>().As<ICodeGenFunctions>().SingleInstance();
+
+            builder.RegisterType<DotnetScriptCompilationWarningOutputSink>().AsSelf().SingleInstance();
 
             builder.RegisterAssemblyTypes(assemblies)
                 .AssignableTo<IScriptWrapper>()

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -15,6 +15,7 @@ using Calamari.Common.Features.FunctionScriptContributions;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
+using Calamari.Common.Features.Scripting.DotnetScript;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing;
@@ -65,6 +66,8 @@ namespace Calamari.Common
             var assemblies = GetAllAssembliesToRegister().ToArray();
 
             builder.RegisterAssemblyTypes(assemblies).AssignableTo<ICodeGenFunctions>().As<ICodeGenFunctions>().SingleInstance();
+
+            builder.RegisterType<DotnetScriptCompilationWarningOutputSink>().AsSelf().SingleInstance();
 
             builder.RegisterAssemblyTypes(assemblies)
                    .AssignableTo<IScriptWrapper>()

--- a/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
@@ -7,9 +7,11 @@ namespace Calamari.Common.FeatureToggles
         public static class KnownSlugs
         {
             public const string ArgoCDCreatePullRequestFeatureToggle = "argocd-create-pull-request";
+            public const string DotNetScriptCompilationWarningFeatureToggle = "dotnet-script-compile-warning";
         };
 
         public static readonly OctopusFeatureToggle ArgoCDCreatePullRequestFeatureToggle = new OctopusFeatureToggle(KnownSlugs.ArgoCDCreatePullRequestFeatureToggle);
+        public static readonly OctopusFeatureToggle DotNetScriptCompilationWarningFeatureToggle = new OctopusFeatureToggle(KnownSlugs.DotNetScriptCompilationWarningFeatureToggle);
 
         public class OctopusFeatureToggle
         {

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/Bootstrap.csx
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/Bootstrap.csx
@@ -23,6 +23,7 @@ public static void Initialize(string password)
         throw new Exception("Octopus can only be initialized once.");
     }
     OctopusParameters = new OctopusParametersDictionary(password);
+    WriteVerbose("Script compiled successfully, executing...");
     LogEnvironmentInformation();
 }
 

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/ClassBootstrap.csx
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/ClassBootstrap.csx
@@ -28,6 +28,7 @@ public static class Octopus
             throw new Exception("Octopus can only be initialized once.");
         }
         Parameters = new OctopusParametersDictionary(password);
+        WriteVerbose("Script compiled successfully, executing...");
         LogEnvironmentInformation();
     }
 

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptCompilationWarningOutputSink.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptCompilationWarningOutputSink.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Calamari.Common.Plumbing.Commands;
+
+namespace Calamari.Common.Features.Scripting.DotnetScript
+{
+    public class DotnetScriptCompilationWarningOutputSink : ICommandInvocationOutputSink
+    {
+        public bool SuccessfullyCompiled { get; private set; }
+
+        public void WriteInfo(string line) => CheckIfExecutingLine(line);
+
+        public void WriteError(string line) => CheckIfExecutingLine(line);
+
+        void CheckIfExecutingLine(string line)
+        {
+            if (!SuccessfullyCompiled && string.Equals(line, "Script compiled successfully, executing...", StringComparison.OrdinalIgnoreCase))
+            {
+                SuccessfullyCompiled = true;
+            }
+        }
+    }
+}

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptCompilationWarningOutputSink.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptCompilationWarningOutputSink.cs
@@ -20,7 +20,7 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
         }
 
         /// <summary>
-        /// 
+        /// Marks the sink as assuming successful compilation. This results in the warning message not being outputted
         /// </summary>
         public void AssumeSuccessfullyCompiled()
         {

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptCompilationWarningOutputSink.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptCompilationWarningOutputSink.cs
@@ -18,5 +18,13 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
                 SuccessfullyCompiled = true;
             }
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void AssumeSuccessfullyCompiled()
+        {
+            SuccessfullyCompiled = true;
+        }
     }
 }

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptCompilerWarningWrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptCompilerWarningWrapper.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Features.Scripts;
+using Calamari.Common.Plumbing.Logging;
+
+namespace Calamari.Common.Features.Scripting.DotnetScript
+{
+    public class DotnetScriptCompilerWarningWrapper : IScriptWrapper
+    {
+        public const string WarningLogLine = "dotnet-script failed to execute the script. This may be due to syntax differences between dotnet-script and ScriptCS. As of 2025.4, ScriptCS is no longer supported.";
+        
+        readonly ILog log;
+        readonly DotnetScriptCompilationWarningOutputSink outputSink;
+        
+        public int Priority => ScriptWrapperPriorities.DotnetScriptCompileWarning;
+
+        public IScriptWrapper? NextWrapper { get; set; }
+
+        public bool IsEnabled(ScriptSyntax syntax) => syntax == ScriptSyntax.CSharp;
+
+        public DotnetScriptCompilerWarningWrapper(ILog log, DotnetScriptCompilationWarningOutputSink outputSink)
+        {
+            this.log = log;
+            this.outputSink = outputSink;
+        }
+
+        public CommandResult ExecuteScript(Script script, ScriptSyntax scriptSyntax, ICommandLineRunner commandLineRunner, Dictionary<string, string>? environmentVars)
+        {
+            var result = NextWrapper!.ExecuteScript(script, scriptSyntax, commandLineRunner, environmentVars);
+
+            //there was a failure
+            if (result.ExitCode != 0 && !outputSink.SuccessfullyCompiled)
+            {
+                log.Warn(WarningLogLine);
+            }
+
+            return result;
+        }
+    }
+}

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptCompilerWarningWrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptCompilerWarningWrapper.cs
@@ -7,7 +7,7 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
 {
     public class DotnetScriptCompilerWarningWrapper : IScriptWrapper
     {
-        public const string WarningLogLine = "dotnet-script failed to execute the script. This may be due to syntax differences between dotnet-script and ScriptCS. As of 2025.4, ScriptCS is no longer supported.";
+        public const string WarningLogLine = "dotnet-script failed to execute the script. This may be due to syntax differences between dotnet-script and ScriptCS. As of 2025.4, ScriptCS is [no longer supported](https://oc.to/scriptcs-deprecation).";
         
         readonly ILog log;
         readonly DotnetScriptCompilationWarningOutputSink outputSink;

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
@@ -12,9 +12,12 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
     public class DotnetScriptExecutor : ScriptExecutor
     {
         readonly ICommandLineRunner commandLineRunner;
-        public DotnetScriptExecutor(ICommandLineRunner commandLineRunner, ILog log): base(log)
+        readonly DotnetScriptCompilationWarningOutputSink outputSink;
+
+        public DotnetScriptExecutor(ICommandLineRunner commandLineRunner, ILog log, DotnetScriptCompilationWarningOutputSink outputSink): base(log)
         {
             this.commandLineRunner = commandLineRunner;
+            this.outputSink = outputSink;
         }
         protected override IEnumerable<ScriptExecution> PrepareExecution(Script script,
             IVariables variables,
@@ -38,6 +41,8 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
             cli.EnvironmentVars = environmentVars;
             cli.WorkingDirectory = workingDirectory;
             cli.Isolate = !bypassDotnetScriptIsolation;
+
+            cli.AdditionalInvocationOutputSink = outputSink;
 
             yield return new ScriptExecution(cli, otherTemporaryFiles.Concat(new[] { bootstrapFile, configurationFile }));
         }

--- a/source/Calamari.Common/Features/Scripting/ScriptEngine.cs
+++ b/source/Calamari.Common/Features/Scripting/ScriptEngine.cs
@@ -29,11 +29,13 @@ namespace Calamari.Common.Features.Scripting
     {
         readonly IEnumerable<IScriptWrapper> scriptWrapperHooks;
         readonly ILog log;
+        readonly DotnetScriptCompilationWarningOutputSink dotnetScriptCompilationWarningOutputSink;
 
-        public ScriptEngine(IEnumerable<IScriptWrapper> scriptWrapperHooks, ILog log)
+        public ScriptEngine(IEnumerable<IScriptWrapper> scriptWrapperHooks, ILog log, DotnetScriptCompilationWarningOutputSink dotnetScriptCompilationWarningOutputSink)
         {
             this.scriptWrapperHooks = scriptWrapperHooks;
             this.log = log;
+            this.dotnetScriptCompilationWarningOutputSink = dotnetScriptCompilationWarningOutputSink;
         }
 
         public ScriptSyntax[] GetSupportedTypes()
@@ -102,7 +104,7 @@ namespace Calamari.Common.Features.Scripting
                 case ScriptSyntax.PowerShell:
                     return new PowerShellScriptExecutor(log);
                 case ScriptSyntax.CSharp:
-                    return runDotnetScript ? (IScriptExecutor) new DotnetScriptExecutor(commandLineRunner, log) : new ScriptCSScriptExecutor(log);
+                    return runDotnetScript ? (IScriptExecutor) new DotnetScriptExecutor(commandLineRunner, log, dotnetScriptCompilationWarningOutputSink) : new ScriptCSScriptExecutor(log);
                 case ScriptSyntax.Bash:
                     return new BashScriptExecutor(log);
                 case ScriptSyntax.Python:

--- a/source/Calamari.Common/Features/Scripting/ScriptWrapperPriorities.cs
+++ b/source/Calamari.Common/Features/Scripting/ScriptWrapperPriorities.cs
@@ -33,6 +33,12 @@ namespace Calamari.Common.Features.Scripting
         public const int ToolConfigPriority = 100;
 
         /// <summary>
+        /// The priority for the script wrapper to handle dotnet-script compilation warnings.
+        /// Used while ScriptCS is being deprecated.
+        /// </summary>
+        public const int DotnetScriptCompileWarning = 10;
+
+        /// <summary>
         /// The priority for tools the terminal script wrapper, which should always
         /// be run last
         /// </summary>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -180,6 +180,9 @@
     <None Update="Fixtures\DotnetScript\Scripts\ThrowsException.csx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Fixtures\ScriptCS\Scripts\InvalidSyntax.csx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Remove="TestResults\**" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -177,6 +177,9 @@
     <None Update="KubernetesFixtures\ResourceStatus\assets\invalid-syntax.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Fixtures\DotnetScript\Scripts\ThrowsException.csx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Remove="TestResults\**" />

--- a/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptFixture.cs
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Calamari.Common.Features.Scripting.DotnetScript;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment;
 using Calamari.Testing.Helpers;
@@ -17,7 +18,7 @@ namespace Calamari.Tests.Fixtures.DotnetScript
     public class DotnetScriptFixture : CalamariFixture
     {
         static readonly Dictionary<string, string> RunWithDotnetScriptVariable = new Dictionary<string, string>() { { ScriptVariables.UseDotnetScript, bool.TrueString } };
-        
+
         [Test]
         public void ShouldPrintEncodedVariable()
         {
@@ -58,15 +59,16 @@ namespace Calamari.Tests.Fixtures.DotnetScript
         [Test]
         public void ShouldCallHello()
         {
-            var (output, _) = RunScript("Hello.csx", new Dictionary<string, string>()
-            {
-                ["Name"] = "Paul",
-                ["Variable2"] = "DEF",
-                ["Variable3"] = "GHI",
-                ["Foo_bar"] = "Hello",
-                ["Host"] = "Never",
-                [ScriptVariables.UseDotnetScript] = bool.TrueString
-            });
+            var (output, _) = RunScript("Hello.csx",
+                                        new Dictionary<string, string>()
+                                        {
+                                            ["Name"] = "Paul",
+                                            ["Variable2"] = "DEF",
+                                            ["Variable3"] = "GHI",
+                                            ["Foo_bar"] = "Hello",
+                                            ["Host"] = "Never",
+                                            [ScriptVariables.UseDotnetScript] = bool.TrueString
+                                        });
 
             output.AssertSuccess();
             output.AssertOutput("Hello Paul");
@@ -76,11 +78,13 @@ namespace Calamari.Tests.Fixtures.DotnetScript
         [Test]
         public void ShouldCallHelloWithSensitiveVariable()
         {
-            var (output, _) = RunScript("Hello.csx", new Dictionary<string, string>()
-            {
-                ["Name"] = "NameToEncrypt",
-                [ScriptVariables.UseDotnetScript] = bool.TrueString
-            }, sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
+            var (output, _) = RunScript("Hello.csx",
+                                        new Dictionary<string, string>()
+                                        {
+                                            ["Name"] = "NameToEncrypt",
+                                            [ScriptVariables.UseDotnetScript] = bool.TrueString
+                                        },
+                                        sensitiveVariablesPassword: "5XETGOgqYR2bRhlfhDruEg==");
 
             output.AssertSuccess();
             output.AssertOutput("Hello NameToEncrypt");
@@ -89,11 +93,12 @@ namespace Calamari.Tests.Fixtures.DotnetScript
         [Test]
         public void ShouldConsumeParametersWithQuotes()
         {
-            var (output, _) = RunScript("Parameters.csx", new Dictionary<string, string>()
-            {
-                [SpecialVariables.Action.Script.ScriptParameters] = "-- \"Para meter0\" Parameter1",
-                [ScriptVariables.UseDotnetScript] = bool.TrueString
-            });
+            var (output, _) = RunScript("Parameters.csx",
+                                        new Dictionary<string, string>()
+                                        {
+                                            [SpecialVariables.Action.Script.ScriptParameters] = "-- \"Para meter0\" Parameter1",
+                                            [ScriptVariables.UseDotnetScript] = bool.TrueString
+                                        });
 
             output.AssertSuccess();
             output.AssertOutput("Parameters Para meter0Parameter1");
@@ -102,11 +107,12 @@ namespace Calamari.Tests.Fixtures.DotnetScript
         [Test]
         public void ShouldConsumeParametersWithoutParametersPrefix()
         {
-            var (output, _) = RunScript("Parameters.csx", new Dictionary<string, string>()
-            {
-                [SpecialVariables.Action.Script.ScriptParameters] = "Parameter0 Parameter1",
-                [ScriptVariables.UseDotnetScript] = bool.TrueString
-            });
+            var (output, _) = RunScript("Parameters.csx",
+                                        new Dictionary<string, string>()
+                                        {
+                                            [SpecialVariables.Action.Script.ScriptParameters] = "Parameter0 Parameter1",
+                                            [ScriptVariables.UseDotnetScript] = bool.TrueString
+                                        });
 
             output.AssertSuccess();
             output.AssertOutput("Parameters Parameter0Parameter1");
@@ -136,26 +142,44 @@ namespace Calamari.Tests.Fixtures.DotnetScript
         }
 
         [Test]
-        public void HasInvalidSyntax_ShouldWriteExtraWarningLine()
+        public void HasInvalidSyntax_FeatureToggleIsEnabled_ShouldWriteExtraWarningLine()
         {
-            var (output, _) = RunScript("InvalidSyntax.csx", new Dictionary<string, string>()
-            {
-                [ScriptVariables.UseDotnetScript] = bool.TrueString
-            });
+            var (output, _) = RunScript("InvalidSyntax.csx",
+                                        new Dictionary<string, string>()
+                                        {
+                                            [ScriptVariables.UseDotnetScript] = bool.TrueString,
+                                            [KnownVariables.EnabledFeatureToggles] = OctopusFeatureToggles.KnownSlugs.DotNetScriptCompilationWarningFeatureToggle
+                                        });
 
             output.CapturedOutput.AllMessages.Should().Contain(DotnetScriptCompilerWarningWrapper.WarningLogLine);
 
             //We are expecting failure
             output.AssertFailure();
         }
-        
+
         [Test]
-        public void ThrowsException_ShowNotWriteExtraWarningLine()
+        public void HasInvalidSyntax_FeatureToggleIsDisabled_ShouldNotWriteExtraWarningLine()
         {
-            var (output, _) = RunScript("ThrowsException.csx", new Dictionary<string, string>()
-            {
-                [ScriptVariables.UseDotnetScript] = bool.TrueString
-            });
+            var (output, _) = RunScript("InvalidSyntax.csx",
+                                        new Dictionary<string, string>()
+                                        {
+                                            [ScriptVariables.UseDotnetScript] = bool.TrueString
+                                        });
+
+            output.CapturedOutput.AllMessages.Should().NotContain(DotnetScriptCompilerWarningWrapper.WarningLogLine);
+
+            //We are expecting failure
+            output.AssertFailure();
+        }
+
+        [Test]
+        public void ThrowsException_ShouldNotWriteExtraWarningLine()
+        {
+            var (output, _) = RunScript("ThrowsException.csx",
+                                        new Dictionary<string, string>()
+                                        {
+                                            [ScriptVariables.UseDotnetScript] = bool.TrueString
+                                        });
 
             output.CapturedOutput.AllMessages.Should().NotContain(DotnetScriptCompilerWarningWrapper.WarningLogLine);
             //We are expecting failure

--- a/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptFixture.cs
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptFixture.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using Calamari.Common.Features.Scripting.DotnetScript;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
 using Calamari.Tests.Helpers;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures.DotnetScript
@@ -131,6 +133,33 @@ namespace Calamari.Tests.Fixtures.DotnetScript
                 output.AssertFailure();
                 output.AssertErrorOutput("Could not load file or assembly 'NuGet.Protocol, Version=6.10.0.");
             }
+        }
+
+        [Test]
+        public void HasInvalidSyntax_ShouldWriteExtraWarningLine()
+        {
+            var (output, _) = RunScript("InvalidSyntax.csx", new Dictionary<string, string>()
+            {
+                [ScriptVariables.UseDotnetScript] = bool.TrueString
+            });
+
+            output.CapturedOutput.AllMessages.Should().Contain(DotnetScriptCompilerWarningWrapper.WarningLogLine);
+
+            //We are expecting failure
+            output.AssertFailure();
+        }
+        
+        [Test]
+        public void ThrowsException_ShowNotWriteExtraWarningLine()
+        {
+            var (output, _) = RunScript("ThrowsException.csx", new Dictionary<string, string>()
+            {
+                [ScriptVariables.UseDotnetScript] = bool.TrueString
+            });
+
+            output.CapturedOutput.AllMessages.Should().NotContain(DotnetScriptCompilerWarningWrapper.WarningLogLine);
+            //We are expecting failure
+            output.AssertFailure();
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptFixture.cs
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/DotnetScriptFixture.cs
@@ -13,11 +13,12 @@ namespace Calamari.Tests.Fixtures.DotnetScript
 {
     [TestFixture]
     [Category(TestCategory.ScriptingSupport.DotnetScript)]
+    [RequiresDotNetCore]
     public class DotnetScriptFixture : CalamariFixture
     {
         static readonly Dictionary<string, string> RunWithDotnetScriptVariable = new Dictionary<string, string>() { { ScriptVariables.UseDotnetScript, bool.TrueString } };
         
-        [Test, RequiresDotNetCore]
+        [Test]
         public void ShouldPrintEncodedVariable()
         {
             var (output, _) = RunScript("PrintEncodedVariable.csx", RunWithDotnetScriptVariable);
@@ -26,7 +27,7 @@ namespace Calamari.Tests.Fixtures.DotnetScript
             output.AssertOutput("##octopus[setVariable name='RG9ua2V5' value='S29uZw==']");
         }
 
-        [Test, RequiresDotNetCore]
+        [Test]
         public void ShouldPrintSensitiveVariable()
         {
             var (output, _) = RunScript("PrintSensitiveVariable.csx", RunWithDotnetScriptVariable);
@@ -35,7 +36,7 @@ namespace Calamari.Tests.Fixtures.DotnetScript
             output.AssertOutput("##octopus[setVariable name='UGFzc3dvcmQ=' value='Y29ycmVjdCBob3JzZSBiYXR0ZXJ5IHN0YXBsZQ==' sensitive='VHJ1ZQ==']");
         }
 
-        [Test, RequiresDotNetCore]
+        [Test]
         public void ShouldCreateArtifact()
         {
             var (output, _) = RunScript("CreateArtifact.csx", RunWithDotnetScriptVariable);
@@ -45,7 +46,7 @@ namespace Calamari.Tests.Fixtures.DotnetScript
             output.AssertOutput("name='bXlGaWxlLnR4dA==' length='MTAw']");
         }
 
-        [Test, RequiresDotNetCore]
+        [Test]
         public void ShouldUpdateProgress()
         {
             var (output, _) = RunScript("UpdateProgress.csx", RunWithDotnetScriptVariable);
@@ -54,7 +55,7 @@ namespace Calamari.Tests.Fixtures.DotnetScript
             output.AssertOutput("##octopus[progress percentage='NTA=' message='SGFsZiBXYXk=']");
         }
 
-        [Test, RequiresDotNetCore]
+        [Test]
         public void ShouldCallHello()
         {
             var (output, _) = RunScript("Hello.csx", new Dictionary<string, string>()
@@ -72,7 +73,7 @@ namespace Calamari.Tests.Fixtures.DotnetScript
             output.AssertOutput("This is dotnet script");
         }
 
-        [Test, RequiresDotNetCore]
+        [Test]
         public void ShouldCallHelloWithSensitiveVariable()
         {
             var (output, _) = RunScript("Hello.csx", new Dictionary<string, string>()
@@ -85,7 +86,7 @@ namespace Calamari.Tests.Fixtures.DotnetScript
             output.AssertOutput("Hello NameToEncrypt");
         }
 
-        [Test, RequiresDotNetCore]
+        [Test]
         public void ShouldConsumeParametersWithQuotes()
         {
             var (output, _) = RunScript("Parameters.csx", new Dictionary<string, string>()
@@ -98,7 +99,7 @@ namespace Calamari.Tests.Fixtures.DotnetScript
             output.AssertOutput("Parameters Para meter0Parameter1");
         }
 
-        [Test, RequiresDotNetCore]
+        [Test]
         public void ShouldConsumeParametersWithoutParametersPrefix()
         {
             var (output, _) = RunScript("Parameters.csx", new Dictionary<string, string>()
@@ -113,7 +114,6 @@ namespace Calamari.Tests.Fixtures.DotnetScript
 
         [TestCase(true)]
         [TestCase(false)]
-        [RequiresDotNetCore]
         public void UsingIsolatedAssemblyLoadContext(bool enableIsolatedLoadContext)
         {
             var (output, _) = RunScript("IsolatedLoadContext.csx",

--- a/source/Calamari.Tests/Fixtures/DotnetScript/Scripts/InvalidSyntax.csx
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/Scripts/InvalidSyntax.csx
@@ -1,0 +1,14 @@
+#r "RestSharp.dll"
+
+using RestSharp;
+
+public class DoATHing
+{
+    public void Hi()
+    {
+        var client = new RestClient("https://pokeapi.co/api/v2/");
+        var request = new RestRequest("pokemon/ditto")
+        var response = await client.ExecuteGetAsync(request);
+        Console.WriteLine(response.Content);
+    }
+}

--- a/source/Calamari.Tests/Fixtures/DotnetScript/Scripts/ThrowsException.csx
+++ b/source/Calamari.Tests/Fixtures/DotnetScript/Scripts/ThrowsException.csx
@@ -1,0 +1,3 @@
+using System;
+
+throw new Exception("Boom");

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderFixture.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
+using Calamari.Common.Features.Scripting.DotnetScript;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -16,6 +17,7 @@ using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
 using Calamari.Tests.Helpers;
 using FluentAssertions;
+using NSubstitute;
 using NUnit.Framework;
 using Octopus.Versioning.Semver;
 
@@ -256,7 +258,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         static DockerImagePackageDownloader GetDownloader(ILog log)
         {
             var runner = new CommandLineRunner(log, new CalamariVariables());
-            return new DockerImagePackageDownloader(new ScriptEngine(Enumerable.Empty<IScriptWrapper>(), log), CalamariPhysicalFileSystem.GetPhysicalFileSystem(), runner, new CalamariVariables(), log, new FeedLoginDetailsProviderFactory());
+            return new DockerImagePackageDownloader(new ScriptEngine(Enumerable.Empty<IScriptWrapper>(), log, new DotnetScriptCompilationWarningOutputSink()), CalamariPhysicalFileSystem.GetPhysicalFileSystem(), runner, new CalamariVariables(), log, new FeedLoginDetailsProviderFactory());
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/CSharpScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/CSharpScriptEngineFixture.cs
@@ -25,7 +25,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
                 variables.Add(ScriptVariables.UseDotnetScript, bool.TrueString);
                 File.WriteAllText(scriptFile.FilePath, "System.Console.WriteLine(OctopusParameters[\"mysecrect\"]);");
                 var commandLineRunner = new TestCommandLineRunner(new InMemoryLog(), new CalamariVariables());
-                var result = ExecuteScript(new DotnetScriptExecutor(commandLineRunner, Substitute.For<ILog>()), scriptFile.FilePath, variables);
+                var result = ExecuteScript(new DotnetScriptExecutor(commandLineRunner, Substitute.For<ILog>(), new DotnetScriptCompilationWarningOutputSink()), scriptFile.FilePath, variables);
                 result.AssertOutput("KingKong");
             }
         }

--- a/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Scripting/ScriptEngineFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Calamari.Common.Features.Scripting;
+using Calamari.Common.Features.Scripting.DotnetScript;
 using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Testing.Helpers;
@@ -45,7 +46,7 @@ namespace Calamari.Tests.Fixtures.Integration.Scripting
 
         void DeterminesCorrectScriptTypePreferenceOrder(IEnumerable<ScriptSyntax> expected)
         {
-            var engine = new ScriptEngine(new List<IScriptWrapper>(), Substitute.For<ILog>());
+            var engine = new ScriptEngine(new List<IScriptWrapper>(), Substitute.For<ILog>(), new DotnetScriptCompilationWarningOutputSink());
             var supportedTypes = engine.GetSupportedTypes();
 
             supportedTypes.Should().Equal(expected);

--- a/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ScriptCS/ScriptCSFixture.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using Calamari.Common.Features.Scripting.DotnetScript;
 using Calamari.Deployment;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
 using Calamari.Tests.Helpers;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Calamari.Tests.Fixtures.ScriptCS
@@ -95,6 +97,16 @@ namespace Calamari.Tests.Fixtures.ScriptCS
 
             output.AssertSuccess();
             output.AssertOutput("Parameters Parameter0Parameter1");
+        }
+        
+        [Test, RequiresDotNet45]
+        public void HasInvalidSyntax_ShowNotWriteExtraWarningLine()
+        {
+            var (output, _) = RunScript("InvalidSyntax.csx", new Dictionary<string, string>());
+
+            output.CapturedOutput.AllMessages.Should().NotContain(DotnetScriptCompilerWarningWrapper.WarningLogLine);
+            //We are expecting failure
+            output.AssertFailure();
         }
     }
 }

--- a/source/Calamari.Tests/Fixtures/ScriptCS/Scripts/InvalidSyntax.csx
+++ b/source/Calamari.Tests/Fixtures/ScriptCS/Scripts/InvalidSyntax.csx
@@ -1,0 +1,10 @@
+public class DoATHing
+{
+    public void Hi()
+    {
+        var client = new RestClient("https://pokeapi.co/api/v2/");
+        var request = new RestRequest("pokemon/ditto")
+        var response = await client.ExecuteGetAsync(request);
+        Console.WriteLine(response.Content);
+    }
+}

--- a/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
@@ -7,6 +7,7 @@ using Calamari.Commands.Java;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
+using Calamari.Common.Features.Scripting.DotnetScript;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing.Commands;
@@ -131,7 +132,7 @@ namespace Calamari.Tests.Java.Fixtures.Deployment
             var commandLineRunner = new CommandLineRunner(log, variables);
             var command = new DeployJavaArchiveCommand(
                 log,
-                new ScriptEngine(Enumerable.Empty<IScriptWrapper>(), log),
+                new ScriptEngine(Enumerable.Empty<IScriptWrapper>(), log, new DotnetScriptCompilationWarningOutputSink()),
                 variables,
                 fileSystem,
                 commandLineRunner,

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperFixture.cs
@@ -12,6 +12,7 @@ using Calamari.Aws.Integration;
 using Calamari.Common.Features.EmbeddedResources;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
+using Calamari.Common.Features.Scripting.DotnetScript;
 using Calamari.Common.Features.Scripts;
 using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
@@ -23,6 +24,7 @@ using Calamari.Testing.Requirements;
 using Calamari.Tests.Fixtures.Integration.FileSystem;
 using Calamari.Tests.Helpers;
 using FluentAssertions;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Calamari.Tests.KubernetesFixtures
@@ -450,7 +452,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 wrappers.Add(new AwsScriptWrapper(log, variables) { VerifyAmazonLogin = () => Task.FromResult(true) });
             }
 
-            var engine = new ScriptEngine(wrappers, log);
+            var engine = new ScriptEngine(wrappers, log, new DotnetScriptCompilationWarningOutputSink());
             var result = engine.Execute(new Script(scriptName), variables, runner, environmentVariables);
 
             return new CalamariResult(result.ExitCode, new CaptureCommandInvocationOutputSink());


### PR DESCRIPTION
Adds a warning log line when a CSharp script being executed by dotnet-script fails to compile (and thus the bootstrapper script fails to execute).