### PR TITLE
Argo Template step to handle Input Path

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateGitRepositoryInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateGitRepositoryInstallConventionTests.cs
@@ -165,6 +165,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
         [Test]
         public void InputPathIndicatesFileButIsDirectoryThereforeNoFilesAreChanged()
         {
+            // Arrange
             const string firstFilename = "first.yaml";
             CreateFileUnderPackageDirectory(firstFilename);
             const string nestedFilename = "nested/second.yaml";
@@ -192,11 +193,12 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                                       new DeploymentConfigFactory(nonSensitiveCalamariVariables), 
                                                                       customPropertiesLoader,
                                                                       argoCdApplicationManifestParser);
-            convention.Install(runningDeployment);
             
-            var resultPath = CloneOrigin();
-            File.Exists(Path.Combine(resultPath, firstFilename)).Should().BeTrue();
-            File.Exists(Path.Combine(resultPath, nestedFilename)).Should().BeFalse();
+            // Act
+            Action act = () => convention.Install(runningDeployment);
+            
+            // Assert
+            act.Should().Throw<CommandException>();
         }
 
         //Accepts a relative path and creates a file under the package directory, which

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateGitRepositoryInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateGitRepositoryInstallConventionTests.cs
@@ -163,7 +163,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
         }
 
         [Test]
-        public void InputPathIndicatesFileButIsDirectoryThereforeNoFilesAreChanged()
+        public void InputPathIndicatesFileButIsDirectoryThereforeOperationThrows()
         {
             // Arrange
             const string firstFilename = "first.yaml";

--- a/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
@@ -127,10 +127,17 @@ namespace Calamari.ArgoCD.Conventions
 
         IPackageRelativeFile[] SelectFiles(string pathToExtractedPackageFiles, ArgoCommitToGitConfig config)
         {
+            var inputIsDirectory = config.InputSubPath.EndsWith("/"); // needs to be platform agnostic.
+            
             var absInputPath = Path.Combine(pathToExtractedPackageFiles, config.InputSubPath);
-            if (File.Exists(absInputPath))
+            if (inputIsDirectory)
             {
-                return new[] { new PackageRelativeFile(absolutePath: absInputPath, packageRelativePath: Path.GetFileName(absInputPath)) };
+                if (File.Exists(absInputPath))
+                {
+                    return new[] { new PackageRelativeFile(absolutePath: absInputPath, packageRelativePath: Path.GetFileName(absInputPath)) };
+                }
+                log.Warn($"Unable to locate {config.InputSubPath} in supplied package files, no changes will be made");
+                return Array.Empty<IPackageRelativeFile>();
             }
             
             if (Directory.Exists(absInputPath))

--- a/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
@@ -130,14 +130,13 @@ namespace Calamari.ArgoCD.Conventions
             var inputIsDirectory = config.InputSubPath.EndsWith("/"); // needs to be platform agnostic.
             
             var absInputPath = Path.Combine(pathToExtractedPackageFiles, config.InputSubPath);
-            if (inputIsDirectory)
+            if (!inputIsDirectory)
             {
                 if (File.Exists(absInputPath))
                 {
                     return new[] { new PackageRelativeFile(absolutePath: absInputPath, packageRelativePath: Path.GetFileName(absInputPath)) };
                 }
-                log.Warn($"Unable to locate {config.InputSubPath} in supplied package files, no changes will be made");
-                return Array.Empty<IPackageRelativeFile>();
+                throw new CommandException($"Unable to locate file '{config.InputSubPath}' in supplied package files, no changes will be made");
             }
             
             if (Directory.Exists(absInputPath))
@@ -163,7 +162,7 @@ namespace Calamari.ArgoCD.Conventions
                                        })
                                .ToArray<IPackageRelativeFile>();
             }
-            throw new InvalidOperationException($"Supplied input path '{config.InputSubPath}' does not exist within the supplied package");
+            throw new CommandException($"Unable to locate directory '{config.InputSubPath}' within the supplied package");
         }
     }
 }


### PR DESCRIPTION
During testing it was found that if an input path, not containing a "/" was used - but a directory of that name existed - the entire directory would be templated.

This change change checks in the InputPath's closing character is a  "/" - and if so - the resulting file-system entity _must_ be a directory and vice versa.

If the an filesystem entity of the correct type, with the correct name does not exist, the command will fail.


:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
