### PR TITLE
Fix published library versions

### DIFF
--- a/build/Build.Consolidation.cs
+++ b/build/Build.Consolidation.cs
@@ -102,7 +102,9 @@ public partial class Build
                                //Build the consolidated package libraries
                                DotNetBuild(s =>
                                                s.SetConfiguration(Configuration)
-                                                .SetProjectFile(project));
+                                                .SetProjectFile(project)
+                                                .SetVersion(NugetVersion.Value)
+                                                .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion));
 
                                File.Copy(KnownPaths.RootDirectory / "global.json", buildDirectory / "global.json");
 

--- a/build/Build.Contracts.cs
+++ b/build/Build.Contracts.cs
@@ -13,10 +13,12 @@ public partial class Build
 
                            var buildDirectory = KnownPaths.SourceDirectory / project.Name / "bin" / Configuration;
 
-                           //Build the consolidated package libraries
+                           //Build the contracts library
                            DotNetBuild(s =>
                                            s.SetConfiguration(Configuration)
-                                            .SetProjectFile(project));
+                                            .SetProjectFile(project)
+                                            .SetVersion(NugetVersion.Value)
+                                            .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion));
 
                            File.Copy(KnownPaths.RootDirectory / "global.json", buildDirectory / "global.json");
 


### PR DESCRIPTION
These DLL's should be property versioned, and they weren't

This is the new Contracts and the Consolidation libraries consumed by Octopus Server