### PR TITLE
Lazily register git transport

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
-using Calamari.ArgoCD;
 using Calamari.ArgoCD.Git;
 using Calamari.ArgoCD.Git.PullRequests;
 using Calamari.Common.Commands;
@@ -24,8 +22,7 @@ public class GitHttpSmartSubTransportTests
     static GitHttpSmartSubTransportTests()
     {
         // Ensure the custom HTTP smart sub-transport is registered with libgit2.
-        // ArgoCDModule's static constructor handles this; RunClassConstructor is idempotent.
-        RuntimeHelpers.RunClassConstructor(typeof(ArgoCDModule).TypeHandle);
+        LibGit2SharpTransportRegistration.EnsureRegistered();
     }
 
     readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();

--- a/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Calamari.ArgoCD;
+using Calamari.ArgoCD.Git;
+using Calamari.ArgoCD.Git.PullRequests;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Integration.Time;
+using Calamari.Testing.Helpers;
+using Calamari.Tests.Fixtures.Integration.FileSystem;
+using FluentAssertions;
+using NUnit.Framework;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Calamari.Tests.ArgoCD.Git;
+
+[TestFixture]
+public class GitHttpSmartSubTransportTests
+{
+    static GitHttpSmartSubTransportTests()
+    {
+        // Ensure the custom HTTP smart sub-transport is registered with libgit2.
+        // ArgoCDModule's static constructor handles this; RunClassConstructor is idempotent.
+        RuntimeHelpers.RunClassConstructor(typeof(ArgoCDModule).TypeHandle);
+    }
+
+    readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();
+
+    InMemoryLog log;
+    string tempDirectory;
+    WireMockServer server;
+
+    [SetUp]
+    public void Init()
+    {
+        log = new InMemoryLog();
+        tempDirectory = fileSystem.CreateTemporaryDirectory();
+        server = WireMockServer.Start();
+
+        // Return 200 for any request. The body is not valid git smart HTTP,
+        // so the clone will fail after the request is sent — but WireMock
+        // will have recorded the request headers we need to inspect.
+        server.Given(Request.Create().UsingAnyMethod())
+              .RespondWith(Response.Create().WithStatusCode(200).WithBody("not-a-git-response"));
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        server?.Stop();
+        server?.Dispose();
+        RepositoryHelpers.DeleteRepositoryDirectory(fileSystem, tempDirectory);
+    }
+
+    [Test]
+    public void BasicAuthHeaderIsSentOnFirstRequest()
+    {
+        var username = "testuser";
+        var password = "testpassword";
+        var expectedAuth = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+
+        var repoUrl = new Uri($"{server.Url}/fake-repo.git");
+        var connection = new GitConnection(username, password, repoUrl, GitBranchName.CreateFromFriendlyName("main"));
+        var repositoryFactory = new RepositoryFactory(
+            log,
+            fileSystem,
+            tempDirectory,
+            new GitVendorPullRequestClientResolver([]),
+            new SystemClock());
+
+        // The clone will fail because WireMock doesn't speak git protocol,
+        // but the HTTP request will have been sent and recorded.
+        var act = () => repositoryFactory.CloneRepository("test-repo", connection);
+        act.Should().Throw<CommandException>();
+
+        var requests = server.LogEntries.ToList();
+        requests.Should().NotBeEmpty("at least one HTTP request should have been made");
+
+        var firstRequest = requests.First();
+        firstRequest.RequestMessage.Headers.Should().ContainKey("Authorization");
+
+        var authHeader = firstRequest.RequestMessage.Headers?["Authorization"].First();
+        authHeader.Should().Be($"Basic {expectedAuth}",
+            "the Basic auth header should be sent proactively on the first request, not after a 401 challenge");
+    }
+
+    [Test]
+    public void NoAuthHeaderIsSentWhenCredentialsAreNotProvided()
+    {
+        var repoUrl = new Uri($"{server.Url}/fake-repo.git");
+        var connection = new GitConnection(null, null, repoUrl, GitBranchName.CreateFromFriendlyName("main"));
+        var repositoryFactory = new RepositoryFactory(
+            log,
+            fileSystem,
+            tempDirectory,
+            new GitVendorPullRequestClientResolver([]),
+            new SystemClock());
+
+        var act = () => repositoryFactory.CloneRepository("test-repo", connection);
+        act.Should().Throw<CommandException>();
+
+        var requests = server.LogEntries.ToList();
+        requests.Should().NotBeEmpty("at least one HTTP request should have been made");
+
+        var firstRequest = requests.First();
+        firstRequest.RequestMessage.Headers.Should().NotContainKey("Authorization",
+            "no auth header should be sent when credentials are not provided");
+    }
+}

