### PR TITLE
Fix: KustomzieDiscovery returns abs path to file

### DIFF
--- a/source/Calamari/ArgoCD/KustomizeDiscovery.cs
+++ b/source/Calamari/ArgoCD/KustomizeDiscovery.cs
@@ -12,9 +12,10 @@ namespace Calamari.ArgoCD
         {
             foreach (var fileName in ArgoCDConstants.KustomizationFileNames)
             {
-                if (fileSystem.FileExists(Path.Combine(rootPath, fileName)))
+                var absPath = Path.Combine(rootPath, fileName);
+                if (fileSystem.FileExists(absPath))
                 {
-                    return fileName;
+                    return absPath;
                 }
             }
 


### PR DESCRIPTION
It was found the KustomizeDiscovery was returning just the filename found - not the absolutepath to the file it had found.

This change updates the discovery to return the ABS path - and puts a test in place to ensure it functions as expected,

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
