### PR TITLE
Migrate from deprecated Microsoft.Azure.Management.Fluent to …

### DIFF
--- a/source/Calamari.Azure/AzureKnownEnvironment.cs
+++ b/source/Calamari.Azure/AzureKnownEnvironment.cs
@@ -1,38 +1,31 @@
-﻿using System;
+using System;
 using Azure.Identity;
 using Azure.ResourceManager;
-using Microsoft.Azure.Management.ResourceManager.Fluent;
 
 namespace Calamari.Azure
 {
     public sealed class AzureKnownEnvironment
-    { 
+    {
         /// <param name="environment">The environment name exactly matching the names defined in Azure SDK (see here https://github.com/Azure/azure-libraries-for-net/blob/master/src/ResourceManagement/ResourceManager/AzureEnvironment.cs)
         /// Other names are allowed in case this list is ever expanded/changed, but will likely result in an error at deployment time.
         /// </param>
         public AzureKnownEnvironment(string environment)
         {
             Value = environment;
-            
+
             if (string.IsNullOrEmpty(environment) || environment == "AzureCloud") // This environment name is defined in Sashimi.Azure.Accounts.AzureEnvironmentsListAction
                 Value = Global.Value;                                             // We interpret it as the normal Azure environment for historical reasons)
 
-            azureSdkEnvironment = AzureEnvironment.FromName(Value) ??
-                               throw new InvalidOperationException($"Unknown environment name {Value}");
+            // Validate that the environment name is known by attempting to resolve it
+            ToArmEnvironment(Value);
         }
 
-        private readonly AzureEnvironment azureSdkEnvironment;
         public string Value { get; }
 
         public static readonly AzureKnownEnvironment Global = new AzureKnownEnvironment("AzureGlobalCloud");
         public static readonly AzureKnownEnvironment AzureChinaCloud = new AzureKnownEnvironment("AzureChinaCloud");
         public static readonly AzureKnownEnvironment AzureUSGovernment = new AzureKnownEnvironment("AzureUSGovernment");
         public static readonly AzureKnownEnvironment AzureGermanCloud = new AzureKnownEnvironment("AzureGermanCloud");
-
-        public AzureEnvironment AsAzureSDKEnvironment()
-        {
-            return azureSdkEnvironment;
-        }
 
         public ArmEnvironment AsAzureArmEnvironment() => ToArmEnvironment(Value);
 
@@ -42,7 +35,7 @@ namespace Calamari.Azure
             "AzureChinaCloud" => ArmEnvironment.AzureChina,
             "AzureGermanCloud" => ArmEnvironment.AzureGermany,
             "AzureUSGovernment" => ArmEnvironment.AzureGovernment,
-            _ => throw  new InvalidOperationException($"ARM Environment {name} is not a known Azure Environment name.")
+            _ => throw new InvalidOperationException($"Unknown environment name {name}")
         };
 
         public Uri GetAzureAuthorityHost() => ToAzureAuthorityHost(Value);
@@ -55,7 +48,7 @@ namespace Calamari.Azure
             "AzureGermanCloud" => AzureAuthorityHosts.AzureGermany,
 #pragma warning restore CS0618 // Type or member is obsolete
             "AzureUSGovernment" => AzureAuthorityHosts.AzureGovernment,
-            _ => throw new InvalidOperationException($"ARM Environment {name} is not a known Azure Environment name.")
+            _ => throw new InvalidOperationException($"Unknown environment name {name}")
         };
     }
 }

--- a/source/Calamari.Azure/Calamari.Azure.csproj
+++ b/source/Calamari.Azure/Calamari.Azure.csproj
@@ -11,8 +11,9 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Azure.Identity" Version="1.13.1" />
-        <PackageReference Include="Azure.ResourceManager" Version="1.11.0" />
+        <PackageReference Include="Azure.ResourceManager" Version="1.13.0" />
         <PackageReference Include="Azure.ResourceManager.AppService" Version="1.0.2" />
+        <PackageReference Include="Azure.ResourceManager.ContainerService" Version="1.2.3" />
         
     </ItemGroup>
     <ItemGroup>

