### PR TITLE
Change SubstituteInFiles to support custom file matching/discovery

### DIFF
--- a/source/Calamari.Common/Features/Behaviours/NonSensitiveSubstituteInFilesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/NonSensitiveSubstituteInFilesBehaviour.cs
@@ -1,12 +1,5 @@
 ﻿using System;
-using System.IO;
-using System.Threading.Tasks;
-using Calamari.Common.Commands;
 using Calamari.Common.Features.Substitutions;
-using Calamari.Common.Plumbing.Extensions;
-using Calamari.Common.Plumbing.Pipeline;
-using Calamari.Common.Plumbing.Variables;
-using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Common.Features.Behaviours
 {
@@ -14,8 +7,9 @@ namespace Calamari.Common.Features.Behaviours
     {
         public NonSensitiveSubstituteInFilesBehaviour(
             INonSensitiveSubstituteInFiles substituteInFiles,
-            string subdirectory = "")
-            : base(substituteInFiles, subdirectory)
+            string subdirectory = "",
+            ISubstituteFileMatcher? customFileMatcher = null)
+            : base(substituteInFiles, subdirectory, customFileMatcher)
         {
         }
     }

--- a/source/Calamari.Common/Features/Behaviours/SubstituteInFilesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/SubstituteInFilesBehaviour.cs
@@ -6,33 +6,30 @@ using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Variables;
-using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Common.Features.Behaviours
 {
     public class SubstituteInFilesBehaviour : IBehaviour
     {
         readonly ISubstituteInFiles substituteInFiles;
-        private readonly string subdirectory;
+        readonly string subdirectory;
+        readonly ISubstituteFileMatcher? customFileMatcher;
 
         public SubstituteInFilesBehaviour(
             ISubstituteInFiles substituteInFiles,
-            string subdirectory = "")
+            string subdirectory = "",
+            ISubstituteFileMatcher? customFileMatcher = null)
         {
             this.substituteInFiles = substituteInFiles;
             this.subdirectory = subdirectory;
+            this.customFileMatcher = customFileMatcher;
         }
 
-        public bool IsEnabled(RunningDeployment context)
-        {
-            return context.Variables.IsFeatureEnabled(KnownVariables.Features.SubstituteInFiles);
-        }
-
-        public bool WarnIfFilesNotFound { get; set; } = true;
+        public bool IsEnabled(RunningDeployment context) => context.Variables.IsFeatureEnabled(KnownVariables.Features.SubstituteInFiles);
 
         public Task Execute(RunningDeployment context)
         {
-            substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(Path.Combine(context.CurrentDirectory, subdirectory), WarnIfFilesNotFound);
+            substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(Path.Combine(context.CurrentDirectory, subdirectory), customFileMatcher: customFileMatcher);
             return Task.CompletedTask;
         }
     }

--- a/source/Calamari.Common/Features/Behaviours/SubstituteInFilesBehaviour.cs
+++ b/source/Calamari.Common/Features/Behaviours/SubstituteInFilesBehaviour.cs
@@ -28,9 +28,11 @@ namespace Calamari.Common.Features.Behaviours
             return context.Variables.IsFeatureEnabled(KnownVariables.Features.SubstituteInFiles);
         }
 
+        public bool WarnIfFilesNotFound { get; set; } = true;
+
         public Task Execute(RunningDeployment context)
         {
-            substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(Path.Combine(context.CurrentDirectory, subdirectory));
+            substituteInFiles.SubstituteBasedSettingsInSuppliedVariables(Path.Combine(context.CurrentDirectory, subdirectory), WarnIfFilesNotFound);
             return Task.CompletedTask;
         }
     }

