### PR TITLE
fix: KustomizeFile patching executes even if no actual change occured.

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -1038,11 +1038,9 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
 
             var sourceDetails = actual.TrackedSourceDetails.First();
             sourceDetails.CommitSha.Should().BeNull("no commit was made");
-            // The placeholder-substitution technique locates the tag value in the YAML and produces a patch entry,
-            // but because the before/after content is identical the resulting patch has zero operations.
             sourceDetails.PatchedFiles.Should().HaveCount(1);
             sourceDetails.PatchedFiles.Single().FilePath.Should().Be("kustomization.yaml");
-            sourceDetails.PatchedFiles.Single().JsonPatch.Should().Be("[]");
+            sourceDetails.PatchedFiles.Single().JsonPatch.Should().Be(SerializeReplacePatch(("/0/images/0/newTag", "1.27.1")));
         }
 
         [Test]

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -258,6 +258,68 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
         }
 
         [Test]
+        public void DirectorySource_ImageMatches_Update_TargetImageInCommentDoesNotAppearInPatch()
+        {
+            // Arrange: the target image reference (nginx:1.27.1) appears in an inline YAML comment alongside
+            // the old image field. CreateTemporaryBeforeContent uses a naive string.Replace, so the comment
+            // would receive the placeholder during JSON-patch generation. The committed file must come from
+            // ReplaceImages(originalContent) whose regex ignores comments — so CALAMARI_PLACEHOLDER must
+            // never appear in the repo.
+            var updater = CreateConvention();
+            var runningDeployment = CreateRunningDeployment(("nginx", "index.docker.io/nginx:1.27.1"));
+
+            var yamlFilename = "include/file1.yaml";
+            originRepo.AddFilesToBranch(argoCDBranchName,
+            [
+                (
+                    yamlFilename,
+                    """
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: sample
+                    spec:
+                      template:
+                        spec:
+                          containers:
+                            - name: nginx
+                              image: nginx:1.19 # update to nginx:1.27.1
+                    """
+                )
+            ]);
+
+            // Act
+            updater.Install(runningDeployment);
+
+            // Assert: the image field is updated; the comment retains the original text; no placeholder leaks
+            const string updatedYamlContent =
+                """
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: sample
+                spec:
+                  template:
+                    spec:
+                      containers:
+                        - name: nginx
+                          image: nginx:1.27.1 # update to nginx:1.27.1
+                """;
+
+            var clonedRepoPath = RepositoryHelpers.CloneOrigin(tempDirectory, OriginPath, argoCDBranchName);
+            AssertFileContents(clonedRepoPath, yamlFilename, updatedYamlContent);
+
+            var committedContent = fileSystem.ReadFile(Path.Combine(clonedRepoPath, yamlFilename));
+            committedContent.Should().NotContain(":__CALAMARI_PLACEHOLDER__",
+                "the internal placeholder used for JSON-patch generation must never be written to the repository");
+
+            using var resultRepo = new Repository(clonedRepoPath);
+            resultRepo.Head.Tip.Message.TrimEnd().Should().Contain("---\nImages updated:");
+
+            AssertOutputVariables();
+        }
+
+        [Test]
         public void DirectorySource_UnknownCrd_LogsWarning()
         {
             // Arrange

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -310,7 +310,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             AssertFileContents(clonedRepoPath, yamlFilename, updatedYamlContent);
 
             var committedContent = fileSystem.ReadFile(Path.Combine(clonedRepoPath, yamlFilename));
-            committedContent.Should().NotContain(":__CALAMARI_PLACEHOLDER__",
+            committedContent.Should().NotContain("__CALAMARI_PLACEHOLDER__",
                 "the internal placeholder used for JSON-patch generation must never be written to the repository");
 
             using var resultRepo = new Repository(clonedRepoPath);

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -533,8 +533,10 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
 
             var sourceDetails = actual.TrackedSourceDetails.First();
             sourceDetails.CommitSha.Should().BeNull("no commit was made");
-            sourceDetails.PatchedFiles.Should().HaveCount(1, "a patch should be generated even when no commit is needed");
-            sourceDetails.PatchedFiles.First().FilePath.Should().Be(yamlFilename);
+            sourceDetails.PatchedFiles.Should()
+                         .BeEquivalentTo([
+                             new FileJsonPatch(yamlFilename, SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"))),
+                         ]);
         }
 
         [TestCase(false, TestName = "DirectorySource_SameImage_OneOutdated_OneUpToDate_SameFile")]
@@ -585,26 +587,26 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             sourceDetails.CommitSha.Should().HaveLength(40);
             sourceDetails.ReplacedFiles.Should().BeEmpty();
 
+            var singleContainerPatch = SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"));
+
             if (useSeparateFiles)
             {
                 // Each file is processed independently — one patch entry per file, one operation each.
-                sourceDetails.PatchedFiles.Should().HaveCount(2);
-
-                var singleContainerPatch = SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"));
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file1)
-                             .Which.JsonPatch.Should().Be(singleContainerPatch);
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file2)
-                             .Which.JsonPatch.Should().Be(singleContainerPatch);
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, singleContainerPatch),
+                                 new FileJsonPatch(file2, singleContainerPatch),
+                             ]);
             }
             else
             {
                 // Both containers are in one file — one patch entry with two replace operations.
-                sourceDetails.PatchedFiles.Should().HaveCount(1);
-                sourceDetails.PatchedFiles.Single().FilePath.Should().Be(file1);
-
-                sourceDetails.PatchedFiles.Single().JsonPatch.Should().Be(SerializeReplacePatch(
-                    ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
-                    ("/0/spec/template/spec/containers/1/image", "nginx:1.27.1")));
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, SerializeReplacePatch(
+                                     ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
+                                     ("/0/spec/template/spec/containers/1/image", "nginx:1.27.1"))),
+                             ]);
             }
         }
 
