### PR TITLE
Allow control of whether we generate output variables for S3 commands

### DIFF
--- a/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
+++ b/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
@@ -31,7 +31,7 @@ namespace Calamari.Aws.Commands
         PathToPackage pathToPackage;
         string bucket;
         string targetMode;
-        bool includeOutputVariables = true;
+        S3OutputVariablesStrategy s3OutputVariablesStrategy = S3OutputVariablesStrategy.AllFiles;
 
         public UploadAwsS3Command(
             ILog log,
@@ -51,7 +51,8 @@ namespace Calamari.Aws.Commands
             Options.Add("package=", "Path to the package to extract that contains the package.", v => pathToPackage = new PathToPackage(Path.GetFullPath(v)));
             Options.Add("bucket=", "The bucket to use", v => bucket = v);
             Options.Add("targetMode=", "Whether the entire package or files within the package should be uploaded to the s3 bucket", v => targetMode = v);
-            Options.Add("includeOutputVariables=", "True to generate output variables for uploaded files (default), False to skip output variable generation.", v => includeOutputVariables = !bool.FalseString.Equals(v, StringComparison.OrdinalIgnoreCase));
+            Options.Add("s3OutputVariablesStrategy=", "Strategy for generating output variables. Options: CalamariDefault (default), AllFiles, NoFiles.",
+                        v => s3OutputVariablesStrategy = Enum.TryParse<S3OutputVariablesStrategy>(v, out var result) ? result : S3OutputVariablesStrategy.AllFiles);;
         }
 
         public override int Execute(string[] commandLineArguments)
@@ -85,7 +86,7 @@ namespace Calamari.Aws.Commands
                     bucketKeyProvider,
                     substituteInFiles,
                     structuredConfigVariablesService,
-                    includeOutputVariables
+                    s3OutputVariablesStrategy
                 )
             };
 

--- a/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
+++ b/source/Calamari.Aws/Commands/UploadAwsS3Command.cs
@@ -31,6 +31,7 @@ namespace Calamari.Aws.Commands
         PathToPackage pathToPackage;
         string bucket;
         string targetMode;
+        bool includeOutputVariables = true;
 
         public UploadAwsS3Command(
             ILog log,
@@ -50,6 +51,7 @@ namespace Calamari.Aws.Commands
             Options.Add("package=", "Path to the package to extract that contains the package.", v => pathToPackage = new PathToPackage(Path.GetFullPath(v)));
             Options.Add("bucket=", "The bucket to use", v => bucket = v);
             Options.Add("targetMode=", "Whether the entire package or files within the package should be uploaded to the s3 bucket", v => targetMode = v);
+            Options.Add("includeOutputVariables=", "True to generate output variables for uploaded files (default), False to skip output variable generation.", v => includeOutputVariables = !bool.FalseString.Equals(v, StringComparison.OrdinalIgnoreCase));
         }
 
         public override int Execute(string[] commandLineArguments)
@@ -82,7 +84,8 @@ namespace Calamari.Aws.Commands
                     new VariableS3TargetOptionsProvider(variables),
                     bucketKeyProvider,
                     substituteInFiles,
-                    structuredConfigVariablesService
+                    structuredConfigVariablesService,
+                    includeOutputVariables
                 )
             };
 

--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -44,6 +44,7 @@ namespace Calamari.Aws.Deployment.Conventions
         readonly ISubstituteInFiles substituteInFiles;
         readonly IStructuredConfigVariablesService structuredConfigVariablesService;
         private readonly bool md5HashSupported;
+        readonly bool includeOutputVariables;
 
         private static readonly HashSet<S3CannedACL> CannedAcls = new HashSet<S3CannedACL>(ConstantHelpers.GetConstantValues<S3CannedACL>());
 
@@ -56,7 +57,8 @@ namespace Calamari.Aws.Deployment.Conventions
             IProvideS3TargetOptions optionsProvider,
             IBucketKeyProvider bucketKeyProvider,
             ISubstituteInFiles substituteInFiles,