--- a/source/Calamari.Common/Features/Substitutions/GlobSubstituteFileMatcher.cs
+++ b/source/Calamari.Common/Features/Substitutions/GlobSubstituteFileMatcher.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Common.Features.Substitutions
+{
+    public class GlobSubstituteFileMatcher : ISubstituteFileMatcher
+    {
+        readonly ICalamariFileSystem fileSystem;
+        readonly IVariables variables;
+
+        public GlobSubstituteFileMatcher(ICalamariFileSystem fileSystem, IVariables variables)
+        {
+            this.fileSystem = fileSystem;
+            this.variables = variables;
+        }
+        
+        public List<string> FindMatchingFiles(string currentDirectory, string target)
+        {
+            var files = fileSystem.EnumerateFilesWithGlob(currentDirectory, target).Select(Path.GetFullPath).ToList();
+
+            foreach (var path in variables.GetStrings(ActionVariables.AdditionalPaths)
+                                          .Where(s => !string.IsNullOrWhiteSpace(s)))
+            {
+                var pathFiles = fileSystem.EnumerateFilesWithGlob(path, target).Select(Path.GetFullPath);
+                files.AddRange(pathFiles);
+            }
+
+            return files;
+        }
+    }
+}

--- a/source/Calamari.Common/Features/Substitutions/ISubstituteFileMatcher.cs
+++ b/source/Calamari.Common/Features/Substitutions/ISubstituteFileMatcher.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Common.Features.Substitutions
+{
+    public interface ISubstituteFileMatcher
+    {
+        List<string> FindMatchingFiles(string currentDirectory, string target);
+    }
+
+    public class GlobSubstituteFileMatcher : ISubstituteFileMatcher
+    {
+        readonly ICalamariFileSystem fileSystem;
+        readonly IVariables variables;
+
+        public GlobSubstituteFileMatcher(ICalamariFileSystem fileSystem, IVariables variables)
+        {
+            this.fileSystem = fileSystem;
+            this.variables = variables;
+        }
+        
+        public List<string> FindMatchingFiles(string currentDirectory, string target)
+        {
+            var files = fileSystem.EnumerateFilesWithGlob(currentDirectory, target).Select(Path.GetFullPath).ToList();
+
+            foreach (var path in variables.GetStrings(ActionVariables.AdditionalPaths)
+                                          .Where(s => !string.IsNullOrWhiteSpace(s)))
+            {
+                var pathFiles = fileSystem.EnumerateFilesWithGlob(path, target).Select(Path.GetFullPath);
+                files.AddRange(pathFiles);
+            }
+
+            return files;
+        }
+    }
+}

--- a/source/Calamari.Common/Features/Substitutions/ISubstituteFileMatcher.cs
+++ b/source/Calamari.Common/Features/Substitutions/ISubstituteFileMatcher.cs
@@ -1,39 +1,9 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using Calamari.Common.Plumbing.FileSystem;
-using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Common.Features.Substitutions
 {
     public interface ISubstituteFileMatcher
     {
         List<string> FindMatchingFiles(string currentDirectory, string target);
-    }
-
-    public class GlobSubstituteFileMatcher : ISubstituteFileMatcher
-    {
-        readonly ICalamariFileSystem fileSystem;
-        readonly IVariables variables;
-
-        public GlobSubstituteFileMatcher(ICalamariFileSystem fileSystem, IVariables variables)
-        {
-            this.fileSystem = fileSystem;
-            this.variables = variables;
-        }
-        
-        public List<string> FindMatchingFiles(string currentDirectory, string target)
-        {
-            var files = fileSystem.EnumerateFilesWithGlob(currentDirectory, target).Select(Path.GetFullPath).ToList();
-
-            foreach (var path in variables.GetStrings(ActionVariables.AdditionalPaths)
-                                          .Where(s => !string.IsNullOrWhiteSpace(s)))
-            {
-                var pathFiles = fileSystem.EnumerateFilesWithGlob(path, target).Select(Path.GetFullPath);
-                files.AddRange(pathFiles);
-            }
-
-            return files;
-        }
     }
 }

