### PR TITLE
Remove the file listing in the recursive delete

### DIFF
--- a/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
@@ -59,8 +59,7 @@ namespace Calamari.ArgoCD.Git
                 cleansedSubPath += "/";
             } 
             
-            Log.Verbose("Removing files recursively.");
-            repository.Index.ForEach(i => log.Info($" - {i.Path}"));
+            Log.Info("Removing files recursively.");
             List<IndexEntry> filesToRemove = repository.Index.Where(i => i.Path.StartsWith(cleansedSubPath)).ToList();
             filesToRemove.ForEach(i => repository.Index.Remove(i.Path));
         }


### PR DESCRIPTION
The following is seen in Calamari when pruning is turned on - it APPEARS to show a bunch of files being copied - except they're actually being removed.
<img width="2086" height="1086" alt="image" src="https://github.com/user-attachments/assets/288db0cc-6fdc-4943-b4ca-475192bfae34" />

Verbose shows:
<img width="1304" height="501" alt="image" src="https://github.com/user-attachments/assets/f68120c3-1b48-4ed0-975f-5966bff59588" />


This PR updates the "Removing files recursively" line to be INFO level, and removes the file listing.




:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