-            IStructuredConfigVariablesService structuredConfigVariablesService
+            IStructuredConfigVariablesService structuredConfigVariablesService,
+            bool includeOutputVariables
         )
         {
             this.log = log;
@@ -69,6 +71,7 @@ namespace Calamari.Aws.Deployment.Conventions
             this.substituteInFiles = substituteInFiles;
             this.structuredConfigVariablesService = structuredConfigVariablesService;
             this.md5HashSupported = HashCalculator.IsAvailableHashingAlgorithm(MD5.Create);
+            this.includeOutputVariables = includeOutputVariables;
         }
 
         private static string ExceptionMessageWithFilePath(PutObjectRequest request, Exception exception)
@@ -121,9 +124,15 @@ namespace Calamari.Aws.Deployment.Conventions
                 (await UploadAll(options, Factory, deployment)).Tee(responses =>
                 {
                     var results = responses.Where(z => z.IsSuccess()).ToArray();
+
+                    if (!includeOutputVariables)
+                    {
+                        return;
+                    }
+
                     if (targetMode == S3TargetMode.EntirePackage && results.FirstOrDefault() != null)
                     {
-                        SetOutputVariables(deployment, results.FirstOrDefault());
+                        SetOutputVariables(deployment, results.FirstOrDefault(), "");
                     }
                     else if (targetMode == S3TargetMode.FileSelections)
                     {

--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -44,7 +44,7 @@ namespace Calamari.Aws.Deployment.Conventions
         readonly ISubstituteInFiles substituteInFiles;
         readonly IStructuredConfigVariablesService structuredConfigVariablesService;
         private readonly bool md5HashSupported;
-        readonly bool includeOutputVariables;
+        readonly S3OutputVariablesStrategy s3OutputVariablesStrategy;
 
         private static readonly HashSet<S3CannedACL> CannedAcls = new HashSet<S3CannedACL>(ConstantHelpers.GetConstantValues<S3CannedACL>());
 
@@ -58,7 +58,7 @@ namespace Calamari.Aws.Deployment.Conventions
             IBucketKeyProvider bucketKeyProvider,
             ISubstituteInFiles substituteInFiles,
             IStructuredConfigVariablesService structuredConfigVariablesService,
-            bool includeOutputVariables
+            S3OutputVariablesStrategy s3OutputVariablesStrategy
         )
         {
             this.log = log;
@@ -71,7 +71,7 @@ namespace Calamari.Aws.Deployment.Conventions
             this.substituteInFiles = substituteInFiles;
             this.structuredConfigVariablesService = structuredConfigVariablesService;
             this.md5HashSupported = HashCalculator.IsAvailableHashingAlgorithm(MD5.Create);
-            this.includeOutputVariables = includeOutputVariables;
+            this.s3OutputVariablesStrategy = s3OutputVariablesStrategy;
         }
 
         private static string ExceptionMessageWithFilePath(PutObjectRequest request, Exception exception)
@@ -125,7 +125,7 @@ namespace Calamari.Aws.Deployment.Conventions
                 {
                     var results = responses.Where(z => z.IsSuccess()).ToArray();
 
-                    if (!includeOutputVariables)
+                    if (s3OutputVariablesStrategy == S3OutputVariablesStrategy.NoFiles)
                     {
                         return;
                     }

--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -132,7 +132,7 @@ namespace Calamari.Aws.Deployment.Conventions
 
                     if (targetMode == S3TargetMode.EntirePackage && results.FirstOrDefault() != null)
                     {
-                        SetOutputVariables(deployment, results.FirstOrDefault(), "");
+                        SetOutputVariables(deployment, results.FirstOrDefault());
                     }
                     else if (targetMode == S3TargetMode.FileSelections)
                     {

--- a/source/Calamari.Aws/Integration/S3/S3OutputVariableStrategy.cs
+++ b/source/Calamari.Aws/Integration/S3/S3OutputVariableStrategy.cs
@@ -1,0 +1,8 @@
+﻿namespace Calamari.Aws.Integration.S3
+{
+    public enum S3OutputVariablesStrategy
+    {
+        AllFiles,
+        NoFiles
+    }
+}

--- a/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
+++ b/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
@@ -97,7 +97,7 @@ namespace Calamari.Tests.AWS
         }
 
         [Test]
-        public async Task UploadPackageWithIncludeOutputVariablesEnabled()
+        public async Task UploadPackageWithS3OutputVariablesStrategySetToAllFiles()
         {
             var packageOptions = new List<S3TargetPropertiesBase>
             {
@@ -109,7 +109,7 @@ namespace Calamari.Tests.AWS
                 }
             };
 
-            var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage, true);
+            var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage, S3OutputVariablesStrategy.AllFiles);
             var outputVariables = GetOutputVariables(log);
 
             outputVariables.Should().ContainKey(PackageVariables.Output.FileName);
@@ -127,7 +127,7 @@ namespace Calamari.Tests.AWS
         }
 
         [Test]
