### PR TITLE
Add Calamari-side coverage for package transfer + delta reconstruction

### DIFF
--- a/source/Calamari.Tests/Fixtures/ApplyDelta/TransferAndApplyDeltaFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ApplyDelta/TransferAndApplyDeltaFixture.cs
@@ -1,0 +1,123 @@
+using System;
+using System.IO;
+using Calamari.Common.Plumbing.Extensions;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Testing;
+using Calamari.Testing.Helpers;
+using Calamari.Tests.Fixtures.Deployment.Packages;
+using Calamari.Tests.Helpers;
+using NUnit.Framework;
+using Octostache;
+
+namespace Calamari.Tests.Fixtures.ApplyDelta
+{
+    [TestFixture]
+    public class TransferAndApplyDeltaFixture : CalamariFixture
+    {
+        static readonly string TentacleHome = TestEnvironment.GetTestPath("Fixtures", "TransferAndApplyDelta");
+        static readonly string DownloadPath = Path.Combine(TentacleHome, "Files");
+
+        string transferDirectory = null!;
+
+        [OneTimeSetUp]
+        public void TestFixtureSetUp()
+        {
+            Environment.SetEnvironmentVariable("TentacleHome", TentacleHome);
+        }
+
+        [OneTimeTearDown]
+        public void TestFixtureTearDown()
+        {
+            Environment.SetEnvironmentVariable("TentacleHome", null);
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+
+            transferDirectory = Path.Combine(Path.GetTempPath(), "CalamariTransferDelta-" + Guid.NewGuid());
+            fileSystem.EnsureDirectoryExists(transferDirectory);
+
+            if (!Directory.Exists(DownloadPath))
+                Directory.CreateDirectory(DownloadPath);
+
+            Environment.SetEnvironmentVariable("TentacleJournal", Path.Combine(transferDirectory, "DeploymentJournal.xml"));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(DownloadPath))
+                Directory.Delete(DownloadPath, true);
+            if (Directory.Exists(transferDirectory))
+                Directory.Delete(transferDirectory, true);
+        }
+
+        [Test]
+        public void TransferredBasisPackageCanBeReconstructedByApplyDelta()
+        {
+            using (var basisFile = new TemporaryFile(PackageBuilder.BuildSamplePackage("Acme.Web", "1.0.0")))
+            {
+                var transferResult = TransferPackage(basisFile.FilePath);
+                transferResult.AssertSuccess();
+
+                var transferredBasisPath = Path.Combine(transferDirectory, Path.GetFileName(basisFile.FilePath));
+                Assert.IsTrue(File.Exists(transferredBasisPath), "Basis package was not transferred to the expected location.");
+
+                using (var signatureFile = new TemporaryFile(transferredBasisPath + ".octosig"))
+                {
+                    var signatureExitCode = Octodiff.Program.Main(new[] { "signature", transferredBasisPath, signatureFile.FilePath });
+                    Assert.That(signatureExitCode, Is.EqualTo(0));
+
+                    using (var newFile = new TemporaryFile(PackageBuilder.BuildSamplePackage("Acme.Web", "1.0.1", true)))
+                    using (var deltaFile = new TemporaryFile(transferredBasisPath + "_to_Acme.Web.1.0.1.nupkg.octodelta"))
+                    {
+                        var deltaExitCode = Octodiff.Program.Main(new[] { "delta", signatureFile.FilePath, newFile.FilePath, deltaFile.FilePath });
+                        Assert.That(deltaExitCode, Is.EqualTo(0));
+
+                        var transferredBasisHash = HashCalculator.Hash(transferredBasisPath);
+                        var patchResult = ApplyDelta(transferredBasisPath, transferredBasisHash, deltaFile.FilePath, "Acme.Web.1.0.1.nupkg");
+                        patchResult.AssertSuccess();
+
+                        patchResult.AssertPackageDeltaVerificationServiceMessage();
+                        Assert.AreEqual(newFile.Hash, patchResult.CapturedOutput.DeltaVerification.Hash);
+                        Assert.AreEqual(newFile.Hash, HashCalculator.Hash(patchResult.CapturedOutput.DeltaVerification.FullPathOnRemoteMachine));
+                    }
+                }
+            }
+        }
+
+        CalamariResult TransferPackage(string packageFilePath)
+        {
+            var variables = new VariableDictionary
+            {
+                [PackageVariables.TransferPath] = transferDirectory,
+                [PackageVariables.OriginalFileName] = Path.GetFileName(packageFilePath),
+                [TentacleVariables.CurrentDeployment.PackageFilePath] = packageFilePath,
+                [ActionVariables.Name] = "MyAction",
+                [MachineVariables.Name] = "MyMachine"
+            };
+
+            using (var variablesFile = new TemporaryFile(Path.GetTempFileName()))
+            {
+                var encryptionKey = variables.SaveAsEncryptedExecutionVariables(variablesFile.FilePath);
+
+                return Invoke(Calamari()
+                    .Action("transfer-package")
+                    .VariablesFileArguments(variablesFile.FilePath, encryptionKey));
+            }
+        }
+
+        CalamariResult ApplyDelta(string basisFile, string fileHash, string deltaFile, string newFile)
+        {
+            return Invoke(Calamari()
+                .Action("apply-delta")
+                .Argument("basisFileName", basisFile)
+                .Argument("fileHash", fileHash)
+                .Argument("deltaFileName", deltaFile)
+                .Argument("newFileName", newFile));
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Deployment/TransferPackageFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Deployment/TransferPackageFixture.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
-using Calamari.Integration.FileSystem;
 using Calamari.Testing;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Fixtures.Deployment.Packages;
@@ -25,9 +22,8 @@ namespace Calamari.Tests.Fixtures.Deployment
             nupkgFile = new TemporaryFile(PackageBuilder.BuildSamplePackage("Acme.Web", "1.0.0"));
         }
 
-
-        protected string StagingDirectory { get; private set; }
-        protected string CustomDirectory { get; private set; }
+        string StagingDirectory { get; set; }
+        string CustomDirectory { get; set; }
 
 
         [SetUp]
@@ -35,7 +31,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         {
             var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
 
-            // Ensure staging directory exists and is empty 
+            // Ensure staging directory exists and is empty
             StagingDirectory = Path.Combine(Path.GetTempPath(), "CalamariTestStaging");
             CustomDirectory = Path.Combine(Path.GetTempPath(), "CalamariTestCustom");
             fileSystem.EnsureDirectoryExists(StagingDirectory);
@@ -50,7 +46,7 @@ namespace Calamari.Tests.Fixtures.Deployment
         public void ShouldPreserveFileInStagingDirectory()
         {
             var result = TransferPackage();
-        
+
             result.AssertSuccess();
             Assert.IsTrue(File.Exists(nupkgFile.FilePath));
         }
@@ -59,10 +55,10 @@ namespace Calamari.Tests.Fixtures.Deployment
         public void ShouldCopyFileToTransferPath()
         {
             var result = TransferPackage();
-        
-            result.AssertSuccess();     
 
-            var outputResult = Path.Combine(CustomDirectory, Path.GetFileName(nupkgFile.FilePath));               
+            result.AssertSuccess();
+
+            var outputResult = Path.Combine(CustomDirectory, Path.GetFileName(nupkgFile.FilePath));
             Assert.IsTrue(File.Exists(outputResult));
         }
 
@@ -90,13 +86,41 @@ namespace Calamari.Tests.Fixtures.Deployment
                 $"Copied package '{Path.GetFileName(nupkgFile.FilePath)}' to directory '{CustomDirectory}'");
         }
 
