### PR TITLE
fix: throw out dot-notation keys when flattening

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Helm/HelmYamlParserTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Helm/HelmYamlParserTests.cs
@@ -143,6 +143,40 @@ root:
             //ensure platform-agnostic multiline comparison
             result.ReplaceLineEndings().Should().Be(expectedUpdate.ReplaceLineEndings());
         }
+
+        [Test]
+        public void CreateDotPathsForNodes_WithExistingDotNotationKeys_IgnoresThoseKeys()
+        {
+            const string yamlContent = @"
+image.name: nginx
+image.tag: latest
+";
+            
+            var sut = new HelmYamlParser(yamlContent);
+
+            var result = sut.CreateDotPathsForNodes();
+
+            result.Should().BeEmpty();
+        }
+        
+        [Test]
+        public void CreateDotPathsForNodes_WithMixOfDotNotationAndNestedKeysKeys_ReturnsCorrectKeys()
+        {
+            const string yamlContent = @"
+image1.name: nginx
+image1.tag: latest
+image2:
+  name: alpine
+  tag: 1.29
+";
+            
+            var sut = new HelmYamlParser(yamlContent);
+
+            var result = sut.CreateDotPathsForNodes();
+
+            result.Should().BeEquivalentTo("image2.name", "image2.tag");
+        }
+        
     }
 }
 

--- a/source/Calamari/ArgoCD/Helm/HelmYamlParser.cs
+++ b/source/Calamari/ArgoCD/Helm/HelmYamlParser.cs
@@ -146,8 +146,12 @@ namespace Calamari.ArgoCD.Helm
                     foreach (var kvp in dict)
                     {
                         var key = kvp.Key.ToString() ?? "";
-                        var newPath = string.IsNullOrEmpty(currentPath) ? key : $"{currentPath}.{key}";
-                        FlattenObject(kvp.Value, newPath, paths);
+                        // Ignore any keys that are using dot notation. Helm does not support these specifying values.
+                        if (!key.Contains('.'))
+                        {
+                            var newPath = string.IsNullOrEmpty(currentPath) ? key : $"{currentPath}.{key}";
+                            FlattenObject(kvp.Value, newPath, paths);
+                        }
                     }
 
                     break;


### PR DESCRIPTION
Errors were being thrown when handlnig values files that contained dot notation style keys.

E.g. 

```
service:
  type: LoadBalancer
  port: 80
  annotations:
    # https://stackoverflow.com/a/76247614/8246539
    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
    service.beta.kubernetes.io/aws-load-balancer-type: external
    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
```

While this is valid Helm values content, Helm does NOT support using dot-notation for expressing paths to replacement values.

i.e.

for

```
containers:
  - name: nginx-container
    image: {{ .Values.image.name }}:{{ .Values.image.tag}}
```


```
image:
  name: "nginx"
  tag: "latest"
```
  
 Is valid, whereas 
 
```
image.name: "nginx"
image.tag: "latest"
```

Is not.

Given our sole purpose of flattening the yaml in Helm Values files is facilitate variable value replacement, we can ignore any keys that contain dot-notation.
