### PR TITLE
Return replaced/patched files when creating PR and don't send service message

### DIFF
--- a/source/Calamari.Common/Plumbing/Extensions/StringExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/StringExtensions.cs
@@ -102,5 +102,7 @@ namespace Calamari.Common.Plumbing.Extensions
         public static string EnsureDoubleQuoteIfContainsSpaces(this string text) => EnsureDoubleQuote(text, t => t.Contains(" "));
         public static string EnsureDoubleQuote(this string text) => EnsureDoubleQuote(text, t => !t.EndsWith("\"") && !t.StartsWith("\""));
         public static string EnsureDoubleQuote(this string text, Predicate<string> shouldQuote) => shouldQuote(text) ? $"\"{text}\"" : text;
+
+        public static string EnsurePosixDirectorySeparator(this string source) => source.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     }
 }

--- a/source/Calamari.Tests/ArgoCD/ArgoCDFilesUpdatedReporterTests.cs
+++ b/source/Calamari.Tests/ArgoCD/ArgoCDFilesUpdatedReporterTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using Calamari.ArgoCD;
+using Calamari.ArgoCD.Conventions;
 using Calamari.ArgoCD.Models;
 using Calamari.Testing.Helpers;
 using FluentAssertions;
@@ -13,18 +14,27 @@ namespace Calamari.Tests.ArgoCD
     [TestFixture]
     public class ArgoCDFilesUpdatedReporterTests
     {
+        GitCommitParameters gitParams = new(string.Empty, string.Empty, false);
+
         [Test]
         public void ReportDeployments_WithNoUpdatedApplications_WritesNoServiceMessages()
         {
             var log = new InMemoryLog();
+            var gitParams = new GitCommitParameters(string.Empty, string.Empty, false);
             var reporter = new ArgoCDFilesUpdatedReporter(log);
 
             var applicationResults = new List<ProcessApplicationResult>
             {
-                new("gateway1", new ApplicationName("app1"), 2, 2, [], [], [])
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    2,
+                    2,
+                    [],
+                    [],
+                    [])
             };
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(gitParams, applicationResults);
 
             var messages = log.ServiceMessages;
             messages.Should().BeEmpty();
@@ -40,21 +50,36 @@ namespace Calamari.Tests.ArgoCD
 
             var applicationResults = new List<ProcessApplicationResult>
             {
-                new("gateway1", new ApplicationName("app1"), 2, 2, [new TrackedSourceDetail("abc123", timestamp, 0, [], [])], [], [])
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    2,
+                    2,
+                    [
+                        new TrackedSourceDetail("abc123",
+                                                timestamp,
+                                                0,
+                                                [],
+                                                [])
+                    ],
+                    [],
+                    [])
             };
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(gitParams, applicationResults);
 
-            log.ServiceMessages.Should().ContainSingle().Which.Should().BeEquivalentTo(new
-            {
-                Name = "argocd-files-updated",
-                Properties = new Dictionary<string, string>
-                {
-                    ["gatewayId"] = "gateway1",
-                    ["applicationName"] = "app1",
-                    ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[],\"PatchedFiles\":[]}}]"
-                }
-            });
+            log.ServiceMessages.Should()
+               .ContainSingle()
+               .Which.Should()
+               .BeEquivalentTo(new
+               {
+                   Name = "argocd-files-updated",
+                   Properties = new Dictionary<string, string>
+                   {
+                       ["gatewayId"] = "gateway1",
+                       ["applicationName"] = "app1",
+                       ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[],\"PatchedFiles\":[]}}]"
+                   }
+               });
         }
 
         [Test]
@@ -67,34 +92,59 @@ namespace Calamari.Tests.ArgoCD
 
             var applicationResults = new List<ProcessApplicationResult>
             {
-                new("gateway1", new ApplicationName("app1"), 2, 2, [new TrackedSourceDetail("abc123", timestamp, 0, [], [])], [], []),
-                new("gateway2", new ApplicationName("app2"), 1, 1, [new TrackedSourceDetail("def456", timestamp, 0, [], [])], [], [])
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    2,
+                    2,
+                    [
+                        new TrackedSourceDetail("abc123",
+                                                timestamp,
+                                                0,
+                                                [],
+                                                [])
+                    ],
+                    [],
+                    []),
+                new("gateway2",
+                    new ApplicationName("app2"),
+                    1,
+                    1,
+                    [
+                        new TrackedSourceDetail("def456",
+                                                timestamp,
+                                                0,
+                                                [],
+                                                [])
+                    ],
+                    [],
+                    [])
             };
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(gitParams, applicationResults);
 
-            log.ServiceMessages.Should().BeEquivalentTo([
-                new
-                {
-                    Name = "argocd-files-updated",
-                    Properties = new Dictionary<string, string>
-                    {
-                        ["gatewayId"] = "gateway1",
-                        ["applicationName"] = "app1",
-                        ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[],\"PatchedFiles\":[]}}]"
-                    }
-                },
-                new
-                {
-                    Name = "argocd-files-updated",
-                    Properties = new Dictionary<string, string>
-                    {
-                        ["gatewayId"] = "gateway2",
-                        ["applicationName"] = "app2",
-                        ["sources"] = $"[{{\"CommitSha\":\"def456\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[],\"PatchedFiles\":[]}}]"
-                    }
-                }
-            ]);
+            log.ServiceMessages.Should()
+               .BeEquivalentTo([
+                   new
+                   {
+                       Name = "argocd-files-updated",
+                       Properties = new Dictionary<string, string>
+                       {
+                           ["gatewayId"] = "gateway1",
+                           ["applicationName"] = "app1",
+                           ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[],\"PatchedFiles\":[]}}]"
+                       }
+                   },
+                   new
+                   {
+                       Name = "argocd-files-updated",
+                       Properties = new Dictionary<string, string>
+                       {
+                           ["gatewayId"] = "gateway2",
+                           ["applicationName"] = "app2",
+                           ["sources"] = $"[{{\"CommitSha\":\"def456\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[],\"PatchedFiles\":[]}}]"
+                       }
+                   }
+               ]);
         }
 
         [Test]
@@ -107,23 +157,36 @@ namespace Calamari.Tests.ArgoCD
 
             var applicationResults = new List<ProcessApplicationResult>
             {
-                new("gateway1", new ApplicationName("app1"), 2, 2,
-                    [new TrackedSourceDetail("abc123", timestamp, 0, [new FileHash("values.yaml", "22c0df2cceca5273e4dc569dda52805d27df3360")], [])],
-                    [], [])
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    2,
+                    2,
+                    [
+                        new TrackedSourceDetail("abc123",
+                                                timestamp,
+                                                0,
+                                                [new FileHash("values.yaml", "22c0df2cceca5273e4dc569dda52805d27df3360")],
+                                                [])
+                    ],
+                    [],
+                    [])
             };
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(gitParams, applicationResults);
 
