### PR TITLE
ConsolidatePackages: Use System.IO.Compression and slightly tweak extraction loop

### DIFF
--- a/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
@@ -19,7 +19,6 @@
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Serilog" Version="2.10.0" />
-      <PackageReference Include="SharpCompress" Version="0.37.2" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Calamari.ConsolidateCalamariPackages.Api\Calamari.ConsolidateCalamariPackages.Api.csproj" />

--- a/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackage.cs
+++ b/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackage.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using Octopus.Calamari.ConsolidatedPackage.Api;
-using SharpCompress.Archives.Zip;
 
 namespace Octopus.Calamari.ConsolidatedPackage
 {
@@ -30,16 +30,16 @@ namespace Octopus.Calamari.ConsolidatedPackage
 
             using (var sourceStream = packageStreamProvider.OpenStream())
             {
-                using (var source = ZipArchive.Open(sourceStream))
+                using (var source = new ZipArchive(sourceStream, ZipArchiveMode.Read))
                 {
                     foreach (var fileTransfer in platformFiles)
                     {
-                        var sourceEntry = source.Entries.FirstOrDefault(e => e.Key is not null && e.Key.Equals(fileTransfer.Source));
+                        var sourceEntry = source.Entries.FirstOrDefault(e => e.FullName.Equals(fileTransfer.Source));
                         if(sourceEntry is null) continue;
                     
-                        using (var sourceEntryStream = sourceEntry.OpenEntryStream())
+                        using (var sourceEntryStream = sourceEntry.Open())
                         {
-                            yield return (fileTransfer.Destination, sourceEntry.Size, sourceEntryStream);
+                            yield return (fileTransfer.Destination, sourceEntry.Length, sourceEntryStream);
                         }
                     }
                 }

--- a/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackage.cs
+++ b/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackage.cs
@@ -28,21 +28,16 @@ namespace Octopus.Calamari.ConsolidatedPackage
                 throw new Exception($"Could not find platform {platform} for {calamariFlavour}");
             }
 
-            using (var sourceStream = packageStreamProvider.OpenStream())
+            var platformFilesLookup = platformFiles.ToDictionary(f => f.Source);
+
+            using var sourceStream = packageStreamProvider.OpenStream();
+            using var source = new ZipArchive(sourceStream, ZipArchiveMode.Read);
+            foreach (var sourceEntry in source.Entries)
             {
-                using (var source = new ZipArchive(sourceStream, ZipArchiveMode.Read))
-                {
-                    foreach (var fileTransfer in platformFiles)
-                    {
-                        var sourceEntry = source.Entries.FirstOrDefault(e => e.FullName.Equals(fileTransfer.Source));
-                        if(sourceEntry is null) continue;
-                    
-                        using (var sourceEntryStream = sourceEntry.Open())
-                        {
-                            yield return (fileTransfer.Destination, sourceEntry.Length, sourceEntryStream);
-                        }
-                    }
-                }
+                if (!platformFilesLookup.TryGetValue(sourceEntry.FullName, out var fileTransfer)) continue;
+
+                using var sourceEntryStream = sourceEntry.Open();
+                yield return (fileTransfer.Destination, sourceEntry.Length, sourceEntryStream);
             }
         }
     }

--- a/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackageIndexLoader.cs
+++ b/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackageIndexLoader.cs
@@ -1,9 +1,8 @@
 using System;
 using System.IO;
-using System.Linq;
+using System.IO.Compression;
 using Newtonsoft.Json;
 using Octopus.Calamari.ConsolidatedPackage.Api;
-using SharpCompress.Archives.Zip;
 
 namespace Octopus.Calamari.ConsolidatedPackage
 {
@@ -11,14 +10,14 @@ namespace Octopus.Calamari.ConsolidatedPackage
     {
         public IConsolidatedPackageIndex Load(Stream zipStream)
         {
-            using var zip = ZipArchive.Open(zipStream);
-            var entry = zip.Entries.First(e => e.Key == "index.json");
+            using var zip = new ZipArchive(zipStream, ZipArchiveMode.Read);
+            var entry = zip.GetEntry("index.json");
             if (entry == null)
             {
                 throw new Exception($"index.json not found in supplied stream.");
             }
 
-            using var entryStream = entry.OpenEntryStream();
+            using var entryStream = entry.Open();
             return From(entryStream);
         }
 


### PR DESCRIPTION
# Background

https://octopusdeploy.slack.com/archives/C03SG0LFJHX/p1777933912502139

Renovate pulled through an update to the SharpCompress library for Octopus Server. SharpCompress is at version `0.x` and reserves the right to make breaking changes at any time, and they've moved a few things around and renamed some methods in the public API surface.

In particular, the `ZipArchive.Open` method is now `ZipArchive.OpenArchive`.

When we update Server to the new SharpCompress, `Calamari.ConsolidatePackages` is also loaded into the Server process, and is still expecting the old method signature. The code throws a Method Not Found exception at runtime.

```
System.MissingMethodException : Method not found: 'SharpCompress.Archives.Zip.ZipArchive SharpCompress.Archives.Zip.ZipArchive.Open(System.IO.Stream, SharpCompress.Readers.ReaderOptions)'.
   at Octopus.Calamari.ConsolidatedPackage.ConsolidatedPackageIndexLoader.Load(Stream zipStream)
   at Octopus.Calamari.ConsolidatedPackage.ConsolidatedPackageFactory.LoadFrom(IConsolidatedPackageStreamProvider streamProvider)
   at Octopus.Server.ExecutionsV2.Infrastructure.ExecutionProps.BundledConsolidatedPackageProvider.LoadConsolidatedPackage() in ./source/Octopus.Server/ExecutionsV2/Infrastructure/ExecutionProps/BundledConsolidatedPackageFactory.cs:line 40
```

# Analysis

We could simply update the version of SharpCompress used by `Calamari.ConsolidatePackages` to align with Server, however our default preference is to use the builtin libraries. They are generally much more stable, better supported, and sometimes more performant than third-party libraries -- Unless there is some case-specific reason not to.

`Calamari.ConsolidatePackages` is just doing ordinary zip-reading things, it isn't complex and there's no niche requirements, we can easily drop SharpCompress here and switch to `System.IO.Compression`, avoiding any future breaking changes that SharpCompress may have.

# Results

- Removes `SharpCompress` package reference from `Calamari.ConsolidatePackages`
- Swaps in equivalents from the BCL

This change does not require a Server PR.

# Reducing Risk

This is the sticky part. The changes are simple, and to the best of my understanding, should be safe, but I don't have any knowledge or ability to test them. Are Calamari's TeamCity tests sufficient for us to be able to merge here? Do we need to do any extra testing? I would appreciate some advice from the owning team please.

