### PR TITLE
Git safe clone handles no protocol on uri

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
@@ -117,7 +117,7 @@ image:
                     {
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = OriginPath,
+                            OriginalRepoUrl = $"file://{OriginPath}",
                             Path = "files",
                             TargetRevision = argoCDBranchName.Value,
                             Helm = new HelmConfig()
@@ -181,7 +181,7 @@ service:
                                           })
                                           .WithSource(new ApplicationSource
                                               {
-                                                  OriginalRepoUrl = OriginPath,
+                                                  OriginalRepoUrl = $"file://{OriginPath}",
                                                   TargetRevision = ArgoCDBranchFriendlyName
                                               },
                                               SourceTypeConstants.Helm)
@@ -344,7 +344,7 @@ image:
                     {
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = OriginPath,
+                            OriginalRepoUrl = $"file://{OriginPath}",
                             Path = "files",
                             TargetRevision = argoCDBranchName.Value,
                             Name = "wrong-scoping",
@@ -428,7 +428,7 @@ image:
                         },
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = OriginPath,
+                            OriginalRepoUrl = $"file://{OriginPath}",
                             TargetRevision = argoCDBranchName.Value,
                             Ref = "values",
                         }
@@ -497,7 +497,7 @@ image:
                     {
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = OriginPath,
+                            OriginalRepoUrl = $"file://{OriginPath}",
                             TargetRevision = argoCDBranchName.Value,
                             Path = "files",
                             Helm = new HelmConfig()
@@ -576,7 +576,7 @@ image:
                     {
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = OriginPath,
+                            OriginalRepoUrl = $"file://{OriginPath}",
                             TargetRevision = argoCDBranchName.Value,
                             Path = "files",
                             Name = "helm-source",
@@ -660,7 +660,7 @@ image:
                         },
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = OriginPath,
+                            OriginalRepoUrl = $"file://{OriginPath}",
                             TargetRevision = argoCDBranchName.Value,
                             Ref = "values",
                             Name = "ref-source",
@@ -744,7 +744,7 @@ image:
                         },
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = OriginPath,
+                            OriginalRepoUrl = $"file://{OriginPath}",
                             TargetRevision = argoCDBranchName.Value,
                             Ref = "values",
                         }
@@ -835,7 +835,7 @@ containerPort: 8070
                                           })
                                           .WithSource(new ApplicationSource
                                               {
-                                                  OriginalRepoUrl = OriginPath,
+                                                  OriginalRepoUrl = $"file://{OriginPath}",
                                                   Path = "",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
                                                   Helm = new HelmConfig()
@@ -918,7 +918,7 @@ containerPort: 8070
                                           })
                                           .WithSource(new ApplicationSource
                                               {
-                                                  OriginalRepoUrl = OriginPath,
+                                                  OriginalRepoUrl = $"file://{OriginPath}",
                                                   Path = "",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
                                                   Helm = new HelmConfig()
@@ -1002,7 +1002,7 @@ containerPort: 8070
                                           })
                                           .WithSource(new ApplicationSource
                                               {
-                                                  OriginalRepoUrl = OriginPath,
+                                                  OriginalRepoUrl = $"file://{OriginPath}",
                                                   Path = "",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
                                                   Helm = new HelmConfig()
@@ -1088,7 +1088,7 @@ service:
                                           })
                                           .WithSource(new ApplicationSource
                                               {
-                                                  OriginalRepoUrl = OriginPath,
+                                                  OriginalRepoUrl = $"file://{OriginPath}",
                                                   Path = "",
                                                   TargetRevision = ArgoCDBranchFriendlyName
                                               },
@@ -1188,7 +1188,7 @@ autoscaling:
                                                   Name = "ref-source",
                                                   Ref = "values",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = OriginPath,
+                                                  OriginalRepoUrl = $"file://{OriginPath}",
                                               },
                                               SourceTypeConstants.Directory)
                                           .Build();
@@ -1319,7 +1319,7 @@ service:
                                                   Ref = "values",
                                                   Path = "include/",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = OriginPath,
+                                                  OriginalRepoUrl = $"file://{OriginPath}",
                                               },
                                               SourceTypeConstants.Directory)
                                           .Build();
@@ -1472,7 +1472,7 @@ service:
                                                   Name = "ref-source",
                                                   Ref = "values",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = OriginPath,
