### PR TITLE
fix values file collation

### DIFF
--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
@@ -65,10 +65,10 @@ namespace Calamari.ArgoCD.Conventions
             var newImagesWritten = new HashSet<string>();
             var gitReposUpdated = new HashSet<string>();
             var gatewayIds = new HashSet<string>();
-
-            var valuesFilesToUpdate = new List<HelmValuesFileImageUpdateTarget>();
+            
             foreach (var application in argoProperties.Applications)
             {
+                var valuesFilesToUpdate = new List<HelmValuesFileImageUpdateTarget>();
                 var applicationFromYaml = argoCdApplicationManifestParser.ParseManifest(application.Manifest);
                 gatewayIds.Add(application.GatewayId);
 


### PR DESCRIPTION
When iterating over the Applications & Applicatuion Sources, the "detected" helm charts do not get cleaned between applications - meaning a HelmChart from App1 will get swept up for specialisation in App2 - which is not what is wanted.

Still trying to work out if this is easily testable.



:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