--- a/source/Calamari.Common/Features/Substitutions/ISubstituteInFiles.cs
+++ b/source/Calamari.Common/Features/Substitutions/ISubstituteInFiles.cs
@@ -5,7 +5,13 @@ namespace Calamari.Common.Features.Substitutions
 {
     public interface ISubstituteInFiles
     {
-        void SubstituteBasedSettingsInSuppliedVariables(string currentDirectory, bool warnIfFileNotFound = true);
-        void Substitute(string currentDirectory, IList<string> filesToTarget, bool warnIfFileNotFound = true);
+        void SubstituteBasedSettingsInSuppliedVariables(string currentDirectory,
+                                                        bool warnIfFileNotFound = true,
+                                                        ISubstituteFileMatcher? customFileMatcher = null);
+
+        void Substitute(string currentDirectory,
+                        IList<string> filesToTarget,
+                        bool warnIfFileNotFound = true,
+                        ISubstituteFileMatcher? customFileMatcher = null);
     }
 }

--- a/source/Calamari.Common/Features/Substitutions/ISubstituteInFiles.cs
+++ b/source/Calamari.Common/Features/Substitutions/ISubstituteInFiles.cs
@@ -5,7 +5,7 @@ namespace Calamari.Common.Features.Substitutions
 {
     public interface ISubstituteInFiles
     {
-        void SubstituteBasedSettingsInSuppliedVariables(string currentDirectory);
+        void SubstituteBasedSettingsInSuppliedVariables(string currentDirectory, bool warnIfFileNotFound = true);
         void Substitute(string currentDirectory, IList<string> filesToTarget, bool warnIfFileNotFound = true);
     }
 }

--- a/source/Calamari.Common/Features/Substitutions/NonSensitiveSubstituteInFiles.cs
+++ b/source/Calamari.Common/Features/Substitutions/NonSensitiveSubstituteInFiles.cs
@@ -7,8 +7,8 @@ namespace Calamari.Common.Features.Substitutions
 {
     public class NonSensitiveSubstituteInFiles : SubstituteInFiles, INonSensitiveSubstituteInFiles
     {
-        public NonSensitiveSubstituteInFiles(ILog log, ICalamariFileSystem fileSystem, INonSensitiveFileSubstituter substituter, INonSensitiveVariables variables) 
-            : base(log, fileSystem, substituter, variables)
+        public NonSensitiveSubstituteInFiles(ILog log, ISubstituteFileMatcher fileMatcher, INonSensitiveFileSubstituter substituter, INonSensitiveVariables variables) 
+            : base(log, fileMatcher, substituter, variables)
         {
         }
     }

--- a/source/Calamari.Common/Features/Substitutions/SubstituteInFiles.cs
+++ b/source/Calamari.Common/Features/Substitutions/SubstituteInFiles.cs
@@ -23,10 +23,10 @@ namespace Calamari.Common.Features.Substitutions
             this.variables = variables;
         }
 
-        public void SubstituteBasedSettingsInSuppliedVariables(string currentDirectory)
+        public void SubstituteBasedSettingsInSuppliedVariables(string currentDirectory, bool warnIfFileNotFound = true)
         {
             var filesToTarget = variables.GetPaths(PackageVariables.SubstituteInFilesTargets);
-            Substitute(currentDirectory, filesToTarget);
+            Substitute(currentDirectory, filesToTarget, warnIfFileNotFound);
         }
 
         public void Substitute(string currentDirectory, IList<string> filesToTarget, bool warnIfFileNotFound = true)