-        public async Task UploadPackageWithIncludeOutputVariablesDisabled()
+        public async Task UploadPackageWithS3OutputVariablesStrategyNotSet()
         {
             var packageOptions = new List<S3TargetPropertiesBase>
             {
@@ -139,7 +139,37 @@ namespace Calamari.Tests.AWS
                 }
             };
 
-            var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage, false);
+            var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage);
+            var outputVariables = GetOutputVariables(log);
+
+            outputVariables.Should().ContainKey(PackageVariables.Output.FileName);
+            outputVariables.Should().ContainKey(PackageVariables.Output.FilePath);
+            outputVariables.Should().ContainKey("Package.S3Uri");
+            outputVariables.Should().ContainKey("Package.Uri");
+            outputVariables.Should().ContainKey("Package.Arn");
+            outputVariables.Should().ContainKey("Package.ObjectVersion");
+            outputVariables.Should().ContainKey("Package.FileName");
+
+            await Validate(async client =>
+                           {
+                               await client.GetObjectAsync(bucketName, $"{prefix}Package3.1.0.0.zip");
+                           });
+        }
+
+        [Test]
+        public async Task UploadPackageWithS3OutputVariablesStrategySetToNoFiles()
+        {
+            var packageOptions = new List<S3TargetPropertiesBase>
+            {
+                new S3PackageOptions
+                {
+                    StorageClass = "STANDARD",
+                    CannedAcl = "private",
+                    BucketKeyBehaviour = BucketKeyBehaviourType.Filename,
+                }
+            };
+
+            var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage, S3OutputVariablesStrategy.NoFiles);
             var outputVariables = GetOutputVariables(log);
 
             outputVariables.Should().NotContainKey(PackageVariables.Output.FileName);
@@ -735,7 +765,7 @@ namespace Calamari.Tests.AWS
             }
         }
 
-        protected async Task<(string bucketKeyPrefix, InMemoryLog log)> Upload(string packageName, List<S3TargetPropertiesBase> propertiesList, VariableDictionary customVariables = null, S3TargetMode s3TargetMode = S3TargetMode.FileSelections, bool? includeOutputVariables = null)
+        protected async Task<(string bucketKeyPrefix, InMemoryLog log)> Upload(string packageName, List<S3TargetPropertiesBase> propertiesList, VariableDictionary customVariables = null, S3TargetMode s3TargetMode = S3TargetMode.FileSelections, S3OutputVariablesStrategy? s3OutputVariablesStrategy = null)
         {
             const string packageVersion = "1.0.0";
             var bucketKeyPrefix = $"calamaritest/{Guid.NewGuid():N}/";
@@ -807,10 +837,10 @@ namespace Calamari.Tests.AWS
                     "--targetMode", s3TargetMode.ToString()
                 };
 