@@ -661,22 +663,21 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             if (useSeparateFiles)
             {
                 // Each file is processed independently — one patch entry per file, one operation each.
-                sourceDetails.PatchedFiles.Should().HaveCount(2);
-
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file1)
-                             .Which.JsonPatch.Should().Be(SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1")));
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file2)
-                             .Which.JsonPatch.Should().Be(SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "redis:7.0")));
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"))),
+                                 new FileJsonPatch(file2, SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "redis:7.0"))),
+                             ]);
             }
             else
             {
                 // Both containers are in one file — one patch entry with two replace operations.
-                sourceDetails.PatchedFiles.Should().HaveCount(1);
-                sourceDetails.PatchedFiles.Single().FilePath.Should().Be(file1);
-
-                sourceDetails.PatchedFiles.Single().JsonPatch.Should().Be(SerializeReplacePatch(
-                    ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
-                    ("/0/spec/template/spec/containers/1/image", "redis:7.0")));
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, SerializeReplacePatch(
+                                     ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
+                                     ("/0/spec/template/spec/containers/1/image", "redis:7.0"))),
+                             ]);
             }
         }
 
@@ -727,24 +728,24 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             sourceDetails.CommitSha.Should().HaveLength(40);
             sourceDetails.ReplacedFiles.Should().BeEmpty();
 
+            var singleContainerPatch = SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"));
+
             if (useSeparateFiles)
             {
-                sourceDetails.PatchedFiles.Should().HaveCount(2);
-
-                var singleContainerPatch = SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"));
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file1)
-                             .Which.JsonPatch.Should().Be(singleContainerPatch);
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file2)
-                             .Which.JsonPatch.Should().Be(singleContainerPatch);
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, singleContainerPatch),
+                                 new FileJsonPatch(file2, singleContainerPatch),
+                             ]);
             }
             else
             {
-                sourceDetails.PatchedFiles.Should().HaveCount(1);
-                sourceDetails.PatchedFiles.Single().FilePath.Should().Be(file1);
-
-                sourceDetails.PatchedFiles.Single().JsonPatch.Should().Be(SerializeReplacePatch(
-                    ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
-                    ("/0/spec/template/spec/containers/1/image", "nginx:1.27.1")));
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, SerializeReplacePatch(
+                                     ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
+                                     ("/0/spec/template/spec/containers/1/image", "nginx:1.27.1"))),
+                             ]);
             }
         }
 
@@ -799,21 +800,20 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
 
             if (useSeparateFiles)
             {
-                sourceDetails.PatchedFiles.Should().HaveCount(2);
-
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file1)
-                             .Which.JsonPatch.Should().Be(SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1")));
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file2)
-                             .Which.JsonPatch.Should().Be(SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "redis:7.0")));
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"))),
+                                 new FileJsonPatch(file2, SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "redis:7.0"))),
+                             ]);
             }
             else
             {
-                sourceDetails.PatchedFiles.Should().HaveCount(1);
-                sourceDetails.PatchedFiles.Single().FilePath.Should().Be(file1);
-
-                sourceDetails.PatchedFiles.Single().JsonPatch.Should().Be(SerializeReplacePatch(
-                    ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
-                    ("/0/spec/template/spec/containers/1/image", "redis:7.0")));
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, SerializeReplacePatch(
+                                     ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
+                                     ("/0/spec/template/spec/containers/1/image", "redis:7.0"))),
+                             ]);
             }
         }
 