--- a/source/Calamari/ArgoCD/ArgoCDModule.cs
+++ b/source/Calamari/ArgoCD/ArgoCDModule.cs
@@ -3,7 +3,6 @@ using Calamari.ArgoCD.Conventions;
 using Calamari.ArgoCD.Git;
 using Calamari.ArgoCD.Git.PullRequests;
 using Calamari.ArgoCD.Git.PullRequests.Vendors.GitLab;
-using LibGit2Sharp;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 
@@ -11,20 +10,6 @@ namespace Calamari.ArgoCD
 {
     public class ArgoCDModule : Module
     {
-        static ArgoCDModule()
-        {
-            // Note this cannot be set in the RepositoryFactory as it causes tests to fail, due to the following issue.
-            
-            // LibGit2Sharp custom sub-transports are registered by calling a static registration
-            // method on GlobalSettings. Additionally, if you try and register a multiple transports
-            // with the same scheme, it throws an exception. It's not ideal, but it's what we've got
-            // to work with.
-            //
-            // Using the type constructor to make sure that these methods are only called once.
-            GlobalSettings.RegisterSmartSubtransport<GitHttpSmartSubTransport>("http");
-            GlobalSettings.RegisterSmartSubtransport<GitHttpSmartSubTransport>("https");
-        }
-
         protected override void Load(ContainerBuilder builder)
         {
             builder.RegisterType<DeploymentConfigFactory>().AsSelf().InstancePerLifetimeScope();

--- a/source/Calamari/ArgoCD/Git/LibGit2SharpTransportRegistration.cs
+++ b/source/Calamari/ArgoCD/Git/LibGit2SharpTransportRegistration.cs
@@ -1,0 +1,25 @@
+using System;
+using LibGit2Sharp;
+
+namespace Calamari.ArgoCD.Git;
+
+/// <summary>
+/// Lazily registers custom smart sub-transports for libgit2sharp so that the native
+/// library is only loaded when git operations are actually needed, rather than during
+/// startup.
+/// The only reason not to do it during startup is that we have a new dependency on
+/// OpenSSL3 that older (now unsupported) OS versions may not fulfill. Instead of
+/// breaking everyone if they are running older systems, we will only break them
+/// if they use git functionality.
+/// </summary>
+static class LibGit2SharpTransportRegistration
+{
+    static readonly Lazy<bool> Registered = new(() =>
+        {
+            GlobalSettings.RegisterSmartSubtransport<GitHttpSmartSubTransport>("http");
+            GlobalSettings.RegisterSmartSubtransport<GitHttpSmartSubTransport>("https");
+            return true;
+        });
+
+    public static void EnsureRegistered() => _ = Registered.Value;
+}

--- a/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
@@ -35,6 +35,8 @@ namespace Calamari.ArgoCD.Git
             this.gitVendorPullRequestClientResolver = gitVendorPullRequestClientResolver;
             this.clock = clock;
 
+            LibGit2SharpTransportRegistration.EnsureRegistered();
+
             // Calamari runs as a single-purpose process per deployment step and always receives
             // explicit credentials. Clear the search paths for all global config levels so libgit2
             // cannot load ~/.gitconfig or /etc/gitconfig and pick up a credential helper (e.g.


### PR DESCRIPTION
Built on top of https://github.com/OctopusDeploy/Calamari/pull/1903

When we add support for SSH authentication, we create a dependency on OpenSSL 3.
This is broadly supported at this point by our support platforms, however we can't be sure that our customers are up to date.

The dependency is required only when we access LibGit2Sharp, which only needs to happen for ArgoCD steps at the moment. So I think it's a fairly safe requirement that users using brand new functionality must have up to date workers/targets.

This assumption changed in https://github.com/OctopusDeploy/Calamari/pull/1873 when we forced LibGit2Sharp to load the native binaries during Calamari startup so we can register the transports.

This change makes that registration lazy, so we can return to only requiring any dependencies for actions that need it.

Relates to MD-1806