-            log.ServiceMessages.Should().ContainSingle().Which.Should().BeEquivalentTo(new
-            {
-                Name = "argocd-files-updated",
-                Properties = new Dictionary<string, string>
-                {
-                    ["gatewayId"] = "gateway1",
-                    ["applicationName"] = "app1",
-                    ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[{{\"FilePath\":\"values.yaml\",\"Hash\":\"22c0df2cceca5273e4dc569dda52805d27df3360\"}}],\"PatchedFiles\":[]}}]"
-                }
-            });
+            log.ServiceMessages.Should()
+               .ContainSingle()
+               .Which.Should()
+               .BeEquivalentTo(new
+               {
+                   Name = "argocd-files-updated",
+                   Properties = new Dictionary<string, string>
+                   {
+                       ["gatewayId"] = "gateway1",
+                       ["applicationName"] = "app1",
+                       ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[{{\"FilePath\":\"values.yaml\",\"Hash\":\"22c0df2cceca5273e4dc569dda52805d27df3360\"}}],\"PatchedFiles\":[]}}]"
+                   }
+               });
         }
 
         [Test]
@@ -136,23 +199,36 @@ namespace Calamari.Tests.ArgoCD
 
             var applicationResults = new List<ProcessApplicationResult>
             {
-                new("gateway1", new ApplicationName("app1"), 1, 1,
-                    [new TrackedSourceDetail("def456", timestamp, 0, [], [new FileJsonPatch("kustomization.yaml", """[{"op":"replace","path":"/images/0/name","value":"nginx:latest"}]""")])],
-                    [], [])
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    1,
+                    1,
+                    [
+                        new TrackedSourceDetail("def456",
+                                                timestamp,
+                                                0,
+                                                [],
+                                                [new FileJsonPatch("kustomization.yaml", """[{"op":"replace","path":"/images/0/name","value":"nginx:latest"}]""")])
+                    ],
+                    [],
+                    [])
             };
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(gitParams, applicationResults);
 
-            log.ServiceMessages.Should().ContainSingle().Which.Should().BeEquivalentTo(new
-            {
-                Name = "argocd-files-updated",
-                Properties = new Dictionary<string, string>
-                {
-                    ["gatewayId"] = "gateway1",
-                    ["applicationName"] = "app1",
-                    ["sources"] = $"[{{\"CommitSha\":\"def456\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[],\"PatchedFiles\":[{{\"FilePath\":\"kustomization.yaml\",\"JsonPatch\":\"[{{\\u0022op\\u0022:\\u0022replace\\u0022,\\u0022path\\u0022:\\u0022/images/0/name\\u0022,\\u0022value\\u0022:\\u0022nginx:latest\\u0022}}]\"}}]}}]"
-                }
-            });
+            log.ServiceMessages.Should()
+               .ContainSingle()
+               .Which.Should()
+               .BeEquivalentTo(new
+               {
+                   Name = "argocd-files-updated",
+                   Properties = new Dictionary<string, string>
+                   {
+                       ["gatewayId"] = "gateway1",
+                       ["applicationName"] = "app1",
+                       ["sources"] = $"[{{\"CommitSha\":\"def456\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[],\"PatchedFiles\":[{{\"FilePath\":\"kustomization.yaml\",\"JsonPatch\":\"[{{\\u0022op\\u0022:\\u0022replace\\u0022,\\u0022path\\u0022:\\u0022/images/0/name\\u0022,\\u0022value\\u0022:\\u0022nginx:latest\\u0022}}]\"}}]}}]"
+                   }
+               });
         }
 
         [Test]
@@ -165,25 +241,36 @@ namespace Calamari.Tests.ArgoCD
 
             var applicationResults = new List<ProcessApplicationResult>
             {
-                new("gateway1", new ApplicationName("app1"), 2, 2,
-                    [new TrackedSourceDetail("abc123", timestamp, 0,
-                        [new FileHash("values.yaml", "22c0df2cceca5273e4dc569dda52805d27df3360")],
-                        [new FileJsonPatch("kustomization.yaml", """[{"op":"replace","path":"/images/0/name","value":"nginx:latest"}]""")])],
-                    [], [])
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    2,
+                    2,
+                    [
+                        new TrackedSourceDetail("abc123",
+                                                timestamp,
+                                                0,
+                                                [new FileHash("values.yaml", "22c0df2cceca5273e4dc569dda52805d27df3360")],
+                                                [new FileJsonPatch("kustomization.yaml", """[{"op":"replace","path":"/images/0/name","value":"nginx:latest"}]""")])
+                    ],
+                    [],
+                    [])
             };
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(gitParams, applicationResults);
 
-            log.ServiceMessages.Should().ContainSingle().Which.Should().BeEquivalentTo(new
-            {
-                Name = "argocd-files-updated",
-                Properties = new Dictionary<string, string>
-                {
-                    ["gatewayId"] = "gateway1",
-                    ["applicationName"] = "app1",
-                    ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[{{\"FilePath\":\"values.yaml\",\"Hash\":\"22c0df2cceca5273e4dc569dda52805d27df3360\"}}],\"PatchedFiles\":[{{\"FilePath\":\"kustomization.yaml\",\"JsonPatch\":\"[{{\\u0022op\\u0022:\\u0022replace\\u0022,\\u0022path\\u0022:\\u0022/images/0/name\\u0022,\\u0022value\\u0022:\\u0022nginx:latest\\u0022}}]\"}}]}}]"
-                }
-            });
+            log.ServiceMessages.Should()
+               .ContainSingle()
+               .Which.Should()
+               .BeEquivalentTo(new
+               {
+                   Name = "argocd-files-updated",
+                   Properties = new Dictionary<string, string>
+                   {
+                       ["gatewayId"] = "gateway1",
+                       ["applicationName"] = "app1",
+                       ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[{{\"FilePath\":\"values.yaml\",\"Hash\":\"22c0df2cceca5273e4dc569dda52805d27df3360\"}}],\"PatchedFiles\":[{{\"FilePath\":\"kustomization.yaml\",\"JsonPatch\":\"[{{\\u0022op\\u0022:\\u0022replace\\u0022,\\u0022path\\u0022:\\u0022/images/0/name\\u0022,\\u0022value\\u0022:\\u0022nginx:latest\\u0022}}]\"}}]}}]"
+                   }
+               });
         }
 
         [Test]
@@ -196,31 +283,42 @@ namespace Calamari.Tests.ArgoCD
 
             var applicationResults = new List<ProcessApplicationResult>
             {
-                new("gateway1", new ApplicationName("app1"), 2, 2,
-                    [new TrackedSourceDetail("abc123", timestamp, 0,
-                        [
-                            new FileHash("values.yaml", "22c0df2cceca5273e4dc569dda52805d27df3360"),
-                            new FileHash("values-prod.yaml", "a3b4c5d6e7f8a3b4c5d6e7f8a3b4c5d6e7f8a3b4")
-                        ],
-                        [
-                            new FileJsonPatch("kustomization.yaml", """[{"op":"replace","path":"/images/0/name","value":"nginx:latest"}]"""),
-                            new FileJsonPatch("patch.yaml", """[{"op":"replace","path":"/spec/replicas","value":3}]""")
-                        ])],
-                    [], [])
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    2,
+                    2,
+                    [
+                        new TrackedSourceDetail("abc123",
+                                                timestamp,
+                                                0,
+                                                [
+                                                    new FileHash("values.yaml", "22c0df2cceca5273e4dc569dda52805d27df3360"),
+                                                    new FileHash("values-prod.yaml", "a3b4c5d6e7f8a3b4c5d6e7f8a3b4c5d6e7f8a3b4")
+                                                ],
+                                                [
+                                                    new FileJsonPatch("kustomization.yaml", """[{"op":"replace","path":"/images/0/name","value":"nginx:latest"}]"""),
+                                                    new FileJsonPatch("patch.yaml", """[{"op":"replace","path":"/spec/replicas","value":3}]""")
+                                                ])
+                    ],
+                    [],
+                    [])
             };
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(gitParams, applicationResults);
 
-            log.ServiceMessages.Should().ContainSingle().Which.Should().BeEquivalentTo(new
-            {
-                Name = "argocd-files-updated",
-                Properties = new Dictionary<string, string>
-                {
-                    ["gatewayId"] = "gateway1",
-                    ["applicationName"] = "app1",
-                    ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[{{\"FilePath\":\"values.yaml\",\"Hash\":\"22c0df2cceca5273e4dc569dda52805d27df3360\"}},{{\"FilePath\":\"values-prod.yaml\",\"Hash\":\"a3b4c5d6e7f8a3b4c5d6e7f8a3b4c5d6e7f8a3b4\"}}],\"PatchedFiles\":[{{\"FilePath\":\"kustomization.yaml\",\"JsonPatch\":\"[{{\\u0022op\\u0022:\\u0022replace\\u0022,\\u0022path\\u0022:\\u0022/images/0/name\\u0022,\\u0022value\\u0022:\\u0022nginx:latest\\u0022}}]\"}},{{\"FilePath\":\"patch.yaml\",\"JsonPatch\":\"[{{\\u0022op\\u0022:\\u0022replace\\u0022,\\u0022path\\u0022:\\u0022/spec/replicas\\u0022,\\u0022value\\u0022:3}}]\"}}]}}]"
-                }
-            });
+            log.ServiceMessages.Should()
+               .ContainSingle()
+               .Which.Should()
+               .BeEquivalentTo(new
+               {
+                   Name = "argocd-files-updated",
+                   Properties = new Dictionary<string, string>
+                   {
+                       ["gatewayId"] = "gateway1",
+                       ["applicationName"] = "app1",
+                       ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[{{\"FilePath\":\"values.yaml\",\"Hash\":\"22c0df2cceca5273e4dc569dda52805d27df3360\"}},{{\"FilePath\":\"values-prod.yaml\",\"Hash\":\"a3b4c5d6e7f8a3b4c5d6e7f8a3b4c5d6e7f8a3b4\"}}],\"PatchedFiles\":[{{\"FilePath\":\"kustomization.yaml\",\"JsonPatch\":\"[{{\\u0022op\\u0022:\\u0022replace\\u0022,\\u0022path\\u0022:\\u0022/images/0/name\\u0022,\\u0022value\\u0022:\\u0022nginx:latest\\u0022}}]\"}},{{\"FilePath\":\"patch.yaml\",\"JsonPatch\":\"[{{\\u0022op\\u0022:\\u0022replace\\u0022,\\u0022path\\u0022:\\u0022/spec/replicas\\u0022,\\u0022value\\u0022:3}}]\"}}]}}]"
+                   }
+               });
         }
 
         [Test]
@@ -233,26 +331,41 @@ namespace Calamari.Tests.ArgoCD
 
             var applicationResults = new List<ProcessApplicationResult>
             {
-                new("gateway1", new ApplicationName("app1"), 2, 2,
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    2,
+                    2,
                     [
-                        new TrackedSourceDetail("abc123", timestamp, 0, [new FileHash("values.yaml", "22c0df2cceca5273e4dc569dda52805d27df3360")], []),
-                        new TrackedSourceDetail("abc123", timestamp, 1, [], [new FileJsonPatch("kustomization.yaml", """[{"op":"replace","path":"/images/0/name","value":"redis:latest"}]""")])
+                        new TrackedSourceDetail("abc123",
+                                                timestamp,
+                                                0,
+                                                [new FileHash("values.yaml", "22c0df2cceca5273e4dc569dda52805d27df3360")],
+                                                []),
+                        new TrackedSourceDetail("abc123",
+                                                timestamp,
+                                                1,
+                                                [],
+                                                [new FileJsonPatch("kustomization.yaml", """[{"op":"replace","path":"/images/0/name","value":"redis:latest"}]""")])
                     ],
-                    [], [])
+                    [],
+                    [])
             };
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(gitParams, applicationResults);
 
-            log.ServiceMessages.Should().ContainSingle().Which.Should().BeEquivalentTo(new
-            {
-                Name = "argocd-files-updated",
-                Properties = new Dictionary<string, string>
-                {
-                    ["gatewayId"] = "gateway1",
-                    ["applicationName"] = "app1",
-                    ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[{{\"FilePath\":\"values.yaml\",\"Hash\":\"22c0df2cceca5273e4dc569dda52805d27df3360\"}}],\"PatchedFiles\":[]}},{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":1,\"ReplacedFiles\":[],\"PatchedFiles\":[{{\"FilePath\":\"kustomization.yaml\",\"JsonPatch\":\"[{{\\u0022op\\u0022:\\u0022replace\\u0022,\\u0022path\\u0022:\\u0022/images/0/name\\u0022,\\u0022value\\u0022:\\u0022redis:latest\\u0022}}]\"}}]}}]"
-                }
-            });
+            log.ServiceMessages.Should()
+               .ContainSingle()
+               .Which.Should()
+               .BeEquivalentTo(new
+               {
+                   Name = "argocd-files-updated",
+                   Properties = new Dictionary<string, string>
+                   {
+                       ["gatewayId"] = "gateway1",
+                       ["applicationName"] = "app1",
+                       ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[{{\"FilePath\":\"values.yaml\",\"Hash\":\"22c0df2cceca5273e4dc569dda52805d27df3360\"}}],\"PatchedFiles\":[]}},{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":1,\"ReplacedFiles\":[],\"PatchedFiles\":[{{\"FilePath\":\"kustomization.yaml\",\"JsonPatch\":\"[{{\\u0022op\\u0022:\\u0022replace\\u0022,\\u0022path\\u0022:\\u0022/images/0/name\\u0022,\\u0022value\\u0022:\\u0022redis:latest\\u0022}}]\"}}]}}]"
+                   }
+               });
         }
 
         [Test]
@@ -265,25 +378,36 @@ namespace Calamari.Tests.ArgoCD
 
             var applicationResults = new List<ProcessApplicationResult>
             {
-                new("gateway1", new ApplicationName("app1"), 1, 1,
-                    [new TrackedSourceDetail("abc123", timestamp, 0,
-                        [new FileHash(Path.Combine("some", "nested", "values.yaml"), "22c0df2cceca5273e4dc569dda52805d27df3360")],
-                        [])],
-                    [], [])
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    1,
+                    1,
+                    [
+                        new TrackedSourceDetail("abc123",
+                                                timestamp,
+                                                0,
+                                                [new FileHash(Path.Combine("some", "nested", "values.yaml"), "22c0df2cceca5273e4dc569dda52805d27df3360")],
+                                                [])
+                    ],
+                    [],
+                    [])
             };
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(gitParams, applicationResults);
 
-            log.ServiceMessages.Should().ContainSingle().Which.Should().BeEquivalentTo(new
-            {
-                Name = "argocd-files-updated",
-                Properties = new Dictionary<string, string>
-                {
-                    ["gatewayId"] = "gateway1",
-                    ["applicationName"] = "app1",
-                    ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[{{\"FilePath\":\"some/nested/values.yaml\",\"Hash\":\"22c0df2cceca5273e4dc569dda52805d27df3360\"}}],\"PatchedFiles\":[]}}]"
-                }
-            });
+            log.ServiceMessages.Should()
+               .ContainSingle()
+               .Which.Should()
+               .BeEquivalentTo(new
+               {
+                   Name = "argocd-files-updated",
+                   Properties = new Dictionary<string, string>
+                   {
+                       ["gatewayId"] = "gateway1",
+                       ["applicationName"] = "app1",
+                       ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[{{\"FilePath\":\"some/nested/values.yaml\",\"Hash\":\"22c0df2cceca5273e4dc569dda52805d27df3360\"}}],\"PatchedFiles\":[]}}]"
+                   }
+               });
         }
 
         [Test]
@@ -294,24 +418,36 @@ namespace Calamari.Tests.ArgoCD
 
             var applicationResults = new List<ProcessApplicationResult>
             {
-                new("gateway1", new ApplicationName("app1"), 1, 1,
-                    [new TrackedSourceDetail(null, null, 0, [],
-                        [new FileJsonPatch("values.yaml", """[{"op":"replace","path":"/image","value":"nginx:1.27"}]""")])],
-                    [], [])
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    1,
+                    1,
+                    [
+                        new TrackedSourceDetail(null,
+                                                null,
+                                                0,
+                                                [],
+                                                [new FileJsonPatch("values.yaml", """[{"op":"replace","path":"/image","value":"nginx:1.27"}]""")])
+                    ],
+                    [],
+                    [])
             };
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(gitParams, applicationResults);
 
-            log.ServiceMessages.Should().ContainSingle().Which.Should().BeEquivalentTo(new
-            {
-                Name = "argocd-files-updated",
-                Properties = new Dictionary<string, string>
-                {
-                    ["gatewayId"] = "gateway1",
-                    ["applicationName"] = "app1",
-                    ["sources"] = """[{"CommitSha":null,"CommitTimestamp":null,"SourceIndex":0,"ReplacedFiles":[],"PatchedFiles":[{"FilePath":"values.yaml","JsonPatch":"[{\u0022op\u0022:\u0022replace\u0022,\u0022path\u0022:\u0022/image\u0022,\u0022value\u0022:\u0022nginx:1.27\u0022}]"}]}]"""
-                }
-            });
+            log.ServiceMessages.Should()
+               .ContainSingle()
+               .Which.Should()
+               .BeEquivalentTo(new
+               {
+                   Name = "argocd-files-updated",
+                   Properties = new Dictionary<string, string>
+                   {
+                       ["gatewayId"] = "gateway1",
+                       ["applicationName"] = "app1",
+                       ["sources"] = """[{"CommitSha":null,"CommitTimestamp":null,"SourceIndex":0,"ReplacedFiles":[],"PatchedFiles":[{"FilePath":"values.yaml","JsonPatch":"[{\u0022op\u0022:\u0022replace\u0022,\u0022path\u0022:\u0022/image\u0022,\u0022value\u0022:\u0022nginx:1.27\u0022}]"}]}]"""
+                   }
+               });
         }
 
         [Test]
@@ -324,23 +460,50 @@ namespace Calamari.Tests.ArgoCD
 
             var applicationResults = new List<ProcessApplicationResult>
             {
-                new("gateway1", new ApplicationName("app1"), 2, 2, [], [], []),
-                new("gateway2", new ApplicationName("app2"), 1, 1, [new TrackedSourceDetail("abc123", timestamp, 0, [], [])], [], []),
-                new("gateway3", new ApplicationName("app3"), 1, 1, [], [], [])
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    2,
+                    2,
+                    [],
+                    [],
+                    []),
+                new("gateway2",
+                    new ApplicationName("app2"),
+                    1,
+                    1,
+                    [
+                        new TrackedSourceDetail("abc123",
+                                                timestamp,
+                                                0,
+                                                [],
+                                                [])
+                    ],
+                    [],
+                    []),
+                new("gateway3",
+                    new ApplicationName("app3"),
+                    1,
+                    1,
+                    [],
+                    [],
+                    [])
             };
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(gitParams, applicationResults);
 
-            log.ServiceMessages.Should().ContainSingle().Which.Should().BeEquivalentTo(new
-            {
-                Name = "argocd-files-updated",
-                Properties = new Dictionary<string, string>
-                {
-                    ["gatewayId"] = "gateway2",
-                    ["applicationName"] = "app2",
-                    ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[],\"PatchedFiles\":[]}}]"
-                }
-            });
+            log.ServiceMessages.Should()
+               .ContainSingle()
+               .Which.Should()
+               .BeEquivalentTo(new
+               {
+                   Name = "argocd-files-updated",
+                   Properties = new Dictionary<string, string>
+                   {
+                       ["gatewayId"] = "gateway2",
+                       ["applicationName"] = "app2",
+                       ["sources"] = $"[{{\"CommitSha\":\"abc123\",\"CommitTimestamp\":\"{tsJson}\",\"SourceIndex\":0,\"ReplacedFiles\":[],\"PatchedFiles\":[]}}]"
+                   }
+               });
         }
     }
 }

--- a/source/Calamari.Tests/ArgoCD/ArgoCDFilesUpdatedReporterTests.cs
+++ b/source/Calamari.Tests/ArgoCD/ArgoCDFilesUpdatedReporterTests.cs
@@ -14,13 +14,43 @@ namespace Calamari.Tests.ArgoCD
     [TestFixture]
     public class ArgoCDFilesUpdatedReporterTests
     {
-        GitCommitParameters gitParams = new(string.Empty, string.Empty, false);
+        readonly GitCommitParameters gitParams = new(string.Empty, string.Empty, false);
+        
+        [Test]
+        public void ReportDeployments_WhenGitParamsRequirePullRequest_WritesNoServiceMessages()
+        {
+            var log = new InMemoryLog();
+            var prGitParams = new GitCommitParameters(string.Empty, string.Empty, true);
+            var timestamp = DateTimeOffset.UtcNow;
+            var reporter = new ArgoCDFilesUpdatedReporter(log);
+            
+            var applicationResults = new List<ProcessApplicationResult>
+            {
+                new("gateway1",
+                    new ApplicationName("app1"),
+                    2,
+                    2,
+                    [
+                        new TrackedSourceDetail("abc123",
+                                                timestamp,
+                                                0,
+                                                [],
+                                                [])
+                    ],
+                    [],
+                    [])
+            };
+
+            reporter.ReportFilesUpdated(prGitParams, applicationResults);
+
+            var messages = log.ServiceMessages;
+            messages.Should().BeEmpty();
+        }
 
         [Test]
         public void ReportDeployments_WithNoUpdatedApplications_WritesNoServiceMessages()
         {
             var log = new InMemoryLog();
-            var gitParams = new GitCommitParameters(string.Empty, string.Empty, false);
             var reporter = new ArgoCDFilesUpdatedReporter(log);
 
             var applicationResults = new List<ProcessApplicationResult>

--- a/source/Calamari.Tests/ArgoCD/ArgoCDOutputVariablesWriterTests.cs
+++ b/source/Calamari.Tests/ArgoCD/ArgoCDOutputVariablesWriterTests.cs
@@ -121,7 +121,7 @@ namespace Calamari.Tests.ArgoCD
             AssertPullRequestVariables(serviceMessages, 1);
         }
         
-        //Zero = No (but NOCOMMIT is part of the forbidden words list)
+        //Zero = No (but NO COMMIT is part of the forbidden words list)
         static void AssertZeroCommitVariables(ServiceMessage[] serviceMessages, int sourceIndex)
         {
             serviceMessages.GetPropertyValue($"ArgoCD.Gateway[{GatewayName}].Application[{ApplicationName}].Source[{sourceIndex}].CommitSha").Should().BeNull();

--- a/source/Calamari.Tests/ArgoCD/ArgoCDOutputVariablesWriterTests.cs
+++ b/source/Calamari.Tests/ArgoCD/ArgoCDOutputVariablesWriterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Calamari.ArgoCD;
+using Calamari.ArgoCD.Conventions;
 using Calamari.ArgoCD.Git;
 using Calamari.Common.Plumbing.ServiceMessages;
 using Calamari.Common.Plumbing.Variables;
@@ -14,7 +15,6 @@ namespace Calamari.Tests.ArgoCD
     public class ArgoCDOutputVariablesWriterTests
     {
         InMemoryLog log;
-        IVariables variables;
         ArgoCDOutputVariablesWriter writer;
 
         const string GatewayName = "TestGateway";
@@ -32,19 +32,37 @@ namespace Calamari.Tests.ArgoCD
         public void SetUp()
         {
             log = new InMemoryLog();
-            variables = new CalamariVariables();
-            writer = new ArgoCDOutputVariablesWriter(log, variables);
+            writer = new ArgoCDOutputVariablesWriter(log);
         }
-
+        
         [Test]
-        public void WritePushResultOutput_WithoutPullRequest_WritesCommitOutputVariables()
+        public void WriteSourceUpdateResultOutputWhenPushResultExists_NoPushResult_NoOutputVariablesAreWritten()
         {
             // Arrange
             const int sourceIndex = 0;
-            var pushResult = new PushResult(CommitSha, ShortSha, Timestamp);
+            var sourceUpdateResult = new SourceUpdateResult([], null, [], []);
 
             // Act
-            writer.WritePushResultOutput(GatewayName, ApplicationName, sourceIndex, pushResult);
+            writer.WriteSourceUpdateResultOutputWhenPushResultExists(GatewayName, ApplicationName, sourceIndex, sourceUpdateResult);
+
+            // Assert
+            using var _ = new AssertionScope();
+            var serviceMessages = log.Messages.GetServiceMessagesOfType("setVariable");
+
+            AssertZeroCommitVariables(serviceMessages, sourceIndex);
+            AssertNoPullRequestVariables(serviceMessages, sourceIndex);
+        }
+
+        [Test]
+        public void WriteSourceUpdateResultOutputWhenPushResultExists_WithoutPullRequest_WritesCommitOutputVariables()
+        {
+            // Arrange
+            const int sourceIndex = 0;
+            var pullResult = new PushResult(CommitSha, ShortSha, Timestamp);
+            var sourceUpdateResult = new SourceUpdateResult([], pullResult, [], []);
+
+            // Act
+            writer.WriteSourceUpdateResultOutputWhenPushResultExists(GatewayName, ApplicationName, sourceIndex, sourceUpdateResult);
 
             // Assert
             using var _ = new AssertionScope();
@@ -60,9 +78,10 @@ namespace Calamari.Tests.ArgoCD
             // Arrange
             const int sourceIndex = 1;
             var pullRequestPushResult = new PullRequestPushResult(CommitSha, ShortSha, Timestamp, RepositoryUrl, PrTitle, PrUrl, PrNumber);
+            var sourceUpdateResult = new SourceUpdateResult([], pullRequestPushResult, [], []);
 
             // Act
-            writer.WritePushResultOutput(GatewayName, ApplicationName, sourceIndex, pullRequestPushResult);
+            writer.WriteSourceUpdateResultOutputWhenPushResultExists(GatewayName, ApplicationName, sourceIndex, sourceUpdateResult);
 
             // Assert
             using var _ = new AssertionScope();
@@ -80,11 +99,14 @@ namespace Calamari.Tests.ArgoCD
             const string shortSha2 = "abcdef1";
 
             var pushResult1 = new PushResult(CommitSha, ShortSha, Timestamp);
+            var sourceUpdateResult1 = new SourceUpdateResult([], pushResult1, [], []);
+            
             var pushResult2 = new PullRequestPushResult(commitSha2, shortSha2, Timestamp, RepositoryUrl, PrTitle, PrUrl, PrNumber);
+            var sourceUpdateResult2 = new SourceUpdateResult([], pushResult2, [], []);
 
             // Act
-            writer.WritePushResultOutput(GatewayName, ApplicationName, 0, pushResult1);
-            writer.WritePushResultOutput(GatewayName, ApplicationName, 1, pushResult2);
+            writer.WriteSourceUpdateResultOutputWhenPushResultExists(GatewayName, ApplicationName, 0, sourceUpdateResult1);
+            writer.WriteSourceUpdateResultOutputWhenPushResultExists(GatewayName, ApplicationName, 1, sourceUpdateResult2);
 
             // Assert
             using var _ = new AssertionScope();
@@ -97,6 +119,14 @@ namespace Calamari.Tests.ArgoCD
             // Source 1
             AssertCommitVariables(serviceMessages, 1, commitSha2, shortSha2);
             AssertPullRequestVariables(serviceMessages, 1);
+        }
+        
+        //Zero = No (but NOCOMMIT is part of the forbidden words list)
+        static void AssertZeroCommitVariables(ServiceMessage[] serviceMessages, int sourceIndex)
+        {
+            serviceMessages.GetPropertyValue($"ArgoCD.Gateway[{GatewayName}].Application[{ApplicationName}].Source[{sourceIndex}].CommitSha").Should().BeNull();
+            serviceMessages.GetPropertyValue($"ArgoCD.Gateway[{GatewayName}].Application[{ApplicationName}].Source[{sourceIndex}].ShortSha").Should().BeNull();
+            serviceMessages.GetPropertyValue($"ArgoCD.Gateway[{GatewayName}].Application[{ApplicationName}].Source[{sourceIndex}].CommitTimestamp").Should().BeNull();
         }
 
         static void AssertCommitVariables(ServiceMessage[] serviceMessages, int sourceIndex, string commitSha = CommitSha, string shortSha = ShortSha)

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
@@ -68,7 +68,7 @@ image:
                 Substitute.For<IGitVendorPullRequestClientResolver>(),
                 new SystemClock(),
                 deploymentReporter,
-                new ArgoCDOutputVariablesWriter(log, nonSensitiveCalamariVariables));
+                new ArgoCDOutputVariablesWriter(log));
         }
 
         [SetUp]
@@ -1198,7 +1198,7 @@ autoscaling:
                                            .Returns(argoCDAppWithHelmSource);
 
             IReadOnlyList<ProcessApplicationResult> capturedResults = null;
-            deploymentReporter.ReportFilesUpdated(Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => capturedResults = x));
+            deploymentReporter.ReportFilesUpdated(Arg.Any<GitCommitParameters>(), Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => capturedResults = x));
 
             // Act
             updater.Install(runningDeployment);
@@ -1384,7 +1384,7 @@ service:
             runningDeployment.StagingDirectory = tempDirectory;
 
             IReadOnlyList<ProcessApplicationResult> capturedResults = null;
-            deploymentReporter.ReportFilesUpdated(Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => capturedResults = x));
+            deploymentReporter.ReportFilesUpdated(Arg.Any<GitCommitParameters>(),Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => capturedResults = x));
 
             updater.Install(runningDeployment);
 
@@ -1636,7 +1636,7 @@ image:
             runningDeployment.StagingDirectory = tempDirectory;
 
             IReadOnlyList<ProcessApplicationResult> capturedResults = null;
-            deploymentReporter.ReportFilesUpdated(Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => capturedResults = x));
+            deploymentReporter.ReportFilesUpdated(Arg.Any<GitCommitParameters>(),Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => capturedResults = x));
 
             // Act
             updater.Install(runningDeployment);

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -63,7 +63,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                 Substitute.For<IGitVendorPullRequestClientResolver>(),
                 new SystemClock(),
                 deploymentReporter,
-                new ArgoCDOutputVariablesWriter(log, nonSensitiveCalamariVariables));
+                new ArgoCDOutputVariablesWriter(log));
         }
 
         [SetUp]
@@ -977,7 +977,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
         Func<IReadOnlyList<ProcessApplicationResult>> CaptureReporterResults()
         {
             IReadOnlyList<ProcessApplicationResult> captured = null;
-            deploymentReporter.ReportFilesUpdated(Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => captured = x));
+            deploymentReporter.ReportFilesUpdated(Arg.Any<GitCommitParameters>(), Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => captured = x));
             return () => captured;
         }
 

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
@@ -116,7 +116,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                 Substitute.For<IGitVendorPullRequestClientResolver>(),
                 new SystemClock(),
                 deploymentReporter,
-                new ArgoCDOutputVariablesWriter(log, variables));
+                new ArgoCDOutputVariablesWriter(log));
         }
 
         [Test]