--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -62,9 +62,9 @@ namespace Calamari.Azure.Kubernetes.Discovery
                     discoveredClusters.AddRange(
                                                 clusters
                                                     .Select(c => KubernetesCluster.CreateForAks(
-                                                                                                $"aks/{account.SubscriptionNumber}/{c.Id.ResourceGroupName}/{c.Data.Name}",
+                                                                                                $"aks/{account.SubscriptionNumber}/{resourceGroup.Data.Name}/{c.Data.Name}",
                                                                                                 c.Data.Name,
-                                                                                                c.Id.ResourceGroupName,
+                                                                                                resourceGroup.Data.Name,
                                                                                                 accountId,
                                                                                                 c.Data.Tags.ToTargetTags())));
                 }

--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -2,10 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using Azure;
+using Azure.Core;
+using Azure.ResourceManager;
+using Azure.ResourceManager.ContainerService;
 using Calamari.CloudAccounts;
 using Calamari.Common.Features.Discovery;
 using Calamari.Common.Plumbing.Logging;
-using Microsoft.Rest.Azure;
 using Newtonsoft.Json;
 
 namespace Calamari.Azure.Kubernetes.Discovery
@@ -39,38 +42,38 @@ namespace Calamari.Azure.Kubernetes.Discovery
             Log.Verbose($"  Subscription ID: {account.SubscriptionNumber}");
             Log.Verbose($"  Tenant ID: {account.TenantId}");
             Log.Verbose($"  Client ID: {account.ClientId}");
-            var azureClient = account.CreateAzureClient();
+
+            var armClient = account.CreateArmClient();
+            var subscription = armClient.GetSubscriptionResource(
+                new ResourceIdentifier($"/subscriptions/{account.SubscriptionNumber}"));
 
             var discoveredClusters = new List<KubernetesCluster>();
 
-            // There appears to be an issue where the azure client returns stale data
-            // We need to upgrade this to use the newer SDK, but we need to upgrade to .NET 4.6.2 to support that.
-            var resourceGroups = azureClient.ResourceGroups.List();
-            //we don't care about resource groups that are being deleted 
-            foreach (var resourceGroup in resourceGroups.Where(rg => rg.ProvisioningState != "Deleting"))
+            var resourceGroups = subscription.GetResourceGroups().GetAll();
+            foreach (var resourceGroup in resourceGroups)
             {
                 try
                 {
                     // There appears to be an issue where the azure client returns stale data
                     // to mitigate this, specifically for scenario's where the resource group doesn't exist anymore
                     // we specifically list the clusters in each resource group
-                    var clusters = azureClient.KubernetesClusters.ListByResourceGroup(resourceGroup.Name);
+                    var clusters = resourceGroup.GetContainerServiceManagedClusters().GetAll();
 
                     discoveredClusters.AddRange(
                                                 clusters
                                                     .Select(c => KubernetesCluster.CreateForAks(
-                                                                                                $"aks/{account.SubscriptionNumber}/{c.ResourceGroupName}/{c.Name}",
-                                                                                                c.Name,
-                                                                                                c.ResourceGroupName,
+                                                                                                $"aks/{account.SubscriptionNumber}/{c.Id.ResourceGroupName}/{c.Data.Name}",
+                                                                                                c.Data.Name,
+                                                                                                c.Id.ResourceGroupName,
                                                                                                 accountId,
-                                                                                                c.Tags.ToTargetTags())));
+                                                                                                c.Data.Tags.ToTargetTags())));
                 }
-                catch (CloudException ex)
+                catch (RequestFailedException ex)
                 {
-                    Log.Verbose($"Failed to list kubernetes clusters for resource group {resourceGroup.Name}. Response message: {ex.Message}, Status code: {ex.Response.StatusCode}");
-                    
+                    Log.Verbose($"Failed to list kubernetes clusters for resource group {resourceGroup.Data.Name}. Response message: {ex.Message}, Status code: {ex.Status}");
+
                     // if the resource group was not found, we don't care and move on
-                    if (ex.Response.StatusCode == HttpStatusCode.NotFound && ex.Message.StartsWith("Resource group"))
+                    if (ex.Status == (int)HttpStatusCode.NotFound && ex.Message.StartsWith("Resource group"))
                         continue;
 
                     //throw in all other scenario's

--- a/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
+++ b/source/Calamari.Azure/Kubernetes/Discovery/AzureKubernetesDiscoverer.cs
@@ -45,12 +45,12 @@ namespace Calamari.Azure.Kubernetes.Discovery
 
             var armClient = account.CreateArmClient();
             var subscription = armClient.GetSubscriptionResource(
-                new ResourceIdentifier($"/subscriptions/{account.SubscriptionNumber}"));
+                                                                 new ResourceIdentifier($"/subscriptions/{account.SubscriptionNumber}"));
 
             var discoveredClusters = new List<KubernetesCluster>();
 
             var resourceGroups = subscription.GetResourceGroups().GetAll();
