### PR TITLE
Enable Envirnment Variable for WaitForDebugger

### DIFF
--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -14,7 +14,6 @@ using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Processes.ScriptIsolation;
 using Calamari.Common.Features.Scripting;
-using Calamari.Common.Features.Scripting.DotnetScript;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing;

--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -62,7 +62,7 @@ namespace Calamari.Common
 
                 using var container = builder.Build();
                 container.Resolve<VariableLogger>().LogVariables();
-
+#if DEBUG
                 if (CalamariEnvironment.ShouldWaitForDebugger(container.Resolve<IVariables>()))
                 {
                     using var proc = Process.GetCurrentProcess();
@@ -73,7 +73,7 @@ namespace Calamari.Common
                         Thread.Sleep(1000);
                     }
                 }
-
+#endif
                 var isolation = container.Resolve<IScriptIsolationEnforcer>();
                 using var _ = isolation.Enforce(options.ScriptIsolation);
                 return ResolveAndExecuteCommand(container, options);

--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -63,10 +63,7 @@ namespace Calamari.Common
                 using var container = builder.Build();
                 container.Resolve<VariableLogger>().LogVariables();
 
-#if DEBUG
-                var waitForDebugger = container.Resolve<IVariables>().Get(KnownVariables.Calamari.WaitForDebugger);
-
-                if (string.Equals(waitForDebugger, "true", StringComparison.OrdinalIgnoreCase))
+                if (CalamariEnvironment.ShouldWaitForDebugger(container.Resolve<IVariables>()))
                 {
                     using var proc = Process.GetCurrentProcess();
                     log.Info($"Waiting for debugger to attach... (PID: {proc.Id})");
@@ -76,7 +73,6 @@ namespace Calamari.Common
                         Thread.Sleep(1000);
                     }
                 }
-#endif
 
                 var isolation = container.Resolve<IScriptIsolationEnforcer>();
                 using var _ = isolation.Enforce(options.ScriptIsolation);

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -17,7 +17,6 @@ using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Processes.ScriptIsolation;
 using Calamari.Common.Features.Scripting;
-using Calamari.Common.Features.Scripting.DotnetScript;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing;

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -129,11 +129,8 @@ namespace Calamari.Common
                 
                 using var container = builder.Build();
                 container.Resolve<VariableLogger>().LogVariables();
-                
-#if DEBUG
-                var waitForDebugger = container.Resolve<IVariables>().Get(KnownVariables.Calamari.WaitForDebugger);
 
-                if (string.Equals(waitForDebugger, "true", StringComparison.OrdinalIgnoreCase))
+                if (CalamariEnvironment.ShouldWaitForDebugger(container.Resolve<IVariables>()))
                 {
                     using var proc = Process.GetCurrentProcess();
                     Log.Info($"Waiting for debugger to attach... (PID: {proc.Id})");
@@ -143,7 +140,6 @@ namespace Calamari.Common
                         await Task.Delay(1000);
                     }
                 }
-#endif
 
                 var isolation = container.Resolve<IScriptIsolationEnforcer>();
                 await using var _ = await isolation.EnforceAsync(options.ScriptIsolation, CancellationToken.None);

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -129,7 +129,7 @@ namespace Calamari.Common
                 
                 using var container = builder.Build();
                 container.Resolve<VariableLogger>().LogVariables();
-
+#if DEBUG
                 if (CalamariEnvironment.ShouldWaitForDebugger(container.Resolve<IVariables>()))
                 {
                     using var proc = Process.GetCurrentProcess();
@@ -140,7 +140,7 @@ namespace Calamari.Common
                         await Task.Delay(1000);
                     }
                 }
-
+#endif
                 var isolation = container.Resolve<IScriptIsolationEnforcer>();
                 await using var _ = await isolation.EnforceAsync(options.ScriptIsolation, CancellationToken.None);
                 await ResolveAndExecuteCommand(container, options);

--- a/source/Calamari.Common/Plumbing/CalamariEnvironment.cs
+++ b/source/Calamari.Common/Plumbing/CalamariEnvironment.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Common.Plumbing
 {
@@ -18,6 +19,18 @@ namespace Calamari.Common.Plumbing
             Environment.OSVersion.Platform == PlatformID.Win32S ||
             Environment.OSVersion.Platform == PlatformID.Win32Windows ||
             Environment.OSVersion.Platform == PlatformID.WinCE;
+
+        public static bool ShouldWaitForDebugger(IVariables variables)
+        {
+#if DEBUG
+
+            var waitForDebugger = variables.Get(KnownVariables.Calamari.WaitForDebugger);
+            var waitForDebuggerInEnv = Environment.GetEnvironmentVariable(KnownVariables.Calamari.WaitForDebugger);
+            
+            return string.Equals(waitForDebugger, "true", StringComparison.OrdinalIgnoreCase) || string.Equals(waitForDebuggerInEnv, "true", StringComparison.OrdinalIgnoreCase);
+#endif
+            return false;
+        }
 
         public static bool IsRunningOnMac
         {


### PR DESCRIPTION
Currently Calamari.WaitForDebugger can be set as part of a Project variables passed by Server, but there is no way to enable it for non-project Calamari scenarios (i.e. Healthchecks of Targets etc).

This PR centralises the logic for checking that variables either from Variables passed or via an Environment variable specified in Octopus Server env `_CALAMARI_WAIT_FOR_DEBUGGER` inline with other Debug relevant Env Variable naming

<img width="2512" height="536" alt="CleanShot 2026-04-13 at 11 45 13@2x" src="https://github.com/user-attachments/assets/c39b179a-2047-4af3-b663-34bff2e9b2a4" />