@@ -427,7 +427,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             runningDeployment.StagingDirectory = WorkingDirectory;
 
             IReadOnlyList<ProcessApplicationResult> capturedResults = null;
-            deploymentReporter.ReportFilesUpdated(Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => capturedResults = x));
+            deploymentReporter.ReportFilesUpdated(Arg.Any<GitCommitParameters>(), Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => capturedResults = x));
 
             var convention = CreateConvention(nonSensitiveCalamariVariables);
             convention.Install(runningDeployment);
@@ -474,7 +474,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             // Install again with the same files — this is the no-op case
             IReadOnlyList<ProcessApplicationResult> capturedResults = null;
             deploymentReporter = Substitute.For<IArgoCDFilesUpdatedReporter>();
-            deploymentReporter.ReportFilesUpdated(Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => capturedResults = x));
+            deploymentReporter.ReportFilesUpdated(Arg.Any<GitCommitParameters>(), Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => capturedResults = x));
 
             var noOpConvention = CreateConvention(nonSensitiveCalamariVariables);
             noOpConvention.Install(runningDeployment);

--- a/source/Calamari/ArgoCD/ArgoCDFilesUpdatedReporter.cs
+++ b/source/Calamari/ArgoCD/ArgoCDFilesUpdatedReporter.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using Calamari.ArgoCD.Conventions;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.ServiceMessages;
 using Calamari.Kubernetes;
