### PR TITLE
Remove westus2 from Azure web app regions

### DIFF
--- a/source/Calamari.Testing/Azure/RandomAzureRegion.cs
+++ b/source/Calamari.Testing/Azure/RandomAzureRegion.cs
@@ -14,7 +14,7 @@ namespace Calamari.Testing.Azure
             "eastus",
             "eastus2",
             "westus",
-            "westus2",
+            //"westus2", - 2026-04-23   westus2 is low in capacity now
             "australiaeast"
         };
 

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
@@ -1835,7 +1835,7 @@ redis:
                                Name = "ref-source",
                                Ref = "values",
                                TargetRevision = ArgoCDBranchFriendlyName,
-                               OriginalRepoUrl = OriginPath,
+                               OriginalRepoUrl = OriginUrl,
                            },
                            SourceTypeConstants.Directory)
                        .Build();


### PR DESCRIPTION
westus2 has been flaky lately - removing it from the random region list

[Teamcity build](https://build.octopushq.com/buildConfiguration/TeamModernDeployments_Calamari_VNext_Chains_ChainFull/21994103)
<img width="1724" height="862" alt="CleanShot 2026-04-23 at 16 49 51@2x" src="https://github.com/user-attachments/assets/31bd72a1-81f5-4b8c-bb40-c75255f447ed" />
