### PR TITLE
Add selective preload of script modules for Bash and PowerShell

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/Bash/BashScriptBootstrapper.cs
@@ -152,7 +152,12 @@ namespace Calamari.Common.Features.Scripting.Bash
                 writer.NewLine = LinuxNewLine;
                 writer.WriteLine("#!/bin/bash");
                 writer.WriteLine("source \"$(pwd)/" + Path.GetFileName(configurationFile) + "\"");
-                writer.WriteLine("shift"); // Shift the variable decryption key out of scope of the user script (see: https://github.com/OctopusDeploy/Calamari/pull/773)
+                writer.WriteLine("shift"); // Shift the variable decryption key out of scope of the user script and script modules (see: https://github.com/OctopusDeploy/Calamari/pull/773)
+
+                var preloadModules = variables.Get(ScriptVariables.PreloadScriptModules);
+                if (!string.IsNullOrWhiteSpace(preloadModules))
+                    PreloadScriptModules(writer, preloadModules, scriptModulePaths);
+
                 writer.WriteLine("source \"$(pwd)/" + Path.GetFileName(script.File) + "\" " + script.Parameters);
                 writer.Flush();
             }
@@ -160,6 +165,22 @@ namespace Calamari.Common.Features.Scripting.Bash
             File.SetAttributes(bootstrapFile, FileAttributes.Hidden);
             EnsureValidUnixFile(script.File);
             return (bootstrapFile, scriptModulePaths);
+        }
+
+        static void PreloadScriptModules(StreamWriter writer, string preloadModules, string[] scriptModulePaths)
+        {
+            var modules = preloadModules.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var module in modules)
+            {
+                var sanitizedName = ScriptVariables.FormatScriptName(module.Trim());
+                var fileName = $"{sanitizedName}.sh";
+                var scriptModule = scriptModulePaths.FirstOrDefault(p => string.Equals(Path.GetFileName(p), fileName, StringComparison.OrdinalIgnoreCase));
+                if (scriptModule != null)
+                {
+                    Log.VerboseFormat("Preloading script module '{0}'.", module.Trim());
+                    writer.WriteLine("source \"$(pwd)/" + fileName + "\"");
+                }
+            }
         }
 
         static IEnumerable<string> PrepareScriptModules(IVariables variables, string workingDirectory)

--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/PowerShellBootstrapper.cs
@@ -337,6 +337,12 @@ namespace Calamari.Common.Features.Scripting.WindowsPowerShell
 
         static string[] WriteScriptModules(IVariables variables, string parentDirectory, StringBuilder output)
         {
+            var preloadModules = variables.Get(ScriptVariables.PreloadScriptModules);
+            var selectivePreload = !string.IsNullOrWhiteSpace(preloadModules);
+            var selectedModules = selectivePreload
+                ? preloadModules.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries).Select(m => m.Trim()).ToHashSet(StringComparer.OrdinalIgnoreCase)
+                : null;
+
             var scriptModules = new List<string>();
             foreach (var variableName in variables.GetNames().Where(ScriptVariables.IsLibraryScriptModule))
                 if (ScriptVariables.GetLibraryScriptModuleLanguage(variables, variableName) == ScriptSyntax.PowerShell)
@@ -345,13 +351,23 @@ namespace Calamari.Common.Features.Scripting.WindowsPowerShell
                     var name = "Library_" + ScriptVariables.FormatScriptName(libraryScriptModuleName) + "_" + DateTime.Now.Ticks;
                     var moduleFileName = $"{name}.psm1";
                     var moduleFilePath = Path.Combine(parentDirectory, moduleFileName);
-                    Log.VerboseFormat("Writing script module '{0}' as PowerShell module {1}. This module will be automatically imported - functions will automatically be in scope.", libraryScriptModuleName, moduleFileName, name);
                     var contents = variables.Get(variableName);
                     if (contents == null)
                         throw new InvalidOperationException($"Value for variable {variableName} could not be found.");
                     CalamariFileSystem.OverwriteFile(moduleFilePath, contents, Encoding.UTF8);
-                    output.AppendLine($"Import-ScriptModule '{libraryScriptModuleName.EscapeSingleQuotedString()}' '{moduleFilePath.EscapeSingleQuotedString()}'");
-                    output.AppendLine();
+
+                    var shouldImport = !selectivePreload || selectedModules!.Contains(libraryScriptModuleName);
+                    if (shouldImport)
+                    {
+                        Log.VerboseFormat("Writing script module '{0}' as PowerShell module {1}. This module will be automatically imported - functions will automatically be in scope.", libraryScriptModuleName, moduleFileName, name);
+                        output.AppendLine($"Import-ScriptModule '{libraryScriptModuleName.EscapeSingleQuotedString()}' '{moduleFilePath.EscapeSingleQuotedString()}'");
+                        output.AppendLine();
+                    }
+                    else
+                    {
+                        Log.VerboseFormat("Writing script module '{0}' as PowerShell module {1}. Module not in preload list - manual import required via `Import-Module '{1}'`.", libraryScriptModuleName, moduleFileName, name);
+                    }
+
                     scriptModules.Add(moduleFilePath);
                 }
 