+                                                  OriginalRepoUrl = $"file://{OriginPath}",
                                               },
                                               SourceTypeConstants.Directory)
                                           .Build();
@@ -1542,7 +1542,7 @@ service:
                                           .WithSource(new ApplicationSource
                                               {
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = OriginPath,
+                                                  OriginalRepoUrl = $"file://{OriginPath}",
                                                   Path = "",
                                                   Helm = new HelmConfig
                                                   {
@@ -1674,7 +1674,7 @@ image:
             using var _ = new AssertionScope();
             var serviceMessages = log.Messages.GetServiceMessagesOfType("setVariable");
             serviceMessages.GetPropertyValue("ArgoCD.GatewayIds").Should().Be(GatewayId);
-            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? OriginPath : string.Empty);
+            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? $"file://{OriginPath}" : string.Empty);
             serviceMessages.GetPropertyValue("ArgoCD.UpdatedImages").Should().Be(updated ? updatedImages.ToString() : "0");
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplications").Should().Be("App1");
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplicationTotalSourceCounts").Should().Be(matchingApplicationTotalSourceCounts);

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
@@ -38,6 +38,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
         InMemoryLog log;
         string tempDirectory;
         string OriginPath => Path.Combine(tempDirectory, "origin");
+        string OriginUrl => RepositoryHelpers.ToFileUri(OriginPath);
         Repository originRepo;
         const string ArgoCDBranchFriendlyName = "devBranch";
         readonly GitBranchName argoCDBranchName = GitBranchName.CreateFromFriendlyName(ArgoCDBranchFriendlyName);
@@ -96,7 +97,7 @@ image:
                         null)
                 ],
                 [
-                    new GitCredentialDto(new Uri(OriginPath).AbsoluteUri, "", "")
+                    new GitCredentialDto(OriginUrl, "", "")
                 ]);
             customPropertiesLoader.Load<ArgoCDCustomPropertiesDto>().Returns(argoCdCustomPropertiesDto);
 
@@ -117,7 +118,7 @@ image:
                     {
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = $"file://{OriginPath}",
+                            OriginalRepoUrl = OriginUrl,
                             Path = "files",
                             TargetRevision = argoCDBranchName.Value,
                             Helm = new HelmConfig()
@@ -181,7 +182,7 @@ service:
                                           })
                                           .WithSource(new ApplicationSource
                                               {
-                                                  OriginalRepoUrl = $"file://{OriginPath}",
+                                                  OriginalRepoUrl = OriginUrl,
                                                   TargetRevision = ArgoCDBranchFriendlyName
                                               },
                                               SourceTypeConstants.Helm)
@@ -344,7 +345,7 @@ image:
                     {
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = $"file://{OriginPath}",
+                            OriginalRepoUrl = OriginUrl,
                             Path = "files",
                             TargetRevision = argoCDBranchName.Value,
                             Name = "wrong-scoping",
@@ -428,7 +429,7 @@ image:
                         },
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = $"file://{OriginPath}",
+                            OriginalRepoUrl = OriginUrl,
                             TargetRevision = argoCDBranchName.Value,
                             Ref = "values",
                         }
@@ -497,7 +498,7 @@ image:
                     {
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = $"file://{OriginPath}",
+                            OriginalRepoUrl = OriginUrl,
                             TargetRevision = argoCDBranchName.Value,
                             Path = "files",
                             Helm = new HelmConfig()
@@ -576,7 +577,7 @@ image:
                     {
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = $"file://{OriginPath}",
+                            OriginalRepoUrl = OriginUrl,
                             TargetRevision = argoCDBranchName.Value,
                             Path = "files",
                             Name = "helm-source",
@@ -660,7 +661,7 @@ image:
                         },
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = $"file://{OriginPath}",
+                            OriginalRepoUrl = OriginUrl,
                             TargetRevision = argoCDBranchName.Value,
                             Ref = "values",
                             Name = "ref-source",
@@ -744,7 +745,7 @@ image:
                         },
                         new ApplicationSource()
                         {
-                            OriginalRepoUrl = $"file://{OriginPath}",
+                            OriginalRepoUrl = OriginUrl,
                             TargetRevision = argoCDBranchName.Value,
                             Ref = "values",
                         }