-                if (includeOutputVariables.HasValue)
+                if (s3OutputVariablesStrategy.HasValue)
                 {
-                    args.Add("--includeOutputVariables");
-                    args.Add(includeOutputVariables.Value.ToString());
+                    args.Add("--s3OutputVariablesStrategy");
+                    args.Add(s3OutputVariablesStrategy.Value.ToString());
                 }
 
                 var result = command.Execute(args.ToArray());

--- a/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
+++ b/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
@@ -85,13 +85,100 @@ namespace Calamari.Tests.AWS
                 }
             };
 
-            var prefix = await Upload("Package1", fileSelections);
+            var (prefix, _) = await Upload("Package1", fileSelections);
 
             await Validate(async client =>
                            {
                                await client.GetObjectAsync(bucketName, $"{prefix}Resources/TextFile.txt");
                                await client.GetObjectAsync(bucketName, $"{prefix}root/Page.html");
                                await client.GetObjectAsync(bucketName, $"{prefix}Extra/JavaScript.js");
+                           });
+        }
+
+        [Test]
+        public async Task UploadPackageWithIncludeOutputVariablesEnabled()
+        {
+            var packageOptions = new List<S3TargetPropertiesBase>
+            {
+                new S3PackageOptions
+                {
+                    StorageClass = "STANDARD",
+                    CannedAcl = "private",
+                    BucketKeyBehaviour = BucketKeyBehaviourType.Filename,
+                }
+            };
+
+            var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage, true);
+
+            // Verify S3-specific output variables ARE set
+            var logMessages = log.Messages.Select(m => m.FormattedMessage).ToList();
+            logMessages.Should().Contain(m => m.Contains("Saving object version id to variable"));
+            logMessages.Should().Contain(m => m.Contains("Saving bucket key to variable"));
+            logMessages.Should().Contain(m => m.Contains("Saving object S3 URI to variable"));
+            logMessages.Should().Contain(m => m.Contains("Saving object URI to variable"));
+            logMessages.Should().Contain(m => m.Contains("Saving object ARN to variable"));
+
+            await Validate(async client =>
+                           {
+                               await client.GetObjectAsync(bucketName, $"{prefix}Package3.1.0.0.zip");
+                           });
+        }
+
+        [Test]
+        public async Task UploadPackageWithIncludeOutputVariablesDisabled()
+        {
+            var packageOptions = new List<S3TargetPropertiesBase>
+            {
+                new S3PackageOptions
+                {
+                    StorageClass = "STANDARD",
+                    CannedAcl = "private",
+                    BucketKeyBehaviour = BucketKeyBehaviourType.Filename,
+                }
+            };
+
+            var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage, false);
+
+            // Verify S3-specific output variables are NOT set
+            var logMessages = log.Messages.Select(m => m.FormattedMessage).ToList();
+            logMessages.Should().NotContain(m => m.Contains("Saving object version id to variable"));
+            logMessages.Should().NotContain(m => m.Contains("Saving bucket key to variable"));
+            logMessages.Should().NotContain(m => m.Contains("Saving object S3 URI to variable"));
+            logMessages.Should().NotContain(m => m.Contains("Saving object URI to variable"));
+            logMessages.Should().NotContain(m => m.Contains("Saving object ARN to variable"));
+
+            await Validate(async client =>
+                           {
+                               await client.GetObjectAsync(bucketName, $"{prefix}Package3.1.0.0.zip");
+                           });
+        }
+
+        [Test]
+        public async Task UploadPackageWithIncludeOutputVariablesDefaultBehavior()
+        {
+            var packageOptions = new List<S3TargetPropertiesBase>
+            {
+                new S3PackageOptions
+                {
+                    StorageClass = "STANDARD",
+                    CannedAcl = "private",
+                    BucketKeyBehaviour = BucketKeyBehaviourType.Filename,
+                }
+            };
+
+            var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage);
+
+            // Verify default behavior generates all output variables (backward compatible)
+            var logMessages = log.Messages.Select(m => m.FormattedMessage).ToList();
+            logMessages.Should().Contain(m => m.Contains("Saving object version id to variable"));
+            logMessages.Should().Contain(m => m.Contains("Saving bucket key to variable"));
+            logMessages.Should().Contain(m => m.Contains("Saving object S3 URI to variable"));
+            logMessages.Should().Contain(m => m.Contains("Saving object URI to variable"));
+            logMessages.Should().Contain(m => m.Contains("Saving object ARN to variable"));
+
+            await Validate(async client =>
+                           {
+                               await client.GetObjectAsync(bucketName, $"{prefix}Package3.1.0.0.zip");
                            });
         }
 