@@ -11,20 +13,20 @@ namespace Calamari.ArgoCD
 {
     public interface IArgoCDFilesUpdatedReporter
     {
-        void ReportFilesUpdated(IReadOnlyList<ProcessApplicationResult> applicationResults);
+        void ReportFilesUpdated(GitCommitParameters gitCommitParameters, IReadOnlyList<ProcessApplicationResult> applicationResults);
     }
 
-    public class ArgoCDFilesUpdatedReporter : IArgoCDFilesUpdatedReporter
+    public class ArgoCDFilesUpdatedReporter(ILog log) : IArgoCDFilesUpdatedReporter
     {
-        readonly ILog log;
-
-        public ArgoCDFilesUpdatedReporter(ILog log)
+        public void ReportFilesUpdated(GitCommitParameters gitCommitParameters, IReadOnlyList<ProcessApplicationResult> applicationResults)
         {
-            this.log = log;
-        }
-
-        public void ReportFilesUpdated(IReadOnlyList<ProcessApplicationResult> applicationResults)
-        {
+            // if we are creating a pull request, we don't want to report files updated (as this will be passed down as output variables _with_ the PR info)
+            // See ArgoCDOutputVariablesWriter
+            if (gitCommitParameters.RequiresPr)
+            {
+                return;
+            }
+            
             //file paths _must_ use forward slashes for directory separators
             foreach (var appResult in applicationResults.Where(r => r.Tracked))
             {
@@ -49,12 +51,12 @@ namespace Calamari.ArgoCD
                          {
                              ReplacedFiles = usd.ReplacedFiles.Select(rf => rf with
                                                 {
-                                                    FilePath = rf.FilePath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                                                    FilePath = rf.FilePath.EnsurePosixDirectorySeparator()
                                                 })
                                                 .ToList(),
                              PatchedFiles = usd.PatchedFiles.Select(pf => pf with
                                                {
-                                                   FilePath = pf.FilePath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                                                   FilePath = pf.FilePath.EnsurePosixDirectorySeparator()
                                                })
                                                .ToList()
                          })

--- a/source/Calamari/ArgoCD/ArgoCDOutputVariablesWriter.cs
+++ b/source/Calamari/ArgoCD/ArgoCDOutputVariablesWriter.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json;
+using Calamari.ArgoCD.Conventions;
 using Calamari.ArgoCD.Git;
 using Calamari.ArgoCD.Models;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
-using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes;
 
 namespace Calamari.ArgoCD
@@ -13,26 +15,30 @@ namespace Calamari.ArgoCD
     public class ArgoCDOutputVariablesWriter
     {
         readonly ILog log;
-        readonly IVariables variables;
 
-        public ArgoCDOutputVariablesWriter(ILog log, IVariables variables)
+        public ArgoCDOutputVariablesWriter(ILog log)
         {
             this.log = log;
-            this.variables = variables;
         }
 
-        public void WritePushResultOutput(
+        public void WriteSourceUpdateResultOutputWhenPushResultExists(
             string gatewayName,
             string applicationName,
             int sourceIndex,
-            PushResult pushResult)
+            SourceUpdateResult sourceUpdateResult)
         {
+            var pushResult = sourceUpdateResult.PushResult;
+            if (pushResult is null)
+            {
+                return;
+            }
+
             var appSourceVariables = SpecialVariables.ArgoCD.Output
                                                      .Actions()
                                                      .ArgoCDGateways(gatewayName)
                                                      .Applications(applicationName)
                                                      .Sources(sourceIndex);
-            
+
             log.SetOutputVariableButDoNotAddToVariables(appSourceVariables.CommitSha, pushResult.CommitSha);
             log.SetOutputVariableButDoNotAddToVariables(appSourceVariables.ShortSha, pushResult.ShortSha);
             log.SetOutputVariableButDoNotAddToVariables(appSourceVariables.CommitTimestamp, pushResult.CommitTimestamp.ToString("O"));
@@ -43,6 +49,20 @@ namespace Calamari.ArgoCD
                 log.SetOutputVariableButDoNotAddToVariables(appSourceVariables.PullRequestTitle, prResult.PullRequestTitle);
                 log.SetOutputVariableButDoNotAddToVariables(appSourceVariables.PullRequestUrl, prResult.PullRequestUri);
                 log.SetOutputVariableButDoNotAddToVariables(appSourceVariables.PullRequestNumber, prResult.PullRequestNumber.ToString(CultureInfo.InvariantCulture));
+
+                log.SetOutputVariableButDoNotAddToVariables(appSourceVariables.PullRequestReplacedFiles,
+                                                            JsonSerializer.Serialize(sourceUpdateResult.ReplacedFiles.Select(rf => rf with
+                                                                                                       {
+                                                                                                           FilePath = rf.FilePath.EnsurePosixDirectorySeparator()
+                                                                                                       })
+                                                                                                       .ToList()));
+
+                log.SetOutputVariableButDoNotAddToVariables(appSourceVariables.PullRequestPatchedFiles,
+                                                            JsonSerializer.Serialize(sourceUpdateResult.PatchedFiles.Select(rf => rf with
+                                                                                                       {
+                                                                                                           FilePath = rf.FilePath.EnsurePosixDirectorySeparator()
+                                                                                                       })
+                                                                                                       .ToList()));
             }
         }
 
@@ -56,7 +76,7 @@ namespace Calamari.ArgoCD
             WriteGitUris(gitRepos);
             WriteTotalApplicationsWithSourceCounts(totalApplicationsWithSourceCounts);
             WriteUpdatedApplicationsWithSourceCounts(updatedApplicationsWithSourceCounts);
-            
+
             log.SetOutputVariableButDoNotAddToVariables(SpecialVariables.Git.Output.UpdatedImages, imagesUpdatedCount.ToString());
         }
 
@@ -78,7 +98,7 @@ namespace Calamari.ArgoCD
 
             var totalSourceCounts = ToCommaSeparatedString(matchingApplicationsWithSourceCounts.Select(c => c.TotalSourceCount));
             log.SetOutputVariableButDoNotAddToVariables(SpecialVariables.Git.Output.MatchingApplicationTotalSourceCounts, totalSourceCounts);
-            
+
             var matchingSourceCounts = ToCommaSeparatedString(matchingApplicationsWithSourceCounts.Select(c => c.MatchingSourceCount));
             log.SetOutputVariableButDoNotAddToVariables(SpecialVariables.Git.Output.MatchingApplicationMatchingSourceCounts, matchingSourceCounts);
         }

--- a/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppImagesCommand.cs
+++ b/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppImagesCommand.cs
@@ -67,7 +67,7 @@ namespace Calamari.ArgoCD.Commands
                                                            gitVendorPullRequestClientResolver,
                                                            clock,
                                                            new ArgoCDFilesUpdatedReporter(log),
-                                                           new ArgoCDOutputVariablesWriter(log, variables)),
+                                                           new ArgoCDOutputVariablesWriter(log)),
             };
                 
             var conventionRunner = new ConventionProcessor(runningDeployment, conventions, log);

