### PR TITLE
Port ECS update command from SPF

### DIFF
--- a/source/Calamari.Aws/Commands/UpdateEcsServiceCommand.cs
+++ b/source/Calamari.Aws/Commands/UpdateEcsServiceCommand.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using Calamari.Aws.Deployment;
+using Calamari.Aws.Deployment.Conventions;
+using Calamari.Aws.Integration.Ecs;
+using Calamari.CloudAccounts;
+using Calamari.Commands.Support;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Deployment;
+using Calamari.Serialization;
+using Newtonsoft.Json;
+
+namespace Calamari.Aws.Commands;
+
+[Command("update-aws-ecs-service", Description = "Updates an ECS service to a new task definition revision")]
+public class UpdateEcsServiceCommand : Command
+{
+    readonly ILog log;
+    readonly IVariables variables;
+
+    public UpdateEcsServiceCommand(ILog log, IVariables variables)
+    {
+        this.log = log;
+        this.variables = variables;
+    }
+
+    public override int Execute(string[] commandLineArguments)
+    {
+        var inputs = ReadAndValidateInputs();
+        var environment = AwsEnvironmentGeneration.Create(log, variables).GetAwaiter().GetResult();
+
+        using var ecsClient = EcsClientFactory.Create(environment);
+
+        new ConventionProcessor(new RunningDeployment(variables),
+                                [
+                                    new LogAwsUserInfoConvention(environment),
+                                    new UpdateEcsServiceConvention(
+                                        ecsClient,
+                                        log,
+                                        environment,
+                                        inputs.ClusterName,
+                                        inputs.ServiceName,
+                                        inputs.TemplateTaskDefinitionName,
+                                        inputs.TargetTaskDefinitionName,
+                                        inputs.Containers,
+                                        inputs.Tags,
+                                        inputs.WaitOption,
+                                        inputs.WaitTimeout)
+                                ],
+                                log).RunConventions();
+
+        return 0;
+    }
+
+    EcsUpdateServiceInputs ReadAndValidateInputs()
+    {
+        var clusterName = variables.Get(AwsSpecialVariables.Ecs.ClusterName);
+        Guard.NotNullOrWhiteSpace(clusterName, "Cluster name is required");
+
+        var serviceName = variables.Get(AwsSpecialVariables.Ecs.ServiceName);
+        Guard.NotNullOrWhiteSpace(serviceName, "Service name is required");
+
+        var targetFamily = variables.Get(AwsSpecialVariables.Ecs.TargetTaskDefinitionName);
+        Guard.NotNullOrWhiteSpace(targetFamily, "Target task definition name is required");
+
+        var templateFamily = variables.Get(AwsSpecialVariables.Ecs.TemplateTaskDefinitionName);
+        if (string.IsNullOrWhiteSpace(templateFamily))
+        {
+            templateFamily = targetFamily;
+        }
+
+        var containersJson = variables.Get(AwsSpecialVariables.Ecs.Containers) ?? "[]";
+        var containers = JsonConvert.DeserializeObject<List<EcsContainerUpdate>>(containersJson, JsonSerialization.GetDefaultSerializerSettings()) ?? [];
+        if (containers.Count == 0)
+        {
+            throw new CommandException("At least one container is required.");
+        }
+
+        foreach (var c in containers)
+        {
+            Guard.NotNullOrWhiteSpace(c.ContainerName, "Container name is required");
+        }
+
+        var tagsJson = variables.Get(AwsSpecialVariables.CloudFormation.Tags) ?? "[]";
+        var userTags = JsonConvert.DeserializeObject<List<KeyValuePair<string, string>>>(tagsJson) ?? [];
+        var seenTagKeys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var tag in userTags)
+        {
+            if (!seenTagKeys.Add(tag.Key))
+            {
+                throw new CommandException($"Duplicate tag key '{tag.Key}' in inputs.");
+            }
+        }
+
+        var waitOptionRaw = variables.Get(AwsSpecialVariables.Ecs.WaitOption.Type);
+        Guard.NotNullOrWhiteSpace(waitOptionRaw, "The wait option is required");
+        if (!Enum.TryParse<WaitOptionType>(waitOptionRaw, ignoreCase: true, out var waitOption))
+        {
+            throw new CommandException(
+                                       $"The wait option has an invalid value '{waitOptionRaw}'. Expected one of: 'waitUntilCompleted', 'waitWithTimeout', 'dontWait'.");
+        }
+
+        TimeSpan? timeout = null;
+        var timeoutMs = variables.GetInt32(AwsSpecialVariables.Ecs.WaitOption.Timeout);
+        if (waitOption == WaitOptionType.WaitWithTimeout)
+        {
+            if (!timeoutMs.HasValue)
+            {
+                throw new CommandException("Wait option is 'waitWithTimeout' but timeout value is not set.");
+            }
+
+            timeout = TimeSpan.FromMilliseconds(timeoutMs.Value);
+        }
+
+        return new EcsUpdateServiceInputs(
+                                          clusterName,
+                                          serviceName,
+                                          targetFamily,
+                                          templateFamily,
+                                          containers,
+                                          userTags,
+                                          waitOption,
+                                          timeout);
+    }
+}
+
+public record EcsUpdateServiceInputs(
+    string ClusterName,
+    string ServiceName,
+    string TargetTaskDefinitionName,
+    string TemplateTaskDefinitionName,
+    List<EcsContainerUpdate> Containers,
+    List<KeyValuePair<string, string>> Tags,
+    WaitOptionType WaitOption,
+    TimeSpan? WaitTimeout);

