### PR TITLE
Add test category for requiring OpenSSL 3

### DIFF
--- a/build/Build.CalamariTesting.cs
+++ b/build/Build.CalamariTesting.cs
@@ -32,6 +32,19 @@ partial class Build
                       });
 
     [PublicAPI]
+    Target LinuxSpecificTestingWithoutOpenSsl3 =>
+        target => target
+            .Executes(async () =>
+                      {
+                          var dotnetPath = await LocateOrInstallDotNetSdk();
+
+                          CreateTestRun("Binaries/Calamari.Tests.dll")
+                              .WithDotNetPath(dotnetPath)
+                              .WithFilter("TestCategory != Windows & TestCategory != PlatformAgnostic & TestCategory != RunOnceOnWindowsAndLinux & TestCategory != RequiresOpenSsl3")
+                              .Execute();
+                      });
+
+    [PublicAPI]
     Target OncePerWindowsOrLinuxTesting =>
         target => target
             .Executes(async () =>
@@ -41,6 +54,19 @@ partial class Build
                           CreateTestRun("Binaries/Calamari.Tests.dll")
                               .WithDotNetPath(dotnetPath)
                               .WithFilter("(TestCategory != Windows & TestCategory != PlatformAgnostic) | TestCategory = RunOnceOnWindowsAndLinux")
+                              .Execute();
+                      });
+
+    [PublicAPI]
+    Target OncePerWindowsOrLinuxTestingWithoutOpenSsl3 =>
+        target => target
+            .Executes(async () =>
+                      {
+                          var dotnetPath = await LocateOrInstallDotNetSdk();
+
+                          CreateTestRun("Binaries/Calamari.Tests.dll")
+                              .WithDotNetPath(dotnetPath)
+                              .WithFilter("((TestCategory != Windows & TestCategory != PlatformAgnostic) | TestCategory = RunOnceOnWindowsAndLinux) & TestCategory != RequiresOpenSsl3")
                               .Execute();
                       });
 

--- a/source/Calamari.Testing/Helpers/TestCategory.cs
+++ b/source/Calamari.Testing/Helpers/TestCategory.cs
@@ -21,7 +21,9 @@ namespace Calamari.Testing.Helpers
         }
         
         public const string PlatformAgnostic = "PlatformAgnostic";
-		
+
         public const string RunOnceOnWindowsAndLinux = "RunOnceOnWindowsAndLinux";
+
+        public const string RequiresOpenSsl3 = "RequiresOpenSsl3";
     }
 }

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
@@ -29,6 +29,7 @@ using Octopus.Calamari.Contracts.ArgoCD;
 
 namespace Calamari.Tests.ArgoCD.Commands.Conventions
 {
+    [Category(TestCategory.RequiresOpenSsl3)]
     public class UpdateArgoCDAppImagesInstallConventionHelmTests
     {
         const string ProjectSlug = "TheProject";

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -29,6 +29,7 @@ using Octopus.Calamari.Contracts.ArgoCD;
 namespace Calamari.Tests.ArgoCD.Commands.Conventions
 {
     [TestFixture]
+    [Category(TestCategory.RequiresOpenSsl3)]
     public class UpdateArgoCDAppImagesInstallConventionTests
     {
         const string ProjectSlug = "TheProject";

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
@@ -28,6 +28,7 @@ using Octopus.Calamari.Contracts.ArgoCD;
 namespace Calamari.Tests.ArgoCD.Commands.Conventions
 {
     [TestFixture]
+    [Category(TestCategory.RequiresOpenSsl3)]
     public class UpdateArgoCDApplicationManifestsInstallConventionTests
     {
         const string ProjectSlug = "TheProject";

--- a/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
@@ -17,6 +17,7 @@ using WireMock.Server;
 namespace Calamari.Tests.ArgoCD.Git;
 
 [TestFixture]
+[Category(TestCategory.RequiresOpenSsl3)]
 public class GitHttpSmartSubTransportTests
 {
     readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();

--- a/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitVendorApiAdapter_PullRequestTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitVendorApiAdapter_PullRequestTests.cs
@@ -9,6 +9,7 @@ using Calamari.ArgoCD.Git.PullRequests.Vendors.BitBucket;
 using Calamari.ArgoCD.Git.PullRequests.Vendors.GitHub;
 using Calamari.ArgoCD.Git.PullRequests.Vendors.GitLab;
 using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Testing.Helpers;
 using FluentAssertions;
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
@@ -22,6 +23,7 @@ using Repository = LibGit2Sharp.Repository;
 namespace Calamari.Tests.ArgoCD.Git.GitVendorApiAdapters
 {
     [TestFixture]
+    [Category(TestCategory.RequiresOpenSsl3)]
     public class GitHubPullRequestClientTests
     {
         [Test]

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
@@ -16,6 +16,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.ArgoCD.Git
 {
     [TestFixture]
+    [Category(TestCategory.RequiresOpenSsl3)]
     public class RepositoryFactoryTests
     {
         readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
@@ -19,6 +19,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.ArgoCD.Git
 {
     [TestFixture]
+    [Category(TestCategory.RequiresOpenSsl3)]
     public class RepositoryWrapperTest
     {
         readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();


### PR DESCRIPTION
Re-requisite for adding libssh2 requirement to Calamari for SSH git authentication.

Once added, I'll update the teamcity configurations to reference the new build targets so I can check my next PR against them correctly.

I believe when this is merged, there will be no change to existing builds as every build agent will just reference the old build target which runs all the tests.

Relates to MD-1806