@@ -835,7 +836,7 @@ containerPort: 8070
                                           })
                                           .WithSource(new ApplicationSource
                                               {
-                                                  OriginalRepoUrl = $"file://{OriginPath}",
+                                                  OriginalRepoUrl = OriginUrl,
                                                   Path = "",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
                                                   Helm = new HelmConfig()
@@ -918,7 +919,7 @@ containerPort: 8070
                                           })
                                           .WithSource(new ApplicationSource
                                               {
-                                                  OriginalRepoUrl = $"file://{OriginPath}",
+                                                  OriginalRepoUrl = OriginUrl,
                                                   Path = "",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
                                                   Helm = new HelmConfig()
@@ -1002,7 +1003,7 @@ containerPort: 8070
                                           })
                                           .WithSource(new ApplicationSource
                                               {
-                                                  OriginalRepoUrl = $"file://{OriginPath}",
+                                                  OriginalRepoUrl = OriginUrl,
                                                   Path = "",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
                                                   Helm = new HelmConfig()
@@ -1088,7 +1089,7 @@ service:
                                           })
                                           .WithSource(new ApplicationSource
                                               {
-                                                  OriginalRepoUrl = $"file://{OriginPath}",
+                                                  OriginalRepoUrl = OriginUrl,
                                                   Path = "",
                                                   TargetRevision = ArgoCDBranchFriendlyName
                                               },
@@ -1188,7 +1189,7 @@ autoscaling:
                                                   Name = "ref-source",
                                                   Ref = "values",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = $"file://{OriginPath}",
+                                                  OriginalRepoUrl = OriginUrl,
                                               },
                                               SourceTypeConstants.Directory)
                                           .Build();
@@ -1319,7 +1320,7 @@ service:
                                                   Ref = "values",
                                                   Path = "include/",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = $"file://{OriginPath}",
+                                                  OriginalRepoUrl = OriginUrl,
                                               },
                                               SourceTypeConstants.Directory)
                                           .Build();
@@ -1472,7 +1473,7 @@ service:
                                                   Name = "ref-source",
                                                   Ref = "values",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = $"file://{OriginPath}",
+                                                  OriginalRepoUrl = OriginUrl,
                                               },
                                               SourceTypeConstants.Directory)
                                           .Build();
@@ -1542,7 +1543,7 @@ service:
                                           .WithSource(new ApplicationSource
                                               {
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = $"file://{OriginPath}",
+                                                  OriginalRepoUrl = OriginUrl,
                                                   Path = "",
                                                   Helm = new HelmConfig
                                                   {
@@ -1674,7 +1675,7 @@ image:
             using var _ = new AssertionScope();
             var serviceMessages = log.Messages.GetServiceMessagesOfType("setVariable");
             serviceMessages.GetPropertyValue("ArgoCD.GatewayIds").Should().Be(GatewayId);
-            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? $"file://{OriginPath}" : string.Empty);
+            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? OriginUrl : string.Empty);
             serviceMessages.GetPropertyValue("ArgoCD.UpdatedImages").Should().Be(updated ? updatedImages.ToString() : "0");
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplications").Should().Be("App1");
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplicationTotalSourceCounts").Should().Be(matchingApplicationTotalSourceCounts);

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -104,7 +104,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                             })
                                             .WithSource(new ApplicationSource()
                                                 {
-                                                    OriginalRepoUrl = OriginPath,
+                                                    OriginalRepoUrl = $"file://{OriginPath}",
                                                     Path = "",
                                                     TargetRevision = ArgoCDBranchFriendlyName,
                                                 },
@@ -997,7 +997,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                         })
                                                         .WithSource(new ApplicationSource
                                                         {
-                                                            OriginalRepoUrl = OriginPath,
+                                                            OriginalRepoUrl = $"file://{OriginPath}",
                                                             Path = path,
                                                             TargetRevision = ArgoCDBranchFriendlyName,
                                                         }, sourceType)
@@ -1069,8 +1069,8 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                             [ArgoCDConstants.Annotations.OctopusProjectAnnotationKey(new ApplicationSourceName("source1"))] = ProjectSlug,
                                                             [ArgoCDConstants.Annotations.OctopusEnvironmentAnnotationKey(new ApplicationSourceName("source1"))] = EnvironmentSlug,
                                                         })
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginPath, Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginPath, Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
                                                         .Build());
 
             var getResults = CaptureReporterResults();
