### PR TITLE
Fail updating Argo CD app manifests the application has multiple sources

### DIFF
--- a/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppImagesCommand.cs
+++ b/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppImagesCommand.cs
@@ -14,7 +14,7 @@ using Calamari.Deployment.Conventions;
 
 namespace Calamari.ArgoCD.Commands
 {
-    [Command(Name, Description = "Write populated templates from a package into one or more git repositories")]
+    [Command(Name, Description = "Update container image versions for one or more Argo CD Applications, persisting them in a Git repository")]
     public class UpdateArgoCDAppImagesCommand : Command
     {
         public const string Name = "update-argo-cd-app-images";

--- a/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppManifestsCommand.cs
+++ b/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppManifestsCommand.cs
@@ -19,12 +19,12 @@ using Calamari.Deployment.Conventions;
 
 namespace Calamari.ArgoCD.Commands
 {
-    [Command(Name, Description = "Write populated templates from a package into one or more git repositories")]
-    public class CommitToGitCommand : Command
+    [Command(Name, Description = "Update Kubernetes manifests from a package for one or more Argo CD Applications, persisting them in a Git repository")]
+    public class UpdateArgoCDAppManifestsCommand : Command
     {
         public const string PackageDirectoryName = "package";
 
-        public const string Name = "commit-to-git";
+        public const string Name = "update-argo-cd-app-manifests";
 
         readonly ILog log;
         readonly IVariables variables;
@@ -38,7 +38,7 @@ namespace Calamari.ArgoCD.Commands
         string customPropertiesFile;
         string customPropertiesPassword;
 
-        public CommitToGitCommand(
+        public UpdateArgoCDAppManifestsCommand(
             ILog log,
             IVariables variables,
             INonSensitiveVariables nonSensitiveVariables,
@@ -85,7 +85,7 @@ namespace Calamari.ArgoCD.Commands
                                                   d.CurrentDirectoryProvider = DeploymentWorkingDirectory.StagingDirectory;
                                               }),
                 new SubstituteInFilesConvention(new NonSensitiveSubstituteInFilesBehaviour(substituteInFiles, PackageDirectoryName)),
-                new UpdateGitRepositoryInstallConvention(fileSystem, PackageDirectoryName, log, pullRequestCreator, configFactory, new CustomPropertiesLoader(fileSystem, customPropertiesFile, customPropertiesPassword), new ArgoCdApplicationManifestParser()),
+                new UpdateArgoCDApplicationManifestsInstallConvention(fileSystem, PackageDirectoryName, log, pullRequestCreator, configFactory, new CustomPropertiesLoader(fileSystem, customPropertiesFile, customPropertiesPassword), new ArgoCdApplicationManifestParser()),
             };
 
             var runningDeployment = new RunningDeployment(pathToPackage, variables);

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
@@ -19,7 +19,7 @@ using Calamari.Deployment.Conventions;
 
 namespace Calamari.ArgoCD.Conventions
 {
-    public class UpdateGitRepositoryInstallConvention : IInstallConvention
+    public class UpdateArgoCDApplicationManifestsInstallConvention : IInstallConvention
     {
         readonly ICalamariFileSystem fileSystem;
         readonly ILog log;
@@ -29,7 +29,7 @@ namespace Calamari.ArgoCD.Conventions
         readonly ICustomPropertiesLoader customPropertiesLoader;
         readonly IArgoCDApplicationManifestParser argoCdApplicationManifestParser;
 
-        public UpdateGitRepositoryInstallConvention(ICalamariFileSystem fileSystem,
+        public UpdateArgoCDApplicationManifestsInstallConvention(ICalamariFileSystem fileSystem,
                                                     string packageSubfolder,
                                                     ILog log,
                                                     IGitHubPullRequestCreator pullRequestCreator,
@@ -48,7 +48,7 @@ namespace Calamari.ArgoCD.Conventions
 
         public void Install(RunningDeployment deployment)
         {
-            Log.Info("Executing Commit To Git operation");
+            Log.Info("Executing Update Argo CD Application manifests operation");
             var deploymentConfig = deploymentConfigFactory.CreateCommitToGitConfig(deployment);
             var packageFiles = GetReferencedPackageFiles(deploymentConfig);
 

--- a/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateGitRepositoryInstallConvention.cs
@@ -59,10 +59,17 @@ namespace Calamari.ArgoCD.Conventions
             var gitCredentials = argoProperties.Credentials.ToDictionary(c => c.Url);
             log.Info($"Found the following applications: '{argoProperties.Applications.Select(a => a.Name).Join(",")}'");
 
-            int repositoryNumber = 1;
+            var repositoryNumber = 1;
             foreach (var application in argoProperties.Applications)
             {
                 var applicationFromYaml = argoCdApplicationManifestParser.ParseManifest(application.Manifest);
+
+                //currently, if an application has multiple sources, we cannot update it (as we don't know which source to update), so just run away
+                if (applicationFromYaml.Spec.Sources.Count > 1)
+                {
+                    throw new CommandException($"Application {application.Name} has multiple sources and cannot be updated.");
+                }
+                
                 foreach (var applicationSource in applicationFromYaml.Spec.Sources.OfType<BasicSource>())
                 {
                     Log.Info($"Writing files to repository '{applicationSource.RepoUrl}' for '{application.Name}'");
@@ -77,7 +84,7 @@ namespace Calamari.ArgoCD.Conventions
                     var repository = repositoryFactory.CloneRepository(repositoryNumber.ToString(CultureInfo.InvariantCulture), gitConnection);
 
                     Log.Info($"Copying files into repository {applicationSource.RepoUrl}");
-                    var subFolder = applicationSource.Path ?? String.Empty;
+                    var subFolder = applicationSource.Path ?? string.Empty;
                     Log.VerboseFormat("Copying files into subfolder '{0}'", subFolder);
 
                     if (deploymentConfig.PurgeOutputDirectory)


### PR DESCRIPTION
NOTE: The step used to be called `CommitToGitCommand`. I've renamed this to `UpdateArgoCDAppManifestsCommand` for consistency and clarity.

This is a temporary limitation that an application cannot have it's manifests updated if it has more than one source.

There will be future work to enable a scenario where you can target the source you want to update out of many.