### PR TITLE
Argo Image Update Step: Remove package purpose from package filtering

### DIFF
--- a/source/Calamari/ArgoCD/VariablesExtensionMethods.cs
+++ b/source/Calamari/ArgoCD/VariablesExtensionMethods.cs
@@ -14,7 +14,6 @@ namespace Calamari.ArgoCD
             var packageReferences = (from packageIndex in packageIndexes
                                      let image = variables.Get(PackageVariables.IndexedImage(packageIndex), string.Empty)
                                      let purpose = variables.Get(PackageVariables.IndexedPackagePurpose(packageIndex), string.Empty)
-                                     where purpose.Equals("DockerImageReference", StringComparison.Ordinal)
                                      select image)
                 .ToList();
 

--- a/source/Calamari/ArgoCD/VariablesExtensionMethods.cs
+++ b/source/Calamari/ArgoCD/VariablesExtensionMethods.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Calamari.ArgoCD.Models;
 using Calamari.Common.Plumbing.Variables;
+using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.ArgoCD
 {
@@ -10,14 +11,10 @@ namespace Calamari.ArgoCD
     {
         public static IList<string> GetContainerPackageNames(this IVariables variables)
         {
-            var packageIndexes = variables.GetIndexes(PackageVariables.PackageCollection);
-            var packageReferences = (from packageIndex in packageIndexes
-                                     let image = variables.Get(PackageVariables.IndexedImage(packageIndex), string.Empty)
-                                     let purpose = variables.Get(PackageVariables.IndexedPackagePurpose(packageIndex), string.Empty)
-                                     select image)
-                .ToList();
-
-            return packageReferences;
+            return variables.GetIndexes(PackageVariables.PackageCollection)
+                                          .Select(pi => variables.Get(PackageVariables.IndexedImage(pi), string.Empty))
+                                          .Where(name => !name.IsNullOrEmpty())
+                                          .ToList();
         }
 
         public static (ProjectSlug Project, EnvironmentSlug Environment, TenantSlug? Tenant) GetDeploymentScope(this IVariables variables)


### PR DESCRIPTION
Currently, the Argo Image Update step accepts a list of packages which are to be updated.

Calamari filters this list, removing any packages which are not flagged with a purpose of "DockerImageReference".

What is the risk of removing this?

Someone creates a step which has a non-docker package - this package therefore will not exist within the k8s yaml which is to be updated. So we may perform extra iterations for packages which cannot be updated (thus the step takes longer), but it will not functionally change the behaviour.

It should be noted that the step-UI prevents the inclusion of any packages which are _not_ containers - thus 'bad' packages must be added to the step via other means (eg Terraform, via the API etc.).
