### PR TITLE
Allow case insensitive deserialization of Bicep params

### DIFF
--- a/source/Calamari.AzureResourceGroup.Tests/Bicep/BicepToArmParameterMapperFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/Bicep/BicepToArmParameterMapperFixture.cs
@@ -142,6 +142,31 @@ public class BicepToArmParameterMapperFixture
     }
 
     [Test]
+    public void Map_WithLowercaseKeyValueProperties_ReturnsParameterString()
+    {
+      var lowercaseParameters = """
+                                [{"key":"storageAccountName","value":"teststorageaccount"},{"key":"location","value":"Australia South East"},{"key":"myStuff","value":"testvalue"}]
+                                """;
+      var expectedParameterString = """
+                                    {
+                                      "storageAccountName": {
+                                        "value": "teststorageaccount"
+                                      },
+                                      "location": {
+                                        "value": "Australia South East"
+                                      },
+                                      "myStuff": {
+                                        "value": "testvalue"
+                                      }
+                                    }
+                                    """.ReplaceLineEndings();
+
+      var result = BicepToArmParameterMapper.Map(lowercaseParameters, SimpleArmTemplate, variables).ReplaceLineEndings();
+
+      Assert.That(result.ToJson(), Is.EqualTo(expectedParameterString.ToJson()));
+    }
+
+    [Test]
     public void Map_WithOctopusVariableDefinedWithNonDelimitedJsonObject_IsResolvedInParametersStringWithProperDelimiting()
     {
       variables.Add("Octopus.TestValue",

--- a/source/Calamari.AzureResourceGroup/Bicep/BicepToArmParameterMapper.cs
+++ b/source/Calamari.AzureResourceGroup/Bicep/BicepToArmParameterMapper.cs
@@ -26,12 +26,7 @@ public static class BicepToArmParameterMapper
             return string.Empty;
         }
 
-        var parameterKeyValuePairs = JArray.Parse(bicepParametersString)
-                                           .Select(item => new KeyValuePair<string, string>(
-                                                                                            item["Key"]!.Value<string>()!,
-                                                                                            item["Value"]!.Value<string>()!
-                                                                                           ))
-                                           .ToList();
+        var parameterKeyValuePairs = JsonConvert.DeserializeObject<List<KeyValuePair<string, string>>>(bicepParametersString) ?? [];
         
         var result = new JObject();
 


### PR DESCRIPTION
No server change required

 Both `{"key":"x","value":"y"}` and `{"Key":"x","Value":"y"}` (SPF mapper) are handled correctly.