-            foreach (var resourceGroup in resourceGroups)
+            foreach (var resourceGroup in resourceGroups.Where(rg => rg.Data.ResourceGroupProvisioningState != "Deleting"))
             {
                 try
                 {

--- a/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
+++ b/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
@@ -11,7 +11,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
         <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2"/>
         <PackageReference Include="Azure.Identity" Version="1.13.1" />
         <PackageReference Include="Azure.ResourceManager.Resources" Version="1.7.0" />

--- a/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
+++ b/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1"/>
-    <PackageReference Include="Azure.ResourceManager" Version="1.12.0"/>
+    <PackageReference Include="Azure.ResourceManager" Version="1.13.0"/>
     <PackageReference Include="Azure.ResourceManager.AppService" Version="1.2.0"/>
     <PackageReference Include="Azure.ResourceManager.DeploymentManager" Version="1.0.0-beta.3"/>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2"/>

--- a/source/Calamari.CloudAccounts/AzureOidcAccount.cs
+++ b/source/Calamari.CloudAccounts/AzureOidcAccount.cs
@@ -1,15 +1,5 @@
-using System;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Variables;
-using Microsoft.Azure.Management.Fluent;
-using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
-using Microsoft.Rest;
 using Newtonsoft.Json;
-using NetWebRequest = System.Net.WebRequest;
-using AzureEnvironmentEnum = Microsoft.Azure.Management.ResourceManager.Fluent.AzureEnvironment;
 
 namespace Calamari.CloudAccounts
 {
@@ -71,29 +61,6 @@ namespace Calamari.CloudAccounts
                     // The double slash is intentional for public cloud.
                     return "https://management.azure.com//.default";
             }
-        }
-
-        public IAzure CreateAzureClient()
-        {
-            var environment = string.IsNullOrEmpty(AzureEnvironment) || AzureEnvironment == "AzureCloud"
-                ? AzureEnvironmentEnum.AzureGlobalCloud
-                : AzureEnvironmentEnum.FromName(AzureEnvironment) ??
-                  throw new InvalidOperationException($"Unknown environment name {AzureEnvironment}");
-
-            var accessToken = this.GetAuthorizationToken(CancellationToken.None).GetAwaiter().GetResult();
-            var credentials = new AzureCredentials(
-                                                   new TokenCredentials(accessToken),
-                                                   new TokenCredentials(accessToken),
-                                                   TenantId,
-                                                   environment);
-
-            // to ensure the Azure API uses the appropriate web proxy
-            var client = new HttpClient(new HttpClientHandler {Proxy = NetWebRequest.DefaultWebProxy});
-
-            return Microsoft.Azure.Management.Fluent.Azure.Configure()
-                            .WithHttpClient(client)
-                            .Authenticate(credentials)
-                            .WithSubscription(SubscriptionNumber);
         }
     }
 }

--- a/source/Calamari.CloudAccounts/AzureOidcAccountExtensions.cs
+++ b/source/Calamari.CloudAccounts/AzureOidcAccountExtensions.cs
@@ -1,25 +1,12 @@
-﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Logging;
 using Microsoft.Identity.Client;