--- a/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppManifestsCommand.cs
+++ b/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppManifestsCommand.cs
@@ -100,7 +100,7 @@ namespace Calamari.ArgoCD.Commands
                                                                       gitVendorPullRequestClientResolver,
                                                                       clock,
                                                                       new ArgoCDFilesUpdatedReporter(log),
-                                                                      new ArgoCDOutputVariablesWriter(log, variables)),
+                                                                      new ArgoCDOutputVariablesWriter(log)),
             };
 
             var runningDeployment = new RunningDeployment(pathToPackage, variables);

--- a/source/Calamari/ArgoCD/Conventions/ManifestTemplating/ApplicationSourceUpdater.cs
+++ b/source/Calamari/ArgoCD/Conventions/ManifestTemplating/ApplicationSourceUpdater.cs
@@ -60,14 +60,14 @@ public class ApplicationSourceUpdater
         var sourceUpdater = new CopyTemplatesSourceUpdater(packageFiles, log, fileSystem, deploymentConfig.PurgeOutputDirectory, pathOverrideFromAnnotation);
 
         var sourceUpdateResult = repositoryAdapter.Process(sourceWithMetadata, sourceUpdater);
+        
+        outputVariablesWriter.WriteSourceUpdateResultOutputWhenPushResultExists(gateway.Name,
+                                                            applicationFromYaml.Metadata.Name,
+                                                            sourceWithMetadata.Index,
+                                                            sourceUpdateResult);
 
         if (sourceUpdateResult.PushResult is not null)
         {
-            outputVariablesWriter.WritePushResultOutput(gateway.Name,
-                                                        applicationFromYaml.Metadata.Name,
-                                                        sourceWithMetadata.Index,
-                                                        sourceUpdateResult.PushResult);
-
             return new ManifestUpdateResult(true, sourceUpdateResult.PushResult.CommitSha, sourceUpdateResult.PushResult.CommitTimestamp, sourceUpdateResult.ReplacedFiles);
         }
 

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
@@ -86,7 +86,9 @@ namespace Calamari.ArgoCD.Conventions
                                                            })
                                                    .ToList();
 
