### PR TITLE
Use interfaces for git auth and connections

### DIFF
--- a/source/Calamari.Common/Plumbing/Variables/CustomPropertiesLoader.cs
+++ b/source/Calamari.Common/Plumbing/Variables/CustomPropertiesLoader.cs
@@ -4,6 +4,7 @@ using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Newtonsoft.Json;
+using NuGet.Packaging;
 
 namespace Calamari.Common.Plumbing.Variables
 {
@@ -30,10 +31,8 @@ namespace Calamari.Common.Plumbing.Variables
                 TypeNameHandling = TypeNameHandling.None,
                 DateParseHandling = DateParseHandling.None,
             };
-            foreach (var converter in converters)
-            {
-                serializerSettings.Converters.Add(converter);
-            }
+
+            serializerSettings.Converters.AddRange(converters);
         }
 
         public T Load<T>()

--- a/source/Calamari.Common/Plumbing/Variables/CustomPropertiesLoader.cs
+++ b/source/Calamari.Common/Plumbing/Variables/CustomPropertiesLoader.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Security.Cryptography;
 using Calamari.Common.Commands;
-using Calamari.Common.Plumbing.Commands;
-using Calamari.Common.Plumbing.Deployment.PackageRetention;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
-using Calamari.Common.Plumbing.Logging;
 using Newtonsoft.Json;
 
 namespace Calamari.Common.Plumbing.Variables
@@ -22,13 +17,23 @@ namespace Calamari.Common.Plumbing.Variables
         readonly ICalamariFileSystem fileSystem;
         readonly string customPropertiesFile;
         readonly string password;
+        readonly JsonSerializerSettings serializerSettings;
 
-
-        public CustomPropertiesLoader(ICalamariFileSystem fileSystem, string customPropertiesFile, string password)
+        public CustomPropertiesLoader(ICalamariFileSystem fileSystem, string customPropertiesFile, string password, params JsonConverter[] converters)
         {
             this.fileSystem = fileSystem;
             this.customPropertiesFile = customPropertiesFile;
             this.password = password;
+
+            serializerSettings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.None,
+                DateParseHandling = DateParseHandling.None,
+            };
+            foreach (var converter in converters)
+            {
+                serializerSettings.Converters.Add(converter);
+            }
         }
 
         public T Load<T>()
@@ -37,19 +42,13 @@ namespace Calamari.Common.Plumbing.Variables
 
             try
             {
-                return JsonConvert.DeserializeObject<T>(json, SerializerSettings);
+                return JsonConvert.DeserializeObject<T>(json, serializerSettings);
             }
             catch (JsonReaderException)
             {
                 throw new CommandException("Unable to parse custom properties as valid JSON.");
             }
         }
