### PR TITLE
Add support for python and C# scripts with google cloud scripts

### DIFF
--- a/source/Calamari.GoogleCloudScripting/Calamari.GoogleCloudScripting.csproj
+++ b/source/Calamari.GoogleCloudScripting/Calamari.GoogleCloudScripting.csproj
@@ -16,4 +16,19 @@
         <ProjectReference Include="..\Calamari.GoogleCloudAccounts\Calamari.GoogleCloudAccounts.csproj" />
         <ProjectReference Include="..\Calamari.Scripting\Calamari.Scripting.csproj" />
     </ItemGroup>
+
+    <!-- Extract dotnet-script zip files to support C# script execution -->
+    <Target Name="RunResolvePackageDependencies" Condition="'$(RunResolvePackageDependencies)' != ''" />
+    <Target Name="GetToolFiles" DependsOnTargets="RunResolvePackageDependencies">
+        <ItemGroup>
+            <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip"/>
+        </ItemGroup>
+    </Target>
+    <Target Name="CopyDotnetScriptFilesAfterBuild" AfterTargets="Build" DependsOnTargets="GetToolFiles">
+        <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(OutputPath)/" />
+    </Target>
+
+    <Target Name="CopyDotnetScriptFilesAfterPublish" AfterTargets="Publish" DependsOnTargets="GetToolFiles">
+        <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(PublishDir)/" />
+    </Target>
 </Project>

--- a/source/Calamari.GoogleCloudScripting/GoogleCloudContextScriptWrapper.cs
+++ b/source/Calamari.GoogleCloudScripting/GoogleCloudContextScriptWrapper.cs
@@ -15,7 +15,7 @@ namespace Calamari.GoogleCloudScripting
     {
         private readonly ILog log;
         readonly IVariables variables;
-        readonly ScriptSyntax[] supportedScriptSyntax = {ScriptSyntax.PowerShell, ScriptSyntax.Bash, ScriptSyntax.Python};
+        readonly ScriptSyntax[] supportedScriptSyntax = {ScriptSyntax.PowerShell, ScriptSyntax.Bash, ScriptSyntax.Python, ScriptSyntax.CSharp};
 
         public GoogleCloudContextScriptWrapper(ILog log, IVariables variables)
         {

--- a/source/Calamari.GoogleCloudScripting/GoogleCloudContextScriptWrapper.cs
+++ b/source/Calamari.GoogleCloudScripting/GoogleCloudContextScriptWrapper.cs
@@ -15,7 +15,7 @@ namespace Calamari.GoogleCloudScripting
     {
         private readonly ILog log;
         readonly IVariables variables;
-        readonly ScriptSyntax[] supportedScriptSyntax = {ScriptSyntax.PowerShell, ScriptSyntax.Bash};
+        readonly ScriptSyntax[] supportedScriptSyntax = {ScriptSyntax.PowerShell, ScriptSyntax.Bash, ScriptSyntax.Python};
 
         public GoogleCloudContextScriptWrapper(ILog log, IVariables variables)
         {


### PR DESCRIPTION
We currently we only support PowerShell and Bash when using a Google Cloud script step.

This PR adds support for Python and C# scripts.

Ref FD-84

## Before

### Bash ✅ 
<img width="557" height="324" alt="image" src="https://github.com/user-attachments/assets/45eb1a95-24f2-4a1b-a0b9-8389f2f2dbe7" />

### PowerShell ✅ 
<img width="561" height="415" alt="image" src="https://github.com/user-attachments/assets/a2840c7b-6610-48ef-a357-bef2243ab4a2" />

### Python ❌ 
<img width="579" height="301" alt="image" src="https://github.com/user-attachments/assets/5c38d708-5f21-42c5-a883-d5d4fe383e20" />

### C# ❌ 
<img width="575" height="239" alt="image" src="https://github.com/user-attachments/assets/9c3db9ae-e7b0-4697-ba90-4273e3a14f40" />

## After

### Bash ✅ 
<img width="533" height="320" alt="image" src="https://github.com/user-attachments/assets/f74d8a88-7301-4c26-a124-de9b394968da" />

### PowerShell ✅ 
<img width="545" height="404" alt="image" src="https://github.com/user-attachments/assets/3a6898e4-13ad-4a1b-9a3f-d55b9d1a8c27" />

### Python ✅ 
<img width="563" height="363" alt="image" src="https://github.com/user-attachments/assets/e82bd8a8-3297-41ab-918a-71654309d26d" />

### C# ✅ 
<img width="555" height="397" alt="image" src="https://github.com/user-attachments/assets/c1b17f98-87cf-400b-b27b-5dd679d0ae8c" />