-            reporter.ReportFilesUpdated(applicationResults);
+            //if we are creating a pull request, we don't want to report files updated (as this will be passed down as output variables _with_ the PR info)
+
+                reporter.ReportFilesUpdated(deploymentConfig.CommitParameters, applicationResults);
 
             var totalApplicationsWithSourceCounts = applicationResults.Select(r => (r.ApplicationName, r.TotalSourceCount, r.MatchingSourceCount)).ToList();
             var updatedApplications = applicationResults.Where(r => r.Updated).ToList();

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
@@ -62,10 +62,10 @@ namespace Calamari.ArgoCD.Conventions
             var packageFiles = GetReferencedPackageFiles(deploymentConfig);
 
             var repositoryFactory = new RepositoryFactory(log,
-                fileSystem,
-                deployment.CurrentDirectory,
-                gitVendorPullRequestClientResolver,
-                clock);
+                                                          fileSystem,
+                                                          deployment.CurrentDirectory,
+                                                          gitVendorPullRequestClientResolver,
+                                                          clock);
 
             var argoProperties = customPropertiesLoader.Load<ArgoCDCustomPropertiesDto>();
 
@@ -92,7 +92,7 @@ namespace Calamari.ArgoCD.Conventions
                                                            })
                                                    .ToList();
 
