### PR TITLE
fix: Erroneous Commit message for Argo Manifest Template step

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -24,7 +24,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="NuGet.CommandLine" Version="7.0.1">
+        <PackageReference Include="NuGet.CommandLine" Version="7.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -22,10 +22,6 @@
         <NukeExcludeDirectoryBuild>True</NukeExcludeDirectoryBuild>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <WarningsNotAsErrors>NU1901</WarningsNotAsErrors>
-    </PropertyGroup>
-    
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="NuGet.CommandLine" Version="7.0.3">

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -22,6 +22,10 @@
         <NukeExcludeDirectoryBuild>True</NukeExcludeDirectoryBuild>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <WarningsNotAsErrors>NU1901</WarningsNotAsErrors>
+    </PropertyGroup>
+    
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="NuGet.CommandLine" Version="7.0.1">

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NuGet.Commands" Version="7.0.1" />
+        <PackageReference Include="NuGet.Commands" Version="7.0.3" />
         <PackageReference Include="NuGet.Packaging" Version="7.4.0-octopus-release.17001" />
         <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
     <PackageReference Include="Polly" Version="8.3.1" />
-    <PackageReference Include="NuGet.Commands" Version="7.0.1" />
+    <PackageReference Include="NuGet.Commands" Version="7.0.3" />
     <PackageReference Include="Markdown" Version="2.1.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
@@ -62,7 +62,6 @@ image:
                 log,
                 fileSystem,
                 new DeploymentConfigFactory(nonSensitiveCalamariVariables),
-                new CommitMessageGenerator(),
                 customPropertiesLoader,
                 argoCdApplicationManifestParser,
                 Substitute.For<IGitVendorPullRequestClientResolver>(),

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -251,6 +251,9 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             var clonedRepoPath = RepositoryHelpers.CloneOrigin(tempDirectory, OriginPath, argoCDBranchName);
             AssertFileContents(clonedRepoPath, yamlFilename, updatedYamlContent);
 
+            using var resultRepo = new Repository(clonedRepoPath);
+            resultRepo.Head.Tip.Message.TrimEnd().Should().Contain("---\nImages updated:");
+            
             AssertOutputVariables();
         }
 

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -57,7 +57,6 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                 log,
                 fileSystem,
                 new DeploymentConfigFactory(nonSensitiveCalamariVariables),
-                new CommitMessageGenerator(),
                 customPropertiesLoader,
                 argoCdApplicationManifestParser,
                 Substitute.For<IGitVendorPullRequestClientResolver>(),

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
@@ -159,7 +159,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             fileSystem.FileExists(Path.Combine(resultPath, fourthFilename)).Should().BeTrue();
 
             using var resultRepo = new Repository(resultPath);
-            resultRepo.Head.Tip.MessageShort.Should().Be(nonSensitiveCalamariVariables[SpecialVariables.Git.CommitMessageSummary]);
+            resultRepo.Head.Tip.Message.TrimEnd().Should().Be(nonSensitiveCalamariVariables[SpecialVariables.Git.CommitMessageSummary]);
 
             AssertOutputVariables();
         }

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
@@ -158,6 +158,9 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             fileSystem.FileExists(Path.Combine(resultPath, thirdFilename)).Should().BeTrue();
             fileSystem.FileExists(Path.Combine(resultPath, fourthFilename)).Should().BeTrue();
 
+            using var resultRepo = new Repository(resultPath);
+            resultRepo.Head.Tip.MessageShort.Should().Be(nonSensitiveCalamariVariables[SpecialVariables.Git.CommitMessageSummary]);
+
             AssertOutputVariables();
         }
 

--- a/source/Calamari.Tests/ArgoCD/Git/ImageTagUpdateCommitMessageGeneratorTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/ImageTagUpdateCommitMessageGeneratorTests.cs
@@ -1,22 +1,23 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
+using Calamari.ArgoCD.Conventions;
+using Calamari.ArgoCD.Conventions.UpdateImageTag;
 using Calamari.ArgoCD.Git;
-using Calamari.Tests.Helpers;
 using FluentAssertions;