--- a/source/Calamari.Aws/Deployment/AwsSpecialVariables.cs
+++ b/source/Calamari.Aws/Deployment/AwsSpecialVariables.cs
@@ -23,6 +23,9 @@
         {
             public const string ClusterName = "Octopus.Action.Aws.Ecs.ClusterName";
             public const string ServiceName = "Octopus.Action.Aws.Ecs.ServiceName";
+            public const string TargetTaskDefinitionName = "Octopus.Action.Aws.Ecs.TargetTaskDefinitionName";
+            public const string TemplateTaskDefinitionName = "Octopus.Action.Aws.Ecs.TemplateTaskDefinitionName";
+            public const string Containers = "Octopus.Action.Aws.Ecs.Containers";
 
             public static class WaitOption
             {

--- a/source/Calamari.Aws/Deployment/Conventions/UpdateEcsServiceConvention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UpdateEcsServiceConvention.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Amazon.ECS;
+using Amazon.ECS.Model;
+using Calamari.Aws.Integration.Ecs;
+using Calamari.CloudAccounts;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Deployment.Conventions;
+using Task = System.Threading.Tasks.Task;
+
+namespace Calamari.Aws.Deployment.Conventions;
+
+public class UpdateEcsServiceConvention : IInstallConvention
+{
+    readonly IAmazonECS ecs;
+    readonly ILog log;
+    readonly AwsEnvironmentGeneration environment;
+    readonly string clusterName;
+    readonly string serviceName;
+    readonly string templateTaskDefinitionName;
+    readonly string targetTaskDefinitionName;
+    readonly List<EcsContainerUpdate> containers;
+    readonly List<KeyValuePair<string, string>> tags;
+    readonly EcsPostDeployWatcher watcher;
+
+    public UpdateEcsServiceConvention(
+        IAmazonECS ecs,
+        ILog log,
+        AwsEnvironmentGeneration environment,
+        string clusterName,
+        string serviceName,
+        string templateTaskDefinitionName,
+        string targetTaskDefinitionName,
+        List<EcsContainerUpdate> containers,
+        List<KeyValuePair<string, string>> tags,
+        WaitOptionType waitOption,
+        TimeSpan? waitTimeout,
+        Func<TimeSpan> deploymentPollInterval = null,
+        Func<TimeSpan> taskPollInterval = null)
+    {
+        this.ecs = ecs;
+        this.log = log;
+        this.environment = environment;
+        this.clusterName = clusterName;
+        this.serviceName = serviceName;
+        this.templateTaskDefinitionName = templateTaskDefinitionName;
+        this.targetTaskDefinitionName = targetTaskDefinitionName;
+        this.containers = containers;
+        this.tags = tags;
+        watcher = new EcsPostDeployWatcher(ecs, log, clusterName, serviceName, waitOption, waitTimeout, deploymentPollInterval, taskPollInterval);
+    }
+
+    public void Install(RunningDeployment deployment) => InstallAsync(deployment).GetAwaiter().GetResult();
+
+    public async Task InstallAsync(RunningDeployment deployment)
+    {
+        var ct = CancellationToken.None;
+
+        var templateResp = await ecs.DescribeTaskDefinitionAsync(
+            new DescribeTaskDefinitionRequest { TaskDefinition = templateTaskDefinitionName, Include = ["TAGS"] }, ct);
+        var template = templateResp.TaskDefinition
+            ?? throw new CommandException($"Template task definition '{templateTaskDefinitionName}' not found.");
+
+        // SPF behavior to check if the target task definition family exists before applying the update
+        // Only needed if the target is different from the source
+        // Without this check AWS will just create any task definition family it is given
+        if (targetTaskDefinitionName != templateTaskDefinitionName)
+        {
+            var targetResp = await ecs.DescribeTaskDefinitionAsync(
+                new DescribeTaskDefinitionRequest { TaskDefinition = targetTaskDefinitionName }, ct);
+            if (targetResp.TaskDefinition is null)
+            {
+                throw new CommandException($"Existing destination task definition '{targetTaskDefinitionName}' not found.");
+            }
+        }
+
+        var taskDefTags = EcsDefaultTags.MergeAndDeduplicateTags(deployment.Variables, tags, templateResp.Tags);
+        var registerRequest = RegisterTaskDefinitionRequestFactory.FromTaskDefinition(template, targetTaskDefinitionName, containers, taskDefTags);
+        var registerResp = await ecs.RegisterTaskDefinitionAsync(registerRequest, ct);
+        var registeredTaskDef = registerResp.TaskDefinition;
+
+        var serviceResp = await ecs.DescribeServicesAsync(new DescribeServicesRequest
+        {
+            Cluster = clusterName,
+            Services = [serviceName],
+            Include = ["TAGS"]
+        }, ct);
+        var existingService = serviceResp.Services?.FirstOrDefault()
+            ?? throw new CommandException($"Service '{serviceName}' not found in cluster '{clusterName}'.");
+
+        var updateResp = await ecs.UpdateServiceAsync(new UpdateServiceRequest
+        {
+            Cluster = clusterName,
+            Service = serviceName,
+            TaskDefinition = $"{registeredTaskDef.Family}:{registeredTaskDef.Revision}",
+            ForceNewDeployment = true
+        }, ct);
+        var updatedService = updateResp.Service;
+
+        var serviceTags = EcsDefaultTags.MergeAndDeduplicateTags(deployment.Variables, tags, existingService.Tags);
+        if (serviceTags.Count > 0)
+        {
+            await ecs.TagResourceAsync(new TagResourceRequest
+            {
+                ResourceArn = updatedService.ServiceArn,
+                Tags = serviceTags.Select(t => new Tag { Key = t.Key, Value = t.Value }).ToList()
+            }, ct);
+        }
+
+        SetOutputVariable(deployment.Variables, "TaskDefinitionFamily", registeredTaskDef.Family);
+        SetOutputVariable(deployment.Variables, "TaskDefinitionRevision", registeredTaskDef.Revision.ToString());
+        SetOutputVariable(deployment.Variables, "ClusterName", clusterName);
+        SetOutputVariable(deployment.Variables, "ServiceName", serviceName);
+        SetOutputVariable(deployment.Variables, "Region", environment.AwsRegion.SystemName);
+
+        await watcher.WaitAsync(updatedService, ct);
+    }
+
+    void SetOutputVariable(IVariables variables, string name, string value)
+    {
+        log.Info($"Saving variable \"Octopus.Action[{variables["Octopus.Action.Name"]}].Output.{name}\"");
+        log.SetOutputVariable(name, value, variables);
+    }
+}

--- a/source/Calamari.Aws/Deployment/Conventions/UpdateEcsServiceConvention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UpdateEcsServiceConvention.cs
@@ -56,23 +56,33 @@ public class UpdateEcsServiceConvention : IInstallConvention
 
     public void Install(RunningDeployment deployment) => InstallAsync(deployment).GetAwaiter().GetResult();
 
-    public async Task InstallAsync(RunningDeployment deployment)
+    async Task InstallAsync(RunningDeployment deployment)
     {
         var ct = CancellationToken.None;
 
-        var templateResp = await ecs.DescribeTaskDefinitionAsync(
-            new DescribeTaskDefinitionRequest { TaskDefinition = templateTaskDefinitionName, Include = ["TAGS"] }, ct);
-        var template = templateResp.TaskDefinition
-            ?? throw new CommandException($"Template task definition '{templateTaskDefinitionName}' not found.");
+        DescribeTaskDefinitionResponse templateResp;
+        try
+        {
+            templateResp = await ecs.DescribeTaskDefinitionAsync(
+                new DescribeTaskDefinitionRequest { TaskDefinition = templateTaskDefinitionName, Include = ["TAGS"] }, ct);
+        }
+        catch (ClientException)
+        {
+            throw new CommandException($"Template task definition '{templateTaskDefinitionName}' not found.");
+        }
+        var template = templateResp.TaskDefinition;
 
         // SPF behavior to check if the target task definition family exists before applying the update
         // Only needed if the target is different from the source
         // Without this check AWS will just create any task definition family it is given
         if (targetTaskDefinitionName != templateTaskDefinitionName)
         {
-            var targetResp = await ecs.DescribeTaskDefinitionAsync(
-                new DescribeTaskDefinitionRequest { TaskDefinition = targetTaskDefinitionName }, ct);
-            if (targetResp.TaskDefinition is null)
+            try
+            {
+                await ecs.DescribeTaskDefinitionAsync(
+                    new DescribeTaskDefinitionRequest { TaskDefinition = targetTaskDefinitionName }, ct);
+            }
+            catch (ClientException)
             {
                 throw new CommandException($"Existing destination task definition '{targetTaskDefinitionName}' not found.");
             }

--- a/source/Calamari.Aws/Integration/Ecs/EcsClientFactory.cs
+++ b/source/Calamari.Aws/Integration/Ecs/EcsClientFactory.cs
@@ -1,0 +1,11 @@
+using Amazon.ECS;
+using Calamari.Aws.Util;
+using Calamari.CloudAccounts;
+
+namespace Calamari.Aws.Integration.Ecs;
+
+public static class EcsClientFactory
+{
+    public static IAmazonECS Create(AwsEnvironmentGeneration environment) =>
+        new AmazonECSClient(environment.AwsCredentials, environment.AsClientConfig<AmazonECSConfig>());
+}

--- a/source/Calamari.Aws/Integration/Ecs/EcsContainerUpdate.cs
+++ b/source/Calamari.Aws/Integration/Ecs/EcsContainerUpdate.cs
@@ -1,0 +1,7 @@
+namespace Calamari.Aws.Integration.Ecs;
+
+public record EcsContainerUpdate(
+    string ContainerName,
+    string Image,
+    EnvAction<EnvVarItem> EnvironmentVariables,
+    EnvAction<string> EnvironmentFiles);

--- a/source/Calamari.Aws/Integration/Ecs/EcsDefaultTags.cs
+++ b/source/Calamari.Aws/Integration/Ecs/EcsDefaultTags.cs
@@ -1,12 +1,15 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Amazon.ECS.Model;
 using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Aws.Integration.Ecs;
 
-// Merges 19 default Octopus tags with user tags, sanitizes, and truncates to AWS limits (128/256).
-// Mirrors SPF's generateDefaultOctopusTags + sanitizeAwsTagString.
+/// <summary>
+/// Sanitize and merge tags used in ECS steps to match SPF
+/// Deploy step does no deduplication but the update step does
+/// </summary>
 public static partial class EcsDefaultTags
 {
     const int KeyMaxLength = 128;
@@ -35,23 +38,45 @@ public static partial class EcsDefaultTags
         "Octopus.Machine.Name"
     ];
 
-    public static List<KeyValuePair<string, string>> Merge(IVariables variables, IEnumerable<KeyValuePair<string, string>> userTags)
-    {
-        var defaultTags = OctopusVariableNames
-                          .Select(name => new KeyValuePair<string, string>(name, variables.Get(name)))
-                          .Where(p => !string.IsNullOrEmpty(p.Value));
+    public static List<KeyValuePair<string, string>> Merge(
+        IVariables variables,
+        IEnumerable<KeyValuePair<string, string>> userTags) =>
+        Sanitize(GetDefaults(variables)
+                     .Concat(userTags?.Select(t => (t.Key, t.Value)) ?? []))
+            .Select(t => new KeyValuePair<string, string>(t.Key, t.Value))
+            .ToList();
 
-        return defaultTags.Concat(userTags)
-                          .Select(t => new KeyValuePair<string, string>(Truncate(SanitizeAwsTag(t.Key), KeyMaxLength), Truncate(SanitizeAwsTag(t.Value), ValueMaxLength)))
-                          .Where(t => !string.IsNullOrEmpty(t.Key) && !string.IsNullOrEmpty(t.Value))
-                          .ToList();
-    }
+    public static List<KeyValuePair<string, string>> MergeAndDeduplicateTags(
+        IVariables variables,
+        IEnumerable<KeyValuePair<string, string>> userTags,
+        IEnumerable<Tag> existingTags) =>
+        // Tag sources in priority order matching SPF
+        // existing tags < Octopus defaults < user
+        // GroupBy preserves ordering
+        Sanitize((existingTags?.Select(t => (t.Key, t.Value)) ?? [])
+                 .Concat(GetDefaults(variables))
+                 .Concat(userTags?.Select(t => (t.Key, t.Value)) ?? [])
+                 .GroupBy(t => t.Key)
+                 .Select(g => g.Last()))
+            .Select(t => new KeyValuePair<string, string>(t.Key, t.Value))
+            .ToList();
 
-    static string SanitizeAwsTag(string value) =>
-        string.IsNullOrEmpty(value) ? value : InvalidAwsCharsRegex().Replace(value, "").Trim();
+    static IEnumerable<(string Key, string Value)> GetDefaults(IVariables variables) =>
+        OctopusVariableNames
+            .Select(n => (Key: n, Value: variables.Get(n)))
+            .Where(p => !string.IsNullOrEmpty(p.Value));
 
-    static string Truncate(string value, int maxLength) =>
-        string.IsNullOrEmpty(value) || value.Length <= maxLength ? value : value[..maxLength];
+    static IEnumerable<(string Key, string Value)> Sanitize(IEnumerable<(string Key, string Value)> tags) =>
+        tags.Select(t => (
+                        Key: Truncate(StripInvalidChars(t.Key), KeyMaxLength),
+                        Value: Truncate(StripInvalidChars(t.Value), ValueMaxLength)))
+            .Where(t => !string.IsNullOrEmpty(t.Key) && !string.IsNullOrEmpty(t.Value));
+
+    static string StripInvalidChars(string v) =>
+        string.IsNullOrEmpty(v) ? v : InvalidAwsCharsRegex().Replace(v, "").Trim();
+
+    static string Truncate(string v, int max) =>
+        string.IsNullOrEmpty(v) || v.Length <= max ? v : v[..max];
 
     [GeneratedRegex("[^a-zA-Z0-9 +=.:/@_-]")]
     private static partial Regex InvalidAwsCharsRegex();

--- a/source/Calamari.Aws/Integration/Ecs/EcsPostDeployWatcher.cs
+++ b/source/Calamari.Aws/Integration/Ecs/EcsPostDeployWatcher.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Linq;
+using System.Threading;
+using Amazon.ECS;
+using Amazon.ECS.Model;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Logging;
+using Task = System.Threading.Tasks.Task;
+
+namespace Calamari.Aws.Integration.Ecs;
+
+public class EcsPostDeployWatcher
+{
+    readonly IAmazonECS ecs;
+    readonly ILog log;
+    readonly string clusterName;
+    readonly string serviceName;
+    readonly WaitOptionType waitOption;
+    readonly TimeSpan? waitTimeout;
+    readonly Func<TimeSpan> deploymentPollInterval;
+    readonly Func<TimeSpan> taskPollInterval;
+
+    public EcsPostDeployWatcher(
+        IAmazonECS ecs,
+        ILog log,
+        string clusterName,
+        string serviceName,
+        WaitOptionType waitOption,
+        TimeSpan? waitTimeout,
+        Func<TimeSpan> deploymentPollInterval = null,
+        Func<TimeSpan> taskPollInterval = null)
+    {
+        this.ecs = ecs;
+        this.log = log;
+        this.clusterName = clusterName;
+        this.serviceName = serviceName;
+        this.waitOption = waitOption;
+        this.waitTimeout = waitTimeout;
+        this.deploymentPollInterval = deploymentPollInterval ?? (() => TimeSpan.FromSeconds(3));
+        this.taskPollInterval = taskPollInterval ?? (() => TimeSpan.FromSeconds(10));
+    }
+
+    public async Task WaitAsync(Service service, CancellationToken ct = default)
+    {
+        if (waitOption == WaitOptionType.DontWait)
+        {
+            return;
+        }
+
+        if (service.DeploymentController?.Type is not null
+            && service.DeploymentController.Type != DeploymentControllerType.ECS)
+        {
+            log.Verbose($"Deployment controller type is '{service.DeploymentController.Type}'; skipping service and task checks.");
+            return;
+        }
+
+        await WaitForDeploymentAsync(ct);
+        await WaitForTaskStatesAsync(ct);
+    }
+
+    async Task WaitForDeploymentAsync(CancellationToken ct)
+    {
+        var timeout = GetTimeout(waitTimeout);
+
+        log.Info($"Waiting for ECS service '{serviceName}' deployment to reach COMPLETED.");
+        string lastReportedState = null;
+
+        while (true)
+        {
+            var response = await ecs.DescribeServicesAsync(new DescribeServicesRequest
+            {
+                Cluster = clusterName,
+                Services = [serviceName]
+            }, ct);
+
+            var service = response.Services?.FirstOrDefault();
+            if (service is null)
+            {
+                throw new CommandException($"Service '{serviceName}' was not found in cluster '{clusterName}' while waiting for deployment to complete.");
+            }
+
+            var primaryDeployment = service.Deployments.FirstOrDefault(d => d.Status == "PRIMARY");
+            var rolloutState = primaryDeployment?.RolloutState?.Value;
+            if (primaryDeployment is not null)
+            {
+                switch (rolloutState)
+                {
+                    case "COMPLETED":
+                        log.Info("ECS service deployment completed.");
+                        return;
+                    case "FAILED":
+                        throw new CommandException($"Reached deployment state: FAILED. Reason: {primaryDeployment.RolloutStateReason}");
+                }
+
+                if (rolloutState != lastReportedState)
+                {
+                    lastReportedState = rolloutState;
+                    log.Info($"Service rollout state: {lastReportedState}.");
+                }
+            }
+
+            if (timeout.HasValue && DateTime.UtcNow >= timeout.Value)
+            {
+                var events = service.Events?.Take(5).ToList() ?? [];
+                if (events.Count > 0)
+                {
+                    log.Info("Recent ECS service events:");
+                    foreach (var e in events)
+                    {
+                        log.Info($"  [{e.CreatedAt:o}] {e.Message}");
+                    }
+                }
+
+                throw new CommandException("Timed out waiting for ECS service deployment.");
+            }
+
+            await Task.Delay(deploymentPollInterval(), ct);
+        }
+    }
+
+    async Task WaitForTaskStatesAsync(CancellationToken ct)
+    {
+        var timeout = GetTimeout(waitTimeout);
+
+        while (true)
+        {
+            var listResp = await ecs.ListTasksAsync(new ListTasksRequest
+            {
+                Cluster = clusterName,
+                ServiceName = serviceName
+            }, ct);
+
+            if (listResp.TaskArns is null || listResp.TaskArns.Count == 0)
+            {
+                log.Info($"No tasks found for service '{serviceName}'; skipping task check.");
+                return;
+            }
+
+            var describeResponse = await ecs.DescribeTasksAsync(new DescribeTasksRequest
+            {
+                Cluster = clusterName,
+                Tasks = listResp.TaskArns
+            }, ct);
+
+            var stoppedTasks = describeResponse.Tasks.Where(t => t.LastStatus == "STOPPED").ToArray();
+            var allTasksRunning = describeResponse.Tasks.All(t => t.LastStatus == "RUNNING");
+
+            if (stoppedTasks.Length != 0)
+            {
+                log.Info("Stopped ECS tasks");
+                foreach (var stoppedTask in stoppedTasks)
+                {
+                    log.Info($"  Task: {stoppedTask.TaskArn} StopCode: {stoppedTask.StopCode?.Value ?? "<none>"} StoppedReason: {stoppedTask.StoppedReason ?? "<none>"}");
+                }
+
+                throw new CommandException("ECS task check failed as some tasks are stopped.");
+            }
+
+            if (allTasksRunning)
+            {
+                log.Info("All ECS tasks are in RUNNING state.");
+                return;
+            }
+
+            if (timeout.HasValue && DateTime.UtcNow >= timeout.Value)
+            {
+                throw new CommandException("Timed out waiting for all ECS tasks to reach RUNNING state.");
+            }
+
+            await Task.Delay(taskPollInterval(), ct);
+        }
+    }
+
+    static DateTime? GetTimeout(TimeSpan? waitTimeout) => waitTimeout.HasValue ? DateTime.UtcNow + waitTimeout.Value : null;
+}

--- a/source/Calamari.Aws/Integration/Ecs/EnvAction.cs
+++ b/source/Calamari.Aws/Integration/Ecs/EnvAction.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+
+namespace Calamari.Aws.Integration.Ecs;
+
+public enum EnvActionMode { Replace, Merge }
+
+public record EnvAction<T>(EnvActionMode Action, IReadOnlyList<T> Items);

--- a/source/Calamari.Aws/Integration/Ecs/EnvVarItem.cs
+++ b/source/Calamari.Aws/Integration/Ecs/EnvVarItem.cs
@@ -1,0 +1,5 @@
+namespace Calamari.Aws.Integration.Ecs;
+
+public enum EnvVarType { Text, Secret }
+
+public record EnvVarItem(EnvVarType Type, string Key, string Value);

--- a/source/Calamari.Aws/Integration/Ecs/RegisterTaskDefinitionRequestFactory.cs
+++ b/source/Calamari.Aws/Integration/Ecs/RegisterTaskDefinitionRequestFactory.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.ECS.Model;
+using Calamari.Common.Commands;
+using Newtonsoft.Json;
+
+namespace Calamari.Aws.Integration.Ecs;
+
+public static class RegisterTaskDefinitionRequestFactory
+{
+    static readonly JsonSerializerSettings Settings = new() { NullValueHandling = NullValueHandling.Ignore };
+
+    public static RegisterTaskDefinitionRequest FromTaskDefinition(
+        TaskDefinition source,
+        string targetFamily,
+        IReadOnlyList<EcsContainerUpdate> containerUpdates,
+        IReadOnlyList<KeyValuePair<string, string>> tags)
+    {
+        // Serialize task definition to JSON and then deserialize back to request
+        // This avoids us dropping any fields from task definition when performing our update
+        var json = JsonConvert.SerializeObject(source, Settings);
+        var request = JsonConvert.DeserializeObject<RegisterTaskDefinitionRequest>(json);
+        request.Family = targetFamily;
+        request.Tags = tags.Select(t => new Tag { Key = t.Key, Value = t.Value }).ToList();
+
+        var containerLookup = (request.ContainerDefinitions ?? []).ToDictionary(c => c.Name);
+        foreach (var containerUpdate in containerUpdates)
+        {
+            if (!containerLookup.TryGetValue(containerUpdate.ContainerName, out var containerToUpdate))
+            {
+                throw new CommandException($"No matching container found for '{containerUpdate.ContainerName}' in template task definition '{source.Family}'.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(containerUpdate.Image))
+            {
+                containerToUpdate.Image = containerUpdate.Image;
+            }
+
+            ApplyEnvVars(containerToUpdate, containerUpdate.EnvironmentVariables);
+            ApplyEnvFiles(containerToUpdate, containerUpdate.EnvironmentFiles);
+        }
+
+        return request;
+    }
+
+    static void ApplyEnvVars(ContainerDefinition container, EnvAction<EnvVarItem> action)
+    {
+        if (action is null || action.Items.Count == 0)
+        {
+            return;
+        }
+
+        var plain = action.Items.Where(i => i.Type == EnvVarType.Text)
+                          .Select(i => new Amazon.ECS.Model.KeyValuePair { Name = i.Key, Value = i.Value })
+                          .ToList();
+        var secrets = action.Items.Where(i => i.Type == EnvVarType.Secret)
+                            .Select(i => new Secret { Name = i.Key, ValueFrom = i.Value })
+                            .ToList();
+
+        if (action.Action == EnvActionMode.Replace)
+        {
+            container.Environment = plain;
+            container.Secrets = secrets;
+        }
+        else // Merge
+        {
+            var existingEnv = container.Environment ?? [];
+            container.Environment = existingEnv
+                                    .Where(e => plain.All(p => p.Name != e.Name))
+                                    .Concat(plain)
+                                    .ToList();
+
+            var existingSecrets = container.Secrets ?? [];
+            container.Secrets = existingSecrets
+                                .Where(s => secrets.All(ns => ns.Name != s.Name))
+                                .Concat(secrets)
+                                .ToList();
+        }
+    }
+
+    static void ApplyEnvFiles(ContainerDefinition container, EnvAction<string> action)
+    {
+        if (action is null || action.Items.Count == 0)
+        {
+            return;
+        }
+
+        var files = action.Items.Select(s => new EnvironmentFile { Type = "s3", Value = s }).ToList();
+
+        if (action.Action == EnvActionMode.Replace)
+        {
+            container.EnvironmentFiles = files;
+        }
+        else // Merge
+        {
+            var existing = container.EnvironmentFiles ?? [];
+            container.EnvironmentFiles = existing.Concat(files)
+                                                 .GroupBy(f => f.Value)
+                                                 .Select(g => g.Last())
+                                                 .ToList();
+        }
+    }
+}

--- a/source/Calamari.Aws/Integration/Ecs/WaitOptionType.cs
+++ b/source/Calamari.Aws/Integration/Ecs/WaitOptionType.cs
@@ -1,0 +1,8 @@
+namespace Calamari.Aws.Integration.Ecs;
+
+public enum WaitOptionType
+{
+    WaitUntilCompleted,
+    WaitWithTimeout,
+    DontWait
+}

--- a/source/Calamari.Tests/AWS/Ecs/EcsDefaultTagsTests.cs
+++ b/source/Calamari.Tests/AWS/Ecs/EcsDefaultTagsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Amazon.ECS.Model;
 using Calamari.Aws.Integration.Ecs;
 using Calamari.Common.Plumbing.Variables;
 using FluentAssertions;
@@ -10,47 +11,18 @@ namespace Calamari.Tests.AWS.Ecs;
 public class EcsDefaultTagsTests
 {
     [Test]
-    public void EmitsDefaultTag_WhenOctopusVariableHasValue()
+    public void Sanitize_TruncatesKeyTo128AndValueTo256()
     {
-        var variables = new CalamariVariables();
-        variables.Set("Octopus.Project.Name", "MyProject");
-
-        var tags = EcsDefaultTags.Merge(variables, []);
-
-        tags.Should().ContainSingle()
-            .Which.Should().BeEquivalentTo(new KeyValuePair<string, string>("Octopus.Project.Name", "MyProject"));
-    }
-
-    [Test]
-    public void OmitsDefaultTag_WhenOctopusVariableIsUnset()
-    {
-        var tags = EcsDefaultTags.Merge(new CalamariVariables(), []);
-
-        tags.Should().BeEmpty();
-    }
-
-    [Test]
-    public void TruncatesKeyLongerThan128Chars()
-    {
-        var userTags = new[] { new KeyValuePair<string, string>(new string('k', 200), "v") };
+        var userTags = new[] { new KeyValuePair<string, string>(new string('k', 200), new string('v', 300)) };
 
         var tags = EcsDefaultTags.Merge(new CalamariVariables(), userTags);
 
         tags[0].Key.Length.Should().Be(128);
-    }
-
-    [Test]
-    public void TruncatesValueLongerThan256Chars()
-    {
-        var userTags = new[] { new KeyValuePair<string, string>("k", new string('v', 300)) };
-
-        var tags = EcsDefaultTags.Merge(new CalamariVariables(), userTags);
-
         tags[0].Value.Length.Should().Be(256);
     }
 
     [Test]
-    public void StripsInvalidCharactersFromKeyAndValue()
+    public void Sanitize_StripsInvalidCharactersFromKeyAndValue()
     {
         var userTags = new[] { new KeyValuePair<string, string>("my!@#$key", "val!ue%") };
 
@@ -61,7 +33,23 @@ public class EcsDefaultTagsTests
     }
 
     [Test]
-    public void MergesDefaultsThenUserTags_PreservingOrder()
+    public void Sanitize_DropsTagWhenSanitizationProducesEmptyKey()
+    {
+        // All-invalid-chars key sanitises to "", which the final Where() filter drops so AWS
+        // isn't sent a tag with an empty key.
+        var userTags = new[]
+        {
+            new KeyValuePair<string, string>("!!!", "value"),
+            new KeyValuePair<string, string>("validKey", "validValue")
+        };
+
+        var tags = EcsDefaultTags.Merge(new CalamariVariables(), userTags);
+
+        tags.Should().ContainSingle().Which.Key.Should().Be("validKey");
+    }
+
+    [Test]
+    public void Merge_PreservesOctopusVariableNamesDeclarationOrder()
     {
         var variables = new CalamariVariables();
         // Environment.Name is declared before Project.Name in OctopusVariableNames,
@@ -69,10 +57,7 @@ public class EcsDefaultTagsTests
         variables.Set("Octopus.Environment.Name", "Production");
         variables.Set("Octopus.Project.Name", "MyProject");
 
-        var userTags = new[]
-        {
-            new KeyValuePair<string, string>("Owner", "team@example.com")
-        };
+        var userTags = new[] { new KeyValuePair<string, string>("Owner", "team@example.com") };
 
         var tags = EcsDefaultTags.Merge(variables, userTags);
 
@@ -83,18 +68,31 @@ public class EcsDefaultTagsTests
     }
 
     [Test]
-    public void DropsTag_WhenSanitizeProducesEmptyKey()
+    public void MergeTemplateTags_PriorityChain_TemplateBelowDefaultsBelowUser()
     {
-        // All-invalid-chars key sanitizes to "", which the final Where() filter drops
-        // so AWS isn't sent a tag with an empty key.
+        var v = new CalamariVariables();
+        v.Set("Octopus.Project.Name", "fromDefault");
+        v.Set("Octopus.Action.Name", "fromDefault");
+
+        var templateTags = new[]
+        {
+            new Tag { Key = "CostCenter", Value = "fromTemplate" },
+            new Tag { Key = "Octopus.Action.Name", Value = "fromTemplate" },
+            new Tag { Key = "Env", Value = "fromTemplate" },
+        };
         var userTags = new[]
         {
-            new KeyValuePair<string, string>("!!!", "value"),
-            new KeyValuePair<string, string>("validKey", "validValue")
+            new KeyValuePair<string, string>("Env", "fromUser"),
+            new KeyValuePair<string, string>("Octopus.Project.Name", "fromUser"),
         };
 
-        var tags = EcsDefaultTags.Merge(new CalamariVariables(), userTags);
+        var tags = EcsDefaultTags.MergeAndDeduplicateTags(v, userTags, templateTags);
 
-        tags.Should().ContainSingle().Which.Key.Should().Be("validKey");
+        tags.Should().BeEquivalentTo([
+            new Tag { Key = "CostCenter", Value = "fromTemplate" },          // template-only carryforward
+            new Tag { Key = "Octopus.Action.Name", Value = "fromDefault" },  // default beats template
+            new Tag { Key = "Env", Value = "fromUser" },                     // user beats template
+            new Tag { Key = "Octopus.Project.Name", Value = "fromUser" }     // user beats default
+        ]);
     }
 }

--- a/source/Calamari.Tests/AWS/Ecs/EcsPostDeployWatcherTests.cs
+++ b/source/Calamari.Tests/AWS/Ecs/EcsPostDeployWatcherTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Threading;
+using Amazon.ECS;
+using Amazon.ECS.Model;
+using Calamari.Aws.Integration.Ecs;
+using Calamari.Common.Commands;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Task = System.Threading.Tasks.Task;
+using EcsTask = Amazon.ECS.Model.Task;
+using EcsDeployment = Amazon.ECS.Model.Deployment;
+
+namespace Calamari.Tests.AWS.Ecs;
+
+[TestFixture]
+public class EcsPostDeployWatcherTests
+{
+    IAmazonECS ecs;
+
+    [SetUp]
+    public void SetUp()
+    {
+        ecs = Substitute.For<IAmazonECS>();
+    }
+
+    EcsPostDeployWatcher Watcher(WaitOptionType waitOption = WaitOptionType.WaitUntilCompleted, TimeSpan? waitTimeout = null) =>
+        new(
+            ecs,
+            new InMemoryLog(),
+            clusterName: "cluster-x",
+            serviceName: "svc-x",
+            waitOption: waitOption,
+            waitTimeout: waitTimeout,
+            deploymentPollInterval: () => TimeSpan.Zero,
+            taskPollInterval: () => TimeSpan.Zero);
+
+    [Test]
+    public async Task DontWaitSkipsPolling()
+    {
+        await Watcher(WaitOptionType.DontWait).WaitAsync(Service());
+
+        await ecs.DidNotReceive().DescribeServicesAsync(Arg.Any<DescribeServicesRequest>(), Arg.Any<CancellationToken>());
+        await ecs.DidNotReceive().ListTasksAsync(Arg.Any<ListTasksRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task AllTasksRunningCompletesSuccessfully()
+    {
+        ecs.DescribeServicesAsync(Arg.Any<DescribeServicesRequest>(), Arg.Any<CancellationToken>())
+           .Returns(ServicesWithRollout(DeploymentRolloutState.COMPLETED));
+        ecs.ListTasksAsync(Arg.Any<ListTasksRequest>(), Arg.Any<CancellationToken>())
+           .Returns(new ListTasksResponse { TaskArns = ["arn:task/1"] });
+        ecs.DescribeTasksAsync(Arg.Any<DescribeTasksRequest>(), Arg.Any<CancellationToken>())
+           .Returns(new DescribeTasksResponse
+           {
+               Tasks = [new EcsTask { TaskArn = "arn:task/1", LastStatus = "RUNNING" }]
+           });
+
+        await Watcher().WaitAsync(Service());
+    }
+
+    [Test]
+    public async Task DeploymentFailedThrowsWithRolloutReason()
+    {
+        ecs.DescribeServicesAsync(Arg.Any<DescribeServicesRequest>(), Arg.Any<CancellationToken>())
+           .Returns(ServicesWithRollout(DeploymentRolloutState.FAILED, "task failed to start"));
+
+        var act = async () => await Watcher().WaitAsync(Service());
+
+        await act.Should().ThrowAsync<CommandException>().WithMessage("*FAILED*task failed to start*");
+    }
+
+    [Test]
+    public async Task AnyTaskStoppedThrows()
+    {
+        ecs.DescribeServicesAsync(Arg.Any<DescribeServicesRequest>(), Arg.Any<CancellationToken>())
+           .Returns(ServicesWithRollout(DeploymentRolloutState.COMPLETED));
+        ecs.ListTasksAsync(Arg.Any<ListTasksRequest>(), Arg.Any<CancellationToken>())
+           .Returns(new ListTasksResponse { TaskArns = ["arn:task/1"] });
+        ecs.DescribeTasksAsync(Arg.Any<DescribeTasksRequest>(), Arg.Any<CancellationToken>())
+           .Returns(new DescribeTasksResponse
+           {
+               Tasks =
+               [
+                   new EcsTask
+                   {
+                       TaskArn = "arn:task/1",
+                       LastStatus = "STOPPED",
+                       StopCode = TaskStopCode.EssentialContainerExited,
+                       StoppedReason = "container exited with code 1"
+                   }
+               ]
+           });
+
+        var act = async () => await Watcher().WaitAsync(Service());
+
+        await act.Should().ThrowAsync<CommandException>().WithMessage("*ECS task check failed*");
+    }
+
+    [Test]
+    public async Task NoServiceWhilePollingThrows()
+    {
+        ecs.DescribeServicesAsync(Arg.Any<DescribeServicesRequest>(), Arg.Any<CancellationToken>())
+           .Returns(new DescribeServicesResponse { Services = [] });
+
+        var act = async () => await Watcher().WaitAsync(Service());
+
+        await act.Should().ThrowAsync<CommandException>().WithMessage("*svc-x*not found*cluster-x*");
+    }
+
+    [Test]
+    public async Task DeploymentDoesNotCompleteTimesOut()
+    {
+        ecs.DescribeServicesAsync(Arg.Any<DescribeServicesRequest>(), Arg.Any<CancellationToken>())
+           .Returns(ServicesWithRollout(DeploymentRolloutState.IN_PROGRESS));
+
+        var act = async () => await Watcher(WaitOptionType.WaitWithTimeout, TimeSpan.Zero).WaitAsync(Service());
+
+        await act.Should().ThrowAsync<CommandException>().WithMessage("*Timed out*deployment*");
+    }
+
+    [Test]
+    public async Task TasksStuckPendingTimesOut()
+    {
+        ecs.DescribeServicesAsync(Arg.Any<DescribeServicesRequest>(), Arg.Any<CancellationToken>())
+           .Returns(ServicesWithRollout(DeploymentRolloutState.COMPLETED));
+        ecs.ListTasksAsync(Arg.Any<ListTasksRequest>(), Arg.Any<CancellationToken>())
+           .Returns(new ListTasksResponse { TaskArns = ["arn:task/1"] });
+        ecs.DescribeTasksAsync(Arg.Any<DescribeTasksRequest>(), Arg.Any<CancellationToken>())
+           .Returns(new DescribeTasksResponse
+           {
+               Tasks = [new EcsTask { TaskArn = "arn:task/1", LastStatus = "PENDING" }]
+           });
+
+        var act = async () => await Watcher(WaitOptionType.WaitWithTimeout, TimeSpan.Zero).WaitAsync(Service());
+
+        await act.Should().ThrowAsync<CommandException>().WithMessage("*tasks to reach RUNNING*");
+    }
+
+    static Service Service(DeploymentControllerType controllerType = null) => new()
+    {
+        ServiceName = "svc-x",
+        DeploymentController = controllerType is null ? null : new DeploymentController { Type = controllerType }
+    };
+
+    static DescribeServicesResponse ServicesWithRollout(DeploymentRolloutState state, string reason = null) => new()
+    {
+        Services =
+        [
+            new Service
+            {
+                Deployments =
+                [
+                    new EcsDeployment
+                    {
+                        Status = "PRIMARY",
+                        RolloutState = state,
+                        RolloutStateReason = reason,
+                        UpdatedAt = DateTime.UtcNow
+                    }
+                ]
+            }
+        ]
+    };
+}

--- a/source/Calamari.Tests/AWS/Ecs/RegisterTaskDefinitionRequestFactoryTests.cs
+++ b/source/Calamari.Tests/AWS/Ecs/RegisterTaskDefinitionRequestFactoryTests.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using Amazon.ECS.Model;
+using Calamari.Aws.Integration.Ecs;
+using Calamari.Common.Commands;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.AWS.Ecs;
+
+[TestFixture]
+public class RegisterTaskDefinitionRequestFactoryTests
+{
+    static TaskDefinition Template(params ContainerDefinition[] containers) => new()
+    {
+        Family = "fam",
+        ContainerDefinitions = [..containers]
+    };
+
+    static RegisterTaskDefinitionRequest Build(TaskDefinition template, EcsContainerUpdate[] updates) =>
+        RegisterTaskDefinitionRequestFactory.FromTaskDefinition(template, targetFamily: "fam", updates, tags: []);
+
+    [Test]
+    public void DoesNotMutateInputTemplate()
+    {
+        var template = Template(new ContainerDefinition { Name = "web", Image = "old:1" });
+        var updates = new[]
+        {
+            new EcsContainerUpdate("web", "new:2", null, null)
+        };
+
+        var request = Build(template, updates);
+
+        template.ContainerDefinitions[0].Image.Should().Be("old:1");
+        request.ContainerDefinitions[0].Image.Should().Be("new:2");
+    }
+
+    [Test]
+    public void AppliesTargetFamilyAndTags()
+    {
+        var template = Template(new ContainerDefinition { Name = "web", Image = "old:1" });
+        var updates = new[]
+        {
+            new EcsContainerUpdate("web", "new:2", null, null)
+        };
+
+        var request = RegisterTaskDefinitionRequestFactory.FromTaskDefinition(
+            template,
+            targetFamily: "different-fam",
+            updates,
+            tags: [new KeyValuePair<string, string>("Owner", "platform")]);
+
+        request.Family.Should().Be("different-fam");
+        request.Tags.Should().ContainSingle().Which.Key.Should().Be("Owner");
+    }
+
+    [Test]
+    public void NoMatchingContainerThrows()
+    {
+        var template = Template(new ContainerDefinition { Name = "web" });
+        var updates = new[]
+        {
+            new EcsContainerUpdate("api", "x:1", null, null)
+        };
+
+        var act = () => Build(template, updates);
+        act.Should().Throw<CommandException>().WithMessage("*No matching container*");
+    }
+
+    [Test]
+    public void EnvVarsReplaceOverwritesEntireSet()
+    {
+        var template = Template(new ContainerDefinition
+        {
+            Name = "web",
+            Environment = [new Amazon.ECS.Model.KeyValuePair { Name = "OLD", Value = "1" }]
+        });
+        var updates = new[]
+        {
+            new EcsContainerUpdate("web", null,
+                new EnvAction<EnvVarItem>(EnvActionMode.Replace, [new EnvVarItem(EnvVarType.Text, "NEW", "1")]),
+                null)
+        };
+
+        var request = Build(template, updates);
+        var env = request.ContainerDefinitions[0].Environment;
+
+        env.Should().ContainSingle().Which.Name.Should().Be("NEW");
+    }
+
+    [Test]
+    public void EnvVarsMergePrefersNewValueOnKeyCollision()
+    {
+        var template = Template(new ContainerDefinition
+        {
+            Name = "web",
+            Environment = [new Amazon.ECS.Model.KeyValuePair { Name = "K", Value = "old" }]
+        });
+        var updates = new[]
+        {
+            new EcsContainerUpdate("web", null,
+                new EnvAction<EnvVarItem>(EnvActionMode.Merge, [new EnvVarItem(EnvVarType.Text, "K", "new")]),
+                null)
+        };
+
+        var request = Build(template, updates);
+        request.ContainerDefinitions[0].Environment
+               .Should().ContainSingle().Which.Value.Should().Be("new");
+    }
+
+    [Test]
+    public void SecretsReplaceMapsValueFromCorrectly()
+    {
+        var template = Template(new ContainerDefinition { Name = "web" });
+        var updates = new[]
+        {
+            new EcsContainerUpdate("web", null,
+                new EnvAction<EnvVarItem>(EnvActionMode.Replace, [new EnvVarItem(EnvVarType.Secret, "S", "arn:aws:ssm:::parameter/x")]),
+                null)
+        };
+
+        var request = Build(template, updates);
+        var secret = request.ContainerDefinitions[0].Secrets.Should().ContainSingle().Subject;
+
+        secret.Name.Should().Be("S");
+        secret.ValueFrom.Should().Be("arn:aws:ssm:::parameter/x");
+    }
+
+    [Test]
+    public void EnvFilesMergeDedupesByValue()
+    {
+        var template = Template(new ContainerDefinition
+        {
+            Name = "web",
+            EnvironmentFiles = [new EnvironmentFile { Type = "s3", Value = "arn:aws:s3:::bucket/file" }]
+        });
+        var updates = new[]
+        {
+            new EcsContainerUpdate("web", null, null,
+                new EnvAction<string>(EnvActionMode.Merge, ["arn:aws:s3:::bucket/file"]))
+        };
+
+        var request = Build(template, updates);
+
+        request.ContainerDefinitions[0].EnvironmentFiles.Should().ContainSingle();
+    }
+}

--- a/source/Calamari.Tests/AWS/Ecs/Update/UpdateEcsServiceFixture.cs
+++ b/source/Calamari.Tests/AWS/Ecs/Update/UpdateEcsServiceFixture.cs
@@ -9,6 +9,7 @@ using Amazon.Runtime;
 using Calamari.Aws.Commands;
 using Calamari.Aws.Deployment;
 using Calamari.Aws.Integration.Ecs;
+using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Serialization;
 using Calamari.Testing;
@@ -89,6 +90,28 @@ public class UpdateEcsServiceFixture
         });
         var service = serviceResp.Services.Should().ContainSingle().Subject;
         service.TaskDefinition.Should().EndWith($"/{registeredFamily}:{registeredRevision}");
+    }
+
+    [Test]
+    public async Task FailsWhenTargetTaskDefinitionMissing()
+    {
+        // No service is created — the convention errors out at the target-family describe before
+        // any ECS state is touched. Leaving serviceName empty so TearDown skips its delete call.
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        var missingTarget = $"calamari-ecs-missing-target-{unique}";
+
+        var variables = await CreateVariables(serviceName: $"unused-{unique}", newImage: "public.ecr.aws/docker/library/nginx:1.28-alpine");
+        // Default behavior collapses TemplateTaskDefinitionName to TargetTaskDefinitionName when
+        // the former is empty — so we set both explicitly: a known-good template, a known-missing target.
+        variables.Set(AwsSpecialVariables.Ecs.TemplateTaskDefinitionName, TaskDefinitionFamily);
+        variables.Set(AwsSpecialVariables.Ecs.TargetTaskDefinitionName, missingTarget);
+
+        var log = new InMemoryLog();
+        var command = new UpdateEcsServiceCommand(log, variables);
+
+        var act = () => command.Execute([]);
+        act.Should().Throw<CommandException>()
+            .WithMessage($"*Existing destination task definition '{missingTarget}' not found*");
     }
 
     static async Task<IVariables> CreateVariables(string serviceName, string newImage)

--- a/source/Calamari.Tests/AWS/Ecs/Update/UpdateEcsServiceFixture.cs
+++ b/source/Calamari.Tests/AWS/Ecs/Update/UpdateEcsServiceFixture.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.ECS;
+using Amazon.ECS.Model;
+using Amazon.IdentityManagement;
+using Amazon.Runtime;
+using Calamari.Aws.Commands;
+using Calamari.Aws.Deployment;
+using Calamari.Aws.Integration.Ecs;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Serialization;
+using Calamari.Testing;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Task = System.Threading.Tasks.Task;
+
+namespace Calamari.Tests.AWS.Ecs.Update;
+
+[TestFixture]
+[Category(TestCategory.PlatformAgnostic)]
+public class UpdateEcsServiceFixture
+{
+    // Fixed infrastructure in account 017645897735 (us-east-1)
+    const string Region = "us-east-1";
+    const string ClusterName = "calamari-ecs-integration-tests";
+    const string SubnetId = "subnet-0d3da9354f8253081";
+    const string SecurityGroupId = "sg-053ae28309775ea7b";
+
+    const string TaskDefinitionFamily = "calamari-ecs-integration-tests-template";
+    const string ExecutionRoleName = "calamari-ecs-integration-tests-execution-role";
+
+    string serviceName;
+
+    [Test]
+    public async Task RegistersNewRevisionAndForcesNewDeployment()
+    {
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        serviceName = $"upd-svc-{unique}";
+
+        // Create a fresh service that points at the shared template family. DesiredCount=0 means
+        // no Fargate tasks launch (no exec role needed, no compute cost) and the Update step uses
+        // dontWait so the watcher returns immediately after UpdateService is acknowledged.
+        using var client = await CreateClient();
+        await client.CreateServiceAsync(new CreateServiceRequest
+        {
+            Cluster = ClusterName,
+            ServiceName = serviceName,
+            TaskDefinition = TaskDefinitionFamily,
+            DesiredCount = 0,
+            LaunchType = LaunchType.FARGATE,
+            NetworkConfiguration = new NetworkConfiguration
+            {
+                AwsvpcConfiguration = new AwsVpcConfiguration
+                {
+                    Subnets = [SubnetId],
+                    SecurityGroups = [SecurityGroupId],
+                    AssignPublicIp = AssignPublicIp.ENABLED
+                }
+            },
+            Tags =
+            [
+                new Tag { Key = "VantaOwner", Value = "modern-deployments-team@octopus.com" },
+                new Tag { Key = "VantaNonProd", Value = "true" },
+                new Tag { Key = "VantaNoAlert", Value = "Ephemeral ECS service created during integration tests" },
+                new Tag { Key = "VantaContainsUserData", Value = "false" },
+                new Tag { Key = "VantaUserDataStored", Value = "N/A" },
+                new Tag { Key = "VantaDescription", Value = "Ephemeral ECS service created during integration tests" }
+            ]
+        });
+
+        var variables = await CreateVariables(serviceName, newImage: "public.ecr.aws/docker/library/nginx:1.28-alpine");
+        var log = new InMemoryLog();
+        var command = new UpdateEcsServiceCommand(log, variables);
+        var result = command.Execute([]);
+
+        result.Should().Be(0);
+
+        var registeredFamily = variables.Get("TaskDefinitionFamily");
+        var registeredRevision = variables.Get("TaskDefinitionRevision");
+
+        var serviceResp = await client.DescribeServicesAsync(new DescribeServicesRequest
+        {
+            Cluster = ClusterName,
+            Services = [serviceName]
+        });
+        var service = serviceResp.Services.Should().ContainSingle().Subject;
+        service.TaskDefinition.Should().EndWith($"/{registeredFamily}:{registeredRevision}");
+    }
+
+    static async Task<IVariables> CreateVariables(string serviceName, string newImage)
+    {
+        var accessKey = await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, CancellationToken.None);
+        var secretKey = await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, CancellationToken.None);
+
+        var variables = new CalamariVariables();
+
+        variables.Set("Octopus.Account.AccountType", "AmazonWebServicesAccount");
+        variables.Set("Octopus.Action.AwsAccount.Variable", "AWSAccount");
+        variables.Set("AWSAccount.AccessKey", accessKey);
+        variables.Set("AWSAccount.SecretKey", secretKey);
+        variables.Set("Octopus.Action.Aws.Region", Region);
+        variables.Set("Octopus.Action.Aws.AssumeRole", "False");
+        variables.Set("Octopus.Action.AwsAccount.UseInstanceRole", "False");
+
+        variables.Set("Octopus.Environment.Id", "Environments-1");
+        variables.Set("Octopus.Environment.Name", "Test");
+        variables.Set("Octopus.Project.Name", "ECS Update Integration Test");
+        variables.Set("Octopus.Action.Name", "Update ECS");
+
+        variables.Set(AwsSpecialVariables.Ecs.ClusterName, ClusterName);
+        variables.Set(AwsSpecialVariables.Ecs.ServiceName, serviceName);
+        variables.Set(AwsSpecialVariables.Ecs.TargetTaskDefinitionName, TaskDefinitionFamily);
+
+        var environment = new EnvAction<EnvVarItem>(EnvActionMode.Replace,
+        [
+            new EnvVarItem(EnvVarType.Text, "LOG_LEVEL", "info"),
+            new EnvVarItem(EnvVarType.Secret, "DB_PASSWORD", "arn:aws:ssm:us-east-1:017645897735:parameter/calamari-ecs-integration-tests-fake")
+        ]);
+        var containers = new[]
+        {
+            new EcsContainerUpdate("web", newImage, environment, null)
+        };
+        variables.Set(AwsSpecialVariables.Ecs.Containers, JsonConvert.SerializeObject(containers, JsonSerialization.GetDefaultSerializerSettings()));
+
+        variables.Set(AwsSpecialVariables.Ecs.WaitOption.Type, "dontWait");
+
+        return variables;
+    }
+
+    [OneTimeSetUp]
+    public async Task EnsureTaskDefinitionTemplateExists()
+    {
+        using var client = await CreateClient();
+        try
+        {
+            await client.DescribeTaskDefinitionAsync(new DescribeTaskDefinitionRequest { TaskDefinition = TaskDefinitionFamily });
+            return;
+        }
+        catch (ClientException)
+        {
+            // Template does not exist so create it below
+        }
+
+        // Execution role required to attach secrets
+        var executionRoleArn = await EnsureExecutionRole();
+        await client.RegisterTaskDefinitionAsync(new RegisterTaskDefinitionRequest
+        {
+            Family = TaskDefinitionFamily,
+            NetworkMode = NetworkMode.Awsvpc,
+            RequiresCompatibilities = ["FARGATE"],
+            Cpu = "256",
+            Memory = "512",
+            ExecutionRoleArn = executionRoleArn,
+            ContainerDefinitions =
+            [
+                new ContainerDefinition
+                {
+                    Name = "web",
+                    Image = "public.ecr.aws/docker/library/nginx:1.27-alpine",
+                    Essential = true,
+                    PortMappings = [new PortMapping { ContainerPort = 80 }]
+                }
+            ]
+        });
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (string.IsNullOrEmpty(serviceName))
+        {
+            return;
+        }
+
+        try
+        {
+            using var client = await CreateClient();
+            await client.DeleteServiceAsync(new DeleteServiceRequest
+            {
+                Cluster = ClusterName,
+                Service = serviceName,
+                Force = true
+            });
+        }
+        catch (Exception e)
+        {
+            TestContext.WriteLine($"Failed to delete service '{serviceName}': {e.Message}");
+        }
+    }
+
+    static async Task<string> EnsureExecutionRole()
+    {
+        using var iam = await CreateIamClient();
+        try
+        {
+            var resp = await iam.GetRoleAsync(new Amazon.IdentityManagement.Model.GetRoleRequest { RoleName = ExecutionRoleName });
+            return resp.Role.Arn;
+        }
+        catch (Amazon.IdentityManagement.Model.NoSuchEntityException)
+        {
+            const string trustPolicy = """{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ecs-tasks.amazonaws.com"},"Action":"sts:AssumeRole"}]}""";
+            var createResp = await iam.CreateRoleAsync(new Amazon.IdentityManagement.Model.CreateRoleRequest
+            {
+                RoleName = ExecutionRoleName,
+                AssumeRolePolicyDocument = trustPolicy
+            });
+            await iam.AttachRolePolicyAsync(new Amazon.IdentityManagement.Model.AttachRolePolicyRequest
+            {
+                RoleName = ExecutionRoleName,
+                PolicyArn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+            });
+            return createResp.Role.Arn;
+        }
+    }
+
+    static async Task<AmazonECSClient> CreateClient()
+    {
+        var accessKey = await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, CancellationToken.None);
+        var secretKey = await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, CancellationToken.None);
+        var credentials = new BasicAWSCredentials(accessKey, secretKey);
+        var config = new AmazonECSConfig { RegionEndpoint = RegionEndpoint.GetBySystemName(Region) };
+        return new AmazonECSClient(credentials, config);
+    }
+
+    static async Task<AmazonIdentityManagementServiceClient> CreateIamClient()
+    {
+        var accessKey = await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3AccessKey, CancellationToken.None);
+        var secretKey = await ExternalVariables.Get(ExternalVariable.AwsCloudFormationAndS3SecretKey, CancellationToken.None);
+        var credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return new AmazonIdentityManagementServiceClient(credentials, RegionEndpoint.GetBySystemName(Region));
+    }
+}


### PR DESCRIPTION
Ref MD-1814

- A new Calamari command that updates an existing ECS service in-place: clones the template task definition, applies image / env-var / env-file overrides, registers a new revision, and points the service at it via `UpdateService` matching SPF.
 - Post-deploy waits for service deployment and task states from SPF 
 - Output variables for cluster, service, family, revision, and region, mirroring the SPF contract.
 - `EcsDefaultTags` extended to serve both Deploy and Update flows (Update de-dupes on user-tag collision; Deploy keeps existing behaviour).