### PR TITLE
Add null reference guard to DescribeCloudFormationChangeSetConvention

### DIFF
--- a/source/Calamari.Aws/Deployment/Conventions/DescribeCloudFormationChangeSetConvention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/DescribeCloudFormationChangeSetConvention.cs
@@ -67,7 +67,7 @@ namespace Calamari.Aws.Deployment.Conventions
             {
                 throw new PermissionException(
                     "The AWS account used to perform the operation does not have the required permissions to describe the change set.\n" +
-                    "Please ensure the current account has permission to perfrom action 'cloudformation:DescribeChangeSet'." +
+                    "Please ensure the current account has permission to perform action 'cloudformation:DescribeChangeSet'." +
                     ex.Message + "\n");
             }
             catch (AmazonCloudFormationException ex)

--- a/source/Calamari.Aws/Deployment/Conventions/DescribeCloudFormationChangeSetConvention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/DescribeCloudFormationChangeSetConvention.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
 using Amazon.Runtime;
 using Calamari.Aws.Exceptions;
 using Calamari.Aws.Integration.CloudFormation;
@@ -57,9 +59,9 @@ namespace Calamari.Aws.Deployment.Conventions
             try
             {
                 var response = await clientFactory.DescribeChangeSetAsync(stack, changeSet);
-                SetOutputVariable(variables, "ChangeCount", response.Changes.Count.ToString());
-                SetOutputVariable(variables, "Changes",
-                    JsonConvert.SerializeObject(response.Changes, Formatting.Indented));
+                var changes = response?.Changes ?? new List<Change>();
+                SetOutputVariable(variables, "ChangeCount", changes.Count.ToString());
+                SetOutputVariable(variables, "Changes", JsonConvert.SerializeObject(changes, Formatting.Indented));
             }
             catch (AmazonCloudFormationException ex) when (ex.ErrorCode == "AccessDenied")
             {

--- a/source/Calamari.Tests/AWS/CloudFormation/DescribeCloudFormationChangeSetConventionFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/DescribeCloudFormationChangeSetConventionFixture.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using Calamari.Aws.Deployment.Conventions;
+using Calamari.Aws.Integration.CloudFormation;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.AWS.CloudFormation
+{
+    [TestFixture]
+    public class DescribeCloudFormationChangeSetConventionFixture
+    {
+        IAmazonCloudFormation client;
+        DescribeCloudFormationChangeSetConvention convention;
+
+        static StackArn TestStack() => new("test-stack");
+        static ChangeSetArn TestChangeSet() => new("test-changeset");
+        static CalamariVariables TestVariables() => new();
+
+        [SetUp]
+        public void SetUp()
+        {
+            client = Substitute.For<IAmazonCloudFormation>();
+            var log = Substitute.For<ILog>();
+            convention = new DescribeCloudFormationChangeSetConvention(
+                () => client,
+                new StackEventLogger(log),
+                _ => TestStack(),
+                _ => TestChangeSet(),
+                log);
+        }
+
+        [Test]
+        public async Task DescribeChangeset_WithNullChangesInResponseDoesNotThrow()
+        {
+            client.DescribeChangeSetAsync(Arg.Any<DescribeChangeSetRequest>(), Arg.Any<CancellationToken>())
+                  .Returns(new DescribeChangeSetResponse { Changes = null });
+
+            await convention.DescribeChangeset(TestStack(), TestChangeSet(), TestVariables());
+        }
+    }
+}

--- a/source/Calamari.Tests/AWS/CloudFormation/DescribeCloudFormationChangeSetConventionFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/DescribeCloudFormationChangeSetConventionFixture.cs
@@ -7,6 +7,7 @@ using Calamari.Aws.Deployment.Conventions;
 using Calamari.Aws.Integration.CloudFormation;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.Testing.Helpers;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -14,6 +15,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.AWS.CloudFormation
 {
     [TestFixture]
+    [Category(TestCategory.PlatformAgnostic)]
     public class DescribeCloudFormationChangeSetConventionFixture
     {
         IAmazonCloudFormation client;

--- a/source/Calamari.Tests/AWS/CloudFormation/DescribeCloudFormationChangeSetConventionFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/DescribeCloudFormationChangeSetConventionFixture.cs
@@ -7,6 +7,7 @@ using Calamari.Aws.Deployment.Conventions;
 using Calamari.Aws.Integration.CloudFormation;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
+using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -42,6 +43,17 @@ namespace Calamari.Tests.AWS.CloudFormation
                   .Returns(new DescribeChangeSetResponse { Changes = null });
 
             await convention.DescribeChangeset(TestStack(), TestChangeSet(), TestVariables());
+        }
+
+        [Test]
+        public async Task DescribeChangeset_WithNullResponseDoesNotThrow()
+        {
+            client.DescribeChangeSetAsync(Arg.Any<DescribeChangeSetRequest>(), Arg.Any<CancellationToken>())
+                  .Returns((DescribeChangeSetResponse)null);
+
+            var act = () => convention.DescribeChangeset(TestStack(), TestChangeSet(), TestVariables());
+
+            await act.Should().NotThrowAsync();
         }
     }
 }

--- a/source/Calamari.Tests/AWS/CloudFormation/DescribeCloudFormationChangeSetConventionFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/DescribeCloudFormationChangeSetConventionFixture.cs
@@ -42,7 +42,9 @@ namespace Calamari.Tests.AWS.CloudFormation
             client.DescribeChangeSetAsync(Arg.Any<DescribeChangeSetRequest>(), Arg.Any<CancellationToken>())
                   .Returns(new DescribeChangeSetResponse { Changes = null });
 
-            await convention.DescribeChangeset(TestStack(), TestChangeSet(), TestVariables());
+            var act = () => convention.DescribeChangeset(TestStack(), TestChangeSet(), TestVariables());
+            
+            await act.Should().NotThrowAsync();
         }
 
         [Test]


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

A recent bump to AWS SDK v4 has meant that `response.Changes` can now be null when there are no changes (instead of an empty list).

As per title, this PR adds a null reference guard to DescribeCloudFormationChangeSetConvention so this is handled without throwing an exception.

Fixes FD-273