@@ -865,26 +865,26 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             sourceDetails.CommitSha.Should().BeNull();
             sourceDetails.ReplacedFiles.Should().BeEmpty();
 
+            var singleContainerPatch = SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"));
+
             if (useSeparateFiles)
             {
-                sourceDetails.PatchedFiles.Should().HaveCount(2);
-
-                var singleContainerPatch = SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"));
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file1)
-                             .Which.JsonPatch.Should().Be(singleContainerPatch);
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file2)
-                             .Which.JsonPatch.Should().Be(singleContainerPatch);
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, singleContainerPatch),
+                                 new FileJsonPatch(file2, singleContainerPatch),
+                             ]);
             }
             else
             {
                 // AlreadyUpToDateImages = {"nginx:1.27.1"} — both occurrences get the placeholder,
                 // producing two replace operations in the no-op patch.
-                sourceDetails.PatchedFiles.Should().HaveCount(1);
-                sourceDetails.PatchedFiles.Single().FilePath.Should().Be(file1);
-
-                sourceDetails.PatchedFiles.Single().JsonPatch.Should().Be(SerializeReplacePatch(
-                    ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
-                    ("/0/spec/template/spec/containers/1/image", "nginx:1.27.1")));
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, SerializeReplacePatch(
+                                     ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
+                                     ("/0/spec/template/spec/containers/1/image", "nginx:1.27.1"))),
+                             ]);
             }
         }
 
@@ -940,21 +940,20 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
 
             if (useSeparateFiles)
             {
-                sourceDetails.PatchedFiles.Should().HaveCount(2);
-
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file1)
-                             .Which.JsonPatch.Should().Be(SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1")));
-                sourceDetails.PatchedFiles.Should().ContainSingle(p => p.FilePath == file2)
-                             .Which.JsonPatch.Should().Be(SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "redis:7.0")));
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"))),
+                                 new FileJsonPatch(file2, SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "redis:7.0"))),
+                             ]);
             }
             else
             {
-                sourceDetails.PatchedFiles.Should().HaveCount(1);
-                sourceDetails.PatchedFiles.Single().FilePath.Should().Be(file1);
-
-                sourceDetails.PatchedFiles.Single().JsonPatch.Should().Be(SerializeReplacePatch(
-                    ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
-                    ("/0/spec/template/spec/containers/1/image", "redis:7.0")));
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch(file1, SerializeReplacePatch(
+                                     ("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"),
+                                     ("/0/spec/template/spec/containers/1/image", "redis:7.0"))),
+                             ]);
             }
         }
 
@@ -1038,9 +1037,10 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
 
             var sourceDetails = actual.TrackedSourceDetails.First();
             sourceDetails.CommitSha.Should().BeNull("no commit was made");
-            sourceDetails.PatchedFiles.Should().HaveCount(1);
-            sourceDetails.PatchedFiles.Single().FilePath.Should().Be("kustomization.yaml");
-            sourceDetails.PatchedFiles.Single().JsonPatch.Should().Be(SerializeReplacePatch(("/0/images/0/newTag", "1.27.1")));
+            sourceDetails.PatchedFiles.Should()
+                         .BeEquivalentTo([
+                             new FileJsonPatch("kustomization.yaml", SerializeReplacePatch(("/0/images/0/newTag", "1.27.1"))),
+                         ]);
         }
 
         [Test]
@@ -1085,15 +1085,21 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
             actual.TrackedSourceDetails.Should().HaveCount(2, "both sources should be tracked regardless of whether they made a commit");
 
+            var singleContainerPatch = SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"));
+
             var source0 = actual.TrackedSourceDetails.First(d => d.SourceIndex == 0);
             source0.CommitSha.Should().HaveLength(40, "source 0 had an outdated image and was committed");
-            source0.PatchedFiles.Should().HaveCount(1);
-            source0.PatchedFiles.Single().FilePath.Should().Be(file0);
+            source0.PatchedFiles.Should()
+                   .BeEquivalentTo([
+                       new FileJsonPatch(file0, singleContainerPatch),
+                   ]);
 
             var source1 = actual.TrackedSourceDetails.First(d => d.SourceIndex == 1);
             source1.CommitSha.Should().BeNull("source 1 was already at the target tag so no commit was made");