@@ -109,7 +196,7 @@ namespace Calamari.Tests.AWS
                 }
             };
 
-            var prefix = await Upload("Package2", fileSelections);
+            var (prefix, _) = await Upload("Package2", fileSelections);
 
             await Validate(async client =>
                            {
@@ -146,7 +233,7 @@ namespace Calamari.Tests.AWS
             var variables = new CalamariVariables();
             variables.Set("Property1:Property2:Value", "InjectedValue");
 
-            var prefix = await Upload("Package3", fileSelections, variables);
+            var (prefix, _) = await Upload("Package3", fileSelections, variables);
 
             await Validate(async client =>
                            {
@@ -173,7 +260,7 @@ namespace Calamari.Tests.AWS
             var variables = new CalamariVariables();
             variables.Set("Property1:Property2:Value", "InjectedValue");
 
-            var prefix = await Upload("Package3", packageOptions, variables, S3TargetMode.EntirePackage);
+            var (prefix, _) = await Upload("Package3", packageOptions, variables, S3TargetMode.EntirePackage);
 
             await Validate(async client =>
                            {
@@ -272,7 +359,7 @@ namespace Calamari.Tests.AWS
                 }
             };
 
-            var prefix = await Upload("Package1", fileSelections);
+            var (prefix, _) = await Upload("Package1", fileSelections);
 
             await Validate(async client =>
                            {
@@ -540,7 +627,7 @@ namespace Calamari.Tests.AWS
                 }
             };
 
-            var prefix = await Upload("Package1", fileSelections);
+            var (prefix, _) = await Upload("Package1", fileSelections);
 
             await DoSafelyWithRetries(async () =>
                                       {
@@ -626,7 +713,7 @@ namespace Calamari.Tests.AWS
             }
         }
 
-        protected async Task<string> Upload(string packageName, List<S3TargetPropertiesBase> propertiesList, VariableDictionary customVariables = null, S3TargetMode s3TargetMode = S3TargetMode.FileSelections)
+        protected async Task<(string bucketKeyPrefix, InMemoryLog log)> Upload(string packageName, List<S3TargetPropertiesBase> propertiesList, VariableDictionary customVariables = null, S3TargetMode s3TargetMode = S3TargetMode.FileSelections, bool? includeOutputVariables = null)
         {
             const string packageVersion = "1.0.0";
             var bucketKeyPrefix = $"calamaritest/{Guid.NewGuid():N}/";
@@ -653,6 +740,7 @@ namespace Calamari.Tests.AWS
                                        }
                                    });
 
+            var log = new InMemoryLog();
             var variablesFile = Path.GetTempFileName();
 
             variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
@@ -669,7 +757,6 @@ namespace Calamari.Tests.AWS
             using (var package = new TemporaryFile(PackageBuilder.BuildSimpleZip(packageName, packageVersion, packageDirectory)))
             using (new TemporaryFile(variablesFile))
             {
-                var log = new InMemoryLog();
                 var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
                 var command = new UploadAwsS3Command(
@@ -690,18 +777,26 @@ namespace Calamari.Tests.AWS
                                                                                           log)
                                                     );
 
-                var result = command.Execute(new[]
+                var args = new List<string>
                 {
                     "--package", $"{package.FilePath}",
                     "--variables", $"{variablesFile}",
                     "--bucket", bucketName,
                     "--targetMode", s3TargetMode.ToString()
-                });
+                };
+
+                if (includeOutputVariables.HasValue)
+                {
+                    args.Add("--includeOutputVariables");
+                    args.Add(includeOutputVariables.Value.ToString());
+                }
+
+                var result = command.Execute(args.ToArray());
 
                 result.Should().Be(0);
             }
 