@@ -1122,8 +1122,8 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                             [ArgoCDConstants.Annotations.OctopusProjectAnnotationKey(new ApplicationSourceName("source1"))] = ProjectSlug,
                                                             [ArgoCDConstants.Annotations.OctopusEnvironmentAnnotationKey(new ApplicationSourceName("source1"))] = EnvironmentSlug,
                                                         })
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginPath, Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginPath, Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
                                                         .Build());
 
             var getResults = CaptureReporterResults();
@@ -1178,8 +1178,8 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                             [ArgoCDConstants.Annotations.OctopusProjectAnnotationKey(new ApplicationSourceName("source1"))] = ProjectSlug,
                                                             [ArgoCDConstants.Annotations.OctopusEnvironmentAnnotationKey(new ApplicationSourceName("source1"))] = EnvironmentSlug,
                                                         })
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginPath, Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginPath, Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
                                                         .Build());
 
             var getResults = CaptureReporterResults();
@@ -1226,7 +1226,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             using var _ = new AssertionScope();
             var serviceMessages = log.Messages.GetServiceMessagesOfType("setVariable");
             serviceMessages.GetPropertyValue("ArgoCD.GatewayIds").Should().Be(GatewayId);
-            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? OriginPath : string.Empty);
+            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? $"file://{OriginPath}" : string.Empty);
             serviceMessages.GetPropertyValue("ArgoCD.UpdatedImages").Should().Be(updated ? "1" : "0");
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplications").Should().Be("App1");
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplicationTotalSourceCounts").Should().Be(matchingApplicationTotalSourceCounts);

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -40,6 +40,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
         InMemoryLog log;
         string tempDirectory;
         string OriginPath => Path.Combine(tempDirectory, "origin");
+        string OriginUrl => RepositoryHelpers.ToFileUri(OriginPath);
         Repository originRepo;
 
         const string ArgoCDBranchFriendlyName = "devBranch";
@@ -91,7 +92,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                         "http://my-argo.com")
                 ],
                 [
-                    new GitCredentialDto(new Uri(OriginPath).AbsoluteUri, "", "")
+                    new GitCredentialDto(OriginUrl, "", "")
                 ]);
             customPropertiesLoader.Load<ArgoCDCustomPropertiesDto>().Returns(argoCdCustomPropertiesDto);
 
@@ -104,7 +105,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                             })
                                             .WithSource(new ApplicationSource()
                                                 {
-                                                    OriginalRepoUrl = $"file://{OriginPath}",
+                                                    OriginalRepoUrl = OriginUrl,
                                                     Path = "",
                                                     TargetRevision = ArgoCDBranchFriendlyName,
                                                 },
@@ -997,7 +998,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                         })
                                                         .WithSource(new ApplicationSource
                                                         {
-                                                            OriginalRepoUrl = $"file://{OriginPath}",
+                                                            OriginalRepoUrl = OriginUrl,
                                                             Path = path,
                                                             TargetRevision = ArgoCDBranchFriendlyName,
                                                         }, sourceType)
@@ -1069,8 +1070,8 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                             [ArgoCDConstants.Annotations.OctopusProjectAnnotationKey(new ApplicationSourceName("source1"))] = ProjectSlug,
                                                             [ArgoCDConstants.Annotations.OctopusEnvironmentAnnotationKey(new ApplicationSourceName("source1"))] = EnvironmentSlug,
                                                         })
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginUrl, Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginUrl, Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
                                                         .Build());
 
             var getResults = CaptureReporterResults();
@@ -1122,8 +1123,8 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                             [ArgoCDConstants.Annotations.OctopusProjectAnnotationKey(new ApplicationSourceName("source1"))] = ProjectSlug,
                                                             [ArgoCDConstants.Annotations.OctopusEnvironmentAnnotationKey(new ApplicationSourceName("source1"))] = EnvironmentSlug,
                                                         })
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginUrl, Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginUrl, Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
                                                         .Build());
 
             var getResults = CaptureReporterResults();
