### PR TITLE
Improve Calamari compile times

### DIFF
--- a/build/Build.PackageCalamariProjects.cs
+++ b/build/Build.PackageCalamariProjects.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Threading;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Nuke.Common.ProjectModel;
 
 namespace Calamari.Build;
@@ -9,7 +8,7 @@ public partial class Build
 {
     List<CalamariPackageMetadata> PackagesToPublish = new();
     List<Project> CalamariProjects = new();
-    
+
     Target GetCalamariFlavourProjectsToPublish =>
         d =>
             d.DependsOn(RestoreSolution)
@@ -56,43 +55,18 @@ public partial class Build
         d =>
             d.DependsOn(GetCalamariFlavourProjectsToPublish)
              .DependsOn(PublishAzureWebAppNetCoreShim)
-             .Executes(async () =>
+             .Executes(() =>
                        {
-                           var globalSemaphore = new SemaphoreSlim(1);
-                           var semaphores = new ConcurrentDictionary<string, SemaphoreSlim>();
-
-                           var buildTasks = PackagesToPublish.Select(async calamariPackageMetadata =>
-                                                                     {
-                                                                         var projectName = calamariPackageMetadata.Project.Name;
-                                                                         var projectSemaphore = semaphores.GetOrAdd(projectName, _ => new SemaphoreSlim(1, 1));
-                                                                         var architectureSemaphore = semaphores.GetOrAdd(calamariPackageMetadata.Architecture, _ => new SemaphoreSlim(1, 1));
-
-                                                                         await globalSemaphore.WaitAsync();
-                                                                         await projectSemaphore.WaitAsync();
-                                                                         await architectureSemaphore.WaitAsync();
-                                                                         try
-                                                                         {
-                                                                             Log.Information($"Building {calamariPackageMetadata.Project.Name} for framework '{calamariPackageMetadata.Framework}' and arch '{calamariPackageMetadata.Architecture}'");
-
-                                                                             await Task.Run(() => DotNetBuild(s =>
-                                                                                                                  s.SetProjectFile(calamariPackageMetadata.Project)
-                                                                                                                   .SetConfiguration(Configuration)
-                                                                                                                   .SetFramework(calamariPackageMetadata.Framework)
-                                                                                                                   .SetRuntime(calamariPackageMetadata.Architecture)
-                                                                                                                   .SetVersion(NugetVersion.Value)
-                                                                                                                   .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion)
-                                                                                                                   .SetVerbosity(BuildVerbosity)
-                                                                                                                   .EnableSelfContained()));
-                                                                         }
-                                                                         finally
-                                                                         {
-                                                                             projectSemaphore.Release();
-                                                                             architectureSemaphore.Release();
-                                                                             globalSemaphore.Release();
-                                                                         }
-                                                                     });
-
-                           await Task.WhenAll(buildTasks);
+                           // Build the entire solution once without a RID. This compiles all projects
+                           // for their default target framework, and MSBuild handles dependency ordering
+                           // and parallelism internally. The per-RID self-contained compilation happens
+                           // later in the publish step.
+                           DotNetBuild(s =>
+                                           s.SetProjectFile(Solution)
+                                            .SetConfiguration(Configuration)
+                                            .SetVersion(NugetVersion.Value)
+                                            .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion)
+                                            .SetVerbosity(BuildVerbosity));
                        });
 
     Target PublishCalamariProjects =>
