### PR TITLE
test: update to match Worker Images

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -114,7 +114,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 AwsAuthenticatorExecutable = await DownloadCli("aws-iam-authenticator",
                                                                async () =>
                                                                {
-                                                                   string requiredVersion = "v0.5.9";
+                                                                   string requiredVersion = "v0.7.10";
                                                                    client.DefaultRequestHeaders.Add("User-Agent", "Octopus");
                                                                    client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", await ExternalVariables.Get(ExternalVariable.GitHubRateLimitingPersonalAccessToken, CancellationToken.None));
                                                                    var json = await client.GetAsync(


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

https://github.com/OctopusDeploy/DynamicWorkerVmImage-Win2022/commit/d38a854b4af731b85e631fb355ee3e0dc75a254d updated the version of the aws-iam-authentication tool which introduces new requirements that require region to be specified when making auth calls. The warnings currently generated without it have caused customer builds to fail