-            return bucketKeyPrefix;
+            return (bucketKeyPrefix, log);
         }
 
         protected async Task<string> UploadEntireCompressedPackage(string packageFilePath,

--- a/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
+++ b/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
@@ -20,6 +20,7 @@ using Calamari.Aws.Integration.S3;
 using Calamari.Aws.Serialization;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Plumbing.Extensions;
+using Calamari.Common.Plumbing.ServiceMessages;
 using Calamari.Serialization;
 using Calamari.Tests.Fixtures.Deployment.Packages;
 using FluentAssertions;
@@ -109,14 +110,15 @@ namespace Calamari.Tests.AWS
             };
 
             var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage, true);
+            var outputVariables = GetOutputVariables(log);
 
-            // Verify S3-specific output variables ARE set
-            var logMessages = log.Messages.Select(m => m.FormattedMessage).ToList();
-            logMessages.Should().Contain(m => m.Contains("Saving object version id to variable"));
-            logMessages.Should().Contain(m => m.Contains("Saving bucket key to variable"));
-            logMessages.Should().Contain(m => m.Contains("Saving object S3 URI to variable"));
-            logMessages.Should().Contain(m => m.Contains("Saving object URI to variable"));
-            logMessages.Should().Contain(m => m.Contains("Saving object ARN to variable"));
+            outputVariables.Should().ContainKey(PackageVariables.Output.FileName);
+            outputVariables.Should().ContainKey(PackageVariables.Output.FilePath);
+            outputVariables.Should().ContainKey("Package.S3Uri");
+            outputVariables.Should().ContainKey("Package.Uri");
+            outputVariables.Should().ContainKey("Package.Arn");
+            outputVariables.Should().ContainKey("Package.ObjectVersion");
+            outputVariables.Should().ContainKey("Package.FileName");
 
             await Validate(async client =>
                            {
@@ -138,14 +140,15 @@ namespace Calamari.Tests.AWS
             };
 
             var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage, false);
+            var outputVariables = GetOutputVariables(log);
 
-            // Verify S3-specific output variables are NOT set
-            var logMessages = log.Messages.Select(m => m.FormattedMessage).ToList();
-            logMessages.Should().NotContain(m => m.Contains("Saving object version id to variable"));
-            logMessages.Should().NotContain(m => m.Contains("Saving bucket key to variable"));
-            logMessages.Should().NotContain(m => m.Contains("Saving object S3 URI to variable"));
-            logMessages.Should().NotContain(m => m.Contains("Saving object URI to variable"));
-            logMessages.Should().NotContain(m => m.Contains("Saving object ARN to variable"));
+            outputVariables.Should().NotContainKey(PackageVariables.Output.FileName);
+            outputVariables.Should().NotContainKey(PackageVariables.Output.FilePath);
+            outputVariables.Should().NotContainKey("Package.S3Uri");
+            outputVariables.Should().NotContainKey("Package.Uri");
+            outputVariables.Should().NotContainKey("Package.Arn");
+            outputVariables.Should().NotContainKey("Package.ObjectVersion");
+            outputVariables.Should().NotContainKey("Package.FileName");
 
             await Validate(async client =>
                            {
@@ -167,14 +170,15 @@ namespace Calamari.Tests.AWS
             };
 
             var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage);
+            var outputVariables = GetOutputVariables(log);
 
