### PR TITLE
Argo Manifest action always recurses directories

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/DeploymentConfigFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/DeploymentConfigFactoryTests.cs
@@ -18,7 +18,6 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             var nonSensitiveCalamariVariables = new NonSensitiveCalamariVariables()
             {
                 [SpecialVariables.Git.InputPath] = "",
-                [SpecialVariables.Git.Recursive] = "True",
                 [SpecialVariables.Git.CommitMethod] = "DirectCommit",
                 [SpecialVariables.Git.CommitMessageSummary] = "Summary #{Foo}",
                 [SpecialVariables.Git.CommitMessageDescription] = "Description #{Foo}",
@@ -46,7 +45,6 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             var nonSensitiveCalamariVariables = new NonSensitiveCalamariVariables()
             {
                 [SpecialVariables.Git.InputPath] = "",
-                [SpecialVariables.Git.Recursive] = "True",
                 [SpecialVariables.Git.CommitMethod] = "DirectCommit",
                 [SpecialVariables.Git.CommitMessageSummary] = "Sh... #{SuperSecret}",
                 ["Foo"] = "Bar",
@@ -72,7 +70,6 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             var nonSensitiveCalamariVariables = new NonSensitiveCalamariVariables()
             {
                 [SpecialVariables.Git.InputPath] = "",
-                [SpecialVariables.Git.Recursive] = "True",
                 [SpecialVariables.Git.CommitMethod] = "DirectCommit",
                 [SpecialVariables.Git.CommitMessageSummary] = "Summary #{Foo}",
                 [SpecialVariables.Git.CommitMessageDescription] = "Sh... #{SuperSecret}",

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -21,7 +21,7 @@ using LibGit2Sharp;
 using NSubstitute;
 using NUnit.Framework;
 
-namespace Calamari.Tests.ArgoCD.Commands.Conventions.UpdateArgoCdAppImages
+namespace Calamari.Tests.ArgoCD.Commands.Conventions
 {
     [TestFixture]
     public class UpdateArgoCDAppImagesInstallConventionTests

--- a/source/Calamari/ArgoCD/Conventions/ArgoCommitToGitConfig.cs
+++ b/source/Calamari/ArgoCD/Conventions/ArgoCommitToGitConfig.cs
@@ -5,11 +5,10 @@ namespace Calamari.ArgoCD.Conventions
 {
     public class ArgoCommitToGitConfig
     {
-        public ArgoCommitToGitConfig(string workingDirectory, string inputSubPath, bool recurseInputPath, bool purgeOutputDirectory, GitCommitParameters commitParameters)
+        public ArgoCommitToGitConfig(string workingDirectory, string inputSubPath, bool purgeOutputDirectory, GitCommitParameters commitParameters)
         {
             WorkingDirectory = workingDirectory;
             InputSubPath = inputSubPath;
-            RecurseInputPath = recurseInputPath;
             PurgeOutputDirectory = purgeOutputDirectory;
             CommitParameters = commitParameters;
         }
@@ -19,7 +18,6 @@ namespace Calamari.ArgoCD.Conventions
         public string[] FileGlobs => new[] { "*.yaml", "*.yml" };
         
         public string InputSubPath { get; }
-        public bool RecurseInputPath { get; }
         public bool PurgeOutputDirectory { get; }
         public GitCommitParameters CommitParameters { get; }
     }

--- a/source/Calamari/ArgoCD/Conventions/DeploymentConfigFactory.cs
+++ b/source/Calamari/ArgoCD/Conventions/DeploymentConfigFactory.cs
@@ -23,13 +23,11 @@ namespace Calamari.ArgoCD.Conventions
         {
             var commitParameters = CommitParameters(deployment);
             var inputPath = deployment.Variables.Get(SpecialVariables.Git.InputPath, string.Empty);
-            var recursive = deployment.Variables.GetFlag(SpecialVariables.Git.Recursive, false);
             var purgeOutput = deployment.Variables.GetFlag(SpecialVariables.Git.PurgeOutput, false);
             
             return new ArgoCommitToGitConfig(
                                            deployment.CurrentDirectory,
                                            inputPath,
-                                           recursive,
                                            purgeOutput,
                                            commitParameters);
         }

--- a/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
@@ -66,7 +66,7 @@ namespace Calamari.ArgoCD.Conventions
                 foreach (var applicationSource in applicationFromYaml.Spec.Sources.OfType<BasicSource>())
                 {
                     Log.Info($"Writing files to repository '{applicationSource.RepoUrl}' for '{application.Name}'");
-                    
+
                     var gitCredential = gitCredentials[applicationSource.RepoUrl.AbsoluteUri];
                     var gitConnection = new GitConnection(gitCredential.Username, gitCredential.Password, applicationSource.RepoUrl.AbsoluteUri, new GitBranchName(applicationSource.TargetRevision));
                     var repository = repositoryFactory.CloneRepository(repositoryNumber.ToString(CultureInfo.InvariantCulture), gitConnection);
@@ -74,7 +74,7 @@ namespace Calamari.ArgoCD.Conventions
                     Log.Info($"Copying files into repository {applicationSource.RepoUrl}");
                     var subFolder = applicationSource.Path ?? String.Empty;
                     Log.VerboseFormat("Copying files into subfolder '{0}'", subFolder);
-                    
+
                     if (deploymentConfig.PurgeOutputDirectory)
                     {
                         repository.RecursivelyStageFilesForRemoval(subFolder);
@@ -91,7 +91,13 @@ namespace Calamari.ArgoCD.Conventions
                     if (repository.CommitChanges(deploymentConfig.CommitParameters.Summary, deploymentConfig.CommitParameters.Description))
                     {
                         Log.Info("Changes were commited, pushing to remote");
-                        repository.PushChanges(deploymentConfig.CommitParameters.RequiresPr, deploymentConfig.CommitParameters.Summary, deploymentConfig.CommitParameters.Description, new GitBranchName(applicationSource.TargetRevision), CancellationToken.None).GetAwaiter().GetResult();    
+                        repository.PushChanges(deploymentConfig.CommitParameters.RequiresPr,
+                                               deploymentConfig.CommitParameters.Summary,
+                                               deploymentConfig.CommitParameters.Description,
+                                               new GitBranchName(applicationSource.TargetRevision),
+                                               CancellationToken.None)
+                                  .GetAwaiter()
+                                  .GetResult();
                     }
                     else
                     {
@@ -99,7 +105,7 @@ namespace Calamari.ArgoCD.Conventions
                     }
 
                     repositoryNumber++;
-                }     
+                }
             }
         }
 
@@ -121,10 +127,10 @@ namespace Calamari.ArgoCD.Conventions
                 Directory.CreateDirectory(destinationDirectory);
             }
         }
-        
-         IPackageRelativeFile[] GetReferencedPackageFiles(ArgoCommitToGitConfig config)
+
+        IPackageRelativeFile[] GetReferencedPackageFiles(ArgoCommitToGitConfig config)
         {
-            log.Info($"Selecting files from package using '{config.InputSubPath}' (recursive: {config.RecurseInputPath})");
+            log.Info($"Selecting files from package using '{config.InputSubPath}'");
             var filesToApply = SelectFiles(Path.Combine(config.WorkingDirectory, packageSubfolder), config);
             log.Info($"Found {filesToApply.Length} files to apply");
             return filesToApply;
@@ -137,30 +143,17 @@ namespace Calamari.ArgoCD.Conventions
             {
                 return new[] { new PackageRelativeFile(absolutePath: absInputPath, packageRelativePath: Path.GetFileName(absInputPath)) };
             }
-            
+
             if (Directory.Exists(absInputPath))
             {
-                IEnumerable<string> fileList;
-                if (config.RecurseInputPath)
-                {
-                    fileList = fileSystem.EnumerateFilesRecursively(absInputPath, config.FileGlobs);
-                }
-                else
-                {
-                    fileList = fileSystem.EnumerateFiles(absInputPath, config.FileGlobs);
-                }
-                
-                return fileList.Select(absoluteFilepath =>
+                return fileSystem.EnumerateFilesRecursively(absInputPath, config.FileGlobs).Select(absoluteFilepath =>
                                        {
-#if NET
                                            var relativePath = Path.GetRelativePath(absInputPath, absoluteFilepath);
-#else
-                                                  var relativePath = absoluteFilepath.Substring(absInputPath.Length + 1);
-#endif
                                            return new PackageRelativeFile(absoluteFilepath, relativePath);
                                        })
                                .ToArray<IPackageRelativeFile>();
             }
+
             throw new InvalidOperationException($"Supplied input path '{config.InputSubPath}' does not exist within the supplied package");
         }
     }

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -71,8 +71,6 @@ namespace Calamari.Kubernetes
             public static readonly string CommitMethod = "Octopus.Action.ArgoCD.CommitMethod";
 
             public static readonly string InputPath = "Octopus.Action.ArgoCD.InputPath";
-            
-            public static readonly string Recursive = "Octopus.Action.ArgoCD.RecursiveResourceDetection";
 
             public static readonly string PurgeOutput = "Octopus.Action.ArgoCD.PurgeOutputFolder";
             


### PR DESCRIPTION
Previously there existed a flag in the variables indicating if a directory source should be recursed - it has been decided that it will _always_ recurse.


:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
