### PR TITLE
AWS cloud formation - revisit null checks

### DIFF
--- a/source/Calamari.Aws/Deployment/Conventions/ExecuteCloudFormationChangeSetConvention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/ExecuteCloudFormationChangeSetConvention.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Amazon.CloudFormation;
@@ -58,7 +59,8 @@ namespace Calamari.Aws.Deployment.Conventions
             var deploymentStartTime = DateTime.Now;
             
             var response = await clientFactory.DescribeChangeSetAsync(stack, changeSet);
-            if (response.Changes.Count == 0)
+            var changes = response?.Changes ?? new List<Change>();
+            if (changes.Count == 0)
             {
                 await clientFactory().DeleteChangeSetAsync(new DeleteChangeSetRequest
                 {

--- a/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/CloudFormation/CloudFormationObjectExtensions.cs
@@ -117,8 +117,8 @@ namespace Calamari.Aws.Integration.CloudFormation
             {
                 var response = await clientFactory().DescribeStackEventsAsync(new DescribeStackEventsRequest { StackName = stack.Value });
 
-                return response?
-                    .StackEvents.OrderByDescending(stackEvent => stackEvent.Timestamp)
+                return (response?.StackEvents ?? Enumerable.Empty<StackEvent>())
+                    .OrderByDescending(stackEvent => stackEvent.Timestamp)
                     .FirstOrDefault(stackEvent => predicate == null || predicate(stackEvent))
                     .AsSome();
             }
@@ -159,16 +159,15 @@ namespace Calamari.Aws.Integration.CloudFormation
                 {
                     var response = await clientFactory().DescribeStackEventsAsync(new DescribeStackEventsRequest { StackName = stack.Value, NextToken = nextToken });
 
-                    var stackEvents = response?
-                        .StackEvents.Where(stackEvent => predicate == null || predicate(stackEvent))
+                    var stackEvents = (response?.StackEvents ?? Enumerable.Empty<StackEvent>())
+                        .Where(stackEvent => predicate == null || predicate(stackEvent))
                         .ToList();
 
                     currentStackEvents.AddRange(stackEvents);
 
-                    if (!string.IsNullOrEmpty(response.NextToken))
-                        nextToken = response.NextToken; // Get the next page of results
-                    else
+                    if (response == null || string.IsNullOrEmpty(response.NextToken))
                         break;
+                    nextToken = response.NextToken;
                 }
 
                 var results = new List<Maybe<StackEvent>>();
@@ -220,7 +219,7 @@ namespace Calamari.Aws.Integration.CloudFormation
         public static async Task<Stack> DescribeStackAsync(this Func<IAmazonCloudFormation> clientFactory, StackArn stack)
         {
             var response = await clientFactory().DescribeStacksAsync(new DescribeStacksRequest { StackName = stack.Value });
-            return response.Stacks.FirstOrDefault();
+            return response?.Stacks?.FirstOrDefault();
         }
         
         /// <summary>
@@ -232,7 +231,7 @@ namespace Calamari.Aws.Integration.CloudFormation
         public static async Task<List<StackResourceSummary>> ListStackResourcesAsync(this Func<IAmazonCloudFormation> clientFactory, StackArn stack)
         {
             var response = await clientFactory().ListStackResourcesAsync(new ListStackResourcesRequest { StackName = stack.Value });
-            return response.StackResourceSummaries;
+            return response?.StackResourceSummaries ?? new List<StackResourceSummary>();
         }
 
 

--- a/source/Calamari.Aws/Kubernetes/Discovery/AwsKubernetesDiscoverer.cs
+++ b/source/Calamari.Aws/Kubernetes/Discovery/AwsKubernetesDiscoverer.cs
@@ -73,7 +73,7 @@ namespace Calamari.Aws.Kubernetes.Discovery
 
                 var clusters = client.ListClustersAsync(new ListClustersRequest()).GetAwaiter().GetResult();
 
-                foreach (var cluster in clusters.Clusters.Select(c =>
+                foreach (var cluster in (clusters.Clusters ?? Enumerable.Empty<string>()).Select(c =>
                     client.DescribeClusterAsync(new DescribeClusterRequest { Name = c }).GetAwaiter().GetResult().Cluster))
                 {
                     var credentialsRole = authenticationDetails.Role;
@@ -90,7 +90,7 @@ namespace Calamari.Aws.Kubernetes.Discovery
                         accountId,
                         assumedRole,
                         workerPoolId,
-                        cluster.Tags.ToTargetTags());
+                        (cluster.Tags ?? new Dictionary<string, string>()).ToTargetTags());
                 }
             }
         }

--- a/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/S3PackageDownloader.cs
@@ -211,7 +211,7 @@ namespace Calamari.Integration.Packages.Download
                 Prefix = prefix
             };
             var response = await client.ListObjectsAsync(request, cancellationToken);
-            return response.S3Objects.Count == 1 ? response.S3Objects[0].Key : null;
+            return response.S3Objects?.Count == 1 ? response.S3Objects[0].Key : null;
         }
     }
 }