@@ -1178,8 +1179,8 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                             [ArgoCDConstants.Annotations.OctopusProjectAnnotationKey(new ApplicationSourceName("source1"))] = ProjectSlug,
                                                             [ArgoCDConstants.Annotations.OctopusEnvironmentAnnotationKey(new ApplicationSourceName("source1"))] = EnvironmentSlug,
                                                         })
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
-                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = $"file://{OriginPath}", Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginUrl, Path = "source0", Name = "source0", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
+                                                        .WithSource(new ApplicationSource { OriginalRepoUrl = OriginUrl, Path = "source1", Name = "source1", TargetRevision = ArgoCDBranchFriendlyName }, SourceTypeConstants.Directory)
                                                         .Build());
 
             var getResults = CaptureReporterResults();
@@ -1226,7 +1227,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             using var _ = new AssertionScope();
             var serviceMessages = log.Messages.GetServiceMessagesOfType("setVariable");
             serviceMessages.GetPropertyValue("ArgoCD.GatewayIds").Should().Be(GatewayId);
-            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? $"file://{OriginPath}" : string.Empty);
+            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? OriginUrl : string.Empty);
             serviceMessages.GetPropertyValue("ArgoCD.UpdatedImages").Should().Be(updated ? "1" : "0");
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplications").Should().Be("App1");
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplicationTotalSourceCounts").Should().Be(matchingApplicationTotalSourceCounts);

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
@@ -43,6 +43,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
 
         string OriginPath => Path.Combine(tempDirectory, "origin");
         string RepoUrl => OriginPath;
+        string OriginUrl => RepositoryHelpers.ToFileUri(OriginPath);
         Repository originRepo;
 
         const string ArgoCDBranchFriendlyName = "devBranch";
@@ -73,7 +74,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                         "http://my-argo.com")
                 ],
                 [
-                    new GitCredentialDto(new Uri(RepoUrl).AbsoluteUri, "", "")
+                    new GitCredentialDto(OriginUrl, "", "")
                 ]);
             customPropertiesLoader.Load<ArgoCDCustomPropertiesDto>().Returns(argoCdCustomPropertiesDto);
 
@@ -86,7 +87,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                             })
                                             .WithSource(new ApplicationSource()
                                                 {
-                                                    OriginalRepoUrl = $"file://{RepoUrl}",
+                                                    OriginalRepoUrl = OriginUrl,
                                                     Path = "",
                                                     TargetRevision = ArgoCDBranchFriendlyName,
                                                 },
@@ -238,7 +239,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                           })
                                           .WithSource(new ApplicationSource()
                                               {
-                                                  OriginalRepoUrl = $"file://{RepoUrl}",
+                                                  OriginalRepoUrl = OriginUrl,
                                                   Path = "",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
                                                   Helm = new HelmConfig()
@@ -318,7 +319,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                   Name = "refSourceName",
                                                   Ref = "values",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = $"file://{RepoUrl}",
+                                                  OriginalRepoUrl = OriginUrl,
                                               },
                                               SourceTypeConstants.Directory)
                                           .Build();
@@ -388,7 +389,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                   Ref = "valuesFiles",
                                                   Path = "otherPath/values1.yaml", //this should cause an error
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = $"file://{RepoUrl}",
+                                                  OriginalRepoUrl = OriginUrl,
                                               },
                                               SourceTypeConstants.Directory)
                                           .Build();
@@ -524,7 +525,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                           })
                                           .WithSource(new ApplicationSource()
                                           {
-                                              OriginalRepoUrl = $"file://{RepoUrl}",
+                                              OriginalRepoUrl = OriginUrl,
                                               Path = "",
                                               TargetRevision = ArgoCDBranchFriendlyName,
                                               Helm = new HelmConfig()
@@ -567,7 +568,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                             })
                                             .WithSource(new ApplicationSource()
                                                         {
-                                                            OriginalRepoUrl = $"file://{RepoUrl}",
+                                                            OriginalRepoUrl = OriginUrl,
                                                             Path = Path.Combine("this", "will", "be", "overriden"),
                                                             TargetRevision = ArgoCDBranchFriendlyName,
                                                         },
@@ -610,7 +611,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             using var _ = new AssertionScope();
             var serviceMessages = log.Messages.GetServiceMessagesOfType("setVariable");
             serviceMessages.GetPropertyValue("ArgoCD.GatewayIds").Should().Be(GatewayId);
-            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? $"file://{RepoUrl}" : string.Empty);
+            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? OriginUrl : string.Empty);
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplications").Should().Be("App1");
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplicationTotalSourceCounts").Should().Be(matchingApplicationTotalSourceCounts);
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplicationMatchingSourceCounts").Should().Be("1");

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
@@ -86,7 +86,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                             })
                                             .WithSource(new ApplicationSource()
                                                 {
-                                                    OriginalRepoUrl = RepoUrl,
+                                                    OriginalRepoUrl = $"file://{RepoUrl}",
                                                     Path = "",
                                                     TargetRevision = ArgoCDBranchFriendlyName,
                                                 },
@@ -238,7 +238,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                           })
                                           .WithSource(new ApplicationSource()
                                               {
-                                                  OriginalRepoUrl = RepoUrl,
+                                                  OriginalRepoUrl = $"file://{RepoUrl}",
                                                   Path = "",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
                                                   Helm = new HelmConfig()
@@ -318,7 +318,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                   Name = "refSourceName",
                                                   Ref = "values",
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = RepoUrl,
+                                                  OriginalRepoUrl = $"file://{RepoUrl}",
                                               },
                                               SourceTypeConstants.Directory)
                                           .Build();