-        protected CalamariResult TransferPackage()
+        [TestCase(".nupkg")]
+        [TestCase(".zip")]
+        public void ShouldCopyPackageRegardlessOfFormat(string extension)
+        {
+            using (var packageFile = new TemporaryFile(BuildPackageWithExtension(extension)))
+            {
+                var result = TransferPackage(packageFile.FilePath);
+                result.AssertSuccess();
+
+                var outputResult = Path.Combine(CustomDirectory, Path.GetFileName(packageFile.FilePath));
+                Assert.IsTrue(File.Exists(outputResult));
+                result.AssertOutputVariable(PackageVariables.Output.FilePath, Is.EqualTo(outputResult));
+            }
+        }
+
+        static string BuildPackageWithExtension(string extension)
+        {
+            if (extension == ".nupkg")
+                return PackageBuilder.BuildSamplePackage("Acme.Web", "1.0.2");
+
+            var sourceDir = Path.Combine(Path.GetTempPath(), "CalamariTransferZipSource-" + Guid.NewGuid());
+            Directory.CreateDirectory(sourceDir);
+            File.WriteAllText(Path.Combine(sourceDir, "marker.txt"), "payload");
+            return PackageBuilder.BuildSimpleZip("Acme.Raw", "1.0.0", sourceDir);
+        }
+
+        CalamariResult TransferPackage() => TransferPackage(nupkgFile.FilePath);
+
+        CalamariResult TransferPackage(string packageFilePath)
         {
             var variables = new VariableDictionary
             {
                 [PackageVariables.TransferPath] = CustomDirectory,
-                [PackageVariables.OriginalFileName] = Path.GetFileName(nupkgFile.FilePath),
-                [TentacleVariables.CurrentDeployment.PackageFilePath] = nupkgFile.FilePath,
+                [PackageVariables.OriginalFileName] = Path.GetFileName(packageFilePath),
+                [TentacleVariables.CurrentDeployment.PackageFilePath] = packageFilePath,
                 [ActionVariables.Name] = "MyAction",
                 [MachineVariables.Name] = "MyMachine"
             };


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

Companion to OctopusDeploy/OctopusDeploy#42443, which asserts that Server sends the correct Calamari command for each delta-compression configuration. That test covers the server decision; these tests cover what Calamari actually does when invoked.

## What's Added

- A new `TransferAndApplyDeltaFixture` chaining `transfer-package` and `apply-delta` end-to-end: transfers a basis package, generates an OctoDiff signature and delta against a new version, then verifies `apply-delta` reconstructs a package whose hash matches the new version. This closes the gap left by the removed `TentaclePackageTransferTestScript` E2E for the delta-enabled path.
- A parameterised `ShouldCopyPackageRegardlessOfFormat` case on `TransferPackageFixture` covering `.nupkg` and `.zip`, so `transfer-package` is no longer only exercised against a single package format.

Cache/skip-cache and delta-disabled scenarios are intentionally not added here. Those are Server-decision paths and are covered by the OctopusDeploy test.