--- a/source/Calamari.Common/Features/Substitutions/SubstituteInFiles.cs
+++ b/source/Calamari.Common/Features/Substitutions/SubstituteInFiles.cs
@@ -11,29 +11,34 @@ namespace Calamari.Common.Features.Substitutions
     public class SubstituteInFiles : ISubstituteInFiles
     {
         readonly ILog log;
-        readonly ICalamariFileSystem fileSystem;
+        readonly ISubstituteFileMatcher fileMatcher;
         readonly IFileSubstituter substituter;
         readonly IVariables variables;
 
-        public SubstituteInFiles(ILog log, ICalamariFileSystem fileSystem, IFileSubstituter substituter, IVariables variables)
+        public SubstituteInFiles(ILog log, ISubstituteFileMatcher fileMatcher, IFileSubstituter substituter, IVariables variables)
         {
             this.log = log;
-            this.fileSystem = fileSystem;
+            this.fileMatcher = fileMatcher;
             this.substituter = substituter;
             this.variables = variables;
         }
 
-        public void SubstituteBasedSettingsInSuppliedVariables(string currentDirectory, bool warnIfFileNotFound = true)
+        public void SubstituteBasedSettingsInSuppliedVariables(string currentDirectory,
+                                                               bool warnIfFileNotFound = true,
+                                                               ISubstituteFileMatcher? customFileMatcher = null)
         {
             var filesToTarget = variables.GetPaths(PackageVariables.SubstituteInFilesTargets);
-            Substitute(currentDirectory, filesToTarget, warnIfFileNotFound);
+            Substitute(currentDirectory, filesToTarget, warnIfFileNotFound, customFileMatcher);
         }
 
-        public void Substitute(string currentDirectory, IList<string> filesToTarget, bool warnIfFileNotFound = true)
+        public void Substitute(string currentDirectory,
+                               IList<string> filesToTarget,
+                               bool warnIfFileNotFound = true,
+                               ISubstituteFileMatcher? customFileMatcher = null)
         {
             foreach (var target in filesToTarget)
             {
-                var matchingFiles = MatchingFiles(currentDirectory, target);
+                var matchingFiles = (customFileMatcher ?? fileMatcher).FindMatchingFiles(currentDirectory, target);
 
                 if (!matchingFiles.Any())
                 {
@@ -46,20 +51,6 @@ namespace Calamari.Common.Features.Substitutions
                 foreach (var file in matchingFiles)
                     substituter.PerformSubstitution(file);
             }
-        }
-
-        List<string> MatchingFiles(string currentDirectory, string target)
-        {
-            var files = fileSystem.EnumerateFilesWithGlob(currentDirectory, target).Select(Path.GetFullPath).ToList();
-
-            foreach (var path in variables.GetStrings(ActionVariables.AdditionalPaths)
-                .Where(s => !string.IsNullOrWhiteSpace(s)))
-            {
-                var pathFiles = fileSystem.EnumerateFilesWithGlob(path, target).Select(Path.GetFullPath);
-                files.AddRange(pathFiles);
-            }
-
-            return files;
         }
     }
 }

