### PR TITLE
Argo Template step to include all files, not just Yaml

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateGitRepositoryInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateGitRepositoryInstallConventionTests.cs
@@ -88,12 +88,16 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
         }
 
         [Test]
-        public void ExecuteCopiesFilesFromPackageIntoRepo()
+        public void ExecuteCopiesFilesOfAnyNameFromPackageIntoRepo()
         {
             const string firstFilename = "first.yaml";
             CreateFileUnderPackageDirectory(firstFilename);
             const string nestedFilename = "nested/second.yaml";
             CreateFileUnderPackageDirectory(nestedFilename);
+            const string thirdFilename = "nested/third";
+            CreateFileUnderPackageDirectory(thirdFilename);
+            const string fourthFilename = "nested/fourth.fourth";
+            CreateFileUnderPackageDirectory(fourthFilename);
             
             var nonSensitiveCalamariVariables = new NonSensitiveCalamariVariables()
             {
@@ -123,6 +127,8 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             var resultNestedContent = File.ReadAllText(Path.Combine(resultPath, nestedFilename));
             resultFirstContent.Should().Be(firstFilename);
             resultNestedContent.Should().Be(nestedFilename);
+            fileSystem.FileExists(Path.Combine(resultPath, thirdFilename)).Should().BeTrue();
+            fileSystem.FileExists(Path.Combine(resultPath, fourthFilename)).Should().BeTrue();
         }
         
         [Test]

--- a/source/Calamari/ArgoCD/Conventions/ArgoCommitToGitConfig.cs
+++ b/source/Calamari/ArgoCD/Conventions/ArgoCommitToGitConfig.cs
@@ -13,9 +13,7 @@ namespace Calamari.ArgoCD.Conventions
             CommitParameters = commitParameters;
         }
         
-        public string WorkingDirectory { get; set; }
-
-        public string[] FileGlobs => new[] { "*.yaml", "*.yml" };
+        public string WorkingDirectory { get; }
         
         public string InputSubPath { get; }
         public bool PurgeOutputDirectory { get; }

--- a/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
@@ -146,7 +146,7 @@ namespace Calamari.ArgoCD.Conventions
 
             if (Directory.Exists(absInputPath))
             {
-                return fileSystem.EnumerateFilesRecursively(absInputPath, config.FileGlobs).Select(absoluteFilepath =>
+                return fileSystem.EnumerateFilesRecursively(absInputPath, "*").Select(absoluteFilepath =>
                                        {
                                            var relativePath = Path.GetRelativePath(absInputPath, absoluteFilepath);
                                            return new PackageRelativeFile(absoluteFilepath, relativePath);


### PR DESCRIPTION
It was found during testing that the template step did not overwrte the helper.tpl style files in a helm repo.

The behavior should be, that any file in the input templates _should_ be copied to the output.

This change removes the "*.yml/*.yaml" filename filter, and replaces it with "*".



:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
