### PR TITLE
Allow stage convention to be selective in its packages to extract

### DIFF
--- a/source/Calamari.Common/Util/IExtractionChecker.cs
+++ b/source/Calamari.Common/Util/IExtractionChecker.cs
@@ -1,0 +1,9 @@
+using System;
+using Calamari.Common.Commands;
+
+namespace Calamari.Common.Util;
+
+public interface IExtractionChecker
+{
+    bool ShouldExtractReference(RunningDeployment deployment, string referenceName);
+}

--- a/source/Calamari.Common/Util/NegatingExtractionChecker.cs
+++ b/source/Calamari.Common/Util/NegatingExtractionChecker.cs
@@ -1,0 +1,19 @@
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Packages;
+
+namespace Calamari.Common.Util;
+
+public class NegatingExtractionChecker : IExtractionChecker
+{
+    readonly IExtractionChecker extractionChecker;
+
+    public NegatingExtractionChecker(IExtractionChecker extractionChecker)
+    {
+        this.extractionChecker = extractionChecker;
+    }
+
+    public bool ShouldExtractReference(RunningDeployment deployment, string referenceName)
+    {
+        return !extractionChecker.ShouldExtractReference(deployment, referenceName);
+    }
+}

--- a/source/Calamari.Shared/Deployment/Conventions/SelectiveDependencyStagingConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/SelectiveDependencyStagingConvention.cs
@@ -1,0 +1,25 @@
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Packages;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Util;
+using Calamari.Deployment.Conventions.DependencyVariables;
+
+namespace Calamari.Deployment.Conventions;
+
+public class SelectiveDependencyStagingConvention : StageDependenciesConvention
+{
+    IExtractionChecker extractionChecker;
+    
+    public SelectiveDependencyStagingConvention(string? dependencyPathContainingPrimaryFiles, ICalamariFileSystem fileSystem, IPackageExtractor extractor, IDependencyVariablesFactory dependencyVariablesFactory,
+                                                IExtractionChecker extractionChecker,
+                                                bool forceExtract = false) : base(dependencyPathContainingPrimaryFiles, fileSystem, extractor, dependencyVariablesFactory,
+                                                                                  forceExtract)
+    {
+        this.extractionChecker = extractionChecker;
+    }
+
+    protected override bool ShouldExtractReference(RunningDeployment deployment, string referenceName)
+    {
+        return extractionChecker.ShouldExtractReference(deployment, referenceName);
+    }
+}

--- a/source/Calamari.Shared/Deployment/Conventions/StageDependenciesConvention.cs
+++ b/source/Calamari.Shared/Deployment/Conventions/StageDependenciesConvention.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Packages;
+using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -66,11 +67,10 @@ namespace Calamari.Deployment.Conventions
                     Log.Verbose($"Dependency '{referenceName}' was not found at '{originalFullPath}', skipping extraction");
                     continue;
                 }
-
-                var shouldExtract = variables.Extract(referenceName);                              
+                
                 var sanitizedReferenceName = fileSystem.RemoveInvalidFileNameChars(referenceName);
 
-                if (forceExtract || shouldExtract)
+                if (forceExtract || ShouldExtractReference(deployment, sanitizedReferenceName))
                 {
                     var extractionPath = Path.Combine(deployment.CurrentDirectory, sanitizedReferenceName);
                     ExtractDependency(originalFullPath, extractionPath);
@@ -86,6 +86,12 @@ namespace Calamari.Deployment.Conventions
                     Log.SetOutputVariable(variables.OutputVariables.FileName(referenceName), localFileName, deployment.Variables);
                 }
             }
+        }
+
+        protected virtual bool ShouldExtractReference(RunningDeployment deployment, string referenceName)
+        {
+            var dependencyVariables = dependencyVariablesFactory.GetDependencyVariables(deployment.Variables);
+            return dependencyVariables.Extract(referenceName);
         }
 
         void ExtractDependency(string file, string extractionDirectory)

--- a/source/Calamari.Tests/Fixtures/Util/NegatingExtractionCheckerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/NegatingExtractionCheckerFixture.cs
@@ -1,0 +1,41 @@
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Common.Util;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Util
+{
+    [TestFixture]
+    public class NegatingExtractionCheckerFixture
+    {
+        IExtractionChecker inner;
+        NegatingExtractionChecker sut;
+        RunningDeployment deployment;
+
+        [SetUp]
+        public void SetUp()
+        {
+            inner = Substitute.For<IExtractionChecker>();
+            sut = new NegatingExtractionChecker(inner);
+            deployment = new RunningDeployment(new CalamariVariables());
+        }
+
+        [Test]
+        public void ReturnsFalseWhenInnerReturnsTrue()
+        {
+            inner.ShouldExtractReference(deployment, "ref").Returns(true);
+
+            sut.ShouldExtractReference(deployment, "ref").Should().BeFalse();
+        }
+
+        [Test]
+        public void ReturnsTrueWhenInnerReturnsFalse()
+        {
+            inner.ShouldExtractReference(deployment, "ref").Returns(false);
+
+            sut.ShouldExtractReference(deployment, "ref").Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
The upcoming CommitToGitStep treats the packages in the step as 2 separate lists:
1. Those which support the script to execute
2. Those that should be copied into the repository (but are not required for script support)

As such, the StageDependencyConvention needs to be updated to be able to selectively extract packages based on arbitrary logic (not defined here).

This change results in no functional changes.

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