--- a/source/Calamari.Common/Features/Substitutions/SubstituteInFiles.cs
+++ b/source/Calamari.Common/Features/Substitutions/SubstituteInFiles.cs
@@ -38,7 +38,8 @@ namespace Calamari.Common.Features.Substitutions
         {
             foreach (var target in filesToTarget)
             {
-                var matchingFiles = (customFileMatcher ?? fileMatcher).FindMatchingFiles(currentDirectory, target);
+                var usedMatcher = customFileMatcher ?? fileMatcher;
+                var matchingFiles = usedMatcher.FindMatchingFiles(currentDirectory, target);
 
                 if (!matchingFiles.Any())
                 {

--- a/source/Calamari.Common/Features/Substitutions/SubstitutionsModule.cs
+++ b/source/Calamari.Common/Features/Substitutions/SubstitutionsModule.cs
@@ -6,6 +6,8 @@ namespace Calamari.Common.Features.Substitutions
     {
         protected override void Load(ContainerBuilder builder)
         {
+            builder.RegisterType<GlobSubstituteFileMatcher>().As<ISubstituteFileMatcher>().InstancePerLifetimeScope();
+            
             //all variables
             builder.RegisterType<SubstituteInFiles>().As<ISubstituteInFiles>().InstancePerLifetimeScope();
             builder.RegisterType<FileSubstituter>().As<IFileSubstituter>().InstancePerLifetimeScope();

--- a/source/Calamari.Shared/Deployment/Conventions/SubstituteInFilesConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/SubstituteInFilesConvention.cs
@@ -17,7 +17,7 @@ namespace Calamari.Deployment.Conventions
         {
             if (substituteInFilesBehaviour.IsEnabled(deployment))
             {
-                substituteInFilesBehaviour.Execute(deployment).Wait();
+                substituteInFilesBehaviour.Execute(deployment).GetAwaiter().GetResult();
             }
         }
     }

--- a/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
+++ b/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
@@ -682,7 +682,7 @@ namespace Calamari.Tests.AWS
                                                      log,
                                                      variables,
                                                      fileSystem,
-                                                     new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem, variables), variables),
+                                                     new SubstituteInFiles(log, new GlobSubstituteFileMatcher(fileSystem, variables), new FileSubstituter(log, fileSystem, variables), variables),
                                                      new ExtractPackage(new CombinedPackageExtractor(log, fileSystem, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
                                                      new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                                                                                           {
@@ -747,7 +747,7 @@ namespace Calamari.Tests.AWS
                                                      log,
                                                      variables,
                                                      fileSystem,
-                                                     new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem, variables), variables),
+                                                     new SubstituteInFiles(log, new GlobSubstituteFileMatcher(fileSystem, variables), new FileSubstituter(log, fileSystem, variables), variables),
                                                      new ExtractPackage(new CombinedPackageExtractor(log, fileSystem, variables, new CommandLineRunner(log, variables)), fileSystem, variables, log),
                                                      new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                                                                                           {

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
@@ -119,7 +119,8 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                                       Substitute.For<IGitHubPullRequestCreator>(), 
                                                                       new DeploymentConfigFactory(nonSensitiveCalamariVariables), 
                                                                       customPropertiesLoader, 
-                                                                      argoCdApplicationManifestParser);
+                                                                      argoCdApplicationManifestParser,
+                                                                      new ArgoCDManifestsFileMatcher(fileSystem));
             convention.Install(runningDeployment);
 
             var resultPath = CloneOrigin();
@@ -165,7 +166,8 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                                       Substitute.For<IGitHubPullRequestCreator>(), 
                                                                       new DeploymentConfigFactory(nonSensitiveCalamariVariables), 
                                                                       customPropertiesLoader,
-                                                                      argoCdApplicationManifestParser);
+                                                                      argoCdApplicationManifestParser,
+                                                                      new ArgoCDManifestsFileMatcher(fileSystem));
             convention.Install(runningDeployment);
             
             // Assert
@@ -236,7 +238,8 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                                                    Substitute.For<IGitHubPullRequestCreator>(), 
                                                                                    new DeploymentConfigFactory(nonSensitiveCalamariVariables), 
                                                                                    customPropertiesLoader,
-                                                                                   argoCdApplicationManifestParser);
+                                                                                   argoCdApplicationManifestParser,
+                                                                                   new ArgoCDManifestsFileMatcher(fileSystem));
             Action action = () => convention.Install(runningDeployment);
             
             //Assert

--- a/source/Calamari.Tests/Fixtures/Deployment/Conventions/SubstituteInFilesFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/Conventions/SubstituteInFilesFixture.cs
@@ -34,7 +34,7 @@ namespace Calamari.Tests.Fixtures.Deployment.Conventions
             fileSystem.EnumerateFilesWithGlob(StagingDirectory, glob).Returns(new[] { Path.Combine(StagingDirectory, actualMatch) });
 
             var substituter = Substitute.For<IFileSubstituter>();
