### PR TITLE
feat: reinstate v4 AWS SDK packages

### DIFF
--- a/source/Calamari.Aws/Calamari.Aws.csproj
+++ b/source/Calamari.Aws/Calamari.Aws.csproj
@@ -22,12 +22,12 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.EKS" Version="4.0.14.1" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.8.11" />
-    <PackageReference Include="AWSSDK.Core" Version="4.0.3.18" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.10" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.19" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.12" />
+    <PackageReference Include="AWSSDK.EKS" Version="4.0.15.1" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.8.19" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.29" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.18" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.21.1" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.20" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari.CloudAccounts\Calamari.CloudAccounts.csproj" />

--- a/source/Calamari.Aws/Calamari.Aws.csproj
+++ b/source/Calamari.Aws/Calamari.Aws.csproj
@@ -22,12 +22,12 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.EKS" Version="3.7.13.24" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.9.14" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.400.62" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.116" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.8.8" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.401.11" />
+    <PackageReference Include="AWSSDK.EKS" Version="4.0.14.1" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.8.11" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.18" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.10" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.19" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.12" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari.CloudAccounts\Calamari.CloudAccounts.csproj" />

--- a/source/Calamari.Aws/Calamari.Aws.csproj
+++ b/source/Calamari.Aws/Calamari.Aws.csproj
@@ -22,6 +22,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AWSSDK.ECS" Version="4.0.19" />
     <PackageReference Include="AWSSDK.EKS" Version="4.0.15.1" />
     <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.8.19" />
     <PackageReference Include="AWSSDK.Core" Version="4.0.3.29" />

--- a/source/Calamari.Aws/Deployment/Conventions/CloudFormationOutputsAsVariablesConvention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/CloudFormationOutputsAsVariablesConvention.cs
@@ -57,7 +57,7 @@ namespace Calamari.Aws.Deployment.Conventions
             Guard.NotNull(query, "Query for stack may not be null");
 
             List<VariableOutput> ConvertStackOutputs(Stack stack) =>
-                stack.Outputs.Select(p => new VariableOutput(p.OutputKey, p.OutputValue)).ToList();
+                stack.Outputs?.Select(p => new VariableOutput(p.OutputKey, p.OutputValue)).ToList() ?? new List<VariableOutput>();
 
             return (await query()).Select(ConvertStackOutputs)
                 .Map(result => (result: result.SomeOr(new List<VariableOutput>()), success: true));

--- a/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
+++ b/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
@@ -18,9 +18,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.Core" Version="3.7.400.62" />
-      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.401.11" />
-      <PackageReference Include="AWSSDK.ECR" Version="3.7.100.0" />
+      <PackageReference Include="AWSSDK.Core" Version="4.0.3.18" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.12" />
+      <PackageReference Include="AWSSDK.ECR" Version="4.0.12" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
       <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />

--- a/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
+++ b/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
@@ -18,9 +18,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.Core" Version="4.0.3.18" />
-      <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.12" />
-      <PackageReference Include="AWSSDK.ECR" Version="4.0.12" />
+      <PackageReference Include="AWSSDK.Core" Version="4.0.3.29" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.20" />
+      <PackageReference Include="AWSSDK.ECR" Version="4.0.13.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
       <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Calamari.CloudAccounts\Calamari.CloudAccounts.csproj" />
     <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.19" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.21.1" />
     <PackageReference Include="Google.Apis.Auth" Version="1.68.0" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.10.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Calamari.CloudAccounts\Calamari.CloudAccounts.csproj" />
     <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.8.8" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.19" />
     <PackageReference Include="Google.Apis.Auth" Version="1.68.0" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.10.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />

--- a/source/Calamari.Terraform/Calamari.Terraform.csproj
+++ b/source/Calamari.Terraform/Calamari.Terraform.csproj
@@ -10,8 +10,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.401.11" />
     <PackageReference Include="NuGet.Versioning" Version="7.4.0-octopus-release.17001" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.12" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari.CloudAccounts\Calamari.CloudAccounts.csproj" />

--- a/source/Calamari.Terraform/Calamari.Terraform.csproj
+++ b/source/Calamari.Terraform/Calamari.Terraform.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Versioning" Version="7.4.0-octopus-release.17001" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.12" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.20" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari.CloudAccounts\Calamari.CloudAccounts.csproj" />

--- a/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
+++ b/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
@@ -22,8 +22,8 @@ namespace Calamari.Tests.AWS
     {
         [Test]
         [TestCase("arn:aws:iam::0123456789AB:role/test-role", "My session name", "900", 900)]
-        [TestCase("arn:aws:iam::0123456789AB:role/test-role", "My session name", null, 0)]
-        [TestCase("arn:aws:iam::0123456789AB:role/test-role", "My session name", "", 0)]
+        [TestCase("arn:aws:iam::0123456789AB:role/test-role", "My session name", null, null)]
+        [TestCase("arn:aws:iam::0123456789AB:role/test-role", "My session name", "", null)]
         public void CreatesAssumeRoleRequestWithExpectedParams(string arn, string sessionName, string duration, int? expectedDuration)
         {
             IVariables variables = new CalamariVariables();

--- a/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
+++ b/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
@@ -268,10 +268,7 @@ namespace Calamari.Tests.AWS
                     CannedAcl = "private",
                     BucketKeyBehaviour = BucketKeyBehaviourType.Filename,
                     Metadata = specialHeaders.Concat(userDefinedMetadata).ToList(),
-                    Tags = new List<KeyValuePair<string, string>>()
-                    {
-                        new KeyValuePair<string, string>("Environment", "Test")
-                    }
+                    Tags = [new KeyValuePair<string, string>("Environment", "Test")]
                 }
             };
 
@@ -287,10 +284,7 @@ namespace Calamari.Tests.AWS
                                {
                                    if (specialHeader.Key == "Expires")
                                    {
-                                       //There's a serialization bug in Json.Net that ends up changing the time to local.
-                                       //Fix this assertion once that's done.
-                                       var expectedDate = DateTime.Parse(specialHeader.Value.TrimEnd('Z')).ToUniversalTime();
-                                       response.Expires.Should().Be(expectedDate);
+                                       response.ExpiresString.Should().Be(specialHeader.Value);
                                    }
                                    else if (specialHeader.Key == "x-amz-website-redirect-location")
                                    {


### PR DESCRIPTION
Off the back of https://github.com/OctopusDeploy/Calamari/commit/651c8c1c2e82c6f4b9bbf4f08b8ab15701e98b5b we are now ready to reinstate the v4 AWS Libraries. 

Plan is to run this in a branch instance and do some additional manual testing to ensure no more cord-pulls/incidents

Bundled with Server PR - https://github.com/OctopusDeploy/OctopusDeploy/pull/42243

