### PR TITLE
Update the contracts package when building locally

### DIFF
--- a/build/Build.LocalPackages.cs
+++ b/build/Build.LocalPackages.cs
@@ -10,12 +10,12 @@ public partial class Build
     //This is a base 64 encoded message from forbidden words in the profanity checker to stop local packages from being commited to server, while still allowing Calamari builds to pass their own forbidden words check
     static string PreventCommitMessage = Encoding.UTF8.GetString(Convert.FromBase64String("Tk9DT01NSVQ="));
 
-    
     Target CopyToLocalPackages =>
         d =>
             d.Requires(() => IsLocalBuild)
              .DependsOn(PublishCalamariProjects)
              .DependsOn(PackCalamariConsolidatedNugetPackage)
+             .DependsOn(PackContractsProject)
              .Executes(() =>
                        {
                            Directory.CreateDirectory(LocalPackagesDirectory);
@@ -34,36 +34,48 @@ public partial class Build
              .Executes(() =>
                        {
                            var serverProjectFile = KnownPaths.RootDirectory / ".." / "OctopusDeploy" / "source" / "Octopus.Server" / "Octopus.Server.csproj";
+                           var coreProjectFile = KnownPaths.RootDirectory / ".." / "OctopusDeploy" / "source" / "Octopus.Core" / "Octopus.Core.csproj";
                            var serverNugetConfigFile = KnownPaths.RootDirectory / ".." / "OctopusDeploy" / "NuGet.Config";
-                           var projectFileExists = File.Exists(serverProjectFile);
+                           var serverProjectFileExists = File.Exists(serverProjectFile);
+                           var coreProjectFileExists = File.Exists(serverProjectFile);
                            var nugetFileExists = File.Exists(serverNugetConfigFile);
-                           if (projectFileExists && nugetFileExists)
+                           if (serverProjectFileExists && coreProjectFileExists && nugetFileExists)
                            {
                                Log.Information("Setting Calamari version in Octopus Server "
                                                + "project {ServerProjectFile} to {NugetVersion}",
-                                               serverProjectFile, NugetVersion.Value);
+                                   serverProjectFile, NugetVersion.Value);
                                SetOctopusServerCalamariVersion(serverProjectFile);
+                               SetOctopusServerCalamariVersion(coreProjectFile);
                                AddLocalPackagesSource(serverNugetConfigFile);
                            }
                            else
                            {
-                               if (!projectFileExists)
+                               if (!serverProjectFileExists)
                                {
                                    Log.Warning("Could not set Calamari version in Octopus Server project "
                                                + "{ServerProjectFile} to {NugetVersion} as could not find "
                                                + "project file",
-                                               serverProjectFile, NugetVersion.Value);
+                                       serverProjectFile, NugetVersion.Value);
                                }
-                               else if (!nugetFileExists)
+
+                               if (!coreProjectFileExists)
+                               {
+                                   Log.Warning("Could not set Calamari version in Octopus Server project "
+                                               + "{ServerProjectFile} to {NugetVersion} as could not find "
+                                               + "project file",
+                                       serverProjectFile, NugetVersion.Value);
+                               }
+
+                               if (!nugetFileExists)
                                {
                                    Log.Warning("Could not set Calamari version in Octopus Server project "
                                                + "{ServerProjectFile} to {NugetVersion} as could not find "
                                                + "nuget config file",
-                                               serverNugetConfigFile, NugetVersion.Value);
+                                       serverNugetConfigFile, NugetVersion.Value);
                                }
-
                            }
                        });
+
     void SetOctopusServerCalamariVersion(string projectFile)
     {
         var text = File.ReadAllText(projectFile);
@@ -75,12 +87,12 @@ public partial class Build
     void AddLocalPackagesSource(string nugetConfigFile)
     {
         var doc = XDocument.Load(nugetConfigFile);
-        
+
         // Add LocalPackages to packageSources
         var packageSources = doc.Descendants("packageSources").FirstOrDefault();
         if (packageSources == null)
             throw new InvalidOperationException("Could not find <packageSources> element in NuGet.config");
-    
+
         var existingSource = packageSources.Elements("add")
                                            .FirstOrDefault(e => e.Attribute("key")?.Value == "LocalPackages");
         if (existingSource == null)
@@ -88,19 +100,19 @@ public partial class Build
             packageSources.Add(new XElement("add",
                                             new XAttribute("key", "LocalPackages"),
                                             new XAttribute("value", "../LocalPackages")));
-    
+
             packageSources.Add(new XComment(PreventCommitMessage));
         }
-    
+
         // Add LocalPackages to packageSourceMapping
         var packageSourceMapping = doc.Descendants("packageSourceMapping").FirstOrDefault();
         if (packageSourceMapping == null)
             throw new InvalidOperationException("Could not find <packageSourceMapping> element in NuGet.config");
-    
+
         var clearElement = packageSourceMapping.Element("clear");
         if (clearElement == null)
             throw new InvalidOperationException("Could not find <clear /> element in <packageSourceMapping>");
-        
+
         var existingMapping = packageSourceMapping.Elements("packageSource")
                                                   .FirstOrDefault(e => e.Attribute("key")?.Value == "LocalPackages");
 
@@ -108,15 +120,16 @@ public partial class Build
         {
             var localPackagesMapping = new XElement("packageSource",
                                                     new XAttribute("key", "LocalPackages"),
-                                                    new[] { 
-                                                        "Octopus.Calamari.Consolidated", 
-                                                        "Octopus.Calamari.ConsolidatedPackage", 
+                                                    new[] {
+                                                        "Octopus.Calamari.Consolidated",
+                                                        "Octopus.Calamari.ConsolidatedPackage",
                                                         "Octopus.Calamari.ConsolidatedPackage.Api",
                                                         "Octopus.Calamari.Contracts"
                                                     }.Select(p => new XElement("package", new XAttribute("pattern", p))));
-    
+
             clearElement.AddAfterSelf(localPackagesMapping);
         }
+
         doc.Save(nugetConfigFile);
     }
 }


### PR DESCRIPTION
Recent changes to create a shared contracts package between Calamari and Server didn't update the local build script that automatically populates Server with the updated versions.

Now it updates the bundle version in both Server and Core
<img width="368" height="135" alt="image" src="https://github.com/user-attachments/assets/ad37fdbb-eb73-4773-b27e-937b3ed6f8db" />

```
  <PropertyGroup>
    <BundledCalamariVersion>2026.99.0-em-update-the-contr-20260428134014</BundledCalamariVersion> <!--NOCOMMIT -->
  </PropertyGroup>
```