@@ -388,7 +388,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                                   Ref = "valuesFiles",
                                                   Path = "otherPath/values1.yaml", //this should cause an error
                                                   TargetRevision = ArgoCDBranchFriendlyName,
-                                                  OriginalRepoUrl = RepoUrl,
+                                                  OriginalRepoUrl = $"file://{RepoUrl}",
                                               },
                                               SourceTypeConstants.Directory)
                                           .Build();
@@ -524,7 +524,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                           })
                                           .WithSource(new ApplicationSource()
                                           {
-                                              OriginalRepoUrl = RepoUrl,
+                                              OriginalRepoUrl = $"file://{RepoUrl}",
                                               Path = "",
                                               TargetRevision = ArgoCDBranchFriendlyName,
                                               Helm = new HelmConfig()
@@ -567,7 +567,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
                                             })
                                             .WithSource(new ApplicationSource()
                                                         {
-                                                            OriginalRepoUrl = RepoUrl,
+                                                            OriginalRepoUrl = $"file://{RepoUrl}",
                                                             Path = Path.Combine("this", "will", "be", "overriden"),
                                                             TargetRevision = ArgoCDBranchFriendlyName,
                                                         },
@@ -610,7 +610,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             using var _ = new AssertionScope();
             var serviceMessages = log.Messages.GetServiceMessagesOfType("setVariable");
             serviceMessages.GetPropertyValue("ArgoCD.GatewayIds").Should().Be(GatewayId);
-            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? RepoUrl : string.Empty);
+            serviceMessages.GetPropertyValue("ArgoCD.GitUris").Should().Be(updated ? $"file://{RepoUrl}" : string.Empty);
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplications").Should().Be("App1");
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplicationTotalSourceCounts").Should().Be(matchingApplicationTotalSourceCounts);
             serviceMessages.GetPropertyValue("ArgoCD.MatchingApplicationMatchingSourceCounts").Should().Be("1");

--- a/source/Calamari.Tests/ArgoCD/Git/GitCloneSafeUrlTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/GitCloneSafeUrlTests.cs
@@ -30,5 +30,13 @@ public class GitCloneSafeUrlTests
         var uri = "git@ihavenopath.com";
         var func = () => GitCloneSafeUrl.FromString(uri);
         func.Should().Throw<FormatException>();
-    } 
+    }
+
+    [Test]
+    public void ANonProtocoledString_AutomaticallyAddsOci()
+    {
+        var uri = "registry-1.docker.io/bitnamicharts";
+        var result = GitCloneSafeUrl.FromString(uri);
+        result.AbsoluteUri.Should().Be($"oci://{uri}");
+    }
 }

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryHelpers.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryHelpers.cs
@@ -40,6 +40,8 @@ namespace Calamari.Tests.ArgoCD.Git
             repository.CreateBranch(branchName.ToFriendlyName(), emptyCommit);
         }
 