-            source1.PatchedFiles.Should().HaveCount(1, "a no-op patch should still be generated for source 1");
-            source1.PatchedFiles.Single().FilePath.Should().Be(file1);
+            source1.PatchedFiles.Should()
+                   .BeEquivalentTo([
+                       new FileJsonPatch(file1, singleContainerPatch),
+                   ]);
         }
 
         [Test]
@@ -1139,15 +1145,21 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             actual.UpdatedImages.Should().BeEmpty();
             actual.TrackedSourceDetails.Should().HaveCount(2, "both in-scope sources should be tracked regardless of commit status");
 
+            var singleContainerPatch = SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"));
+
             var source0 = actual.TrackedSourceDetails.First(d => d.SourceIndex == 0);
             source0.CommitSha.Should().BeNull("source 0 was already at the target tag");
-            source0.PatchedFiles.Should().HaveCount(1, "a no-op patch should still be generated");
-            source0.PatchedFiles.Single().FilePath.Should().Be(file0);
+            source0.PatchedFiles.Should()
+                   .BeEquivalentTo([
+                       new FileJsonPatch(file0, singleContainerPatch),
+                   ]);
 
             var source1 = actual.TrackedSourceDetails.First(d => d.SourceIndex == 1);
             source1.CommitSha.Should().BeNull("source 1 was already at the target tag");
-            source1.PatchedFiles.Should().HaveCount(1, "a no-op patch should still be generated");
-            source1.PatchedFiles.Single().FilePath.Should().Be(file1);
+            source1.PatchedFiles.Should()
+                   .BeEquivalentTo([
+                       new FileJsonPatch(file1, singleContainerPatch),
+                   ]);
         }
 
         [Test]

--- a/source/Calamari/ArgoCD/Conventions/UpdateImageTag/BaseUpdater.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateImageTag/BaseUpdater.cs
@@ -100,7 +100,7 @@ public abstract class BaseUpdater : ISourceUpdater
     /// Running the image replacer on this temporary content produces the correct content, and the diff
     /// between the two gives a meaningful patch that only targets the specific image tag fields.
     /// </summary>