@@ -100,25 +74,25 @@ public partial class Build
             d.DependsOn(BuildCalamariProjects)
              .Executes(async () =>
                        {
-                           var semaphore = new SemaphoreSlim(4);
                            var outputPaths = new ConcurrentBag<AbsolutePath?>();
 
+                           // Publish grouped by RID: sequential within each RID to avoid file
+                           // contention on shared dependency bin/ directories, parallel across RIDs.
                            Log.Information("Publishing projects...");
-                           var publishTasks = PackagesToPublish.Select(async package =>
-                                                                       {
-                                                                           await semaphore.WaitAsync();
-                                                                           try
-                                                                           {
-                                                                               var outputPath = await PublishPackageAsync(package);
-                                                                               outputPaths.Add(outputPath);
-                                                                           }
-                                                                           finally
-                                                                           {
-                                                                               semaphore.Release();
-                                                                           }
-                                                                       });
+                           var publishByRid = PackagesToPublish
+                                              .GroupBy(p => p.Architecture)
+                                              .ToList();
 
-                           await Task.WhenAll(publishTasks);
+                           var ridTasks = publishByRid.Select(async ridGroup =>
+                                                              {
+                                                                  foreach (var package in ridGroup)
+                                                                  {
+                                                                      var outputPath = await PublishPackageAsync(package);
+                                                                      outputPaths.Add(outputPath);
+                                                                  }
+                                                              });
+
+                           await Task.WhenAll(ridTasks);
 
                            // Sign and compress tasks
                            Log.Information("Signing published binaries...");
@@ -150,8 +124,6 @@ public partial class Build
                                               .SetVersion(NugetVersion.Value)
                                               .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion)
                                               .SetVerbosity(BuildVerbosity)
-                                              .EnableNoBuild()
-                                              .EnableNoRestore()
                                               .EnableSelfContained()
                                               .SetOutput(outputDirectory)));
 

--- a/build/Build.PackageCalamariProjects.cs
+++ b/build/Build.PackageCalamariProjects.cs
@@ -55,46 +55,17 @@ public partial class Build
         d =>
             d.DependsOn(GetCalamariFlavourProjectsToPublish)
              .DependsOn(PublishAzureWebAppNetCoreShim)
-             .Executes(async () =>
+             .Executes(() =>
                        {
-                           // First, build the entire solution once without a RID. This compiles all
-                           // shared libraries and flavour projects for their default target framework.
-                           // MSBuild handles dependency ordering and parallelism internally.
+                           // Build the solution once without a RID. Per-RID self-contained
+                           // compilation happens in the publish step.
                            DotNetBuild(s =>
                                            s.SetProjectFile(Solution)
                                             .SetConfiguration(Configuration)
                                             .SetVersion(NugetVersion.Value)
                                             .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion)
-                                            .SetVerbosity(BuildVerbosity));
-
-                           // Then build per-RID, grouped by RID: sequential within each RID to avoid
-                           // file contention on shared dependency bin/ directories, parallel across RIDs.
-                           // The solution build above ensures shared libraries are already compiled,
-                           // so these builds only do RID-specific work for each flavour project.
-                           var buildsByRid = PackagesToPublish
-                                             .GroupBy(p => p.Architecture)
-                                             .ToList();
-
-                           var ridTasks = buildsByRid.Select(async ridGroup =>
-                                                             {
-                                                                 foreach (var calamariPackageMetadata in ridGroup)
-                                                                 {
-                                                                     Log.Information("Building {ProjectName} for framework '{Framework}' and arch '{Architecture}'",
-                                                                                     calamariPackageMetadata.Project.Name, calamariPackageMetadata.Framework, calamariPackageMetadata.Architecture);
-
-                                                                     await Task.Run(() => DotNetBuild(s =>
-                                                                                                          s.SetProjectFile(calamariPackageMetadata.Project)
-                                                                                                           .SetConfiguration(Configuration)
-                                                                                                           .SetFramework(calamariPackageMetadata.Framework)
-                                                                                                           .SetRuntime(calamariPackageMetadata.Architecture)
-                                                                                                           .SetVersion(NugetVersion.Value)
-                                                                                                           .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion)
-                                                                                                           .SetVerbosity(BuildVerbosity)
-                                                                                                           .EnableSelfContained()));
-                                                                 }
-                                                             });
-
-                           await Task.WhenAll(ridTasks);
+                                            .SetVerbosity(BuildVerbosity)
+                                            .EnableNoRestore());
                        });
 
     Target PublishCalamariProjects =>