+        public static string ToFileUri(string path) => new Uri(path).AbsoluteUri;
+
         public static string CloneOrigin(string tempDirectory, string originPath, GitBranchName branchName)
         {
             var subPath = Guid.NewGuid().ToString();

--- a/source/Calamari/ArgoCD/Domain/Sources.cs
+++ b/source/Calamari/ArgoCD/Domain/Sources.cs
@@ -1,36 +1,25 @@
 using System;
 using System.Text.Json.Serialization;
-using Calamari.ArgoCD.Git;
 
 namespace Calamari.ArgoCD.Domain
 {
     public class ApplicationSource
     {
-        string originalRepoUrl = string.Empty;
         [JsonPropertyName("repoURL")]
-        public string OriginalRepoUrl {
-            get => originalRepoUrl;
-            set
-            {
-                originalRepoUrl = value;
-                CloneSafeRepoUrl = GitCloneSafeUrl.FromString(value);
-            }
-        }
+        public string OriginalRepoUrl { get; set; }
 
-        public Uri CloneSafeRepoUrl { get; private set; }
-    
         [JsonPropertyName("targetRevision")]
         public string TargetRevision { get; set; } = string.Empty;
-        
+
         [JsonPropertyName("name")]
         public string Name { get; set; } = string.Empty;
 
         [JsonPropertyName("path")]
         public string? Path { get; set; }
-        
+
         [JsonPropertyName("helm")]
         public HelmConfig? Helm { get; set; }
-        
+
         [JsonPropertyName("ref")]
         public string? Ref { get; set; }
     }

--- a/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
+++ b/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
@@ -25,6 +25,10 @@ public static class GitCloneSafeUrl
     /// </summary>
     /// <param name="uri">A, potentially invalid <see cref="Uri"/> object</param>
     /// <returns>A URI that, if is SSH, is well formed<see cref="Uri"/> object</returns>
+    /// <remarks>
+    /// This is invoked during yaml deserialisation, and may be applied to repoURLs which will never actually be cloned
+    /// during step execution (eg sources which have not been scoped to the step).
+    /// </remarks>
     public static Uri FromString(string uri)
     {
         var validProtocols = new[] { "http://", "https://", "oci://" };

--- a/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
+++ b/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
@@ -31,11 +31,11 @@ public static class GitCloneSafeUrl
     /// </remarks>
     public static Uri FromString(string uri)
     {
-        var validProtocols = new[] { "http://", "https://", "oci://" };
+        var me = Uri.SchemeDelimiter;
         if (!uri.StartsWith(StandardSshScpPrefix))
         {
             // argo does not (always?) add a protocol to helm chart sources.
-            if (!validProtocols.Any(prefix => uri.StartsWith(prefix)))
+            if (!uri.Contains(Uri.SchemeDelimiter))
             {
                 uri = $"oci://{uri}";
             }

--- a/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
+++ b/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace Calamari.ArgoCD.Git;
 
@@ -26,8 +27,14 @@ public static class GitCloneSafeUrl
     /// <returns>A URI that, if is SSH, is well formed<see cref="Uri"/> object</returns>
     public static Uri FromString(string uri)
     {
+        var validProtocols = new[] { "http://", "https://", "oci://" };
         if (!uri.StartsWith(StandardSshScpPrefix))
         {
+            // argo does not (always?) add a protocol to helm chart sources.
+            if (!validProtocols.Any(prefix => uri.StartsWith(prefix)))
+            {
+                uri = $"oci://{uri}";
+            }
             return new Uri(uri);
         }
 

--- a/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
+++ b/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
@@ -31,7 +31,6 @@ public static class GitCloneSafeUrl
     /// </remarks>
     public static Uri FromString(string uri)
     {
-        var me = Uri.SchemeDelimiter;
         if (!uri.StartsWith(StandardSshScpPrefix))
         {
             // argo does not (always?) add a protocol to helm chart sources.


### PR DESCRIPTION
If an argo source is a helm-source, referencing a helm repository - it _may_ not include the protocol in the repoURL.

Thus, in Calamari, when deserialising the application yaml, an error is raised when attempting to map the pro=vided URI into an "ssh-mapped uri"

This change adds a check, such that if no protocol is specified, "oci://" is prepended prior to converting to a URI.

Also - it was found that the value calculated during yaml mapping _wasn't being used_ - and instead we re-calculated the URL at repo-clone time.
This was considered a better solution because:
1. Serialisation will pass even if the provided repoURL is not actually a URI
2. We only "translate/validate" the URLs we want to modify - and ones without a protocol should not be scoped for update (as its clearly _not_ a git url).

Fixes MD-1765