-            reporter.ReportFilesUpdated(applicationResults);
+            reporter.ReportFilesUpdated(deploymentConfig.CommitParameters, applicationResults);
 
             var gitReposUpdated = applicationResults.SelectMany(r => r.GitReposUpdated).ToHashSet();
             var totalApplicationsWithSourceCounts = applicationResults.Select(r => (r.ApplicationName, r.TotalSourceCount, r.MatchingSourceCount)).ToList();
@@ -100,10 +100,10 @@ namespace Calamari.ArgoCD.Conventions
 
             var gatewayIds = argoProperties.Applications.Select(a => a.GatewayId).ToHashSet();
             outputVariablesWriter.WriteManifestUpdateOutput(gatewayIds,
-                gitReposUpdated,
-                totalApplicationsWithSourceCounts,
-                updatedApplicationsWithSources
-            );
+                                                            gitReposUpdated,
+                                                            totalApplicationsWithSourceCounts,
+                                                            updatedApplicationsWithSources
+                                                           );
         }
 
         IPackageRelativeFile[] GetReferencedPackageFiles(ArgoCommitToGitConfig config)

--- a/source/Calamari/ArgoCD/Conventions/UpdateImageTag/ApplicationSourceUpdater.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateImageTag/ApplicationSourceUpdater.cs
@@ -59,13 +59,10 @@ public class ApplicationSourceUpdater
 
         var sourceUpdateResult = repositoryAdapter.Process(sourceWithMetadata, sourceUpdater);
 