-            new SubstituteInFiles(new InMemoryLog(), fileSystem, substituter, variables)
+            new SubstituteInFiles(new InMemoryLog(), new GlobSubstituteFileMatcher(fileSystem, variables), substituter, variables)
                 .SubstituteBasedSettingsInSuppliedVariables(deployment.CurrentDirectory);
 
             substituter.Received().PerformSubstitution(Path.Combine(StagingDirectory, actualMatch));

--- a/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/Deployment/DeployJavaArchiveFixture.cs
@@ -136,7 +136,7 @@ namespace Calamari.Tests.Java.Fixtures.Deployment
                 variables,
                 fileSystem,
                 commandLineRunner,
-                new SubstituteInFiles(log, fileSystem, new FileSubstituter(log, fileSystem, variables), variables),
+                new SubstituteInFiles(log, new GlobSubstituteFileMatcher(fileSystem, variables), new FileSubstituter(log, fileSystem, variables), variables),
                 new ExtractPackage(new CombinedPackageExtractor(log, fileSystem, variables, commandLineRunner), fileSystem, variables, log),
                 new StructuredConfigVariablesService(new PrioritisedList<IFileFormatVariableReplacer>
                 {

--- a/source/Calamari/ArgoCD/ArgoCDModule.cs
+++ b/source/Calamari/ArgoCD/ArgoCDModule.cs
@@ -1,0 +1,21 @@
+﻿using Autofac;
+using Calamari.ArgoCD.Conventions;
+using Calamari.ArgoCD.Git;
+using Calamari.ArgoCD.GitHub;
+
+namespace Calamari.ArgoCD
+{
+    public class ArgoCDModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+#if NET
+            builder.RegisterType<DeploymentConfigFactory>().AsSelf().InstancePerLifetimeScope();
+            builder.RegisterType<CommitMessageGenerator>().As<ICommitMessageGenerator>().InstancePerLifetimeScope();
+            builder.RegisterType<GitHubClientFactory>().As<IGitHubClientFactory>().InstancePerLifetimeScope();
+            builder.RegisterType<GitHubPullRequestCreator>().As<IGitHubPullRequestCreator>().InstancePerLifetimeScope();
+            builder.RegisterType<ArgoCDManifestsFileMatcher>().As<IArgoCDManifestsFileMatcher>().InstancePerLifetimeScope();
+#endif
+        }
+    }
+}

--- a/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppManifestsCommand.cs
+++ b/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppManifestsCommand.cs
@@ -84,7 +84,12 @@ namespace Calamari.ArgoCD.Commands
                                                   d.StagingDirectory = workingDirectory;
                                                   d.CurrentDirectoryProvider = DeploymentWorkingDirectory.StagingDirectory;
                                               }),
-                new SubstituteInFilesConvention(new NonSensitiveSubstituteInFilesBehaviour(substituteInFiles, PackageDirectoryName)),
+                new SubstituteInFilesConvention(new NonSensitiveSubstituteInFilesBehaviour(substituteInFiles, PackageDirectoryName)
+                {
+                    //we don't want to log a warning if files are not found
+                    WarnIfFilesNotFound = false
+                }),
+                
                 new UpdateArgoCDApplicationManifestsInstallConvention(fileSystem, PackageDirectoryName, log, pullRequestCreator, configFactory, new CustomPropertiesLoader(fileSystem, customPropertiesFile, customPropertiesPassword), new ArgoCdApplicationManifestParser()),
             };
 