-using Microsoft.Rest;
 
 namespace Calamari.CloudAccounts
 {
     public static class AzureOidcAccountExtensions
     {
-        public static async Task<ServiceClientCredentials> Credentials(this AzureOidcAccount account, CancellationToken cancellationToken)
-        {
-            return new TokenCredentials(await GetAuthorizationToken(account, cancellationToken));
-        }
-        
-        public static Task<string> GetAuthorizationToken(this AzureOidcAccount account, CancellationToken cancellationToken)
-        {
-            return GetAuthorizationToken(account.TenantId, account.ClientId, account.GetCredentials,
-                                                   account.ResourceManagementEndpointBaseUri, account.ActiveDirectoryEndpointBaseUri, account.AzureEnvironment, cancellationToken);
-        }
-
         public static async Task<string> GetAuthorizationToken(string tenantId, string applicationId, string token, string managementEndPoint, string activeDirectoryEndPoint, string aureEnvironment, CancellationToken cancellationToken)
         {
             var authClientFactory = new AuthHttpClientFactory();

--- a/source/Calamari.CloudAccounts/AzureServicePrincipalAccount.cs
+++ b/source/Calamari.CloudAccounts/AzureServicePrincipalAccount.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Net.Http;
 using Calamari.Common.Plumbing.Variables;
-using Microsoft.Azure.Management.Fluent;
-using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Newtonsoft.Json;
-using AzureEnvironmentEnum = Microsoft.Azure.Management.ResourceManager.Fluent.AzureEnvironment;
-using NetWebRequest = System.Net.WebRequest;
 
 namespace Calamari.CloudAccounts
 {
@@ -51,25 +45,5 @@ namespace Calamari.CloudAccounts
         public string AzureEnvironment { get; }
         public string ResourceManagementEndpointBaseUri { get; }
         public string ActiveDirectoryEndpointBaseUri { get; }
-
-        public IAzure CreateAzureClient()
-        {
-            var environment = string.IsNullOrEmpty(AzureEnvironment) || AzureEnvironment == "AzureCloud"
-                ? AzureEnvironmentEnum.AzureGlobalCloud
-                : AzureEnvironmentEnum.FromName(AzureEnvironment) ??
-                  throw new InvalidOperationException($"Unknown environment name {AzureEnvironment}");
-
-            var credentials = SdkContext.AzureCredentialsFactory.FromServicePrincipal(ClientId,
-                                                                                      GetCredentials, TenantId, environment
-                                                                                     );
-
-            // to ensure the Azure API uses the appropriate web proxy
-            var client = new HttpClient(new HttpClientHandler {Proxy = NetWebRequest.DefaultWebProxy});
-
-            return Microsoft.Azure.Management.Fluent.Azure.Configure()
-                                            .WithHttpClient(client)
-                                            .Authenticate(credentials)
-                                            .WithSubscription(SubscriptionNumber);
-        }
     }
 }

--- a/source/Calamari.CloudAccounts/AzureServicePrincipalAccountExtensions.cs
+++ b/source/Calamari.CloudAccounts/AzureServicePrincipalAccountExtensions.cs
@@ -1,19 +1,11 @@
-﻿using System;
 using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Logging;
 using Microsoft.Identity.Client;
-using Microsoft.Rest;
-using AzureEnvironmentEnum = Microsoft.Azure.Management.ResourceManager.Fluent.AzureEnvironment;
 
 namespace Calamari.CloudAccounts
 {
     public static class AzureServicePrincipalAccountExtensions
     {
-        public static async Task<ServiceClientCredentials> Credentials(this AzureServicePrincipalAccount account)
-        {
-            return new TokenCredentials(await GetAuthorizationToken(account));
-        }
-
         public static Task<string> GetAuthorizationToken(this AzureServicePrincipalAccount account)
         {
             return GetAuthorizationToken(account.TenantId, account.ClientId, account.GetCredentials,

--- a/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
+++ b/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
@@ -23,8 +23,6 @@
       <PackageReference Include="AWSSDK.ECR" Version="4.0.12" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
-      <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
-      <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
     </ItemGroup>
 
 </Project>

--- a/source/Calamari.CloudAccounts/IAzureAccount.cs
+++ b/source/Calamari.CloudAccounts/IAzureAccount.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Management.Fluent;
-
 namespace Calamari.CloudAccounts
 {
     public interface IAzureAccount
@@ -16,7 +11,6 @@ namespace Calamari.CloudAccounts
 
         AccountType AccountType { get; }
         string GetCredentials { get; }
-        IAzure CreateAzureClient();
     }
 
     public enum AccountType


### PR DESCRIPTION
…Azure.ResourceManager SDK

Replaces the EOL Fluent SDK (retired Sep 2023) with the Azure.ResourceManager Track 2 SDK across Calamari.CloudAccounts and Calamari.Azure:

- Remove Microsoft.Azure.Management.Fluent and Microsoft.Rest.ClientRuntime packages
- Drop IAzureAccount.CreateAzureClient() (IAzure); AKS discovery now uses the existing CreateArmClient() extension in AzureClient.cs
- Migrate AzureKubernetesDiscoverer to Azure.ResourceManager.ContainerService (resource groups via GetResourceGroups().GetAll(), clusters via GetContainerServiceManagedClusters().GetAll(), CloudException -> RequestFailedException)
- Remove AzureKnownEnvironment dependency on Fluent AzureEnvironment; validation is now done via the existing ToArmEnvironment() switch
- Remove unused Credentials() extension methods that returned Microsoft.Rest ServiceClientCredentials (callers already use GetAuthorizationToken directly)

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
