### PR TITLE
Remove dotnet mirrors

### DIFF
--- a/build/Build.InstallDotNetSdk.cs
+++ b/build/Build.InstallDotNetSdk.cs
@@ -225,11 +225,7 @@ public partial class Build
     {
         // CDN's
         "https://builds.dotnet.microsoft.com/dotnet",
-        "https://ci.dot.net/public",
-
-        // direct
-        "https://dotnetcli.blob.core.windows.net/dotnet",
-        "https://dotnetbuilds.blob.core.windows.net/public"
+        "https://ci.dot.net/public"
     };
 
     static async Task<T> PerformOperationWithFeedAndRetries<T>(Func<string, Task<T>> performOperation)


### PR DESCRIPTION
Some CDN changes to net core artefacts means links will soon no longer be available
see https://github.com/dotnet/announcements/issues/383

This change simply removes some of the fallback URLs used to load net core, the existing links should continue to exist
