### PR TITLE
fix: ensure image references contain the full image and not just the image tag

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
@@ -1,0 +1,179 @@
+using System.Collections.Generic;
+using Calamari.ArgoCD;
+using Calamari.ArgoCD.Conventions;
+using Calamari.ArgoCD.Models;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NUnit.Framework;
+
+namespace Calamari.Tests.ArgoCD.Helm;
+
+public class HelmValuesImageReplaceStepVariablesTests
+{
+    const string DefaultRegistry = "docker.io";
+    readonly InMemoryLog log = new();
+
+    [Test]
+    public void UnstructuredValue_UpdatesTag_TracksWithFriendlyName()
+    {
+        const string yaml = @"
+image:
+  tag: 1.0
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "image.tag")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEquivalentTo(["nginx:1.27.1"]);
+        result.UpdatedContents.Should().Contain("tag: 1.27.1");
+    }
+
+    [Test]
+    public void UnstructuredValue_AlreadyAtTarget_TracksWithFriendlyName()
+    {
+        const string yaml = @"
+image:
+  tag: 1.27.1
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "image.tag")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEmpty();
+        result.AlreadyUpToDateImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
+    }
+
+    [Test]
+    public void StructuredValue_UpdatesFullRef()
+    {
+        const string yaml = @"
+image:
+  name: nginx:1.0
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "image.name")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().HaveCount(1);
+        result.UpdatedContents.Should().Contain("name: nginx:1.27.1");
+    }
+
+    [Test]
+    public void StructuredValue_AlreadyAtTarget_TracksWithFriendlyName()
+    {
+        const string yaml = @"
+image:
+  name: nginx:1.27.1
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "image.name")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEmpty();
+        result.AlreadyUpToDateImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
+    }
+
+    [Test]
+    public void TwoImagesWithSameTag_OnlyUpdatesConfiguredPath()
+    {
+        const string yaml = @"
+nginx:
+  tag: 1.0
+redis:
+  tag: 1.0
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "nginx.tag")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEquivalentTo(["nginx:1.27.1"]);
+        result.UpdatedContents.Should().Contain("nginx:\n  tag: 1.27.1");
+        result.UpdatedContents.Should().Contain("redis:\n  tag: 1.0");
+    }
+
+    [Test]
+    public void NoHelmReference_SkipsImage()
+    {
+        const string yaml = @"
+image:
+  tag: 1.0
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry))
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEmpty();
+        result.AlreadyUpToDateImages.Should().BeEmpty();
+    }
+
+    [Test]
+    public void PathNotFoundInYaml_SkipsImage()
+    {
+        const string yaml = @"
+image:
+  tag: 1.0
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "nonexistent.path")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEmpty();
+        result.UpdatedContents.Should().Be(yaml);
+    }
+
+    [Test]
+    public void StructuredValue_MismatchedImageName_DoesNotUpdate()
+    {
+        const string yaml = @"
+image:
+  name: alpine:3.18
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "image.name")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEmpty();
+        result.UpdatedContents.Should().Contain("name: alpine:3.18");
+    }
+}

--- a/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Calamari.ArgoCD;
 using Calamari.ArgoCD.Conventions;
@@ -103,6 +104,14 @@ nginx:
 redis:
   tag: 1.0
 ";
+        
+        const string updatedYaml = @"
+nginx:
+  tag: 1.27.1
+redis:
+  tag: 1.0
+";
+
         var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
         var images = new List<ContainerImageReferenceAndHelmReference>
         {
@@ -113,8 +122,7 @@ redis:
 
         using var scope = new AssertionScope();
         result.UpdatedImageReferences.Should().BeEquivalentTo(["nginx:1.27.1"]);
-        result.UpdatedContents.Should().Contain("nginx:\n  tag: 1.27.1");
-        result.UpdatedContents.Should().Contain("redis:\n  tag: 1.0");
+        result.UpdatedContents.Should().Be(updatedYaml);
     }
 
     [Test]

--- a/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
@@ -105,13 +105,6 @@ redis:
   tag: 1.0
 ";
         
-        const string updatedYaml = @"
-nginx:
-  tag: 1.27.1
-redis:
-  tag: 1.0
-";
-
         var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
         var images = new List<ContainerImageReferenceAndHelmReference>
         {
@@ -122,7 +115,8 @@ redis:
 
         using var scope = new AssertionScope();
         result.UpdatedImageReferences.Should().BeEquivalentTo(["nginx:1.27.1"]);
-        result.UpdatedContents.Should().Be(updatedYaml);
+        result.UpdatedContents.Should().Contain($"nginx:{Environment.NewLine}  tag: 1.27.1");
+        result.UpdatedContents.Should().Contain($"redis:{Environment.NewLine}  tag: 1.0");
     }
 
     [Test]

--- a/source/Calamari/ArgoCD/HelmValuesImageReplaceStepVariables.cs
+++ b/source/Calamari/ArgoCD/HelmValuesImageReplaceStepVariables.cs
@@ -42,12 +42,12 @@ public class HelmValuesImageReplaceStepVariables : IContainerImageReplacer
             {
                 if (valueToUpdate == newImageTag.ContainerReference.Tag)
                 {
-                    alreadyUpToDate.Add(newImageTag.ContainerReference.Tag);
+                    alreadyUpToDate.Add(newImageTag.ContainerReference.FriendlyName());
                 }
                 else
                 {
                     updatedYaml = HelmValuesEditor.UpdateNodeValue(updatedYaml, helmReference, newImageTag.ContainerReference.Tag);
-                    imagesUpdated.Add(newImageTag.ContainerReference.Tag);
+                    imagesUpdated.Add(newImageTag.ContainerReference.FriendlyName());
                 }
             }
             else


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

I was adding tests for `HelmValuesImageReplaceStepVariables` class in this pr: https://github.com/OctopusDeploy/Calamari/pull/1894 and I think I found a bug. I've extracted the tests and the fix for the bug into this PR for separate review.

The test failure looks like:
```
Expected result.UpdatedImageReferences[0] to be the same string, but they differ at index 0:
   ↓ (actual)
  "1.27.1"
  "nginx:1.27.1"
   ↑ (expected).
```

These tests fail before fix is applied:
<img width="1042" height="82" alt="Screenshot 2026-04-20 at 13 15 49" src="https://github.com/user-attachments/assets/344534d9-677e-487f-9093-be19866168d3" />
