### PR TITLE
Use explicit region for AWS auth

### DIFF
--- a/source/Calamari.Aws/Kubernetes/Discovery/AwsAuthenticationDetails.cs
+++ b/source/Calamari.Aws/Kubernetes/Discovery/AwsAuthenticationDetails.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Amazon;
 using Amazon.Runtime;
 using Amazon.SecurityToken;
 using Amazon.SecurityToken.Model;
@@ -51,7 +53,8 @@ namespace Calamari.Aws.Kubernetes.Discovery
                 var sessionDuration = Credentials.Account.SessionDuration;
                 var jwt = Credentials.Account.Jwt;
 
-                var assumeRoleWithWebIdentityResponse = new AmazonSecurityTokenServiceClient(new AnonymousAWSCredentials()).AssumeRoleWithWebIdentityAsync(new AssumeRoleWithWebIdentityRequest
+                var regionEndpoint = RegionEndpoint.GetBySystemName(Regions.First());
+                var assumeRoleWithWebIdentityResponse = new AmazonSecurityTokenServiceClient(new AnonymousAWSCredentials(), regionEndpoint).AssumeRoleWithWebIdentityAsync(new AssumeRoleWithWebIdentityRequest
                 {
                     RoleArn = roleArn,
                     DurationSeconds = int.TryParse(sessionDuration, out var seconds) ? seconds : 3600,

--- a/source/Calamari.CloudAccounts/AwsAuthenticationProvider.cs
+++ b/source/Calamari.CloudAccounts/AwsAuthenticationProvider.cs
@@ -26,7 +26,8 @@ namespace Calamari.CloudAccounts
                 var region = variables.Get(AuthenticationVariables.Aws.Region);
                 var sessionDuration = variables.Get(AuthenticationVariables.Aws.SessionDuration);
                 
-                var client = new AmazonSecurityTokenServiceClient(new AnonymousAWSCredentials());
+                var regionEndpoint = RegionEndpoint.GetBySystemName(region);
+                var client = new AmazonSecurityTokenServiceClient(new AnonymousAWSCredentials(), regionEndpoint);
                 var assumeRoleWithWebIdentityResponse = await client.AssumeRoleWithWebIdentityAsync(new AssumeRoleWithWebIdentityRequest
                 {
                     RoleArn = roleArn,
@@ -37,7 +38,6 @@ namespace Calamari.CloudAccounts
                 var credentials = new SessionAWSCredentials(assumeRoleWithWebIdentityResponse.Credentials.AccessKeyId,
                                                             assumeRoleWithWebIdentityResponse.Credentials.SecretAccessKey,
                                                             assumeRoleWithWebIdentityResponse.Credentials.SessionToken);
-                var regionEndpoint = RegionEndpoint.GetBySystemName(region);
                 var ecrClient = new AmazonECRClient(credentials, regionEndpoint);
                 var authToken = await GetAuthorizationData(ecrClient);
                 var creds = DecodeCredentials(authToken);

--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -22,7 +22,7 @@ namespace Calamari.CloudAccounts
         const string RoleUri = "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
         const string MetadataHeaderToken = "X-aws-ec2-metadata-token";
         const string MetadataHeaderTTL = "X-aws-ec2-metadata-token-ttl-seconds";
-        private const string DefaultSessionName = "OctopusAwsAuthentication";
+        const string DefaultSessionName = "OctopusAwsAuthentication";
 
         readonly ILog log;
         readonly Func<Task<bool>> verifyLogin;
@@ -98,14 +98,14 @@ namespace Calamari.CloudAccounts
                         variables.Get("Octopus.Action.Amazon.AccessKey")?.Trim();
             secretKey = variables.Get(account + ".SecretKey")?.Trim() ?? variables.Get("Octopus.Action.Amazon.SecretKey")?.Trim();
             accountType = variables.Get("Octopus.Account.AccountType")?.Trim();
-            
+
             roleArn = variables.Get($"{account}.RoleArn")?.Trim() ??
                       variables.Get("Octopus.Action.Amazon.RoleArn")?.Trim();
             sessionDuration = variables.Get($"{account}.SessionDuration")?.Trim() ??
                               variables.Get("Octopus.Action.Amazon.SessionDuration")?.Trim();
             oidcJwt = variables.Get($"{account}.OpenIdConnect.Jwt")?.Trim() ??
                       variables.Get("Octopus.OpenIdConnect.Jwt")?.Trim();
-            
+
             assumeRole = variables.Get("Octopus.Action.Aws.AssumeRole")?.Trim();
             assumeRoleArn = variables.Get("Octopus.Action.Aws.AssumedRoleArn")?.Trim();
             assumeRoleExternalId = variables.Get("Octopus.Action.Aws.AssumeRoleExternalId")?.Trim();
@@ -145,9 +145,7 @@ namespace Calamari.CloudAccounts
         {
             try
             {
-                var client = string.IsNullOrWhiteSpace(region)
-                    ? new AmazonSecurityTokenServiceClient(AwsCredentials)
-                    : new AmazonSecurityTokenServiceClient(AwsCredentials, AwsRegion);
+                var client = new AmazonSecurityTokenServiceClient(AwsCredentials, AwsRegion);
                 await client.GetCallerIdentityAsync(new GetCallerIdentityRequest());
                 return true;
             }
@@ -166,9 +164,15 @@ namespace Calamari.CloudAccounts
         /// </summary>
         void PopulateCommonSettings()
         {
+            if (string.IsNullOrWhiteSpace(region))
+            {
+                throw new Exception("AWS-LOGIN-ERROR-0007: "
+                                    + "No AWS region was specified. Please set the region in the AWS account or the step configuration.");
+            }
+
             EnvironmentVars["AWS_DEFAULT_REGION"] = region;
             EnvironmentVars["AWS_REGION"] = region;
-        } 
+        }
 
         /// <summary>
         /// If the keys were explicitly supplied, use them directly
@@ -181,7 +185,7 @@ namespace Calamari.CloudAccounts
                 // Prioritise auth flows based on account type
                 case "AmazonWebServicesAccount" when await TryPopulateKeysDirectly():
                 case "AmazonWebServicesOidcAccount" when await TryPopulateKeysUsingOidc():
-                    return true; 
+                    return true;
                 default:
                     // Default priority if no matching account type
                     return await TryPopulateKeysDirectly() || await TryPopulateKeysUsingOidc();
@@ -208,9 +212,7 @@ namespace Calamari.CloudAccounts
             if(string.IsNullOrEmpty(oidcJwt)) return false;
             try
             {
-                var client = string.IsNullOrWhiteSpace(region)
-                    ? new AmazonSecurityTokenServiceClient(new AnonymousAWSCredentials())
-                    : new AmazonSecurityTokenServiceClient(new AnonymousAWSCredentials(), AwsRegion);
+                var client = new AmazonSecurityTokenServiceClient(new AnonymousAWSCredentials(), AwsRegion);
                 var assumeRoleWithWebIdentityResponse = await client.AssumeRoleWithWebIdentityAsync(new AssumeRoleWithWebIdentityRequest
                 {
                     RoleArn = roleArn,
@@ -251,7 +253,7 @@ namespace Calamari.CloudAccounts
                     string payload;
                     using (var client = new HttpClient())
                     {
-                        log.Verbose("Fetching IMDSv2 token from instance metadata service");    
+                        log.Verbose("Fetching IMDSv2 token from instance metadata service");
                         client.DefaultRequestHeaders.Add(MetadataHeaderToken, await GetIMDSv2Token());
                         log.Verbose("Fetching instance role from instance metadata service");
                         var instanceRole = await client.GetStringAsync(RoleUri);
@@ -330,7 +332,7 @@ namespace Calamari.CloudAccounts
                 return await body.Content.ReadAsStringAsync();
             }
         }
-        
+
         /// <summary>
         /// This method reads the AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE environment variable, loads the token
         /// from the associated file, and then assumes the role using the credentials provided by the pod identity
@@ -368,7 +370,7 @@ namespace Calamari.CloudAccounts
         {
             if ("True".Equals(assumeRole, StringComparison.OrdinalIgnoreCase))
             {
-                var client = string.IsNullOrWhiteSpace(region) ? new AmazonSecurityTokenServiceClient(AwsCredentials) : new AmazonSecurityTokenServiceClient(AwsCredentials, AwsRegion);
+                var client = new AmazonSecurityTokenServiceClient(AwsCredentials, AwsRegion);
                 var credentials = (await client.AssumeRoleAsync(GetAssumeRoleRequest())).Credentials;
 
                 EnvironmentVars["AWS_ACCESS_KEY_ID"] = credentials.AccessKeyId;
@@ -381,7 +383,7 @@ namespace Calamari.CloudAccounts
         {
             // RoleSessionName is required in .NET; if not provided, generate a random one like the JavaScript SDK.
             var roleSessionName = String.IsNullOrEmpty(assumeRoleSession) ? $"aws-sdk-dotnet-{Guid.NewGuid()}" : assumeRoleSession;
-            
+
             var request = new AssumeRoleRequest
             {
                 RoleArn = assumeRoleArn,

--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -82,7 +82,7 @@ namespace Calamari.CloudAccounts
                    || await PopulateKeysFromInstanceRole();
         }
 
-        public Dictionary<string, string> EnvironmentVars { get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> EnvironmentVars { get; } = new();
 
         internal AwsEnvironmentGeneration(ILog log, IVariables variables, Func<Task<bool>> verifyLogin = null)
         {
@@ -121,12 +121,12 @@ namespace Calamari.CloudAccounts
         {
             get
             {
-                if (EnvironmentVars.ContainsKey("AWS_SESSION_TOKEN"))
+                if (EnvironmentVars.TryGetValue("AWS_SESSION_TOKEN", out var sessionToken))
                 {
                     return new SessionAWSCredentials(
                                                      EnvironmentVars["AWS_ACCESS_KEY_ID"],
                                                      EnvironmentVars["AWS_SECRET_ACCESS_KEY"],
-                                                     EnvironmentVars["AWS_SESSION_TOKEN"]);
+                                                     sessionToken);
                 }
 
                 return new BasicAWSCredentials(
@@ -135,7 +135,16 @@ namespace Calamari.CloudAccounts
             }
         }
 
-        public RegionEndpoint AwsRegion => RegionEndpoint.GetBySystemName(EnvironmentVars["AWS_REGION"]);
+        public RegionEndpoint AwsRegion
+        {
+            get
+            {
+                if (!EnvironmentVars.TryGetValue("AWS_REGION", out var awsRegion) || string.IsNullOrWhiteSpace(awsRegion))
+                    throw new Exception("AWS-LOGIN-ERROR-0007: No AWS region was specified. Please set the region in the step configuration.");
+
+                return RegionEndpoint.GetBySystemName(awsRegion);
+            }
+        }
 
         /// <summary>
         /// Verify that we can login with the supplied credentials
@@ -164,12 +173,6 @@ namespace Calamari.CloudAccounts
         /// </summary>
         void PopulateCommonSettings()
         {
-            if (string.IsNullOrWhiteSpace(region))
-            {
-                throw new Exception("AWS-LOGIN-ERROR-0007: "
-                                    + "No AWS region was specified. Please set the region in the AWS account or the step configuration.");
-            }
-
             EnvironmentVars["AWS_DEFAULT_REGION"] = region;
             EnvironmentVars["AWS_REGION"] = region;
         }

--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -99,12 +99,9 @@ namespace Calamari.CloudAccounts
             secretKey = variables.Get(account + ".SecretKey")?.Trim() ?? variables.Get("Octopus.Action.Amazon.SecretKey")?.Trim();
             accountType = variables.Get("Octopus.Account.AccountType")?.Trim();
 
-            roleArn = variables.Get($"{account}.RoleArn")?.Trim() ??
-                      variables.Get("Octopus.Action.Amazon.RoleArn")?.Trim();
-            sessionDuration = variables.Get($"{account}.SessionDuration")?.Trim() ??
-                              variables.Get("Octopus.Action.Amazon.SessionDuration")?.Trim();
-            oidcJwt = variables.Get($"{account}.OpenIdConnect.Jwt")?.Trim() ??
-                      variables.Get("Octopus.OpenIdConnect.Jwt")?.Trim();
+            roleArn = variables.Get($"{account}.RoleArn")?.Trim() ?? variables.Get("Octopus.Action.Amazon.RoleArn")?.Trim();
+            sessionDuration = variables.Get($"{account}.SessionDuration")?.Trim() ?? variables.Get("Octopus.Action.Amazon.SessionDuration")?.Trim();
+            oidcJwt = variables.Get($"{account}.OpenIdConnect.Jwt")?.Trim() ?? variables.Get("Octopus.OpenIdConnect.Jwt")?.Trim();
 
             assumeRole = variables.Get("Octopus.Action.Aws.AssumeRole")?.Trim();
             assumeRoleArn = variables.Get("Octopus.Action.Aws.AssumedRoleArn")?.Trim();
@@ -139,8 +136,12 @@ namespace Calamari.CloudAccounts
         {
             get
             {
+                // "aws-global" routes to the global STS endpoint (sts.amazonaws.com), preserving SDK v3 behaviour.
+                // See: https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html
                 if (!EnvironmentVars.TryGetValue("AWS_REGION", out var awsRegion) || string.IsNullOrWhiteSpace(awsRegion))
-                    throw new Exception("AWS-LOGIN-ERROR-0007: No AWS region was specified. Please set the region in the step configuration.");
+                {
+                    return RegionEndpoint.GetBySystemName("aws-global");
+                }
 
                 return RegionEndpoint.GetBySystemName(awsRegion);
             }
@@ -197,7 +198,7 @@ namespace Calamari.CloudAccounts
 
         async Task<bool> TryPopulateKeysDirectly()
         {
-            if(string.IsNullOrEmpty(accessKey)) return false;
+            if (string.IsNullOrEmpty(accessKey)) return false;
             EnvironmentVars["AWS_ACCESS_KEY_ID"] = accessKey;
             EnvironmentVars["AWS_SECRET_ACCESS_KEY"] = secretKey;
             if (!await verifyLogin())
@@ -212,7 +213,7 @@ namespace Calamari.CloudAccounts
 
         async Task<bool> TryPopulateKeysUsingOidc()
         {
-            if(string.IsNullOrEmpty(oidcJwt)) return false;
+            if (string.IsNullOrEmpty(oidcJwt)) return false;
             try
             {
                 var client = new AmazonSecurityTokenServiceClient(new AnonymousAWSCredentials(), AwsRegion);
@@ -282,7 +283,6 @@ namespace Calamari.CloudAccounts
 
             return false;
         }
-
 
         class InstanceRoleKeys
         {
@@ -364,7 +364,6 @@ namespace Calamari.CloudAccounts
 
             return false;
         }
-
 
         /// <summary>
         /// If we assume a secondary role, do it here

--- a/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
+++ b/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
@@ -43,6 +43,7 @@ namespace Calamari.Tests.AWS
         public async Task UsesGenericContainerCredentialsWhenAvailable()
         {
             IVariables variables = new CalamariVariables();
+            variables.Add("Octopus.Action.Aws.Region", "us-east-1");
             var server = WireMockServer.Start();
             
             // Generate data - Keeping as close as possible to AWS
@@ -89,6 +90,19 @@ namespace Calamari.Tests.AWS
             awsEnvironmentGenerator.EnvironmentVars.Should().Contain(new KeyValuePair<string, string>("AWS_ACCESS_KEY_ID", accessKeyId));
             awsEnvironmentGenerator.EnvironmentVars.Should().Contain(new KeyValuePair<string, string>("AWS_SECRET_ACCESS_KEY", secretAccessKey));
             awsEnvironmentGenerator.EnvironmentVars.Should().Contain(new KeyValuePair<string, string>("AWS_SESSION_TOKEN", sessionToken));
+        }
+        [Test]
+        public void ThrowsWhenRegionIsMissing()
+        {
+            IVariables variables = new CalamariVariables();
+            variables.Add("Octopus.Account.AccountType", "AmazonWebServicesAccount");
+            variables.Add("Octopus.Action.AwsAccount.Variable", "AWSAccount");
+            variables.Add("AWSAccount.AccessKey", "AKIAIOSFODNN7EXAMPLE");
+            variables.Add("AWSAccount.SecretKey", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+
+            var ex = Assert.ThrowsAsync<Exception>(async () =>
+                await AwsEnvironmentGeneration.Create(Substitute.For<ILog>(), variables));
+            ex.Message.Should().Contain("AWS-LOGIN-ERROR-0007");
         }
     }
 }

--- a/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
+++ b/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
@@ -92,7 +92,7 @@ namespace Calamari.Tests.AWS
             awsEnvironmentGenerator.EnvironmentVars.Should().Contain(new KeyValuePair<string, string>("AWS_SESSION_TOKEN", sessionToken));
         }
         [Test]
-        public void ThrowsWhenRegionIsMissing()
+        public void FallsBackToAwsGlobalWhenRegionIsMissing()
         {
             IVariables variables = new CalamariVariables();
             variables.Add("Octopus.Account.AccountType", "AmazonWebServicesAccount");
@@ -100,9 +100,8 @@ namespace Calamari.Tests.AWS
             variables.Add("AWSAccount.AccessKey", "AKIAIOSFODNN7EXAMPLE");
             variables.Add("AWSAccount.SecretKey", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
 
-            var ex = Assert.ThrowsAsync<Exception>(async () =>
-                await AwsEnvironmentGeneration.Create(Substitute.For<ILog>(), variables));
-            ex.Message.Should().Contain("AWS-LOGIN-ERROR-0007");
+            var envGeneration = new AwsEnvironmentGeneration(Substitute.For<ILog>(), variables);
+            envGeneration.AwsRegion.SystemName.Should().Be("aws-global");
         }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
+++ b/source/Calamari.Tests/KubernetesFixtures/Approved/KubernetesContextScriptWrapperFixture.ExecutionWithEKS_IAMAuthenticator.approved.txt
@@ -6,8 +6,7 @@
 [Verbose] "kubectl" config set-context octocontext --user=octouser --cluster=octocluster --namespace=calamari-testing --request-timeout=1m
 [Verbose] "kubectl" config use-context octocontext --request-timeout=1m
 [Info] Creating kubectl context to <server> (namespace calamari-testing) using EKS cluster name my-eks-cluster
-[Verbose] Attempting to authenticate with aws-cli
-[Verbose] The EKS cluster Url specified should contain a valid aws region name
+[Verbose] Could not determine AWS region from the EKS cluster URL. The AWS CLI requires a region to authenticate. Falling back to aws-iam-authenticator.
 [Verbose] Attempting to authenticate with aws-iam-authenticator
 [Verbose] "kubectl" config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1beta1 --exec-arg=token --exec-arg=-i --exec-arg=my-eks-cluster --request-timeout=1m
 [Verbose] "kubectl" get namespace calamari-testing --request-timeout=1m

--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
@@ -226,7 +226,7 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
                .Verbose(
                         Arg.Is<string>(
                                        s => s.StartsWith(
-                                                         $"Unable to authenticate to {AwsClusterUrl} using the aws cli. Failed with error message: 'not-a-version' is not a valid version string")));
+                                                         $"Unable to authenticate using the aws cli. Failed with error message: 'not-a-version' is not a valid version string")));
         }
 
         [Test]
@@ -238,14 +238,12 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             variables.Set(SpecialVariables.ClusterUrl, clusterUrl);
 
             AddLogForAwsEksGetToken();
-            AddLogForWhichAws();
 
             var expectedInvocations = SetupClusterContextInvocations(clusterUrl);
-            expectedInvocations.AddRange(AwsCliInvocations());
             expectedInvocations.AddRange(
                                          new List<(string, string)>
                                          {
-                                             IamAuthenticatorInvocation,
+                                             IamAuthenticatorInvocationWithoutRegion,
                                              GetNamespaceInvocation
                                          });
 
@@ -253,7 +251,7 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
 
             result.VerifySuccess();
             AssertInvocations(expectedInvocations);
-            log.Received().Verbose("The EKS cluster Url specified should contain a valid aws region name");
+            log.Received().Verbose("Could not determine AWS region from the EKS cluster URL. The AWS CLI requires a region to authenticate. Falling back to aws-iam-authenticator.");
             log.Received().Verbose("Attempting to authenticate with aws-iam-authenticator");
         }
 
@@ -290,6 +288,10 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
         List<(string, string)> AwsCliInvocations() => new List<(string, string)> { ("aws", "--version") };
 
         static (string, string) IamAuthenticatorInvocation =>
+            ("kubectl",
+             $"config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1alpha1 --exec-arg=token --exec-arg=-i --exec-arg={EksClusterName} --exec-arg=--region --exec-arg={AwsRegion}");
+
+        static (string, string) IamAuthenticatorInvocationWithoutRegion =>
             ("kubectl",
              $"config set-credentials octouser --exec-command=aws-iam-authenticator --exec-api-version=client.authentication.k8s.io/v1alpha1 --exec-arg=token --exec-arg=-i --exec-arg={EksClusterName}");
 

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -37,18 +37,25 @@ namespace Calamari.Kubernetes.Authentication
         public void Configure(string @namespace, string clusterUrl, string user)
         {
             var clusterName = deploymentVariables.Get(SpecialVariables.EksClusterName);
+            var region = GetEksClusterRegion(clusterUrl);
+
             log.Info(
                 $"Creating kubectl context to {clusterUrl} (namespace {@namespace}) using EKS cluster name {clusterName}");
 
-            if (TrySetKubeConfigAuthenticationToAwsCli(clusterName, clusterUrl, user))
+            if (TrySetKubeConfigAuthenticationToAwsCli(clusterName, region, user))
                 return;
 
-            log.Verbose("Attempting to authenticate with aws-iam-authenticator");
-            SetKubeConfigAuthenticationToAwsIAm(user, clusterName);
+            SetKubeConfigAuthenticationToAwsIAm(user, clusterName, region);
         }
 
-        bool TrySetKubeConfigAuthenticationToAwsCli(string clusterName, string clusterUrl, string user)
+        bool TrySetKubeConfigAuthenticationToAwsCli(string clusterName, string region, string user)
         {
+            if (string.IsNullOrWhiteSpace(region))
+            {
+                log.Verbose("Could not determine AWS region from the EKS cluster URL. The AWS CLI requires a region to authenticate. Falling back to aws-iam-authenticator.");
+                return false;
+            }
+
             if (!awsCli.TrySetAws())
             {
                 log.Verbose("Could not find the aws cli, falling back to the aws-iam-authenticator.");
@@ -63,26 +70,18 @@ namespace Calamari.Kubernetes.Authentication
                 var minimumAwsCliVersionForAuth = new SemanticVersion("1.16.156");
                 if (awsCliVersion.CompareTo(minimumAwsCliVersionForAuth) > 0)
                 {
-                    var region = GetEksClusterRegion(clusterUrl);
-                    if (!string.IsNullOrWhiteSpace(region))
+                    //Certain customers have had issues with the AWS CLI token only being a 15min fixed expiry
+                    //This feature toggle changes to use the kubectl config set-credentials using exec, which handles the expired token
+                    if (FeatureToggle.KubernetesAuthAwsCliWithExecFeatureToggle.IsEnabled(deploymentVariables))
                     {
-                        //Certain customers have had issues with the AWS Cli token only being a 15min fixed expiry
-                        //This feature toggle changes to use the kubectl config set-credentials using exec, which handles the expired token
-                        if (FeatureToggle.KubernetesAuthAwsCliWithExecFeatureToggle.IsEnabled(deploymentVariables))
-                        {
-                            SetKubeConfigAuthenticationToAwsCliUsingExec(user, clusterName, region);
-                        }
-                        else
-                        {
-                            SetKubeConfigAuthenticationToAwsCliUsingToken(user, clusterName, region);
-                        }
-                        
-                        return true;
+                        SetKubeConfigAuthenticationToAwsCliUsingExec(user, clusterName, region);
+                    }
+                    else
+                    {
+                        SetKubeConfigAuthenticationToAwsCliUsingToken(user, clusterName, region);
                     }
 
-                    log.Verbose("The EKS cluster Url specified should contain a valid aws region name");
-
-                    return false;
+                    return true;
                 }
 
                 log.Verbose(
@@ -91,31 +90,44 @@ namespace Calamari.Kubernetes.Authentication
             catch (Exception e)
             {
                 log.Verbose(
-                    $"Unable to authenticate to {clusterUrl} using the aws cli. Failed with error message: {e.Message}");
+                    $"Unable to authenticate using the aws cli. Failed with error message: {e.Message}");
             }
 
             return false;
         }
 
-        void SetKubeConfigAuthenticationToAwsIAm(string user, string clusterName)
+        void SetKubeConfigAuthenticationToAwsIAm(string user, string clusterName, string region)
         {
+            log.Verbose("Attempting to authenticate with aws-iam-authenticator");
+
             var apiVersion = GetKubeCtlAuthApiVersion();
 
-            kubectl.ExecuteCommandAndAssertSuccess(
-                                                   "config",
-                                                   "set-credentials",
-                                                   user,
-                                                   "--exec-command=aws-iam-authenticator",
-                                                   $"--exec-api-version={apiVersion}",
-                                                   "--exec-arg=token",
-                                                   "--exec-arg=-i",
-                                                   $"--exec-arg={clusterName}");
+            var arguments = new List<string>
+            {
+                "config",
+                "set-credentials",
+                user,
+                "--exec-command=aws-iam-authenticator",
+                $"--exec-api-version={apiVersion}",
+                "--exec-arg=token",
+                "--exec-arg=-i",
+                $"--exec-arg={clusterName}"
+            };
+
+            // Pass the region to aws-iam-authenticator if available, avoiding an unnecessary IMDS lookup and ensuring the correct regional STS endpoint is used.
+            // When region is not available (e.g. CNAME cluster URL), aws-iam-authenticator resolves the region itself via IMDS or falls back to us-east-1.
+            if (!string.IsNullOrWhiteSpace(region))
+            {
+                arguments.AddRange(["--exec-arg=--region", $"--exec-arg={region}"]);
+            }
+
+            kubectl.ExecuteCommandAndAssertSuccess(arguments.ToArray());
         }
 
         string GetKubeCtlAuthApiVersion()
         {
             var kubectlVersion = kubectl.GetVersion();
-            
+
             //v1alpha1 was deprecated in 1.24 of K8s
             return kubectlVersion.Some() && kubectlVersion.Value > new SemanticVersion("1.23.6")
                 ? "client.authentication.k8s.io/v1beta1"
@@ -127,7 +139,7 @@ namespace Calamari.Kubernetes.Authentication
             if (!environmentVars.ContainsKey("AWS_ACCESS_KEY_ID"))
             {
                 var awsEnvironmentGeneration = AwsEnvironmentGeneration.Create(log, deploymentVariables).GetAwaiter().GetResult();
-                ListExtensions.AddRange(environmentVars, awsEnvironmentGeneration.EnvironmentVars);
+                environmentVars.AddRange(awsEnvironmentGeneration.EnvironmentVars);
             }
         }
 
@@ -146,11 +158,11 @@ namespace Calamari.Kubernetes.Authentication
             log.AddValueToRedact(token, "<token>");
             kubectl.ExecuteCommandAndAssertSuccess(arguments.ToArray());
         }
-        
+
         void SetKubeConfigAuthenticationToAwsCliUsingExec(string user, string clusterName, string region)
         {
             var apiVersion = GetKubeCtlAuthApiVersion();
-            
+
             var arguments = new List<string>
             {
                 "config",


### PR DESCRIPTION
As part of preparing to update to AWS SDK v4 we need to specify a region when authenticating with AWS

- We remove the regionless fallback for AWS step auth, all steps should have a region already.
- K8s step EKS discovery OIDC auth now uses the first region configured for discovery and then uses these credentials for all configured discovery regions.
- K8s step using EKS API target is unchanged as no region is used.
- ECR feed OIDC auth now uses the region set in the feed credentials.
- Prevents warning messages from `aws-iam-authenticator`

This also means the optional region set on AWS account credentials in server is not used for anything on the Calamari side. Full details below.

# Affected flows
| Calamari Path                                             | Region Source                                                               |
|-----------------------------------------------------------|-----------------------------------------------------------------------------|
| AWS Steps (CloudFormation, S3, Run Script, Terraform)     | `Octopus.Action.Aws.Region` (step, always required)                         |
| K8s step targeting EKS API target (AWS CLI)               | Extracted from EKS cluster URL, passed as `--region` to `aws eks get-token` |
| K8s step targeting EKS API target (aws-iam-authenticator) | Resolved by aws-iam-authenticator                                           |
| K8s step using AWS target discovery (OIDC)                | `Regions.First()` from discovery context                                    |
| ECR Feed (OIDC) on worker                                 | `AuthenticationVariables.Aws.Region` (feed config, always present)          |

# Region resolution in aws-iam-authenticator

`aws-iam-authenticator` uses Go SDK v2 and resolves its STS region independently:

1. Explicit `--region` option (not passed in our flow)
2. IMDS (EC2 instance metadata)
3. Hardcoded fallback to `us-east-1`

Source: https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/pkg/token/token.go

```go
if options.Region != "" {
	cfg.Region = options.Region
}
// The SDK requires a region for clients
// https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html
if cfg.Region == "" {
	// Attempt to get the region from IMDS (applicable if run on an EC2 instance)
	imdsClient := imds.NewFromConfig(cfg)
	region, err := imdsClient.GetRegion(context.Background(), &imds.GetRegionInput{})
	if err != nil {
		// Default to the global region
		logrus.Infof("failed to get region from IMDS for token generation, defaulting to us-east-1. imds error: %v", err)
		cfg.Region = "us-east-1"
	} else {
		cfg.Region = region.Region
	}
}
```

Ref MD-1714
Fixes MD-1723