--- a/source/Calamari/ArgoCD/Conventions/ArgoCDManifestsFileMatcher.cs
+++ b/source/Calamari/ArgoCD/Conventions/ArgoCDManifestsFileMatcher.cs
@@ -1,0 +1,51 @@
+﻿#if NET
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Calamari.Common.Features.Substitutions;
+using Calamari.Common.Plumbing.FileSystem;
+
+namespace Calamari.ArgoCD.Conventions
+{
+    public interface IArgoCDManifestsFileMatcher : ISubstituteFileMatcher
+    {
+        IPackageRelativeFile[] FindMatchingPackageFiles(string currentDirectory, string target);
+    }
+    
+    public class ArgoCDManifestsFileMatcher : IArgoCDManifestsFileMatcher
+    {
+        readonly ICalamariFileSystem fileSystem;
+        
+        public ArgoCDManifestsFileMatcher(ICalamariFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+        public List<string> FindMatchingFiles(string currentDirectory, string target)
+        {
+            return FindMatchingPackageFiles(currentDirectory, target).Select(f => f.AbsolutePath).ToList();
+        }
+
+        public IPackageRelativeFile[] FindMatchingPackageFiles(string currentDirectory, string target)
+        {
+            var absoluteTargetPath = Path.Combine(currentDirectory,target);
+            if (File.Exists(absoluteTargetPath))
+            {
+                return new IPackageRelativeFile[]{ new PackageRelativeFile(absolutePath: absoluteTargetPath, packageRelativePath: Path.GetFileName(absoluteTargetPath)) };
+            }
+
+            if (Directory.Exists(absoluteTargetPath))
+            {
+                return fileSystem.EnumerateFilesRecursively(absoluteTargetPath, "*").Select(absoluteFilepath =>
+                                                                                            {
+                                                                                                var relativePath = Path.GetRelativePath(absoluteTargetPath, absoluteFilepath);
+                                                                                                return new PackageRelativeFile(absoluteFilepath, relativePath);
+                                                                                            })
+                                 .ToArray<IPackageRelativeFile>();
+            }
+
+            return Array.Empty<IPackageRelativeFile>();
+        }
+    }
+}
+#endif

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
@@ -151,10 +151,8 @@ namespace Calamari.ArgoCD.Conventions
             return filesToApply;
         }
 
-        IPackageRelativeFile[] SelectFiles(string pathToExtractedPackageFiles, ArgoCommitToGitConfig config)
-        {
-            return argoCDManifestsFileMatcher.FindMatchingPackageFiles(pathToExtractedPackageFiles, config.InputSubPath);
-        }
+        IPackageRelativeFile[] SelectFiles(string pathToExtractedPackageFiles, ArgoCommitToGitConfig config) 
+            => argoCDManifestsFileMatcher.FindMatchingPackageFiles(pathToExtractedPackageFiles, config.InputSubPath);
     }
 }
 #endif

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using Autofac.Features.Metadata;
+using Calamari.ArgoCD;
 using Calamari.ArgoCD.Conventions;
 using Calamari.ArgoCD.Git;
 using Calamari.ArgoCD.GitHub;
@@ -120,18 +121,8 @@ namespace Calamari
                    .Where(x => typeof(ILaunchTool).IsAssignableFrom(x) && !x.IsAbstract && !x.IsInterface)
                    .WithMetadataFrom<LaunchToolAttribute>()
                    .As<ILaunchTool>();
-            
-            RegisterArgoCDComponents(builder);
-        }
 
-        void RegisterArgoCDComponents(ContainerBuilder builder)
-        {
-#if NET
-            builder.RegisterType<DeploymentConfigFactory>().AsSelf().InstancePerLifetimeScope();
-            builder.RegisterType<CommitMessageGenerator>().As<ICommitMessageGenerator>().InstancePerLifetimeScope();
-            builder.RegisterType<GitHubClientFactory>().As<IGitHubClientFactory>().InstancePerLifetimeScope();
-            builder.RegisterType<GitHubPullRequestCreator>().As<IGitHubPullRequestCreator>().InstancePerLifetimeScope();
-#endif
+            builder.RegisterModule<ArgoCDModule>();
         }
 
         IEnumerable<Assembly> GetExtensionAssemblies()


### PR DESCRIPTION
Changes the SubstituteInFiles to have a default `ISubstituteFileMatcher`, which is the existing glob code.

However, it now optionally takes a custom matcher. This is used in the Argo CD App Manifest update command as the file matching does not use globs
