### PR TITLE
Enable script isolation alert service messages

### DIFF
--- a/source/Calamari.Common/Features/Processes/ScriptIsolation/LockOptionsResolver.cs
+++ b/source/Calamari.Common/Features/Processes/ScriptIsolation/LockOptionsResolver.cs
@@ -72,10 +72,7 @@ public sealed class LockOptionsResolver(
     void LogScriptIsolationAlertServiceMessage(LockOptions originalOptions, LockType? typeEnforced)
     {
         var alertMessage = BuildScriptIsolationAlertServiceMessage(originalOptions, typeEnforced);
-        if (string.Empty.Length > 0)  // Temporarily disabling until server support for message
-        {
-            log.WriteServiceMessage(alertMessage);
-        }
+        log.WriteServiceMessage(alertMessage);
     }
 
     static ServiceMessage BuildScriptIsolationAlertServiceMessage(LockOptions originalOptions, LockType? typeEnforced)

--- a/source/Calamari.Tests/Fixtures/ScriptIsolation/LockOptionsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ScriptIsolation/LockOptionsFixture.cs
@@ -423,7 +423,6 @@ namespace Calamari.Tests.Fixtures.ScriptIsolation
         }
 
         [Test]
-        [Ignore("Service Message not yet handled")]
         public void ServiceMessage_EmittedWithExclusiveEnforcedType_WhenSharedPromotedToExclusive()
         {
             // ExclusiveOnly + shared → promoted to exclusive; alert emitted
@@ -444,7 +443,6 @@ namespace Calamari.Tests.Fixtures.ScriptIsolation
         }
 
         [Test]
-        [Ignore("Service Message not yet handled")]
         public void ServiceMessage_EmittedWithNoneEnforcedType_WhenExclusiveUnsupported()
         {
             // Unsupported + exclusive → no lock at all; alert emitted with enforcedType = "None"
@@ -465,7 +463,6 @@ namespace Calamari.Tests.Fixtures.ScriptIsolation
         }
 
         [Test]
-        [Ignore("Service Message not yet handled")]
         public void ServiceMessage_EmittedWithNoneEnforcedType_WhenSharedUnsupported()
         {
             // Unsupported + shared → no lock at all; alert emitted with enforcedType = "None"
@@ -486,7 +483,6 @@ namespace Calamari.Tests.Fixtures.ScriptIsolation
         }
 
         [Test]
-        [Ignore("Service Message not yet handled")]
         public void ServiceMessage_FallbackUsed_IsFalse_WhenNoFallback()
         {
             // The 2-arg LockDirectory constructor sets IsFallback = false
@@ -501,7 +497,6 @@ namespace Calamari.Tests.Fixtures.ScriptIsolation
         }
 
         [Test]
-        [Ignore("Service Message not yet handled")]
         public void ServiceMessage_FallbackUsed_IsTrue_WhenFallbackDirectoryWasChosen()
         {
             // Construct a LockDirectory explicitly marked as a fallback
@@ -522,7 +517,6 @@ namespace Calamari.Tests.Fixtures.ScriptIsolation
         }
 
         [Test]
-        [Ignore("Service Message not yet handled")]
         public void ServiceMessage_CapabilityInfo_IncludesDetectionResults()
         {
             // Construct a LockDirectory with non-empty DetectionResults


### PR DESCRIPTION
To support logging occurrences of script isolation changing levels due to insufficient support of the underlying system, we are now recording a service message which can be handled by Octopus Server so that we can alert/monitor the impact of this change.

Resolves EFT-3167