@@ -104,21 +75,20 @@ public partial class Build
                        {
                            var outputPaths = new ConcurrentBag<AbsolutePath?>();
 
-                           // Publish grouped by RID: sequential within each RID to avoid file
-                           // contention on shared dependency bin/ directories, parallel across RIDs.
+                           // Parallel across RIDs, sequential within each RID.
+                           // --no-restore prevents project.assets.json contention.
+                           // Sequential within RID avoids Unzip post-build target contention.
                            Log.Information("Publishing projects...");
-                           var publishByRid = PackagesToPublish
-                                              .GroupBy(p => p.Architecture)
-                                              .ToList();
-
-                           var ridTasks = publishByRid.Select(async ridGroup =>
-                                                              {
-                                                                  foreach (var package in ridGroup)
-                                                                  {
-                                                                      var outputPath = await PublishPackageAsync(package);
-                                                                      outputPaths.Add(outputPath);
-                                                                  }
-                                                              });
+                           var ridTasks = PackagesToPublish
+                                          .GroupBy(p => p.Architecture)
+                                          .Select(async ridGroup =>
+                                                  {
+                                                      foreach (var package in ridGroup)
+                                                      {
+                                                          var outputPath = await PublishPackageAsync(package);
+                                                          outputPaths.Add(outputPath);
+                                                      }
+                                                  });
 
                            await Task.WhenAll(ridTasks);
 
@@ -152,7 +122,6 @@ public partial class Build
                                               .SetVersion(NugetVersion.Value)
                                               .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion)
                                               .SetVerbosity(BuildVerbosity)
-                                              .EnableNoBuild()
                                               .EnableNoRestore()
                                               .EnableSelfContained()
                                               .SetOutput(outputDirectory)));

--- a/build/Build.PackageCalamariProjects.cs
+++ b/build/Build.PackageCalamariProjects.cs
@@ -55,18 +55,46 @@ public partial class Build
         d =>
             d.DependsOn(GetCalamariFlavourProjectsToPublish)
              .DependsOn(PublishAzureWebAppNetCoreShim)
-             .Executes(() =>
+             .Executes(async () =>
                        {
-                           // Build the entire solution once without a RID. This compiles all projects
-                           // for their default target framework, and MSBuild handles dependency ordering
-                           // and parallelism internally. The per-RID self-contained compilation happens
-                           // later in the publish step.
+                           // First, build the entire solution once without a RID. This compiles all
+                           // shared libraries and flavour projects for their default target framework.
+                           // MSBuild handles dependency ordering and parallelism internally.
                            DotNetBuild(s =>
                                            s.SetProjectFile(Solution)
                                             .SetConfiguration(Configuration)
                                             .SetVersion(NugetVersion.Value)
                                             .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion)
                                             .SetVerbosity(BuildVerbosity));
+
+                           // Then build per-RID, grouped by RID: sequential within each RID to avoid
+                           // file contention on shared dependency bin/ directories, parallel across RIDs.
+                           // The solution build above ensures shared libraries are already compiled,
+                           // so these builds only do RID-specific work for each flavour project.
+                           var buildsByRid = PackagesToPublish
+                                             .GroupBy(p => p.Architecture)
+                                             .ToList();
+
+                           var ridTasks = buildsByRid.Select(async ridGroup =>
+                                                             {
+                                                                 foreach (var calamariPackageMetadata in ridGroup)
+                                                                 {
+                                                                     Log.Information("Building {ProjectName} for framework '{Framework}' and arch '{Architecture}'",
+                                                                                     calamariPackageMetadata.Project.Name, calamariPackageMetadata.Framework, calamariPackageMetadata.Architecture);
+
+                                                                     await Task.Run(() => DotNetBuild(s =>
+                                                                                                          s.SetProjectFile(calamariPackageMetadata.Project)
+                                                                                                           .SetConfiguration(Configuration)
+                                                                                                           .SetFramework(calamariPackageMetadata.Framework)
+                                                                                                           .SetRuntime(calamariPackageMetadata.Architecture)
+                                                                                                           .SetVersion(NugetVersion.Value)
+                                                                                                           .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion)
+                                                                                                           .SetVerbosity(BuildVerbosity)
+                                                                                                           .EnableSelfContained()));
+                                                                 }
+                                                             });
+
+                           await Task.WhenAll(ridTasks);
                        });
 
     Target PublishCalamariProjects =>