-    protected static string CreateTemporaryBeforeContent(string content, HashSet<string> targetedImages)
+    protected virtual string CreateTemporaryBeforeContent(string content, HashSet<string> targetedImages)
     {
         var temporaryBefore = content;
         foreach (var imageRef in targetedImages)

--- a/source/Calamari/ArgoCD/Conventions/UpdateImageTag/KustomizeContainerImageReplacer.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateImageTag/KustomizeContainerImageReplacer.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System.Linq;
 using Calamari.ArgoCD.Models;
 using Calamari.Common.Plumbing.Logging;
+using NuGet.Packaging;
 
 namespace Calamari.ArgoCD.Conventions.UpdateImageTag;
 
@@ -42,58 +44,35 @@ public class KustomizeContainerImageReplacer : IContainerImageReplacer
 
     ImageReplacementResult UpdateKustomizeResource(IReadOnlyCollection<ContainerImageReferenceAndHelmReference> imagesToUpdate, string inputContent)
     {
-        var updatedContent = inputContent;
-        var allUpdatedImages = new HashSet<string>();
 
-        var kustomizeReplacer = new KustomizeImageReplacer(updatedContent, defaultRegistry, log);
+        var kustomizeReplacer = new KustomizeImageReplacer(inputContent, defaultRegistry, log);
         var result = kustomizeReplacer.UpdateImages(imagesToUpdate);
-
-        if (result.UpdatedImageReferences.Count > 0)
-        {
-            updatedContent = result.UpdatedContents;
-            allUpdatedImages.UnionWith(result.UpdatedImageReferences);
-        }
 
         if (updateKustomizePatches)
         {
             if (KustomizePatchDiscovery.HasPatchesNode(inputContent, log))
             {
-                var inlinePatchReplacer = new InlineJsonPatchReplacer(updatedContent, defaultRegistry, log);
+                var inlinePatchReplacer = new InlineJsonPatchReplacer(result.UpdatedContents, defaultRegistry, log);
                 var patchResult = inlinePatchReplacer.UpdateImages(imagesToUpdate);
-
-                if (patchResult.UpdatedImageReferences.Count > 0)
-                {
-                    updatedContent = patchResult.UpdatedContents;
-                    allUpdatedImages.UnionWith(patchResult.UpdatedImageReferences);
-                }
+                result = MergeResults(result, patchResult);
             }
 
             if (KustomizePatchDiscovery.HasStrategicMergePatchNode(inputContent, log))
             {
-                var replacer = new InlineStrategicMergeImageReplacer(updatedContent, defaultRegistry, log);
+                var replacer = new InlineStrategicMergeImageReplacer(result.UpdatedContents, defaultRegistry, log);
                 var strategicMergeResult = replacer.UpdateImages(imagesToUpdate);
-
-                if (strategicMergeResult.UpdatedImageReferences.Count > 0)
-                {
-                    updatedContent = strategicMergeResult.UpdatedContents;
-                    allUpdatedImages.UnionWith(strategicMergeResult.UpdatedImageReferences);
-                }
+                result = MergeResults(result, strategicMergeResult);
             }
 
             if (KustomizePatchDiscovery.HasJson6902PatchesNode(inputContent, log))
             {
-                var replacer = new InlineJson6902ImageReplacer(updatedContent, defaultRegistry, log);
+                var replacer = new InlineJson6902ImageReplacer(result.UpdatedContents, defaultRegistry, log);
                 var json6902Result = replacer.UpdateImages(imagesToUpdate);
-
-                if (json6902Result.UpdatedImageReferences.Count > 0)
-                {
-                    updatedContent = json6902Result.UpdatedContents;
-                    allUpdatedImages.UnionWith(json6902Result.UpdatedImageReferences);
-                }
+                result = MergeResults(result, json6902Result);
             }
         }
 
-        return new ImageReplacementResult(updatedContent, allUpdatedImages, new HashSet<string>());
+        return result;
     }
 
     ImageReplacementResult UpdateKustomizePatch(IReadOnlyCollection<ContainerImageReferenceAndHelmReference> imagesToUpdate, string inputContent)
@@ -114,6 +93,27 @@ public class KustomizeContainerImageReplacer : IContainerImageReplacer
 
         log.Verbose($"Unable to determine patch type for content, no image updates will be performed");
         return new ImageReplacementResult(inputContent, new HashSet<string>(), new HashSet<string>());
+    }
+    
+    ImageReplacementResult MergeResults(ImageReplacementResult existingResult, ImageReplacementResult toInclude) 
+    {
+        string finalContent = existingResult.UpdatedContents; 
+        if (toInclude.UpdatedImageReferences.Count > 0)
+        {
+            finalContent = toInclude.UpdatedContents;
+        }
+
+        var updatedImageReferences = new HashSet<string>(existingResult.UpdatedImageReferences);
+        updatedImageReferences.UnionWith(toInclude.UpdatedImageReferences);
+        
+        var alreadyUpToDateImages = new HashSet<string>(existingResult.AlreadyUpToDateImages);
+        alreadyUpToDateImages.UnionWith(toInclude.AlreadyUpToDateImages);
+        
+        var unrecognisedKinds = new HashSet<string>(existingResult.UnrecognisedKinds);
+        unrecognisedKinds.UnionWith(toInclude.UnrecognisedKinds);
+        
+        
+        return new ImageReplacementResult(finalContent, updatedImageReferences, alreadyUpToDateImages, unrecognisedKinds);
     }
 
 }

--- a/source/Calamari/ArgoCD/Conventions/UpdateImageTag/KustomizeUpdater.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateImageTag/KustomizeUpdater.cs
@@ -32,6 +32,34 @@ public class KustomizeUpdater : BaseUpdater
         return imageReplacer.UpdateImages(imagesToUpdate);
     }
 
