### PR TITLE
Add an empty Commit-to-Git Step

### DIFF
--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -1,0 +1,25 @@
+using System;
+using Calamari.Commands.Support;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Logging;
+
+namespace Calamari.Commands;
+
+[Command(Name, Description = "Update a Git repository with selected package content, then transform with optional script")]
+public class CommitToGitCommand : Command
+{
+    public const string Name = "commit-to-git";
+    readonly ILog log;
+
+    public CommitToGitCommand(ILog log)
+    {
+        this.log = log;
+    }
+
+    public override int Execute(string[] commandLineArguments)
+    {
+        Options.Parse(commandLineArguments);
+        log.Error("This step should not be executed");
+        return 1;
+    }
+}


### PR DESCRIPTION
This adds a new command to Calamari, but does not define any behavour - it is a placeholder for future work.