### PR TITLE
Bump dotnet to 419

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.415",
+    "version": "8.0.419",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
Dotnet release 8.0.25 contains aa security patch for net8 in sdk 8.0.419

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