-
-        static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
-        {
-            TypeNameHandling = TypeNameHandling.None,
-            DateParseHandling = DateParseHandling.None,
-        };
 
         static string Decrypt(byte[] encryptedJson, string encryptionPassword)
         {

--- a/source/Calamari.Contracts/ArgoCD/ArgoCDCustomPropertiesDto.cs
+++ b/source/Calamari.Contracts/ArgoCD/ArgoCDCustomPropertiesDto.cs
@@ -2,7 +2,11 @@ using System;
 
 namespace Octopus.Calamari.Contracts.ArgoCD;
 
-public record ArgoCDCustomPropertiesDto(ArgoCDGatewayDto[] Gateways, ArgoCDApplicationDto[] Applications, GitCredentialDto[] Credentials);
+public record ArgoCDCustomPropertiesDto(
+    ArgoCDGatewayDto[] Gateways,
+    ArgoCDApplicationDto[] Applications,
+    IGitCredentialDto[] Credentials
+);
 
 public record ArgoCDGatewayDto(string Id, string Name);
 
@@ -14,4 +18,14 @@ public record ArgoCDApplicationDto(
     string DefaultRegistry,
     string? InstanceWebUiUrl);
 
-public record GitCredentialDto(string Url, string Username, string Password);
+public interface IGitCredentialDto
+{
+    string Type { get; }
+    string Url { get; }
+}
+
+// UsernamePasswordGitCredentialDto - could rename, but not worth altering the API
+public record GitCredentialDto(string Url, string Username, string Password) : IGitCredentialDto
+{
+    public string Type => nameof(GitCredentialDto);
+}

--- a/source/Calamari.Contracts/ArgoCD/ArgoCDCustomPropertiesDto.cs
+++ b/source/Calamari.Contracts/ArgoCD/ArgoCDCustomPropertiesDto.cs
@@ -27,5 +27,6 @@ public interface IGitCredentialDto
 // UsernamePasswordGitCredentialDto - could rename, but not worth altering the API
 public record GitCredentialDto(string Url, string Username, string Password) : IGitCredentialDto
 {
-    public string Type => nameof(GitCredentialDto);
+    public const string DiscriminatorValue = "UsernamePassword";
+    public string Type => DiscriminatorValue;
 }

--- a/source/Calamari.Tests/ArgoCD/Contracts/ArgoCDCustomPropertiesDtoSerializationTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Contracts/ArgoCDCustomPropertiesDtoSerializationTests.cs
@@ -1,0 +1,110 @@
+#nullable enable
+using Calamari.ArgoCD.Git;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Octopus.Calamari.Contracts.ArgoCD;
+
+namespace Calamari.Tests.ArgoCD.Contracts;
+
+/// <summary>
+/// Deserialisation tests for <see cref="ArgoCDCustomPropertiesDto"/> with a focus on
+/// the polymorphic <see cref="IGitCredentialDto"/> array. The converter discriminates on
+/// the <c>Type</c> field emitted by Octopus Server (the concrete type name); a missing
+/// <c>Type</c> defaults to <see cref="GitCredentialDto"/> for backwards compatibility.
+/// </summary>
+[TestFixture]
+public class ArgoCDCustomPropertiesDtoSerializationTests
+{
+    static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+    {
+        TypeNameHandling = TypeNameHandling.None,
+        DateParseHandling = DateParseHandling.None,
+        Converters = { new IGitCredentialDtoJsonConverter() }
+    };
+
+    static T DeserializeRaw<T>(string json)
+        => JsonConvert.DeserializeObject<T>(json, Settings)!;
+
+    [Test]
+    public void TypeGitCredentialDto_DeserializesAsHttpsCredential()
+    {
+        const string json = """
+            {
+              "Gateways": [], "Applications": [],
+              "Credentials": [
+                {
+                  "Type": "GitCredentialDto",
+                  "Url": "https://github.com/org/repo.git",
+                  "Username": "user",
+                  "Password": "pass"
+                }
+              ]
+            }
+            """;
+
+        var result = DeserializeRaw<ArgoCDCustomPropertiesDto>(json);
+
+        result.Credentials.Should().HaveCount(1);
+        var credential = result.Credentials[0].Should().BeOfType<GitCredentialDto>().Subject;
+        credential.Url.Should().Be("https://github.com/org/repo.git");
+        credential.Username.Should().Be("user");
+        credential.Password.Should().Be("pass");
+    }
+
+    [Test]
+    public void MissingType_DefaultsToHttpsCredential()
+    {
+        // Backwards compatibility: older server versions don't emit the Type field.
+        const string json = """
+            {
+              "Gateways": [], "Applications": [],
+              "Credentials": [
+                {
+                  "Url": "https://github.com/org/repo.git",
+                  "Username": "user",
+                  "Password": "pass"
+                }
+              ]
+            }
+            """;
+
+        var result = DeserializeRaw<ArgoCDCustomPropertiesDto>(json);
+
+        result.Credentials.Should().HaveCount(1);
+        result.Credentials[0].Should().BeOfType<GitCredentialDto>();
+    }
+
+    [Test]
+    public void UnknownType_Throws()
+    {
+        const string json = """
+            {
+              "Gateways": [], "Applications": [],
+              "Credentials": [
+                { "Type": "MysteryCredentialDto", "Url": "x" }
+              ]
+            }
+            """;
+
+        var act = () => DeserializeRaw<ArgoCDCustomPropertiesDto>(json);
+
+        act.Should().Throw<JsonSerializationException>()
+           .WithMessage("*MysteryCredentialDto*");
+    }
+
+    [Test]
+    public void EmptyCredentialsArray_Deserializes()
+    {
+        const string json = """
+            {
+              "Gateways": [], "Applications": [],
+              "Credentials": []
+            }
+            """;
+
+        var result = DeserializeRaw<ArgoCDCustomPropertiesDto>(json);
+
+        result.Credentials.Should().BeEmpty();
+    }
+}

--- a/source/Calamari.Tests/ArgoCD/Contracts/ArgoCDCustomPropertiesDtoSerializationTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Contracts/ArgoCDCustomPropertiesDtoSerializationTests.cs
@@ -34,7 +34,7 @@ public class ArgoCDCustomPropertiesDtoSerializationTests
               "Gateways": [], "Applications": [],
               "Credentials": [
                 {
-                  "Type": "GitCredentialDto",
+                  "Type": "UsernamePassword",
                   "Url": "https://github.com/org/repo.git",
                   "Username": "user",
                   "Password": "pass"

--- a/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Calamari.ArgoCD.Git;
+using Calamari.ArgoCD.Git.PullRequests;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Integration.Time;
+using Calamari.Testing.Helpers;
+using Calamari.Tests.Fixtures.Integration.FileSystem;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Calamari.Contracts.ArgoCD;
+
+namespace Calamari.Tests.ArgoCD.Git;
+
+[Category(TestCategory.RequiresOpenSsl3)]
+public abstract class AuthenticatingRepositoryFactoryTestBase
+{
+    protected readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();
+    protected readonly GitBranchName branchName = GitBranchName.CreateFromFriendlyName("devBranch");
+
+    protected InMemoryLog log;
+    protected string tempDirectory;
+    protected string OriginPath => Path.Combine(tempDirectory, "origin");
+    protected RepositoryFactory repositoryFactory;
+
+    [SetUp]
+    public void Init()
+    {
+        log = new InMemoryLog();
+        tempDirectory = fileSystem.CreateTemporaryDirectory();
+        RepositoryHelpers.CreateBareRepository(OriginPath);
+        RepositoryHelpers.CreateBranchIn(branchName, OriginPath);
+
+        repositoryFactory = new RepositoryFactory(
+            log,
+            fileSystem,
+            tempDirectory,
+            new GitVendorPullRequestClientResolver([]),
+            new SystemClock());
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        RepositoryHelpers.DeleteRepositoryDirectory(fileSystem, tempDirectory);
+    }
+
+    [TestFixture]
+    public class HttpsUrlTests : AuthenticatingRepositoryFactoryTestBase
+    {
+        [Test]
+        public void HttpsCredentialIsSelectedWhenUrlMatchesHttpsCredential()
+        {
+            var httpsUrl = RepositoryHelpers.ToFileUri(OriginPath);
+            var factory = new AuthenticatingRepositoryFactory(
+                new Dictionary<string, IGitCredentialDto>
+                {
+                    [httpsUrl] = new GitCredentialDto(httpsUrl, "", "")
+                },
+                repositoryFactory,
+                log);
+
+            using var wrapper = factory.CloneRepository(httpsUrl, branchName.ToFriendlyName());
+            wrapper.Should().NotBeNull();
+        }
+
+        [Test]
+        public void AnonymousCloneWhenNoCredentialsMatch()
+        {
+            var originUrl = RepositoryHelpers.ToFileUri(OriginPath);
+            var factory = new AuthenticatingRepositoryFactory(
+                new Dictionary<string, IGitCredentialDto>(),
+                repositoryFactory,
+                log);
+
+            using var wrapper = factory.CloneRepository(originUrl, branchName.ToFriendlyName());
+            wrapper.Should().NotBeNull();
+            log.Messages.Should().Contain(m => m.FormattedMessage.Contains("No Git credentials found"));
+        }
+    }
+
+    [TestFixture]
+    public class ScpStyleUrlTests : AuthenticatingRepositoryFactoryTestBase
+    {
+        [Test]
+        public void ScpStyleUrlDoesNotMatchHttpsCredential()
+        {
+            // An SCP-style URL should not accidentally match an HTTPS credential for the same host
+            var scpUrl = "git@github.com:org/repo.git";
+            var httpsUrl = "https://github.com/org/repo.git";
+
+            var factory = new AuthenticatingRepositoryFactory(
+                new Dictionary<string, IGitCredentialDto>
+                {
+                    [httpsUrl] = new GitCredentialDto(httpsUrl, "user", "pass")
+                },
+                repositoryFactory,
+                log);
+
+            // This will fail to clone (no real repo at this URL) but we can verify it
+            // falls through to anonymous because the SCP URL doesn't match the HTTPS URL
+            var act = () => factory.CloneRepository(scpUrl, "main");
+            act.Should().Throw<Exception>(); // clone failure expected
+            log.Messages.Should().Contain(m => m.FormattedMessage.Contains("No Git credentials found"));
+        }
+    }
+}

--- a/source/Calamari.Tests/ArgoCD/Git/GitCloneSafeUrlTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/GitCloneSafeUrlTests.cs
@@ -13,7 +13,7 @@ public class GitCloneSafeUrlTests
     public void FromString_ShouldConvertGitScpAddressToUri(string scpAddress, string expectedUrl)
     {
         var result = GitCloneSafeUrl.FromString(scpAddress);
-        result.AbsoluteUri.Should().Be(expectedUrl);
+        result.Should().Be(expectedUrl);
     } 
 
     [Test]
@@ -21,7 +21,7 @@ public class GitCloneSafeUrlTests
     {
         var uri = "https://github.com/Foo/Bar.git";
         var result = GitCloneSafeUrl.FromString(uri);
-        result.AbsoluteUri.Should().Be(uri);
+        result.Should().Be(uri);
     } 
     
     [Test]
@@ -37,6 +37,6 @@ public class GitCloneSafeUrlTests
     {
         var uri = "registry-1.docker.io/bitnamicharts";
         var result = GitCloneSafeUrl.FromString(uri);
-        result.AbsoluteUri.Should().Be($"oci://{uri}");
+        result.Should().Be($"oci://{uri}");
     }
 }

--- a/source/Calamari.Tests/ArgoCD/Git/GitCloneSafeUrlTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/GitCloneSafeUrlTests.cs
@@ -12,7 +12,7 @@ public class GitCloneSafeUrlTests
     [TestCase("git@bitbucket.com:FooBar.git", "https://bitbucket.com/FooBar.git")]
     public void FromString_ShouldConvertGitScpAddressToUri(string scpAddress, string expectedUrl)
     {
-        var result = GitCloneSafeUrl.FromString(scpAddress);
+        var result = GitCloneSafeUrl.ConvertToUriString(scpAddress);
         result.Should().Be(expectedUrl);
     } 
 
@@ -20,7 +20,7 @@ public class GitCloneSafeUrlTests
     public void FromString_ShouldReturnValidUriUnmodified()
     {
         var uri = "https://github.com/Foo/Bar.git";
-        var result = GitCloneSafeUrl.FromString(uri);
+        var result = GitCloneSafeUrl.ConvertToUriString(uri);
         result.Should().Be(uri);
     } 
     
@@ -28,7 +28,7 @@ public class GitCloneSafeUrlTests
     public void FromString_ShouldThrowInvalidGitScpAddress()
     {
         var uri = "git@ihavenopath.com";
-        var func = () => GitCloneSafeUrl.FromString(uri);
+        var func = () => GitCloneSafeUrl.ConvertToUriString(uri);
         func.Should().Throw<FormatException>();
     }
 
@@ -36,7 +36,7 @@ public class GitCloneSafeUrlTests
     public void ANonProtocoledString_AutomaticallyAddsOci()
     {
         var uri = "registry-1.docker.io/bitnamicharts";
-        var result = GitCloneSafeUrl.FromString(uri);
+        var result = GitCloneSafeUrl.ConvertToUriString(uri);
         result.Should().Be($"oci://{uri}");
     }
 }

--- a/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
@@ -55,8 +55,8 @@ public class GitHttpSmartSubTransportTests
         var password = "testpassword";
         var expectedAuth = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
 
-        var repoUrl = new Uri($"{server.Url}/fake-repo.git");
-        var connection = new GitConnection(username, password, repoUrl, GitBranchName.CreateFromFriendlyName("main"));
+        var repoUrl = $"{server.Url}/fake-repo.git";
+        var connection = new HttpsGitConnection(username, password, repoUrl, GitBranchName.CreateFromFriendlyName("main"));
         var repositoryFactory = new RepositoryFactory(
             log,
             fileSystem,
@@ -83,8 +83,8 @@ public class GitHttpSmartSubTransportTests
     [Test]
     public void NoAuthHeaderIsSentWhenCredentialsAreNotProvided()
     {
-        var repoUrl = new Uri($"{server.Url}/fake-repo.git");
-        var connection = new GitConnection(null, null, repoUrl, GitBranchName.CreateFromFriendlyName("main"));
+        var repoUrl = $"{server.Url}/fake-repo.git";
+        var connection = new HttpsGitConnection(null, null, repoUrl, GitBranchName.CreateFromFriendlyName("main"));
         var repositoryFactory = new RepositoryFactory(
             log,
             fileSystem,

--- a/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitPullRequestClientResolverTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitPullRequestClientResolverTests.cs
@@ -20,14 +20,14 @@ namespace Calamari.Tests.ArgoCD.Git.PullRequests;
 public class GitPullRequestClientResolverTests
 {
     ILog log;
-    IRepositoryConnection connection;
+    IHttpsGitConnection connection;
     MemoryCache cache;
 
     [SetUp]
     public void SetUp()
     {
         log = Substitute.For<ILog>();
-        connection = Substitute.For<IRepositoryConnection>();
+        connection = Substitute.For<IHttpsGitConnection>();
         connection.Username.Returns("test-user");
         connection.Password.Returns("test-token");
         cache = new MemoryCache(new MemoryCacheOptions());
@@ -54,7 +54,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task GitHubUrl_ResolvesToGitHubClient()
     {
-        connection.Url.Returns(new Uri("https://github.com/org/repo"));
+        connection.Url.Returns("https://github.com/org/repo");
         var resolver = CreateResolverWithAllRealFactories();
 
         var client = await resolver.TryResolve(connection, log, CancellationToken.None);
@@ -65,7 +65,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task GitLabCloudUrl_ResolvesToGitLabClient()
     {
-        connection.Url.Returns(new Uri("https://gitlab.com/org/repo"));
+        connection.Url.Returns("https://gitlab.com/org/repo");
         var resolver = CreateResolverWithAllRealFactories();
 
         var client = await resolver.TryResolve(connection, log, CancellationToken.None);
@@ -76,7 +76,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task AzureDevOpsUrl_ResolvesToAzureDevOpsClient()
     {
-        connection.Url.Returns(new Uri("https://dev.azure.com/org/project/_git/repo"));
+        connection.Url.Returns("https://dev.azure.com/org/project/_git/repo");
         var resolver = CreateResolverWithAllRealFactories();
 
         var client = await resolver.TryResolve(connection, log, CancellationToken.None);
@@ -87,7 +87,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task BitBucketUrl_ResolvesToBitBucketClient()
     {
-        connection.Url.Returns(new Uri("https://bitbucket.org/org/repo"));
+        connection.Url.Returns("https://bitbucket.org/org/repo");
         var resolver = CreateResolverWithAllRealFactories();
 
         var client = await resolver.TryResolve(connection, log, CancellationToken.None);
@@ -98,7 +98,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task UnrecognisedUrl_ReturnsNull()
     {
-        connection.Url.Returns(new Uri("https://someunknown.example/org/repo"));
+        connection.Url.Returns("https://someunknown.example/org/repo");
         var resolver = new GitVendorPullRequestClientResolver(new IGitVendorPullRequestClientFactory[]
         {
             new NeverMatchesFactory()
@@ -112,7 +112,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task SelfHostedUrl_WithMatchingSelfHostedFactory_ReturnsExpectedClient()
     {
-        connection.Url.Returns(new Uri("https://mygitlab.company.com/org/repo"));
+        connection.Url.Returns("https://mygitlab.company.com/org/repo");
         var expectedClient = Substitute.For<IGitVendorPullRequestClient>();
         var factory = Substitute.For<IGitVendorPullRequestClientFactory>();
         factory.CanHandleAsCloudHosted(Arg.Any<Uri>()).Returns(false);
@@ -131,6 +131,6 @@ public class GitPullRequestClientResolverTests
         public string Name => "NeverMatches";
         public bool CanHandleAsCloudHosted(Uri repositoryUri) => false;
         public Task<bool> CanHandleAsSelfHosted(Uri repositoryUri, CancellationToken cancellationToken) => Task.FromResult(false);
-        public Task<IGitVendorPullRequestClient> Create(IRepositoryConnection repositoryConnection, ILog log, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<IGitVendorPullRequestClient> Create(IHttpsGitConnection repositoryConnection, ILog log, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 }

--- a/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitPullRequestClientResolverTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitPullRequestClientResolverTests.cs
@@ -39,6 +39,12 @@ public class GitPullRequestClientResolverTests
         cache.Dispose();
     }
 
+    void ConfigureConnection(string url)
+    {
+        connection.Url.Returns(url);
+        connection.Uri.Returns(new Lazy<Uri>(() => new Uri(url)));
+    }
+
     GitVendorPullRequestClientResolver CreateResolverWithAllRealFactories()
     {
         var inspector = new SelfHostedGitLabInspector(cache);
@@ -54,7 +60,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task GitHubUrl_ResolvesToGitHubClient()
     {
-        connection.Url.Returns("https://github.com/org/repo");
+        ConfigureConnection("https://github.com/org/repo");
         var resolver = CreateResolverWithAllRealFactories();
 
         var client = await resolver.TryResolve(connection, log, CancellationToken.None);
@@ -65,7 +71,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task GitLabCloudUrl_ResolvesToGitLabClient()
     {
-        connection.Url.Returns("https://gitlab.com/org/repo");
+        ConfigureConnection("https://gitlab.com/org/repo");
         var resolver = CreateResolverWithAllRealFactories();
 
         var client = await resolver.TryResolve(connection, log, CancellationToken.None);
@@ -76,7 +82,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task AzureDevOpsUrl_ResolvesToAzureDevOpsClient()
     {
-        connection.Url.Returns("https://dev.azure.com/org/project/_git/repo");
+        ConfigureConnection("https://dev.azure.com/org/project/_git/repo");
         var resolver = CreateResolverWithAllRealFactories();
 
         var client = await resolver.TryResolve(connection, log, CancellationToken.None);
@@ -87,7 +93,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task BitBucketUrl_ResolvesToBitBucketClient()
     {
-        connection.Url.Returns("https://bitbucket.org/org/repo");
+        ConfigureConnection("https://bitbucket.org/org/repo");
         var resolver = CreateResolverWithAllRealFactories();
 
         var client = await resolver.TryResolve(connection, log, CancellationToken.None);
@@ -98,7 +104,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task UnrecognisedUrl_ReturnsNull()
     {
-        connection.Url.Returns("https://someunknown.example/org/repo");
+        ConfigureConnection("https://someunknown.example/org/repo");
         var resolver = new GitVendorPullRequestClientResolver(new IGitVendorPullRequestClientFactory[]
         {
             new NeverMatchesFactory()
@@ -112,7 +118,7 @@ public class GitPullRequestClientResolverTests
     [Test]
     public async Task SelfHostedUrl_WithMatchingSelfHostedFactory_ReturnsExpectedClient()
     {
-        connection.Url.Returns("https://mygitlab.company.com/org/repo");
+        ConfigureConnection("https://mygitlab.company.com/org/repo");
         var expectedClient = Substitute.For<IGitVendorPullRequestClient>();
         var factory = Substitute.For<IGitVendorPullRequestClientFactory>();
         factory.CanHandleAsCloudHosted(Arg.Any<Uri>()).Returns(false);

--- a/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitVendorApiAdapter_PullRequestTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitVendorApiAdapter_PullRequestTests.cs
@@ -99,11 +99,10 @@ namespace Calamari.Tests.ArgoCD.Git.GitVendorApiAdapters
                                   });
         }
 
-        async Task TestPullRequest(string repositoryUrl, string defaultBranch, string cloneUsername, string clonePassword, Func<IRepositoryConnection, IGitVendorPullRequestClient> createVendorApiAdapter)
+        async Task TestPullRequest(string repositoryUrl, string defaultBranch, string cloneUsername, string clonePassword, Func<HttpsGitConnection, IGitVendorPullRequestClient> createVendorApiAdapter)
         {
-            
             using var temporaryFolder = TemporaryDirectory.Create();
-            
+
             CredentialsHandler credentialsHandler = (url, usernameFromUrl, types) => new UsernamePasswordCredentials { Username = cloneUsername, Password = clonePassword};
             var repositoryPath =  Repository.Clone(repositoryUrl, temporaryFolder.DirectoryPath, new CloneOptions()
             {
@@ -120,8 +119,8 @@ namespace Calamari.Tests.ArgoCD.Git.GitVendorApiAdapters
             repository.Branches.Update(newBranch, branch => branch.Remote = remote.Name, branch => branch.UpstreamBranch = newBranch.CanonicalName);
             repository.Network.Push(newBranch, new PushOptions() { CredentialsProvider = credentialsHandler });
 
-            var conn = Substitute.For<IRepositoryConnection>();
-            conn.Url.Returns(new Uri(repositoryUrl));
+            var conn = Substitute.For<HttpsGitConnection>();
+            conn.Url.Returns(repositoryUrl);
             conn.Username.Returns(cloneUsername);
             conn.Password.Returns(clonePassword);
             try

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
@@ -50,9 +50,9 @@ namespace Calamari.Tests.ArgoCD.Git
         [Test]
         public void ThrowsExceptionIfUrlDoesNotExist()
         {
-            var connection = new GitConnection("username",
+            var connection = new HttpsGitConnection("username",
                                                "password",
-                                               new Uri("file://doesNotExist"),
+                                               "file://doesNotExist",
                                                branchName);
 
             Action action = () => repositoryFactory.CloneRepository("name", connection);
@@ -67,7 +67,7 @@ namespace Calamari.Tests.ArgoCD.Git
             var originalContent = "This is the file content";
             CreateCommitOnOrigin(branchName, filename, originalContent);
 
-            var connection = new GitConnection(null, null, new Uri(OriginPath), branchName);
+            var connection = new HttpsGitConnection(null, null, OriginPath, branchName);
             var clonedRepository = repositoryFactory.CloneRepository("CanCloneAnExistingRepository", connection);
 
             clonedRepository.Should().NotBeNull();
@@ -84,7 +84,7 @@ namespace Calamari.Tests.ArgoCD.Git
             var originalContent = "This is the file content";
             CreateCommitOnOrigin(RepositoryHelpers.MainBranchName, filename, originalContent);
 
-            var connection = new GitConnection(null, null, new Uri(OriginPath), new GitHead());
+            var connection = new HttpsGitConnection(null, null, OriginPath, new GitHead());
             var clonedRepository = repositoryFactory.CloneRepository("CanCloneAnExistingRepository", connection);
 
             clonedRepository.Should().NotBeNull();

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
@@ -52,10 +52,10 @@ namespace Calamari.Tests.ArgoCD.Git
                                                   Arg.Any<GitBranchName>(),
                                                   Arg.Any<CancellationToken>())
                                .Returns(new PullRequest("title", 1, "url"));
-            gitVendorAgnosticPullRequestClientFactory.TryResolve(Arg.Any<IRepositoryConnection>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>()).Returns(gitVendorPullRequestClient);
-
+            gitVendorAgnosticPullRequestClientFactory.TryResolve(Arg.Any<HttpsGitConnection>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>()).Returns(gitVendorPullRequestClient);
+            
             var repositoryFactory = new RepositoryFactory(log, fileSystem, tempDirectory, gitVendorAgnosticPullRequestClientFactory, new SystemClock());
-            gitConnection = new GitConnection(null, null, new Uri(OriginPath), branchName);
+            gitConnection = new HttpsGitConnection(null, null, OriginPath, branchName);
             repository = repositoryFactory.CloneRepository(repositoryPath, gitConnection);
         }
 
@@ -162,8 +162,8 @@ namespace Calamari.Tests.ArgoCD.Git
             bareOrigin.AddFilesToBranch(branchName, ("file.yaml", ""));
             bareOrigin.ApplyTag("1.0.0", bareOrigin.Head.Tip.Sha);
 
-            gitConnection = new GitConnection(null, null, new Uri(OriginPath), GitReference.CreateFromString("1.0.0"));
-
+            gitConnection = new HttpsGitConnection(null, null, OriginPath, GitReference.CreateFromString("1.0.0"));
+            
             var repositoryFactory = new RepositoryFactory(log, fileSystem, tempDirectory, gitVendorAgnosticPullRequestClientFactory, new SystemClock());
             var act = () => repositoryFactory.CloneRepository($"{repositoryPath}/sut", gitConnection);
 

--- a/source/Calamari.Tests/CommitToGit/CommitToGitConfigFactoryTests.cs
+++ b/source/Calamari.Tests/CommitToGit/CommitToGitConfigFactoryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Calamari.ArgoCD.Git;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.CommitToGit;
@@ -44,8 +45,10 @@ public class CommitToGitConfigFactoryTests
 
         var config = factory.CreateRepositoryConfig(deployment, loader);
 
-        config.GitConnection.Username.Should().Be("user-from-file");
-        config.GitConnection.Password.Should().Be("pwd-from-file");
-        config.GitConnection.Url.Should().Be(new Uri("https://example.invalid/repo.git"));
+        var httpsGitConnection = config.GitConnection as HttpsGitConnection;
+        httpsGitConnection.Should().NotBeNull();
+        httpsGitConnection!.Username.Should().Be("user-from-file");
+        httpsGitConnection.Password.Should().Be("pwd-from-file");
+        httpsGitConnection.Uri.Value.Should().Be(new Uri("https://example.invalid/repo.git"));
     }
 }

--- a/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppImagesCommand.cs
+++ b/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppImagesCommand.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using Calamari.ArgoCD.Conventions;
+using Calamari.ArgoCD.Git;
 using Calamari.ArgoCD.Git.PullRequests;
 using Calamari.Commands.Support;
 using Calamari.Common.Commands;
@@ -56,7 +57,7 @@ namespace Calamari.ArgoCD.Commands
                 new UpdateArgoCDAppImagesInstallConvention(log,
                                                            fileSystem,
                                                            configFactory,
-                                                           new CustomPropertiesLoader(fileSystem, customPropertiesFile, customPropertiesPassword),
+                                                           new CustomPropertiesLoader(fileSystem, customPropertiesFile, customPropertiesPassword, new IGitCredentialDtoJsonConverter()),
                                                            new ArgoCdApplicationManifestParser(),
                                                            gitVendorPullRequestClientResolver,
                                                            clock,

--- a/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppManifestsCommand.cs
+++ b/source/Calamari/ArgoCD/Commands/UpdateArgoCDAppManifestsCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Calamari.ArgoCD.Conventions;
+using Calamari.ArgoCD.Git;
 using Calamari.ArgoCD.Git.PullRequests;
 using Calamari.Commands;
 using Calamari.Commands.Support;
@@ -94,7 +95,7 @@ namespace Calamari.ArgoCD.Commands
                                                                       PackageDirectoryName,
                                                                       log,
                                                                       configFactory,
-                                                                      new CustomPropertiesLoader(fileSystem, customPropertiesFile, customPropertiesPassword),
+                                                                      new CustomPropertiesLoader(fileSystem, customPropertiesFile, customPropertiesPassword, new IGitCredentialDtoJsonConverter()),
                                                                       new ArgoCdApplicationManifestParser(),
                                                                       argoCDManifestsFileMatcher,
                                                                       gitVendorPullRequestClientResolver,

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Calamari.ArgoCD.Conventions.UpdateImageTag;
 using Calamari.ArgoCD.Git;
@@ -60,7 +61,9 @@ namespace Calamari.ArgoCD.Conventions
                                                           clock);
 
             var argoProperties = customPropertiesLoader.Load<ArgoCDCustomPropertiesDto>();
-            var gitCredentials = argoProperties.Credentials.ToDictionary(c => c.Url);
+            var gitCredentials = argoProperties.Credentials
+                                               .GroupBy(c => c.Url)
+                                               .ToDictionary(g => g.Key, g => g.OfType<GitCredentialDto>().FirstOrDefault<IGitCredentialDto>() ?? g.First());
             var authenticatingRepositoryFactory = new AuthenticatingRepositoryFactory(gitCredentials, repositoryFactory, log);
             var deploymentScope = deployment.Variables.GetDeploymentScope();
 

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppImagesInstallConvention.cs
@@ -61,6 +61,8 @@ namespace Calamari.ArgoCD.Conventions
                                                           clock);
 
             var argoProperties = customPropertiesLoader.Load<ArgoCDCustomPropertiesDto>();
+
+            // Takes the first git credential per URL, with a preference for username/password credentials (they are more broadly useful)
             var gitCredentials = argoProperties.Credentials
                                                .GroupBy(c => c.Url)
                                                .ToDictionary(g => g.Key, g => g.OfType<GitCredentialDto>().FirstOrDefault<IGitCredentialDto>() ?? g.First());

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
@@ -69,6 +69,7 @@ namespace Calamari.ArgoCD.Conventions
 
             var argoProperties = customPropertiesLoader.Load<ArgoCDCustomPropertiesDto>();
 
+            // Takes the first git credential per URL, with a preference for username/password credentials (they are more broadly useful)
             var gitCredentials = argoProperties.Credentials
                                                .GroupBy(c => c.Url)
                                                .ToDictionary(g => g.Key, g => g.OfType<GitCredentialDto>().FirstOrDefault<IGitCredentialDto>() ?? g.First());

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDApplicationManifestsInstallConvention.cs
@@ -69,7 +69,9 @@ namespace Calamari.ArgoCD.Conventions
 
             var argoProperties = customPropertiesLoader.Load<ArgoCDCustomPropertiesDto>();
 
-            var gitCredentials = argoProperties.Credentials.ToDictionary(c => c.Url);
+            var gitCredentials = argoProperties.Credentials
+                                               .GroupBy(c => c.Url)
+                                               .ToDictionary(g => g.Key, g => g.OfType<GitCredentialDto>().FirstOrDefault<IGitCredentialDto>() ?? g.First());
             var authenticatingRepositoryFactory = new AuthenticatingRepositoryFactory(gitCredentials, repositoryFactory, log);
             var deploymentScope = deployment.Variables.GetDeploymentScope();
 

--- a/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
@@ -25,12 +25,12 @@ public class AuthenticatingRepositoryFactory
         var gitCredential = gitCredentials.GetValueOrDefault(requestedUrl);
         if (gitCredential is GitCredentialDto passwordCredential)
         {
-            var gitConnection = new HttpsGitConnection(passwordCredential.Username, passwordCredential.Password, GitCloneSafeUrl.FromString(requestedUrl), GitReference.CreateFromString(targetRevision));
+            var gitConnection = new HttpsGitConnection(passwordCredential.Username, passwordCredential.Password, GitCloneSafeUrl.ConvertToUriString(requestedUrl), GitReference.CreateFromString(targetRevision));
             return repositoryFactory.CloneRepository(UniqueRepoNameGenerator.Generate(), gitConnection);
         }
 
         log.Info($"No Git credentials found for: '{requestedUrl}', will attempt to clone repository anonymously.");
-        var anonGitConnection = new HttpsGitConnection(null, null, GitCloneSafeUrl.FromString(requestedUrl), GitReference.CreateFromString(targetRevision));
+        var anonGitConnection = new HttpsGitConnection(null, null, GitCloneSafeUrl.ConvertToUriString(requestedUrl), GitReference.CreateFromString(targetRevision));
         return repositoryFactory.CloneRepository(UniqueRepoNameGenerator.Generate(), anonGitConnection);
     }
 }

--- a/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
@@ -6,27 +6,31 @@ namespace Calamari.ArgoCD.Git;
 
 public class AuthenticatingRepositoryFactory
 {
-    readonly Dictionary<string, GitCredentialDto> gitCredentials;
-    readonly RepositoryFactory repositoryFactory;
+    readonly Dictionary<string, IGitCredentialDto> gitCredentials;
+    readonly IRepositoryFactory repositoryFactory;
     readonly ILog log;
-    
 
-    public AuthenticatingRepositoryFactory(Dictionary<string, GitCredentialDto> gitCredentials, RepositoryFactory repositoryFactory, ILog log)
+    public AuthenticatingRepositoryFactory(
+        Dictionary<string, IGitCredentialDto> gitCredentials,
+        IRepositoryFactory repositoryFactory,
+        ILog log)
     {
         this.gitCredentials = gitCredentials;
         this.repositoryFactory = repositoryFactory;
         this.log = log;
     }
-    
+
     public RepositoryWrapper CloneRepository(string requestedUrl, string targetRevision)
     {
         var gitCredential = gitCredentials.GetValueOrDefault(requestedUrl);
-        if (gitCredential == null)
+        if (gitCredential is GitCredentialDto passwordCredential)
         {
-            log.Info($"No Git credentials found for: '{requestedUrl}', will attempt to clone repository anonymously.");
+            var gitConnection = new HttpsGitConnection(passwordCredential.Username, passwordCredential.Password, GitCloneSafeUrl.FromString(requestedUrl), GitReference.CreateFromString(targetRevision));
+            return repositoryFactory.CloneRepository(UniqueRepoNameGenerator.Generate(), gitConnection);
         }
 
-        var gitConnection = new GitConnection(gitCredential?.Username, gitCredential?.Password, GitCloneSafeUrl.FromString(requestedUrl), GitReference.CreateFromString(targetRevision));
-        return repositoryFactory.CloneRepository(UniqueRepoNameGenerator.Generate(), gitConnection);
+        log.Info($"No Git credentials found for: '{requestedUrl}', will attempt to clone repository anonymously.");
+        var anonGitConnection = new HttpsGitConnection(null, null, GitCloneSafeUrl.FromString(requestedUrl), GitReference.CreateFromString(targetRevision));
+        return repositoryFactory.CloneRepository(UniqueRepoNameGenerator.Generate(), anonGitConnection);
     }
 }

--- a/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
+++ b/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
@@ -29,7 +29,7 @@ public static class GitCloneSafeUrl
     /// This is invoked during yaml deserialisation, and may be applied to repoURLs which will never actually be cloned
     /// during step execution (eg sources which have not been scoped to the step).
     /// </remarks>
-    public static Uri FromString(string uri)
+    public static string FromString(string uri)
     {
         if (!uri.StartsWith(StandardSshScpPrefix))
         {
@@ -38,7 +38,7 @@ public static class GitCloneSafeUrl
             {
                 uri = $"oci://{uri}";
             }
-            return new Uri(uri);
+            return new Uri(uri).AbsoluteUri;
         }
 
         var scpAddress = uri.Substring(StandardSshScpPrefix.Length);
@@ -55,6 +55,6 @@ public static class GitCloneSafeUrl
             Host = host,
             Path = path
         };
-        return uriBuilder.Uri;
+        return uriBuilder.Uri.AbsoluteUri;
     }
 }

--- a/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
+++ b/source/Calamari/ArgoCD/Git/GitCloneSafeUrl.cs
@@ -29,7 +29,7 @@ public static class GitCloneSafeUrl
     /// This is invoked during yaml deserialisation, and may be applied to repoURLs which will never actually be cloned
     /// during step execution (eg sources which have not been scoped to the step).
     /// </remarks>
-    public static string FromString(string uri)
+    public static string ConvertToUriString(string uri)
     {
         if (!uri.StartsWith(StandardSshScpPrefix))
         {

--- a/source/Calamari/ArgoCD/Git/GitConnection.cs
+++ b/source/Calamari/ArgoCD/Git/GitConnection.cs
@@ -30,6 +30,7 @@ namespace Calamari.ArgoCD.Git
             Password = password;
             Url = url;
             GitReference = gitReference;
+            Uri = new Lazy<Uri>(() => ParseAsHttpsUri(Url));
         }
 
         public string? Username { get; }
@@ -37,7 +38,7 @@ namespace Calamari.ArgoCD.Git
         public string Url { get; }
         public GitReference GitReference { get; }
 
-        public Lazy<Uri> Uri => new(() => ParseAsHttpsUri(Url));
+        public Lazy<Uri> Uri { get; }
 
         static Uri ParseAsHttpsUri(string repositoryUrl)
         {

--- a/source/Calamari/ArgoCD/Git/GitConnection.cs
+++ b/source/Calamari/ArgoCD/Git/GitConnection.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System;
+
 namespace Calamari.ArgoCD.Git
 {
     public interface IRepositoryConnection
@@ -16,6 +18,8 @@ namespace Calamari.ArgoCD.Git
     {
         string? Username { get; }
         string? Password { get; }
+
+        public Lazy<Uri> Uri { get; }
     }
 
     public class HttpsGitConnection : IHttpsGitConnection
@@ -32,5 +36,19 @@ namespace Calamari.ArgoCD.Git
         public string? Password { get; }
         public string Url { get; }
         public GitReference GitReference { get; }
+
+        public Lazy<Uri> Uri => new(() => ParseAsHttpsUri(Url));
+
+        static Uri ParseAsHttpsUri(string repositoryUrl)
+        {
+            if (!System.Uri.TryCreate(repositoryUrl, UriKind.Absolute, out var uri))
+            {
+                throw new InvalidOperationException(
+                    $"Pull request operations require an HTTPS repository URL, but got: '{repositoryUrl}'. "
+                    + "SCP-style SSH URLs (e.g. git@github.com:org/repo.git) are not supported for pull request creation.");
+            }
+
+            return uri;
+        }
     }
 }

--- a/source/Calamari/ArgoCD/Git/GitConnection.cs
+++ b/source/Calamari/ArgoCD/Git/GitConnection.cs
@@ -1,23 +1,26 @@
 #nullable enable
-using System;
 
 namespace Calamari.ArgoCD.Git
 {
     public interface IRepositoryConnection
     {
-        public string? Username { get;  }
-        public string? Password { get;  }
-        public Uri Url { get;  }
-    }
-    
-    public interface IGitConnection : IRepositoryConnection
-    {
-        public GitReference GitReference { get;  }
+        public string Url { get; }
     }
 
-    public class GitConnection : IGitConnection
+    public interface IGitConnection : IRepositoryConnection
     {
-        public GitConnection(string? username, string? password, Uri url, GitReference gitReference)
+        public GitReference GitReference { get; }
+    }
+
+    public interface IHttpsGitConnection : IGitConnection
+    {
+        string? Username { get; }
+        string? Password { get; }
+    }
+
+    public class HttpsGitConnection : IHttpsGitConnection
+    {
+        public HttpsGitConnection(string? username, string? password, string url, GitReference gitReference)
         {
             Username = username;
             Password = password;
@@ -27,7 +30,7 @@ namespace Calamari.ArgoCD.Git
 
         public string? Username { get; }
         public string? Password { get; }
-        public Uri Url { get; }
+        public string Url { get; }
         public GitReference GitReference { get; }
     }
 }

--- a/source/Calamari/ArgoCD/Git/GitConnection.cs
+++ b/source/Calamari/ArgoCD/Git/GitConnection.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using Calamari.Common.Commands;
 
 namespace Calamari.ArgoCD.Git
 {
@@ -19,6 +20,9 @@ namespace Calamari.ArgoCD.Git
         string? Username { get; }
         string? Password { get; }
 
+        // Resolved as lazy because we don't have a strong trust that the input data is of the correct format
+        // If this is _not_ a URI, the existing code would throw an error when it gets used - so we want to
+        // replicate that same lazy error throwing.
         public Lazy<Uri> Uri { get; }
     }
 
@@ -44,7 +48,7 @@ namespace Calamari.ArgoCD.Git
         {
             if (!System.Uri.TryCreate(repositoryUrl, UriKind.Absolute, out var uri))
             {
-                throw new InvalidOperationException(
+                throw new CommandException(
                     $"Pull request operations require an HTTPS repository URL, but got: '{repositoryUrl}'. "
                     + "SCP-style SSH URLs (e.g. git@github.com:org/repo.git) are not supported for pull request creation.");
             }

--- a/source/Calamari/ArgoCD/Git/IGitCredentialDtoJsonConverter.cs
+++ b/source/Calamari/ArgoCD/Git/IGitCredentialDtoJsonConverter.cs
@@ -7,9 +7,8 @@ namespace Calamari.ArgoCD.Git;
 
 /// <summary>
 /// Discriminates an <see cref="IGitCredentialDto"/> on the <c>Type</c> field emitted by Octopus
-/// Server (matching the concrete type name). A missing <c>Type</c> defaults to
-/// <see cref="GitCredentialDto"/> for backwards compatibility with server versions that pre-date
-/// the field.
+/// Server. A missing <c>Type</c> defaults to <see cref="GitCredentialDto"/> for backwards
+/// compatibility with server versions that pre-date the field.
 /// </summary>
 public class IGitCredentialDtoJsonConverter : JsonConverter<IGitCredentialDto>
 {
@@ -32,7 +31,7 @@ public class IGitCredentialDtoJsonConverter : JsonConverter<IGitCredentialDto>
 
         return type switch
         {
-            null or nameof(GitCredentialDto) => obj.ToObject<GitCredentialDto>(ConcreteSerializer)!,
+            null or GitCredentialDto.DiscriminatorValue => obj.ToObject<GitCredentialDto>(ConcreteSerializer)!,
             _ => throw new JsonSerializationException($"Unrecognised credential Type '{type}'.")
         };
     }

--- a/source/Calamari/ArgoCD/Git/IGitCredentialDtoJsonConverter.cs
+++ b/source/Calamari/ArgoCD/Git/IGitCredentialDtoJsonConverter.cs
@@ -1,0 +1,39 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Octopus.Calamari.Contracts.ArgoCD;
+
+namespace Calamari.ArgoCD.Git;
+
+/// <summary>
+/// Discriminates an <see cref="IGitCredentialDto"/> on the <c>Type</c> field emitted by Octopus
+/// Server (matching the concrete type name). A missing <c>Type</c> defaults to
+/// <see cref="GitCredentialDto"/> for backwards compatibility with server versions that pre-date
+/// the field.
+/// </summary>
+public class IGitCredentialDtoJsonConverter : JsonConverter<IGitCredentialDto>
+{
+    static readonly JsonSerializer ConcreteSerializer = new();
+
+    public override bool CanWrite => false;
+
+    public override void WriteJson(JsonWriter writer, IGitCredentialDto? value, JsonSerializer serializer)
+        => throw new NotSupportedException();
+
+    public override IGitCredentialDto ReadJson(
+        JsonReader reader,
+        Type objectType,
+        IGitCredentialDto? existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        var obj = JObject.Load(reader);
+        var type = obj["Type"]?.Value<string>();
+
+        return type switch
+        {
+            null or nameof(GitCredentialDto) => obj.ToObject<GitCredentialDto>(ConcreteSerializer)!,
+            _ => throw new JsonSerializationException($"Unrecognised credential Type '{type}'.")
+        };
+    }
+}

--- a/source/Calamari/ArgoCD/Git/PullRequests/GitVendorPullRequestClientResolver.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/GitVendorPullRequestClientResolver.cs
@@ -27,7 +27,7 @@ namespace Calamari.ArgoCD.Git.PullRequests
         {
             if (!Uri.TryCreate(repositoryConnection.Url, UriKind.Absolute, out var repositoryUri))
             {
-                log.Verbose($"Could not load a Git vendor: URL is not a valid URI: '{repositoryConnection.Url}'");
+                log.Verbose($"Could not load a Git vendor: URL is not a valid URI '{repositoryConnection.Url}'");
                 return null;
             }
 

--- a/source/Calamari/ArgoCD/Git/PullRequests/GitVendorPullRequestClientResolver.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/GitVendorPullRequestClientResolver.cs
@@ -9,7 +9,7 @@ namespace Calamari.ArgoCD.Git.PullRequests
 {
     public interface IGitVendorPullRequestClientResolver
     {
-        Task<IGitVendorPullRequestClient> TryResolve(IRepositoryConnection repositoryConnection, ILog log,
+        Task<IGitVendorPullRequestClient> TryResolve(IHttpsGitConnection repositoryConnection, ILog log,
                                                      CancellationToken cancellationToken);
     }
     
@@ -22,18 +22,24 @@ namespace Calamari.ArgoCD.Git.PullRequests
             this.clientFactories = clientFactories;
         }
  
-        public async Task<IGitVendorPullRequestClient?> TryResolve(IRepositoryConnection repositoryConnection, ILog log,
-                                                                       CancellationToken cancellationToken)
+        public async Task<IGitVendorPullRequestClient?> TryResolve(IHttpsGitConnection repositoryConnection, ILog log,
+                                                                   CancellationToken cancellationToken)
         {
+            if (!Uri.TryCreate(repositoryConnection.Url, UriKind.Absolute, out var repositoryUri))
+            {
+                log.Verbose($"Could not load a Git vendor: URL is not a valid URI: '{repositoryConnection.Url}'");
+                return null;
+            }
+
             //first try getting a handling factory by checking if it can be handled as a cloud hosted repo
-            var handlingFactory = clientFactories.SingleOrDefault(f => f.CanHandleAsCloudHosted(repositoryConnection.Url));
+            var handlingFactory = clientFactories.SingleOrDefault(f => f.CanHandleAsCloudHosted(repositoryUri));
 
             //if we still don't have a handling factory, try the self-hosted checks.
             if (handlingFactory is null)
             {
                 foreach (var clientFactory in clientFactories)
                 {
-                    if (!await clientFactory.CanHandleAsSelfHosted(repositoryConnection.Url, cancellationToken))
+                    if (!await clientFactory.CanHandleAsSelfHosted(repositoryUri, cancellationToken))
                     {
                         continue;
                     }

--- a/source/Calamari/ArgoCD/Git/PullRequests/GitVendorPullRequestClientResolver.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/GitVendorPullRequestClientResolver.cs
@@ -25,6 +25,8 @@ namespace Calamari.ArgoCD.Git.PullRequests
         public async Task<IGitVendorPullRequestClient?> TryResolve(IHttpsGitConnection repositoryConnection, ILog log,
                                                                    CancellationToken cancellationToken)
         {
+            // Avoid using repositoryConnection.Uri here as we do not want to throw if we somehow got here without a
+            // valid Uri - if we can gather confidence that this is impossible then we could remove this guard
             if (!Uri.TryCreate(repositoryConnection.Url, UriKind.Absolute, out var repositoryUri))
             {
                 log.Verbose($"Could not load a Git vendor: URL is not a valid URI '{repositoryConnection.Url}'");

--- a/source/Calamari/ArgoCD/Git/PullRequests/IGitVendorPullRequestClientFactory.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/IGitVendorPullRequestClientFactory.cs
@@ -26,6 +26,6 @@ namespace Calamari.ArgoCD.Git.PullRequests
             return false;
         }
 
-        Task<IGitVendorPullRequestClient> Create(IRepositoryConnection repositoryConnection, ILog log, CancellationToken cancellationToken);
+        Task<IGitVendorPullRequestClient> Create(IHttpsGitConnection repositoryConnection, ILog log, CancellationToken cancellationToken);
     }
 }

--- a/source/Calamari/ArgoCD/Git/PullRequests/StringExtensionMethods.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/StringExtensionMethods.cs
@@ -13,6 +13,24 @@ namespace Calamari.ArgoCD.Git.PullRequests
             return url;
         }
         
+        /// <summary>
+        /// Parses a repository URL string into a <see cref="Uri"/>. Pull request clients require
+        /// HTTPS URLs for REST API calls — SCP-style SSH URLs (e.g. git@host:path) are not valid URIs.
+        /// The <see cref="GitVendorPullRequestClientResolver"/> guards against this by returning null
+        /// for non-URI URLs, but this method provides a clear error if one slips through.
+        /// </summary>
+        public static Uri ParseAsHttpsUri(this string repositoryUrl)
+        {
+            if (!Uri.TryCreate(repositoryUrl, UriKind.Absolute, out var uri))
+            {
+                throw new InvalidOperationException(
+                    $"Pull request operations require an HTTPS repository URL, but got: '{repositoryUrl}'. " +
+                    "SCP-style SSH URLs (e.g. git@github.com:org/repo.git) are not supported for pull request creation.");
+            }
+
+            return uri;
+        }
+
         // This extension method is here until we can drop netfx and put it into the interface
         public static string[] ExtractPropertiesFromUrlPath(this Uri repositoryUri)
         {

--- a/source/Calamari/ArgoCD/Git/PullRequests/StringExtensionMethods.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/StringExtensionMethods.cs
@@ -12,24 +12,6 @@ namespace Calamari.ArgoCD.Git.PullRequests
 
             return url;
         }
-        
-        /// <summary>
-        /// Parses a repository URL string into a <see cref="Uri"/>. Pull request clients require
-        /// HTTPS URLs for REST API calls — SCP-style SSH URLs (e.g. git@host:path) are not valid URIs.
-        /// The <see cref="GitVendorPullRequestClientResolver"/> guards against this by returning null
-        /// for non-URI URLs, but this method provides a clear error if one slips through.
-        /// </summary>
-        public static Uri ParseAsHttpsUri(this string repositoryUrl)
-        {
-            if (!Uri.TryCreate(repositoryUrl, UriKind.Absolute, out var uri))
-            {
-                throw new InvalidOperationException(
-                    $"Pull request operations require an HTTPS repository URL, but got: '{repositoryUrl}'. " +
-                    "SCP-style SSH URLs (e.g. git@github.com:org/repo.git) are not supported for pull request creation.");
-            }
-
-            return uri;
-        }
 
         // This extension method is here until we can drop netfx and put it into the interface
         public static string[] ExtractPropertiesFromUrlPath(this Uri repositoryUri)

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/AzureDevOps/AzureDevOpsPullRequestClient.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/AzureDevOps/AzureDevOpsPullRequestClient.cs
@@ -13,9 +13,9 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.AzureDevOps
 	{
 		const string CloudHost = "dev.azure.com";
 		
-		readonly IRepositoryConnection repositoryConnection;
+		readonly IHttpsGitConnection repositoryConnection;
 
-		public AzureDevOpsPullRequestClient(IRepositoryConnection repositoryConnection)
+		public AzureDevOpsPullRequestClient(IHttpsGitConnection repositoryConnection)
 		{
 			this.repositoryConnection = repositoryConnection;
 		}
@@ -32,7 +32,7 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.AzureDevOps
 			                                                                           Convert.ToBase64String(Encoding.ASCII.GetBytes($"{repositoryConnection.Username}:{repositoryConnection.Password}")));
 
 			
-			var (organizationName, projectName, repositoryName) = AzureDevOpsRepositoryUriParser.Parse(repositoryConnection.Url);
+			var (organizationName, projectName, repositoryName) = AzureDevOpsRepositoryUriParser.Parse(repositoryConnection.Url.ParseAsHttpsUri());
 			var apiUrl = $"https://{CloudHost}/{organizationName}/{projectName}/_apis/git/repositories/{repositoryName}/pullrequests?api-version=7.1";
 
 			var pullRequest = new
@@ -63,7 +63,7 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.AzureDevOps
 
 		public string GenerateCommitUrl(string commit)
 		{
-			var (organizationName, projectName, repositoryName) = AzureDevOpsRepositoryUriParser.Parse(repositoryConnection.Url);
+			var (organizationName, projectName, repositoryName) = AzureDevOpsRepositoryUriParser.Parse(repositoryConnection.Url.ParseAsHttpsUri());
 			return $"https://{CloudHost}/{organizationName}/{projectName}/_git/{repositoryName}/commit/{commit}";
 		}
 	}

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/AzureDevOps/AzureDevOpsPullRequestClient.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/AzureDevOps/AzureDevOpsPullRequestClient.cs
@@ -32,7 +32,7 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.AzureDevOps
 			                                                                           Convert.ToBase64String(Encoding.ASCII.GetBytes($"{repositoryConnection.Username}:{repositoryConnection.Password}")));
 
 			
-			var (organizationName, projectName, repositoryName) = AzureDevOpsRepositoryUriParser.Parse(repositoryConnection.Url.ParseAsHttpsUri());
+			var (organizationName, projectName, repositoryName) = AzureDevOpsRepositoryUriParser.Parse(repositoryConnection.Uri.Value);
 			var apiUrl = $"https://{CloudHost}/{organizationName}/{projectName}/_apis/git/repositories/{repositoryName}/pullrequests?api-version=7.1";
 
 			var pullRequest = new
@@ -63,7 +63,7 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.AzureDevOps
 
 		public string GenerateCommitUrl(string commit)
 		{
-			var (organizationName, projectName, repositoryName) = AzureDevOpsRepositoryUriParser.Parse(repositoryConnection.Url.ParseAsHttpsUri());
+			var (organizationName, projectName, repositoryName) = AzureDevOpsRepositoryUriParser.Parse(repositoryConnection.Uri.Value);
 			return $"https://{CloudHost}/{organizationName}/{projectName}/_git/{repositoryName}/commit/{commit}";
 		}
 	}

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/AzureDevOps/AzureDevOpsPullRequestClientFactory.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/AzureDevOps/AzureDevOpsPullRequestClientFactory.cs
@@ -11,7 +11,7 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.AzureDevOps
         
         public bool CanHandleAsCloudHosted(Uri repositoryUri) => AzureDevOpsRepositoryUriParser.IsAzureDevOpsRepository(repositoryUri);
         
-        public async Task<IGitVendorPullRequestClient> Create(IRepositoryConnection repositoryConnection, ILog log, CancellationToken cancellationToken)
+        public async Task<IGitVendorPullRequestClient> Create(IHttpsGitConnection repositoryConnection, ILog log, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
             return new AzureDevOpsPullRequestClient(repositoryConnection);

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/BitBucket/BitBucketPullRequestClient.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/BitBucket/BitBucketPullRequestClient.cs
@@ -11,17 +11,17 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.BitBucket
 {
     public class BitBucketPullRequestClient : IGitVendorPullRequestClient
     {
-        readonly IRepositoryConnection repositoryConnection;
+        readonly IHttpsGitConnection repositoryConnection;
         readonly Uri baseUrl;
 
         readonly string workspace;
         readonly string repositorySlug;
-        public BitBucketPullRequestClient(IRepositoryConnection repositoryConnection, Uri baseUrl)
+        public BitBucketPullRequestClient(IHttpsGitConnection repositoryConnection, Uri baseUrl)
         {
             this.repositoryConnection = repositoryConnection;
             this.baseUrl = baseUrl;
 
-            var parts = repositoryConnection.Url.ExtractPropertiesFromUrlPath();
+            var parts = repositoryConnection.Url.ParseAsHttpsUri().ExtractPropertiesFromUrlPath();
             workspace = parts[0];
             repositorySlug = parts[1];
         }

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/BitBucket/BitBucketPullRequestClient.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/BitBucket/BitBucketPullRequestClient.cs
@@ -21,7 +21,7 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.BitBucket
             this.repositoryConnection = repositoryConnection;
             this.baseUrl = baseUrl;
 
-            var parts = repositoryConnection.Url.ParseAsHttpsUri().ExtractPropertiesFromUrlPath();
+            var parts = repositoryConnection.Uri.Value.ExtractPropertiesFromUrlPath();
             workspace = parts[0];
             repositorySlug = parts[1];
         }

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/BitBucket/BitBucketPullRequestClientFactory.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/BitBucket/BitBucketPullRequestClientFactory.cs
@@ -15,7 +15,7 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.BitBucket
             return repositoryUri.Host.Equals(baseUrl.Host, StringComparison.OrdinalIgnoreCase);
         }
 
-        public async Task<IGitVendorPullRequestClient> Create(IRepositoryConnection repositoryConnection, ILog log, CancellationToken cancellationToken)
+        public async Task<IGitVendorPullRequestClient> Create(IHttpsGitConnection repositoryConnection, ILog log, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
             return new BitBucketPullRequestClient(repositoryConnection, baseUrl);

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitHub/GitHubPullRequestClient.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitHub/GitHubPullRequestClient.cs
@@ -3,7 +3,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Octokit;
-using PullRequest = Calamari.ArgoCD.Git.PullRequests.PullRequest;
 
 namespace Calamari.ArgoCD.Git.PullRequests.Vendors.GitHub
 {
@@ -14,12 +13,12 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.GitHub
         readonly string repoOwner;
         readonly string repoName;
 
-        public GitHubPullRequestClient(IGitHubClient client, IRepositoryConnection repositoryConnection, Uri baseUrl)
+        public GitHubPullRequestClient(IGitHubClient client, IHttpsGitConnection repositoryConnection, Uri baseUrl)
         {
             this.client = client;
             this.baseUrl = baseUrl;
 
-            var parts = repositoryConnection.Url.ExtractPropertiesFromUrlPath();
+            var parts = repositoryConnection.Url.ParseAsHttpsUri().ExtractPropertiesFromUrlPath();
             repoOwner = parts[0];
             repoName = parts[1];
         }

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitHub/GitHubPullRequestClient.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitHub/GitHubPullRequestClient.cs
@@ -18,7 +18,7 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.GitHub
             this.client = client;
             this.baseUrl = baseUrl;
 
-            var parts = repositoryConnection.Url.ParseAsHttpsUri().ExtractPropertiesFromUrlPath();
+            var parts = repositoryConnection.Uri.Value.ExtractPropertiesFromUrlPath();
             repoOwner = parts[0];
             repoName = parts[1];
         }

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitHub/GitHubPullRequestClientFactory.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitHub/GitHubPullRequestClientFactory.cs
@@ -16,7 +16,7 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.GitHub
         
         public bool CanHandleAsCloudHosted(Uri repositoryUri) => GitHubRepositoryUriParser.IsGitHub(repositoryUri);
 
-        public async Task<IGitVendorPullRequestClient> Create(IRepositoryConnection repositoryConnection, ILog log, CancellationToken cancellationToken)
+        public async Task<IGitVendorPullRequestClient> Create(IHttpsGitConnection repositoryConnection, ILog log, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
             

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitLab/GitLabPullRequestClient.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitLab/GitLabPullRequestClient.cs
@@ -13,12 +13,12 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.GitLab
         readonly Uri baseUrl;
         readonly string projectPath;
 
-        public GitLabPullRequestClient(GitLabClient gitLabClient, IRepositoryConnection repositoryConnection, Uri baseUrl)
+        public GitLabPullRequestClient(GitLabClient gitLabClient, IHttpsGitConnection repositoryConnection, Uri baseUrl)
         {
             this.gitLabClient = gitLabClient;
             this.baseUrl = baseUrl;
             
-            var parts = repositoryConnection.Url.ExtractPropertiesFromUrlPath();
+            var parts = repositoryConnection.Url.ParseAsHttpsUri().ExtractPropertiesFromUrlPath();
             projectPath = $"{parts[^2]}/{parts[^1]}";
         }
         

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitLab/GitLabPullRequestClient.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitLab/GitLabPullRequestClient.cs
@@ -18,7 +18,7 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.GitLab
             this.gitLabClient = gitLabClient;
             this.baseUrl = baseUrl;
             
-            var parts = repositoryConnection.Url.ParseAsHttpsUri().ExtractPropertiesFromUrlPath();
+            var parts = repositoryConnection.Uri.Value.ExtractPropertiesFromUrlPath();
             projectPath = $"{parts[^2]}/{parts[^1]}";
         }
         

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitLab/GitLabPullRequestClientFactory.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitLab/GitLabPullRequestClientFactory.cs
@@ -21,14 +21,15 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.GitLab
             return await selfHostedGitLabInspector.IsSelfHostedGitLabInstance(repositoryUri, cancellationToken);
         }
 
-        public async Task<IGitVendorPullRequestClient> Create(IRepositoryConnection repositoryConnection, ILog taskLog,
+        public async Task<IGitVendorPullRequestClient> Create(IHttpsGitConnection repositoryConnection, ILog taskLog,
                                                               CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
             //if we aren't cloud hosted, we must be self-hosted 
-            var host = CanHandleAsCloudHosted(repositoryConnection.Url)
+            var repositoryUri = repositoryConnection.Url.ParseAsHttpsUri();
+            var host = CanHandleAsCloudHosted(repositoryUri)
                 ? CloudHost
-                : SelfHostedGitLabInspector.GetSelfHostedBaseRepositoryUrl(repositoryConnection.Url);
+                : SelfHostedGitLabInspector.GetSelfHostedBaseRepositoryUrl(repositoryUri);
 
             var client = new GitLabClient(host, repositoryConnection.Password);
             return new GitLabPullRequestClient(client, repositoryConnection, new Uri(host));

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitLab/GitLabPullRequestClientFactory.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitLab/GitLabPullRequestClientFactory.cs
@@ -26,10 +26,9 @@ namespace Calamari.ArgoCD.Git.PullRequests.Vendors.GitLab
         {
             await Task.CompletedTask;
             //if we aren't cloud hosted, we must be self-hosted 
-            var repositoryUri = repositoryConnection.Url.ParseAsHttpsUri();
-            var host = CanHandleAsCloudHosted(repositoryUri)
+            var host = CanHandleAsCloudHosted(repositoryConnection.Uri.Value)
                 ? CloudHost
-                : SelfHostedGitLabInspector.GetSelfHostedBaseRepositoryUrl(repositoryUri);
+                : SelfHostedGitLabInspector.GetSelfHostedBaseRepositoryUrl(repositoryConnection.Uri.Value);
 
             var client = new GitLabClient(host, repositoryConnection.Password);
             return new GitLabPullRequestClient(client, repositoryConnection, new Uri(host));

--- a/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
@@ -66,12 +66,12 @@ namespace Calamari.ArgoCD.Git
                     BranchName = (gitConnection.GitReference as GitBranchName)?.ToFriendlyName()
                 };
 
-            if (gitConnection.Username != null && gitConnection.Password != null)
+            if (gitConnection is HttpsGitConnection { Username: not null, Password: not null } https)
             {
-                options.FetchOptions.CredentialsProvider = (url, usernameFromUrl, types) => new UsernamePasswordCredentials
+                options.FetchOptions.CredentialsProvider = (_, _, _) => new UsernamePasswordCredentials
                 {
-                    Username = gitConnection.Username!,
-                    Password = gitConnection.Password!
+                    Username = https.Username,
+                    Password = https.Password
                 };
             }
 
@@ -81,7 +81,7 @@ namespace Calamari.ArgoCD.Git
             {
                 try
                 {
-                    repoPath = Repository.Clone(gitConnection.Url.AbsoluteUri, checkoutPath, options);
+                    repoPath = Repository.Clone(gitConnection.Url, checkoutPath, options);
                     timedOp.Complete();
                 }
                 catch (Exception e)
@@ -100,16 +100,16 @@ namespace Calamari.ArgoCD.Git
             //this is required to handle the issue around "HEAD"
             var branchToCheckout = repo.GetBranchName(gitConnection.GitReference);
             var remoteBranch = repo.Branches.First(f => f.IsRemote && f.UpstreamBranchCanonicalName == branchToCheckout.Value);
-            
+
             log.VerboseFormat("Checking out '{0}' @ {1}", branchToCheckout, remoteBranch.Tip.Sha.Substring(0, 10));
-            
+
             //A local branch is required such that libgit2sharp can create "tracking" data
             // libgit2sharp does not support pushing from a detached head
             if (repo.Branches[branchToCheckout.Value] == null)
             {
                 repo.CreateBranch(branchToCheckout.Value, remoteBranch.Tip);
             }
-            
+
             LibGit2Sharp.Commands.Checkout(repo, branchToCheckout.ToFriendlyName());
             }
             catch (LibGit2SharpException e)
@@ -118,7 +118,10 @@ namespace Calamari.ArgoCD.Git
             }
 
             //TODO(tmm): Make this function (and all callers async).
-            var gitVendorApiAdapter = gitVendorPullRequestClientResolver.TryResolve(gitConnection, log, CancellationToken.None).Result;
+            var gitVendorApiAdapter = gitConnection is HttpsGitConnection httpsGitConnection
+                ? gitVendorPullRequestClientResolver.TryResolve(httpsGitConnection, log, CancellationToken.None).Result
+                : null;
+
             return new RepositoryWrapper(repo,
                                          fileSystem,
                                          checkoutPath,

--- a/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
@@ -33,12 +33,16 @@ namespace Calamari.ArgoCD.Git
         readonly IGitVendorPullRequestClient? vendorApiAdapter = vendorApiAdapter;
         readonly IClock clock = clock;
         // ReSharper restore ReplaceWithPrimaryConstructorParameter
-        
+
         readonly Identity repositoryIdentity = new("Octopus", "octopus@octopus.com");
 
         public string WorkingDirectory => repository.Info.WorkingDirectory;
 
-        Credentials RepositoryCredentials => new UsernamePasswordCredentials { Username = connection.Username, Password = connection.Password };
+        Credentials RepositoryCredentials => connection switch
+             {
+                 HttpsGitConnection https => new UsernamePasswordCredentials { Username = https.Username, Password = https.Password },
+                 _ => null
+             };
 
         // returns true if changes were made to the repository
         public bool CommitChanges(string summary, string description)
@@ -140,7 +144,7 @@ namespace Calamari.ArgoCD.Git
                 commit.Sha,
                 commit.ShortSha(),
                 commit.Author.When,
-                connection.Url.AbsoluteUri,
+                connection.Url,
                 title,
                 uri,
                 number);

--- a/source/Calamari/CommitToGit/CommitToGitConfigFactory.cs
+++ b/source/Calamari/CommitToGit/CommitToGitConfigFactory.cs
@@ -32,10 +32,10 @@ namespace Calamari.CommitToGit
             var commitParameters = new GitCommitParameters(summary, description, requiresPullRequest);
 
             return new CommitToGitRepositorySettings(
-                                                     new GitConnection(
+                                                     new HttpsGitConnection(
                                                                        variables.Get(SpecialVariables.Action.Git.Username),
                                                                        variables.Get(SpecialVariables.Action.Git.Password),
-                                                                       new Uri(uriAsString),
+                                                                       uriAsString,
                                                                        GitReference.CreateFromString(gitReferenceAsString)),
             commitParameters,
             variables.Get(SpecialVariables.Action.Git.DestinationPath));

--- a/source/Calamari/CommitToGit/CommitToGitRepositorySettings.cs
+++ b/source/Calamari/CommitToGit/CommitToGitRepositorySettings.cs
@@ -6,14 +6,14 @@ namespace Calamari.CommitToGit
 {
     public class CommitToGitRepositorySettings
     {
-        public CommitToGitRepositorySettings(GitConnection gitConnection, GitCommitParameters commitParameters, string destinationPath)
+        public CommitToGitRepositorySettings(IGitConnection gitConnection, GitCommitParameters commitParameters, string destinationPath)
         {
             GitConnection = gitConnection;
             DestinationPath = destinationPath;
             CommitParameters = commitParameters;
         }
 
-        public GitConnection GitConnection { get; }
+        public IGitConnection GitConnection { get; }
 
         public string DestinationPath { get; }
         public GitCommitParameters CommitParameters { get; }


### PR DESCRIPTION
Relates to MD-1760

We are shortly adding support for SSH key authentication for Git operations. 

This PR is a prepares for that by updating the interface between Server and Calamari to accept an `IGitCredentialDto` interface and introducing an `IGitConnection` that captures the repo url + credential combination.

Future work will introduce `SshKeyGitCredentialDto` and `SshGitConnection` types.

Interesting differences:
- We add a `Type` discriminator to `IGitCredentialDto` + change the contract slightly
    - This should all be backwards compatible.
- Url on `GitConnection` goes from a `URI` to a string
    - Git urls aren't always URIs