### PR TITLE
Remove the sourceDTO which isn't being used anyway

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -52,10 +52,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             
             var argoCdCustomPropertiesDto = new ArgoCDCustomPropertiesDto(new[]
             {
-                new ArgoCDApplicationDto("Gateway1", "App1", "docker.io",new[]
-                {
-                    new ArgoCDApplicationSourceDto(OriginPath, "", argoCDBranchName.Value)
-                }, "yaml")
+                new ArgoCDApplicationDto("Gateway1", "App1", "docker.io", "yaml")
             }, new GitCredentialDto[]
             {
                 new GitCredentialDto(new Uri(OriginPath).AbsoluteUri, "", "")

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
@@ -52,10 +52,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
 
             var argoCdCustomPropertiesDto = new ArgoCDCustomPropertiesDto(new[]
             {
-                new ArgoCDApplicationDto("Gateway1", "App1", "docker.io",new[]
-                {
-                    new ArgoCDApplicationSourceDto(OriginPath, "", argoCdBranchName.Value)
-                }, "yaml")
+                new ArgoCDApplicationDto("Gateway1", "App1", "docker.io", "yaml")
             }, new GitCredentialDto[]
             {
                 new GitCredentialDto(new Uri(RepoUrl).AbsoluteUri, "", "")
@@ -182,11 +179,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             // Arrange
             var argoCdCustomPropertiesDto = new ArgoCDCustomPropertiesDto(new[]
             {
-                new ArgoCDApplicationDto("Gateway1", "App1", "docker.io",new[]
-                {
-                    new ArgoCDApplicationSourceDto(OriginPath, "", argoCdBranchName.Value),
-                    new ArgoCDApplicationSourceDto("https://github.com/do-a-thing/repo", ".", "main")
-                }, "yaml")
+                new ArgoCDApplicationDto("Gateway1", "App1", "docker.io", "yaml")
             }, new GitCredentialDto[]
             {
                 new GitCredentialDto(new Uri(RepoUrl).AbsoluteUri, "", "")

--- a/source/Calamari.Tests/ArgoCD/Helm/ArgoCDHelmVariablesImageUpdaterTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Helm/ArgoCDHelmVariablesImageUpdaterTests.cs
@@ -60,10 +60,6 @@ image:
                                                                               new ArgoCDApplicationDto("Gateway1",
                                                                                                        "App1",
                                                                                                        "docker.io",
-                                                                                                       new[]
-                                                                                                       {
-                                                                                                           new ArgoCDApplicationSourceDto(OriginPath, "", argoCDBranchName.Value)
-                                                                                                       },
                                                                                                        "yaml")
                                                                           },
                                                                           new GitCredentialDto[]

--- a/source/Calamari/ArgoCD/Dtos/ArgoCDCustomPropertiesDto.cs
+++ b/source/Calamari/ArgoCD/Dtos/ArgoCDCustomPropertiesDto.cs
@@ -18,34 +18,18 @@ namespace Calamari.ArgoCD.Dtos
 
     public class ArgoCDApplicationDto
     {
-        public ArgoCDApplicationDto(string gatewayId, string name, string defaultRegistry, ArgoCDApplicationSourceDto[] sources, string manifest)
+        public ArgoCDApplicationDto(string gatewayId, string name, string defaultRegistry, string manifest)
         {
             GatewayId = gatewayId;
             Name = name;
             DefaultRegistry = defaultRegistry;
-            Sources = sources;
             Manifest = manifest;
         }
 
         public string GatewayId { get; }
         public string Name { get; } 
         public string DefaultRegistry { get; set; }
-        public ArgoCDApplicationSourceDto[] Sources { get; }
         public string Manifest { get; }
-    }
-
-    public class ArgoCDApplicationSourceDto
-    {
-        public ArgoCDApplicationSourceDto(string url, string path, string targetRevision)
-        {
-            Url = url;
-            Path = path;
-            TargetRevision = targetRevision;
-        }
-
-        public string Url { get; }
-        public string TargetRevision { get; }
-        public string Path { get; }
     }
 
     public class GitCredentialDto


### PR DESCRIPTION
There was duplication in the Argo steps regarding:
* Data coming from the yaml vs
* Data coming from the 'package custom DTO'.

Given the business logic has moved to using _just_ the yaml - it seems the SourceDTO typ should be removed, and all references to it should be removed from the tests.

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