+    protected override string CreateTemporaryBeforeContent(string content, HashSet<string> targetedImages)
+    {
+        // For kustomization resources, name and tag are separate YAML fields (name + newTag),
+        // so the base class's string replacement of "name:tag" won't find a match.
+        // Instead, run the existing replacer with placeholder tags to produce the "before" content.
+        if (!KustomizationValidator.IsKustomizationResource(content))
+        {
+            return base.CreateTemporaryBeforeContent(content, targetedImages);
+        }
+
+        var placeholderImages = targetedImages
+                                .Select(imageRef =>
+                                {
+                                    var colonIdx = imageRef.LastIndexOf(':');
+                                    var placeholderRef = colonIdx >= 0
+                                        ? imageRef[..colonIdx] + ":__CALAMARI_PLACEHOLDER__"
+                                        : imageRef;
+                                    return new ContainerImageReferenceAndHelmReference(
+                                        ContainerImageReference.FromReferenceString(placeholderRef, defaultRegistry));
+                                })
+                                .ToList();
+
+        var replacer = new KustomizeContainerImageReplacer(content, defaultRegistry, updateKustomizePatches, log);
+        var result = replacer.UpdateImages(placeholderImages);
+
+        return result.UpdatedContents;
+    }
+
     public override FileUpdateResult Process(ApplicationSourceWithMetadata sourceWithMetadata, string workingDirectory)
     {
         var applicationSource = sourceWithMetadata.Source;

--- a/source/Calamari/ArgoCD/KustomizeImageReplacer.cs
+++ b/source/Calamari/ArgoCD/KustomizeImageReplacer.cs
@@ -91,15 +91,14 @@ namespace Calamari.ArgoCD
                 }
 
                 //update or insert the newTag node
-                var newTagNode = imageNode.GetChildNodeIfExists<YamlScalarNode>(NewTagNodeKey);
-                if (newTagNode != null)
+                if (matchedUpdate.ExistingTagNode != null)
                 {
                     if (!matchedUpdate.Comparison.TagMatch)
                     {
-                        newTagNode.Value = matchedUpdate.Reference.Tag;
-                        if (newTagNode.Style != ScalarStyle.SingleQuoted && newTagNode.Style != ScalarStyle.DoubleQuoted)
+                        matchedUpdate.ExistingTagNode.Value = matchedUpdate.Reference.Tag;
+                        if (matchedUpdate.ExistingTagNode.Style != ScalarStyle.SingleQuoted && matchedUpdate.ExistingTagNode.Style != ScalarStyle.DoubleQuoted)
                         {
-                            newTagNode.Style = ScalarStyle.DoubleQuoted;
+                            matchedUpdate.ExistingTagNode.Style = ScalarStyle.DoubleQuoted;
                         }
                         replacementsMade.Add($"{matchedUpdate.Reference.ImageName}:{matchedUpdate.Reference.Tag}");
                     }
@@ -143,13 +142,17 @@ namespace Calamari.ArgoCD
             }
 
             var newNameNode = imageNode.GetChildNodeIfExists<YamlScalarNode>(NewNameNodeKey);
+            var existingTagNode = imageNode.GetChildNodeIfExists<YamlScalarNode>(NewTagNodeKey);
 
             //if the newName node exists, we use that value as the container name, rather than the name node
             var testName = newNameNode?.Value ?? name;
 
-            var currentReference = ContainerImageReference.FromReferenceString(testName, defaultRegistry);
-            
-            return imagesToUpdate.Select(i => new ImageReferenceMatch(i, i.CompareWith(currentReference)))
+            // Include the existing newTag so TagMatch reflects whether the YAML already has the correct tag
+            var testReference = existingTagNode?.Value is { } currentTag ? $"{testName}:{currentTag}" : testName;
+
+            var currentReference = ContainerImageReference.FromReferenceString(testReference, defaultRegistry);
+
+            return imagesToUpdate.Select(i => new ImageReferenceMatch(i, i.CompareWith(currentReference), existingTagNode))
                                               .FirstOrDefault(i => i.Comparison.MatchesImage());
         }
 
@@ -183,7 +186,7 @@ namespace Calamari.ArgoCD
                    .Insert(originalImagesSequenceStartIndex, updatedImagesYaml);
         }
         
-        record ImageReferenceMatch(ContainerImageReference Reference, ContainerImageComparison Comparison);
+        record ImageReferenceMatch(ContainerImageReference Reference, ContainerImageComparison Comparison, YamlScalarNode? ExistingTagNode);
     }
 }
 


### PR DESCRIPTION
It was found that a bug existed in the KustomizeUpdater whereby the newTag field would ALWAYS be updated, even if it was already up to date.

This bug was introduced in f4309c463570449da165875aa01314ec716f8ee3 when the comparison of ContainerImageRefernces was updated.

In fixing this behaviour, it was found the test `KustomizeSource_ImageAlreadyAtTargetTag_TracksSourceWithNullCommitSha` was no longer passing.

The test expects to see a single patched file, with a "no-op" json patch, rather than the current behaviour which states "no files were changed" (and therefore, the patched file list is empty).