### PR TITLE
Suppress NU5104 in Calamari.Common for net462

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)' == 'net462' ">
-        <NoWarn>CS8600;CS8601;CS8602;CS8603;CS8604</NoWarn>
+        <NoWarn>CS8600;CS8601;CS8602;CS8603;CS8604;NU5104</NoWarn>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">


### PR DESCRIPTION
This is being thrown in `Calamari.Common`

>  C:\Program Files\dotnet\sdk\6.0.428\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(221,5): error NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "AlphaFS [2.1.3-octopus0006, )" or update the version field in the nuspec. [C:\BuildAgent\work\62728692c7c35200\source\Calamari.Common\Calamari.Common.csproj]

This has started failing since #1586, not sure why this is occurring only on `main` builds