+using JetBrains.Annotations;
 using NUnit.Framework;
 
 namespace Calamari.Tests.ArgoCD.Git
 {
     [TestFixture]
-    public class CommitMessageGeneratorTests
+    public class ImageTagUpdateCommitMessageGeneratorTests
     {
-        readonly CommitMessageGenerator commitMessageGenerator = new CommitMessageGenerator();
-
         [Test]
         public void SummaryWithNoImages_SummaryAndNoImage()
         {
-            var result = commitMessageGenerator.GenerateDescription(new HashSet<string>(), "Foo");
-
+            var imageTagUpdateCommitMessageGenerator = new ImageTagUpdateCommitMessageGenerator("Foo");
+            var result = imageTagUpdateCommitMessageGenerator.GenerateDescription(CreateFileUpdateResult(new HashSet<string>()));
             var expected = @"Foo
 
 ---
@@ -27,7 +28,8 @@ No images updated".ReplaceLineEndings("\n");
         [Test]
         public void SummaryWithOneImage_SummaryAndImage()
         {
-            var result = commitMessageGenerator.GenerateDescription( new HashSet<string>() { "nginx" }, "Foo");
+            var imageTagUpdateCommitMessageGenerator = new ImageTagUpdateCommitMessageGenerator("Foo");
+            var result = imageTagUpdateCommitMessageGenerator.GenerateDescription( CreateFileUpdateResult(new HashSet<string>() { "nginx" }));
 
             var expected = @"Foo
 
@@ -40,7 +42,8 @@ Images updated:
         [Test]
         public void SummaryWithThreeImages_SummaryAndImagesSorted()
         {
-            var result = commitMessageGenerator.GenerateDescription(new HashSet<string>() {"nginx", "alpine", "ubuntu"}, "Foo");
+            var imageTagUpdateCommitMessageGenerator = new ImageTagUpdateCommitMessageGenerator("Foo");
+            var result = imageTagUpdateCommitMessageGenerator.GenerateDescription(CreateFileUpdateResult(new HashSet<string>() {"nginx", "alpine", "ubuntu"}));
 
             var expected = @"Foo
 
@@ -58,7 +61,8 @@ Images updated:
             var description = @"Dolores animi quia quae enim hic.
 
 Quibusdam qui maxime eos et magnam quod minus rerum perferendis eum iusto neque et tenetur. Porro illum praesentium sit dolorem rerum accusantium enim repellendus qui iste.".ReplaceLineEndings("\n");
-            var result = commitMessageGenerator.GenerateDescription( new HashSet<string>() {"nginx"},description);
+            var imageTagUpdateCommitMessageGenerator = new ImageTagUpdateCommitMessageGenerator(description);
+            var result = imageTagUpdateCommitMessageGenerator.GenerateDescription( CreateFileUpdateResult(new HashSet<string>() {"nginx"}));
 
             var expected = @"Dolores animi quia quae enim hic.
 
@@ -68,6 +72,11 @@ Quibusdam qui maxime eos et magnam quod minus rerum perferendis eum iusto neque 
 Images updated:
 - nginx".ReplaceLineEndings("\n");
             result.Should().Be(expected.ReplaceLineEndings("\n"));
+        }
+        
+        FileUpdateResult CreateFileUpdateResult(HashSet<string> imagesUpdated)
+        {
+            return new FileUpdateResult(imagesUpdated, [], [], []);
         }
     }
 }

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
-        <PackageReference Include="NuGet.CommandLine" Version="7.0.1">
+        <PackageReference Include="NuGet.CommandLine" Version="7.0.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -14,6 +14,9 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
     </PropertyGroup>
+    <PropertyGroup>
+        <WarningsNotAsErrors>NU1901</WarningsNotAsErrors>
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
         <PackageReference Include="NuGet.CommandLine" Version="7.0.1">

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -14,9 +14,6 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
     </PropertyGroup>
-    <PropertyGroup>
-        <WarningsNotAsErrors>NU1901</WarningsNotAsErrors>
-    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
         <PackageReference Include="NuGet.CommandLine" Version="7.0.3">

--- a/source/Calamari/ArgoCD/ArgoCDModule.cs
+++ b/source/Calamari/ArgoCD/ArgoCDModule.cs
@@ -28,7 +28,6 @@ namespace Calamari.ArgoCD
         protected override void Load(ContainerBuilder builder)
         {
             builder.RegisterType<DeploymentConfigFactory>().AsSelf().InstancePerLifetimeScope();
-            builder.RegisterType<ImageTagUpdateCommitMessageGenerator>().As<ICommitMessageGenerator>().InstancePerLifetimeScope();
 
             builder.RegisterAssemblyTypes(GetType().Assembly)
                    .AssignableTo<IGitVendorPullRequestClientFactory>()

--- a/source/Calamari/ArgoCD/ArgoCDModule.cs
+++ b/source/Calamari/ArgoCD/ArgoCDModule.cs
@@ -28,7 +28,7 @@ namespace Calamari.ArgoCD
         protected override void Load(ContainerBuilder builder)
         {
             builder.RegisterType<DeploymentConfigFactory>().AsSelf().InstancePerLifetimeScope();
-            builder.RegisterType<CommitMessageGenerator>().As<ICommitMessageGenerator>().InstancePerLifetimeScope();
+            builder.RegisterType<ImageTagUpdateCommitMessageGenerator>().As<ICommitMessageGenerator>().InstancePerLifetimeScope();
 
             builder.RegisterAssemblyTypes(GetType().Assembly)
                    .AssignableTo<IGitVendorPullRequestClientFactory>()

--- a/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppImagesCommand.cs
+++ b/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppImagesCommand.cs
@@ -25,7 +25,6 @@ namespace Calamari.ArgoCD.Commands
         readonly ICalamariFileSystem fileSystem;
         readonly DeploymentConfigFactory configFactory;
         readonly IGitVendorPullRequestClientResolver gitVendorPullRequestClientResolver;
-        readonly ICommitMessageGenerator commitMessageGenerator;
         string customPropertiesFile;
         string customPropertiesPassword;
 
@@ -39,7 +38,6 @@ namespace Calamari.ArgoCD.Commands
             this.log = log;
             this.variables = variables;
             this.fileSystem = fileSystem;
-            this.commitMessageGenerator = commitMessageGenerator;
             this.configFactory = configFactory;
             this.gitVendorPullRequestClientResolver = gitVendorPullRequestClientResolver;
             Options.Add("customPropertiesFile=",
@@ -61,7 +59,6 @@ namespace Calamari.ArgoCD.Commands
                 new UpdateArgoCDAppImagesInstallConvention(log,
                                                            fileSystem,
                                                            configFactory,
-                                                           commitMessageGenerator,
                                                            new CustomPropertiesLoader(fileSystem, customPropertiesFile, customPropertiesPassword),
                                                            new ArgoCdApplicationManifestParser(),
                                                            gitVendorPullRequestClientResolver,

--- a/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppImagesCommand.cs
+++ b/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppImagesCommand.cs
@@ -1,9 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using Calamari.ArgoCD.Conventions;
-using Calamari.ArgoCD.Git;
 using Calamari.ArgoCD.Git.PullRequests;
-using Calamari.ArgoCD.GitHub;
 using Calamari.Commands.Support;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.FileSystem;
@@ -31,7 +29,6 @@ namespace Calamari.ArgoCD.Commands
         public UpdateArgoCDAppImagesCommand(ILog log,
                                             IVariables variables,
                                             ICalamariFileSystem fileSystem,
-                                            ICommitMessageGenerator commitMessageGenerator,
                                             DeploymentConfigFactory configFactory,
                                             IGitVendorPullRequestClientResolver gitVendorPullRequestClientResolver)
         {

--- a/source/Calamari/ArgoCD/Conventions/ManifestTemplating/ApplicationUpdater.cs
+++ b/source/Calamari/ArgoCD/Conventions/ManifestTemplating/ApplicationUpdater.cs
@@ -18,6 +18,7 @@ public class ApplicationUpdater
     readonly ILog log;
     readonly ICalamariFileSystem fileSystem;
     readonly IArgoCDApplicationManifestParser argoCdApplicationManifestParser;
+    readonly ICommitMessageGenerator commitMessageGenerator;
     readonly ArgoCDOutputVariablesWriter outputVariablesWriter;
     readonly IPackageRelativeFile[] packageFiles;
     
@@ -26,7 +27,8 @@ public class ApplicationUpdater
                               ICalamariFileSystem fileSystem,
                               IArgoCDApplicationManifestParser argoCdApplicationManifestParser,
                               ArgoCDOutputVariablesWriter outputVariablesWriter,
-                              IPackageRelativeFile[] packageFiles)
+                              IPackageRelativeFile[] packageFiles,
+                              ICommitMessageGenerator commitMessageGenerator)
     {
         this.repositoryFactory = repositoryFactory;
         this.deploymentScope = deploymentScope;
@@ -36,6 +38,7 @@ public class ApplicationUpdater
         this.argoCdApplicationManifestParser = argoCdApplicationManifestParser;
         this.outputVariablesWriter = outputVariablesWriter;
         this.packageFiles = packageFiles;
+        this.commitMessageGenerator = commitMessageGenerator;
     }
     
     public ProcessApplicationResult ProcessApplication(
@@ -53,7 +56,7 @@ public class ApplicationUpdater
         
         ValidateApplication(applicationFromYaml);
 
-        var repositoryAdapter = new RepositoryAdapter(repositoryFactory, deploymentConfig.CommitParameters, log, new CommitMessageGenerator());
+        var repositoryAdapter = new RepositoryAdapter(repositoryFactory, deploymentConfig.CommitParameters, log, commitMessageGenerator);
         var sourceUpdater = new ApplicationSourceUpdater(applicationFromYaml,
                                                          gateway,
                                                          deploymentScope,

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
@@ -19,7 +19,6 @@ namespace Calamari.ArgoCD.Conventions
         readonly ICalamariFileSystem fileSystem;
         readonly ILog log;
         readonly DeploymentConfigFactory deploymentConfigFactory;
-        readonly ICommitMessageGenerator commitMessageGenerator;
         readonly ICustomPropertiesLoader customPropertiesLoader;
         readonly IArgoCDApplicationManifestParser argoCdApplicationManifestParser;
         readonly IGitVendorPullRequestClientResolver gitVendorPullRequestClientResolver;
@@ -31,7 +30,6 @@ namespace Calamari.ArgoCD.Conventions
             ILog log,
             ICalamariFileSystem fileSystem,
             DeploymentConfigFactory deploymentConfigFactory,
-            ICommitMessageGenerator commitMessageGenerator,
             ICustomPropertiesLoader customPropertiesLoader,
             IArgoCDApplicationManifestParser argoCdApplicationManifestParser,
             IGitVendorPullRequestClientResolver gitVendorPullRequestClientResolver,
@@ -42,7 +40,6 @@ namespace Calamari.ArgoCD.Conventions
             this.log = log;
             this.fileSystem = fileSystem;
             this.deploymentConfigFactory = deploymentConfigFactory;
-            this.commitMessageGenerator = commitMessageGenerator;
             this.customPropertiesLoader = customPropertiesLoader;
             this.argoCdApplicationManifestParser = argoCdApplicationManifestParser;
             this.gitVendorPullRequestClientResolver = gitVendorPullRequestClientResolver;
@@ -75,7 +72,7 @@ namespace Calamari.ArgoCD.Conventions
                                                     log,
                                                     fileSystem,
                                                     argoCdApplicationManifestParser,
-                                                    commitMessageGenerator,
+                                                    new ImageTagUpdateCommitMessageGenerator(deploymentConfig.CommitParameters.Description),
                                                     outputVariablesWriter);
 
             var applicationResults = argoProperties.Applications

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
@@ -82,7 +82,8 @@ namespace Calamari.ArgoCD.Conventions
                                                             fileSystem,
                                                             argoCdApplicationManifestParser,
                                                             outputVariablesWriter,
-                                                            packageFiles);
+                                                            packageFiles,
+                                                            new ImageTagUpdateCommitMessageGenerator(deploymentConfig.CommitParameters.Description));
 
             var applicationResults = argoProperties.Applications
                                                    .Select(application =>

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
@@ -83,7 +83,7 @@ namespace Calamari.ArgoCD.Conventions
                                                             argoCdApplicationManifestParser,
                                                             outputVariablesWriter,
                                                             packageFiles,
-                                                            new ImageTagUpdateCommitMessageGenerator(deploymentConfig.CommitParameters.Description));
+                                                            new UserDefinedCommitMessageGenerator(deploymentConfig.CommitParameters.Description));
 
             var applicationResults = argoProperties.Applications
                                                    .Select(application =>

--- a/source/Calamari/ArgoCD/Git/CommitMessageGenerator.cs
+++ b/source/Calamari/ArgoCD/Git/CommitMessageGenerator.cs
@@ -2,27 +2,34 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Calamari.ArgoCD.Conventions;
+using Calamari.ArgoCD.Conventions.UpdateImageTag;
 using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.ArgoCD.Git
 {
     public interface ICommitMessageGenerator
     {
-        string GenerateDescription(HashSet<string> updatedImages, string? userDescription);
+        string GenerateDescription(FileUpdateResult result);
     }
-
-    public class CommitMessageGenerator : ICommitMessageGenerator
+    
+    public class ImageTagUpdateCommitMessageGenerator : ICommitMessageGenerator
     {
-        // TODO: This is a leaky abstraction - figure out how to remove
-        public string GenerateDescription(HashSet<string> updatedImages, string? userDescription)
-        {
-            var updatedImagesList = GenerateUpdatedImagesListCommitBody(updatedImages);
-            return string.IsNullOrEmpty(userDescription)
-                ? updatedImagesList
-                : $"{userDescription}\n\n{updatedImagesList}";
-        }
+        readonly string userDefinedCommitMessage;
 
-        string GenerateUpdatedImagesListCommitBody(HashSet<string> updatedImages)
+        public ImageTagUpdateCommitMessageGenerator(string userDefinedCommitMessage)
+        {
+            this.userDefinedCommitMessage = userDefinedCommitMessage;
+        }
+        public string GenerateDescription(FileUpdateResult result)
+        {
+            var updatedImagesList = GenerateUpdatedImagesListCommitBody(result.UpdatedImages);
+            return string.IsNullOrEmpty(userDefinedCommitMessage)
+                ? updatedImagesList
+                : $"{userDefinedCommitMessage}\n\n{updatedImagesList}";
+        }
+        
+        public static string GenerateUpdatedImagesListCommitBody(HashSet<string> updatedImages)
         {
             if (updatedImages.Any())
             {
@@ -33,6 +40,21 @@ namespace Calamari.ArgoCD.Git
             }
 
             return "---\nNo images updated";
+        }
+    }
+    
+    public class UserDefinedCommitMessageGenerator : ICommitMessageGenerator
+    {
+        readonly string userDefinedCommitMessage;
+
+        public UserDefinedCommitMessageGenerator(string userDefinedCommitMessage)
+        {
+            this.userDefinedCommitMessage = userDefinedCommitMessage;
+        }
+
+        public string GenerateDescription(FileUpdateResult result)
+        {
+            return userDefinedCommitMessage;
         }
     }
 }

--- a/source/Calamari/ArgoCD/Git/RepositoryAdapter.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryAdapter.cs
@@ -61,7 +61,7 @@ public class RepositoryAdapter
         repository.AddFiles(result.ReplacedFiles.Select(f => f.FilePath).Concat(result.PatchedFiles.Select(f => f.FilePath)).Distinct().ToArray());
         repository.RemoveFiles(result.FilesRemoved ?? []);
 
-        var commitDescription = commitMessageGenerator.GenerateDescription(result.UpdatedImages, commitParameters.Description);
+        var commitDescription = commitMessageGenerator.GenerateDescription(result);
 
         log.Info("Committing changes");
         if (!repository.CommitChanges(commitParameters.Summary, commitDescription))


### PR DESCRIPTION
It was found that the Manifest inspection step would errantly insert "--No Images updated" as part of its commit message - this was introduced during a recent calamari argo-step refactor.

This change introduces a step-specific "CommitMessageGenerator" such that each step can generate a message independently of each other.

A test was inserted to prevent regression.


* No server change is required