### PR TITLE
fix: bump nuget packages to address vuln

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -24,7 +24,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="NuGet.CommandLine" Version="7.0.1">
+        <PackageReference Include="NuGet.CommandLine" Version="7.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NuGet.Commands" Version="7.0.1" />
+        <PackageReference Include="NuGet.Commands" Version="7.0.3" />
         <PackageReference Include="NuGet.Packaging" Version="7.4.0-octopus-release.17001" />
         <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
     <PackageReference Include="Polly" Version="8.3.1" />
-    <PackageReference Include="NuGet.Commands" Version="7.0.1" />
+    <PackageReference Include="NuGet.Commands" Version="7.0.3" />
     <PackageReference Include="Markdown" Version="2.1.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
-        <PackageReference Include="NuGet.CommandLine" Version="7.0.1">
+        <PackageReference Include="NuGet.CommandLine" Version="7.0.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!


Addresses vulnerabilities in Nuget packages as outlined in https://github.com/advisories/GHSA-g4vj-cjjj-v7hg