@@ -124,6 +152,8 @@ public partial class Build
                                               .SetVersion(NugetVersion.Value)
                                               .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion)
                                               .SetVerbosity(BuildVerbosity)
+                                              .EnableNoBuild()
+                                              .EnableNoRestore()
                                               .EnableSelfContained()
                                               .SetOutput(outputDirectory)));
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -119,7 +119,14 @@ partial class Build : NukeBuild
                        {
                            // A single restore generates asset targets for all RIDs declared
                            // in each project's RuntimeIdentifiers property.
-                           DotNetRestore(s => s.SetProjectFile(Solution));
+                           // When TargetRuntime is set, restore only for that RID.
+                           DotNetRestore(s =>
+                                         {
+                                             s = s.SetProjectFile(Solution);
+                                             if (!string.IsNullOrWhiteSpace(TargetRuntime))
+                                                 s = s.SetRuntime(TargetRuntime);
+                                             return s;
+                                         });
                        });
 
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -117,15 +117,9 @@ partial class Build : NukeBuild
             d.DependsOn(Clean)
              .Executes(() =>
                        {
-                           //Do one big, default restore
+                           // A single restore generates asset targets for all RIDs declared
+                           // in each project's RuntimeIdentifiers property.
                            DotNetRestore(s => s.SetProjectFile(Solution));
-
-                           var allRuntimeIds = ListAllRuntimeIdentifiersInSolution();
-                           //we restore for all individual runtimes
-                           foreach (var runtimeId in allRuntimeIds)
-                           {
-                               DotNetRestore(s => s.SetProjectFile(Solution).SetRuntime(runtimeId));
-                           }
                        });
 
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -184,17 +184,4 @@ partial class Build : NukeBuild
         return BuildableCalamariProjects.GetCalamariProjectsToBuild(OperatingSystem.IsWindows());
     }
 
-    HashSet<string> ListAllRuntimeIdentifiersInSolution()
-    {
-        var allRuntimes = Solution.AllProjects
-                                  .SelectMany(p => p.GetRuntimeIdentifiers() ?? Array.Empty<string>())
-                                  .Distinct()
-                                  .Where(rid => rid != "win7-x86") //I have no idea where this is coming from, but let's ignore it. My theory is it's coming from the netstandard libs
-                                  .ToHashSet();
-
-        if (!string.IsNullOrWhiteSpace(TargetRuntime))
-            allRuntimes = allRuntimes.Where(x => x == TargetRuntime).ToHashSet();
-
-        return allRuntimes;
-    }
 }

--- a/source/Calamari.Azure/Calamari.Azure.csproj
+++ b/source/Calamari.Azure/Calamari.Azure.csproj
@@ -5,7 +5,6 @@
         <OutputType>Library</OutputType>
         <Authors>Octopus Deploy</Authors>
         <Copyright>Octopus Deploy Pty Ltd</Copyright>
-        <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <TargetFramework>net8.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>


### PR DESCRIPTION
Improve parallelism in the build by:

* Doing one solution wide restore upfront
* Build the whole solution so projects that aren't runtime specific are compiled.
* Build each runtime in parallel but each runtime is built sequentially
* Remove semaphores and per package compilation

Compile step improvement from ~15min to ~10min on CI

[New](https://build.octopushq.com/buildConfiguration/TeamModernDeployments_Calamari_VNext_Build_BuildCompile/21821517)
[Old](https://build.octopushq.com/buildConfiguration/TeamModernDeployments_Calamari_VNext_Build_BuildCompile/21821297)