-        if (sourceUpdateResult.PushResult is not null)
-        {
-            outputVariablesWriter.WritePushResultOutput(gateway.Name,
-                                                        applicationFromYaml.Metadata.Name,
-                                                        sourceWithMetadata.Index,
-                                                        sourceUpdateResult.PushResult);
-        }
+        outputVariablesWriter.WriteSourceUpdateResultOutputWhenPushResultExists(gateway.Name,
+                                                            applicationFromYaml.Metadata.Name,
+                                                            sourceWithMetadata.Index,
+                                                            sourceUpdateResult);
 
         return sourceUpdateResult;
     }

--- a/source/Calamari/ArgoCD/ProcessApplicationResult.cs
+++ b/source/Calamari/ArgoCD/ProcessApplicationResult.cs
@@ -17,33 +17,22 @@ namespace Calamari.ArgoCD
         List<FileHash> ReplacedFiles,
         List<FileJsonPatch> PatchedFiles);
 
-    public class ProcessApplicationResult
+    public class ProcessApplicationResult(
+        string gatewayId,
+        ApplicationName applicationName,
+        int totalSourceCount,
+        int matchingSourceCount,
+        List<TrackedSourceDetail> trackedSourceDetails,
+        HashSet<string> updatedImages,
+        HashSet<string> gitReposUpdated)
     {
-        public ProcessApplicationResult(
-            string gatewayId,
-            ApplicationName applicationName,
-            int totalSourceCount,
-            int matchingSourceCount,
-            List<TrackedSourceDetail> trackedSourceDetails,
-            HashSet<string> updatedImages,
-            HashSet<string> gitReposUpdated)
-        {
-            GatewayId = gatewayId;
-            ApplicationName = applicationName;
-            TotalSourceCount = totalSourceCount;
-            MatchingSourceCount = matchingSourceCount;
-            TrackedSourceDetails = trackedSourceDetails;
-            UpdatedImages = updatedImages;
-            GitReposUpdated = gitReposUpdated;
-        }
-
-        public string GatewayId { get; }
-        public ApplicationName ApplicationName { get; }
-        public int TotalSourceCount { get; }
-        public int MatchingSourceCount { get; }
-        public List<TrackedSourceDetail> TrackedSourceDetails { get; }
-        public HashSet<string> UpdatedImages { get; }
-        public HashSet<string> GitReposUpdated { get; }
+        public string GatewayId { get; } = gatewayId;
+        public ApplicationName ApplicationName { get; } = applicationName;
+        public int TotalSourceCount { get; } = totalSourceCount;
+        public int MatchingSourceCount { get; } = matchingSourceCount;
+        public List<TrackedSourceDetail> TrackedSourceDetails { get; } = trackedSourceDetails;
+        public HashSet<string> UpdatedImages { get; } = updatedImages;
+        public HashSet<string> GitReposUpdated { get; } = gitReposUpdated;
         public int UpdatedSourceCount => TrackedSourceDetails.Count(s => !string.IsNullOrEmpty(s.CommitSha));
         public bool Tracked => TrackedSourceDetails.Any();
         public bool Updated => UpdatedSourceCount > 0;

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -128,6 +128,8 @@ namespace Calamari.Kubernetes
                                 public string PullRequestTitle => $"{qualifiedPrefix}.PullRequest.Title";
                                 public string PullRequestNumber => $"{qualifiedPrefix}.PullRequest.Number";
                                 public string PullRequestUrl => $"{qualifiedPrefix}.PullRequest.Url";
+                                public string PullRequestReplacedFiles =>  $"{qualifiedPrefix}.PullRequest.ReplacedFiles";
+                                public string PullRequestPatchedFiles =>  $"{qualifiedPrefix}.PullRequest.PatchedFiles";
                             }
                         }
                     }


### PR DESCRIPTION
Related Server PR: https://github.com/OctopusDeploy/OctopusDeploy/pull/42189

Related to MD-1767

When creating a pull request, we no longer want to send the `argocd-files-updated` service message. This is because this message causes an update of the tracked git state in Octopus Server.
For a pull request, this git state should only change when the PR is merged.

We now don't send this service message when the git commit parameters `IsPr` is `true`.
We also include the replaced & patched files in new output variables, which are then captured in Octopus Server and attached to the pull request tracking entity.