-            // Verify default behavior generates all output variables (backward compatible)
-            var logMessages = log.Messages.Select(m => m.FormattedMessage).ToList();
-            logMessages.Should().Contain(m => m.Contains("Saving object version id to variable"));
-            logMessages.Should().Contain(m => m.Contains("Saving bucket key to variable"));
-            logMessages.Should().Contain(m => m.Contains("Saving object S3 URI to variable"));
-            logMessages.Should().Contain(m => m.Contains("Saving object URI to variable"));
-            logMessages.Should().Contain(m => m.Contains("Saving object ARN to variable"));
+            outputVariables.Should().ContainKey(PackageVariables.Output.FileName);
+            outputVariables.Should().ContainKey(PackageVariables.Output.FilePath);
+            outputVariables.Should().ContainKey("Package.S3Uri");
+            outputVariables.Should().ContainKey("Package.Uri");
+            outputVariables.Should().ContainKey("Package.Arn");
+            outputVariables.Should().ContainKey("Package.ObjectVersion");
+            outputVariables.Should().ContainKey("Package.FileName");
 
             await Validate(async client =>
                            {
@@ -697,6 +701,24 @@ namespace Calamari.Tests.AWS
                                              x.Converters.Add(new FileSelectionsConverter());
                                              x.ContractResolver = new CamelCasePropertyNamesContractResolver();
                                          });
+        }
+
+        protected static Dictionary<string, string> GetOutputVariables(InMemoryLog log)
+        {
+            var serviceMessages = new List<ServiceMessage>();
+            var parser = new ServiceMessageParser(serviceMessages.Add);
+
+            foreach (var line in log.StandardOut)
+            {
+                parser.Parse(line);
+            }
+
+            return serviceMessages
+                .Where(sm => sm.Name == ServiceMessageNames.SetVariable.Name)
+                .ToDictionary(
+                    sm => sm.GetValue(ServiceMessageNames.SetVariable.NameAttribute) ?? string.Empty,
+                    sm => sm.GetValue(ServiceMessageNames.SetVariable.ValueAttribute) ?? string.Empty
+                );
         }
 
         protected async Task Validate(Func<AmazonS3Client, Task> execute)

--- a/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
+++ b/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
@@ -187,36 +187,6 @@ namespace Calamari.Tests.AWS
         }
 
         [Test]
-        public async Task UploadPackageWithIncludeOutputVariablesDefaultBehavior()
-        {
-            var packageOptions = new List<S3TargetPropertiesBase>
-            {
-                new S3PackageOptions
-                {
-                    StorageClass = "STANDARD",
-                    CannedAcl = "private",
-                    BucketKeyBehaviour = BucketKeyBehaviourType.Filename,
-                }
-            };
-
-            var (prefix, log) = await Upload("Package3", packageOptions, null, S3TargetMode.EntirePackage);
-            var outputVariables = GetOutputVariables(log);
-
-            outputVariables.Should().ContainKey(PackageVariables.Output.FileName);
-            outputVariables.Should().ContainKey(PackageVariables.Output.FilePath);
-            outputVariables.Should().ContainKey("Package.S3Uri");
-            outputVariables.Should().ContainKey("Package.Uri");
-            outputVariables.Should().ContainKey("Package.Arn");
-            outputVariables.Should().ContainKey("Package.ObjectVersion");
-            outputVariables.Should().ContainKey("Package.FileName");
-
-            await Validate(async client =>
-                           {
-                               await client.GetObjectAsync(bucketName, $"{prefix}Package3.1.0.0.zip");
-                           });
-        }
-
-        [Test]
         public async Task UploadPackage2()
         {
             var fileSelections = new List<S3TargetPropertiesBase>


### PR DESCRIPTION
This PR introduces a new option in the `UploadAwsS3Command` to allow the caller to disable creation of output variables. This is via the new enum `S3OutputVariablesStrategy`, which can be set to `AllFiles` or `NoFiles`.

For deployments with thousands of files, this can create hundreds of thousands of output variables. For performance, the caller can choose to disable the creation of these output variables for performance purposes.

This defaults to `S3OutputVariablesStrategy.AllFiles` to maintain the existing behaviour of creating these variables.

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