--- a/source/Calamari.Tests/AWS/CloudFormation/CloudFormationObjectExtensionsFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/CloudFormationObjectExtensionsFixture.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using Calamari.Aws.Integration.CloudFormation;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.AWS.CloudFormation
+{
+    [TestFixture]
+    [Category(TestCategory.PlatformAgnostic)]
+    public class CloudFormationObjectExtensionsFixture
+    {
+        IAmazonCloudFormation client;
+        Func<IAmazonCloudFormation> clientFactory;
+
+        static StackArn TestStack() => new("test-stack");
+
+        [SetUp]
+        public void SetUp()
+        {
+            client = Substitute.For<IAmazonCloudFormation>();
+            clientFactory = () => client;
+        }
+
+        [Test]
+        public async Task GetLastStackEvent_WithNullStackEventsInResponse_DoesNotThrow()
+        {
+            client.DescribeStackEventsAsync(Arg.Any<DescribeStackEventsRequest>(), Arg.Any<CancellationToken>())
+                  .Returns(new DescribeStackEventsResponse { StackEvents = null });
+
+            var act = async () => await clientFactory.GetLastStackEvent(TestStack());
+
+            await act.Should().NotThrowAsync();
+        }
+
+        [Test]
+        public async Task GetStackEvents_WithNullStackEventsInResponse_ReturnsEmptyList()
+        {
+            client.DescribeStackEventsAsync(Arg.Any<DescribeStackEventsRequest>(), Arg.Any<CancellationToken>())
+                  .Returns(new DescribeStackEventsResponse { StackEvents = null, NextToken = null });
+
+            var result = await clientFactory.GetStackEvents(TestStack());
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task DescribeStackAsync_WithNullStacksInResponse_ReturnsNull()
+        {
+            client.DescribeStacksAsync(Arg.Any<DescribeStacksRequest>(), Arg.Any<CancellationToken>())
+                  .Returns(new DescribeStacksResponse { Stacks = null });
+
+            var result = await clientFactory.DescribeStackAsync(TestStack());
+
+            result.Should().BeNull();
+        }
+
+        [Test]
+        public async Task ListStackResourcesAsync_WithNullStackResourceSummaries_ReturnsEmptyList()
+        {
+            client.ListStackResourcesAsync(Arg.Any<ListStackResourcesRequest>(), Arg.Any<CancellationToken>())
+                  .Returns(new ListStackResourcesResponse { StackResourceSummaries = null });
+
+            var result = await clientFactory.ListStackResourcesAsync(TestStack());
+
+            result.Should().BeEmpty();
+        }
+    }
+}

--- a/source/Calamari.Tests/AWS/CloudFormation/ExecuteCloudFormationChangeSetConventionFixture.cs
+++ b/source/Calamari.Tests/AWS/CloudFormation/ExecuteCloudFormationChangeSetConventionFixture.cs
@@ -1,0 +1,66 @@
+using System.Threading;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using Calamari.Aws.Deployment.Conventions;
+using Calamari.Aws.Integration.CloudFormation;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.AWS.CloudFormation
+{
+    [TestFixture]
+    [Category(TestCategory.PlatformAgnostic)]
+    public class ExecuteCloudFormationChangeSetConventionFixture
+    {
+        IAmazonCloudFormation client;
+        ExecuteCloudFormationChangeSetConvention convention;
+
+        static StackArn TestStack() => new("test-stack");
+        static ChangeSetArn TestChangeSet() => new("test-changeset");
+        static RunningDeployment TestDeployment() => new(null, new CalamariVariables());
+
+        [SetUp]
+        public void SetUp()
+        {
+            client = Substitute.For<IAmazonCloudFormation>();
+            client.DeleteChangeSetAsync(Arg.Any<DeleteChangeSetRequest>(), Arg.Any<CancellationToken>())
+                  .Returns(new DeleteChangeSetResponse());
+
+            var log = Substitute.For<ILog>();
+            convention = new ExecuteCloudFormationChangeSetConvention(
+                () => client,
+                new StackEventLogger(log),
+                _ => TestStack(),
+                _ => TestChangeSet(),
+                waitForComplete: false,
+                log);
+        }
+
+        [Test]
+        public void Install_WithNullDescribeChangeSetResponse_DoesNotThrow()
+        {
+            client.DescribeChangeSetAsync(Arg.Any<DescribeChangeSetRequest>(), Arg.Any<CancellationToken>())
+                  .Returns((DescribeChangeSetResponse)null);
+
+            var act = () => convention.Install(TestDeployment());
+
+            act.Should().NotThrow();
+        }
+
+        [Test]
+        public void Install_WithNullChangesInDescribeChangeSetResponse_DoesNotThrow()
+        {
+            client.DescribeChangeSetAsync(Arg.Any<DescribeChangeSetRequest>(), Arg.Any<CancellationToken>())
+                  .Returns(new DescribeChangeSetResponse { Changes = null });
+
+            var act = () => convention.Install(TestDeployment());
+
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -48,6 +48,9 @@ namespace Calamari
 
         public int Execute(params string[] args)
         {
+            // Backward compatibility fix for v4 collections to ensure they are not null
+            // from https://docs.aws.amazon.com/sdk-for-net/v4/developer-guide/net-dg-v4.html#net-dg-v4-collections
+            Amazon.AWSConfigs.InitializeCollections = true;
             return Run(args);
         }
 


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

A [previous PR](https://github.com/OctopusDeploy/Calamari/pull/1907) fixed the null reference exception reported by the customer. However the impact of AWS v4 of the SDK returning null collections is wider spread than just the file that was targeted.

This is another attempt to cover off the remaining bases:
- In Program.cs have set `Amazon.AWSConfigs.InitializeCollections = true;` - which restores v3 collection behaviour where empty collections are returned instead of `null` (ref: https://docs.aws.amazon.com/sdk-for-net/v4/developer-guide/net-dg-v4.html)
- Where identified (with the help of Claude) targeted null checks have been added to collections where they may be null.
- AwsKubernetesDiscoverer and S3PackageDownloader have been left untested as they directly instantiate the SDK client (would require refactoring)

Fixes FD-273