### PR TITLE
Fix failing test from poison merge

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
@@ -1835,7 +1835,7 @@ redis:
                                Name = "ref-source",
                                Ref = "values",
                                TargetRevision = ArgoCDBranchFriendlyName,
-                               OriginalRepoUrl = OriginPath,
+                               OriginalRepoUrl = OriginUrl,
                            },
                            SourceTypeConstants.Directory)
                        .Build();


### PR DESCRIPTION
This a follow on PR off https://github.com/OctopusDeploy/Calamari/pull/1893 to fix the poison merge (conflicting with https://github.com/OctopusDeploy/Calamari/commit/0d876a5ba7d47dabf16ad5827a03d75abc8822b0)