--- a/source/Calamari.Common/Plumbing/Variables/ScriptVariables.cs
+++ b/source/Calamari.Common/Plumbing/Variables/ScriptVariables.cs
@@ -12,6 +12,7 @@ namespace Calamari.Common.Plumbing.Variables
         public static readonly string ScriptFileName = "Octopus.Action.Script.ScriptFileName";
         public static readonly string ScriptParameters = "Octopus.Action.Script.ScriptParameters";
         public static readonly string ScriptSource = "Octopus.Action.Script.ScriptSource";
+        public static readonly string PreloadScriptModules = "Octopus.Action.Script.PreloadScriptModules";
 
         public static class ScriptSourceOptions
         {

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -384,6 +384,121 @@ namespace Calamari.Tests.Fixtures.Bash
             output.AssertOutput("Key: VariableName`prop`anotherprop` 13, Value: Value`prop`13");
             output.AssertOutput($"Key: {specialCharacters}, Value: {specialCharacters}");
         }
+
+        [Test]
+        [RequiresBashDotExeIfOnWindows]
+        public void ShouldPreloadScriptModules()
+        {
+            var (output, _) = RunScript("preload-modules.sh",
+                                        new Dictionary<string, string>()
+                                        {
+                                            ["Octopus.Script.Module[test_module]"] = @"function test_function {
+  echo ""Function from preloaded module""
+}
+
+export PRELOADED_VAR=""module_value""",
+                                            ["Octopus.Script.Module.Language[test_module]"] = "Bash",
+                                            ["Octopus.Action.Script.PreloadScriptModules"] = "test_module"
+                                        });
+
+            Assert.Multiple(() =>
+            {
+                output.AssertSuccess();
+                output.AssertOutput("Calling test_function from preloaded module...");
+                output.AssertOutput("Function from preloaded module");
+                output.AssertOutput("Checking preloaded variable...");
+                output.AssertOutput("PRELOADED_VAR=module_value");
+            });
+        }
+
+        [Test]
+        [RequiresBashDotExeIfOnWindows]
+        public void ShouldPreloadMultipleScriptModulesInOrder()
+        {
+            var (output, _) = RunScript("preload-modules.sh",
+                                        new Dictionary<string, string>()
+                                        {
+                                            ["Octopus.Script.Module[module1]"] = @"function test_function {
+  echo ""Module 1""
+}
+
+export PRELOADED_VAR=""value1""",
+                                            ["Octopus.Script.Module.Language[module1]"] = "Bash",
+                                            ["Octopus.Script.Module[module2]"] = @"function test_function {
+  echo ""Module 2""
+}
+
+export PRELOADED_VAR=""value2""",
+                                            ["Octopus.Script.Module.Language[module2]"] = "Bash",
+                                            ["Octopus.Action.Script.PreloadScriptModules"] = "module1,module2"
+                                        });
+
+            Assert.Multiple(() =>
+            {
+                output.AssertSuccess();
+                output.AssertOutput("Module 2");
+                output.AssertOutput("PRELOADED_VAR=value2");
+            });
+        }
+
+        [Test]
+        [RequiresBashDotExeIfOnWindows]
+        [TestCase("module1,module2", "module1,module2")]
+        [TestCase("module1, module2", "module1,module2")]
+        [TestCase("module1 , module2", "module1,module2")]
+        [TestCase("module1;module2", "module1,module2")]
+        [TestCase("module1; module2", "module1,module2")]
+        [TestCase("module1 ; module2", "module1,module2")]
+        [TestCase("module1,module2;module3", "module1,module2,module3")]
+        [TestCase("module1, module2; module3", "module1,module2,module3")]
+        [TestCase("module1,,module2", "module1,module2")]
+        [TestCase(" module1 , module2 ", "module1,module2")]
+        [TestCase("module1,  ,module2", "module1,module2")]
+        [TestCase("module1,missing_module", "module1")]
+        public void PreloadModulesShouldHandleVariousDelimiterCombinations(string moduleList, string expectedModules)
+        {
+            var (output, _) = RunScript("preload-modules.sh",
+                                        new Dictionary<string, string>()
+                                        {
+                                            ["Octopus.Script.Module[module1]"] = @"function test_function {
+  echo ""Module 1""
+}
+
+if [ -z ""$PRELOADED_VAR"" ]; then
+  export PRELOADED_VAR=""module1""
+else
+  export PRELOADED_VAR=""$PRELOADED_VAR,module1""
+fi",
+                                            ["Octopus.Script.Module.Language[module1]"] = "Bash",
+                                            ["Octopus.Script.Module[module2]"] = @"function test_function {
+  echo ""Module 2""
+}
+
+if [ -z ""$PRELOADED_VAR"" ]; then
+  export PRELOADED_VAR=""module2""
+else
+  export PRELOADED_VAR=""$PRELOADED_VAR,module2""
+fi",
+                                            ["Octopus.Script.Module.Language[module2]"] = "Bash",
+                                            ["Octopus.Script.Module[module3]"] = @"function test_function {
+  echo ""Module 3""
+}
+
+if [ -z ""$PRELOADED_VAR"" ]; then
+  export PRELOADED_VAR=""module3""
+else
+  export PRELOADED_VAR=""$PRELOADED_VAR,module3""
+fi",
+                                            ["Octopus.Script.Module.Language[module3]"] = "Bash",
+                                            ["Octopus.Action.Script.PreloadScriptModules"] = moduleList
+                                        });
+
+            Assert.Multiple(() =>
+            {
+                output.AssertSuccess();
+                output.AssertOutput($"PRELOADED_VAR={expectedModules}");
+            });
+        }
     }
 
     public static class AdditionalVariablesExtensions

--- a/source/Calamari.Tests/Fixtures/Bash/Scripts/preload-modules.sh
+++ b/source/Calamari.Tests/Fixtures/Bash/Scripts/preload-modules.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Test that preloaded modules are available
+echo "Calling test_function from preloaded module..."
+test_function
+
+echo "Checking preloaded variable..."
+echo "PRELOADED_VAR=$PRELOADED_VAR"

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
@@ -476,6 +476,52 @@ namespace Calamari.Tests.Fixtures.PowerShell
         }
 
         [Test]
+        public void ShouldPreloadSelectedScriptModules()
+        {
+            var (output, _) = RunPowerShellScript("PreloadModules.ps1", new Dictionary<string, string>
+            {
+                ["Octopus.Script.Module[test_module]"] = "function TestFunction { Write-Host \"Function from preloaded module\" }\n$global:PreloadedVar = \"module_value\"",
+                ["Octopus.Action.Script.PreloadScriptModules"] = "test_module"
+            });
+
+            output.AssertSuccess();
+            output.AssertOutput("Calling test function from preloaded module...");
+            output.AssertOutput("Function from preloaded module");
+            output.AssertOutput("PRELOADED_VAR=module_value");
+            AssertPowerShellEdition(output);
+        }
+
+        [Test]
+        public void ShouldOnlyPreloadSelectedModulesWhenVariableIsSet()
+        {
+            var (output, _) = RunPowerShellScript("UseModule.ps1", new Dictionary<string, string>
+            {
+                ["Octopus.Script.Module[Foo]"] = "function SayHello() { Write-Host \"Hello from module!\" }",
+                ["Octopus.Script.Module[Bar]"] = "function SayGoodbye() { Write-Host \"Goodbye from module!\" }",
+                ["Octopus.Action.Script.PreloadScriptModules"] = "Foo"
+            });
+
+            // Foo is in the preload list so SayHello should work
+            output.AssertSuccess();
+            output.AssertOutput("Hello from module!");
+            AssertPowerShellEdition(output);
+        }
+
+        [Test]
+        public void ShouldStillAutoImportAllModulesWhenPreloadVariableNotSet()
+        {
+            var (output, _) = RunPowerShellScript("UseModule.ps1", new Dictionary<string, string>
+            {
+                ["Octopus.Script.Module[Foo]"] = "function SayHello() { Write-Host \"Hello from module!\" }",
+            });
+
+            // No PreloadScriptModules variable set — existing behavior: all modules auto-imported
+            output.AssertSuccess();
+            output.AssertOutput("Hello from module!");
+            AssertPowerShellEdition(output);
+        }
+
+        [Test]
         public void ShouldShowFriendlyErrorWithInvalidSyntaxInScriptModule()
         {
             var (output, _) = RunPowerShellScript("UseModule.ps1", new Dictionary<string, string>()

--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/PreloadModules.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/PreloadModules.ps1
@@ -1,0 +1,3 @@
+Write-Host "Calling test function from preloaded module..."
+TestFunction
+Write-Host "PRELOADED_VAR=$global:PreloadedVar"


### PR DESCRIPTION
## Summary
- Adds `Octopus.Action.Script.PreloadScriptModules` variable to control which script modules are auto-imported before a user script runs
- **Bash**: selected modules are `source`d in the bootstrapper before the user script (previously no auto-sourcing)
- **PowerShell**: when variable is set, only listed modules are auto-imported. When unset, existing behavior preserved (all modules imported)
- Variable supports comma/semicolon delimited lists and can be scoped per step/environment like any Octopus variable

Builds on the concept from #1730 (Bash-only) and extends it to PowerShell with backwards-compatible selective import.

## Test plan
- [ ] Bash: single module preload works
- [ ] Bash: multiple modules preload in order
- [ ] Bash: delimiter edge cases (comma, semicolon, spaces, empty entries, missing modules)
- [ ] PowerShell: selected module imports and functions are available
- [ ] PowerShell: unselected modules are not auto-imported
- [ ] PowerShell: no variable set = all modules still auto-imported (existing behavior)