### PR TITLE
Check OctopusDisableAzureCLI before reading, for strict mode

### DIFF
--- a/source/Calamari.AzureScripting.Tests/AzurePowershellCommandFixture.cs
+++ b/source/Calamari.AzureScripting.Tests/AzurePowershellCommandFixture.cs
@@ -76,6 +76,26 @@ az group list";
 
         [Test]
         [RequiresPowerShell5OrAbove]
+        public async Task ExecuteAnInlinePowerShellCoreScriptWithStrictMode()
+        {
+            var psScript = @"
+Set-StrictMode -Version Latest
+az group list";
+
+            await CommandTestBuilder.CreateAsync<RunScriptCommand, Program>()
+                                    .WithArrange(context =>
+                                                 {
+                                                     AddDefaults(context);
+                                                     context.Variables.Add(PowerShellVariables.Edition, ScriptVariables.ScriptSourceOptions.Core);
+                                                     context.Variables.Add(ScriptVariables.ScriptSource, ScriptVariables.ScriptSourceOptions.Inline);
+                                                     context.Variables.Add(ScriptVariables.Syntax, ScriptSyntax.PowerShell.ToString());
+                                                     context.Variables.Add(ScriptVariables.ScriptBody, psScript);
+                                                 })
+                                    .Execute();
+        }
+
+        [Test]
+        [RequiresPowerShell5OrAbove]
         public async Task ExecuteAnInlinePowerShellCoreScriptAgainstAnInvalidAzureEnvironment()
         {
             var psScript = @"

--- a/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
+++ b/source/Calamari.AzureScripting/Scripts/AzureContext.ps1
@@ -239,7 +239,8 @@ try {
 
     throw
 } finally {
-    If (!$OctopusDisableAzureCLI -or $OctopusDisableAzureCLI -like [Boolean]::FalseString) {
+    # Check the variable exists before reading in case user's script enabled Set-StrictMode
+    If (-not (Test-Path Variable:OctopusDisableAzureCLI) -or !$OctopusDisableAzureCLI -or $OctopusDisableAzureCLI -like [Boolean]::FalseString) {
         try {
             # Save the last exit code so az logout doesn't clobber it
             $previousLastExitCode = $LastExitCode


### PR DESCRIPTION
## Background
`AzureContext.ps1` script wraps user's scripts supplied in Azure steps. Because this was dot sourced (and I'm guessing there's a good reason to do so), the strict-mode applied to the finally block too.

The finally block reads the `OctopusDisableAzureCLI` variable, which is _optional_. In non-strict mode, this is harmless as an undefined variable evaluates to null. But in strict mode, an undefined variable will throw an error of:
```
InvalidOperation: The variable '$OctopusDisableAzureCLI' cannot be retrieved because it has not been set.
```

This PR is to check whether the variable exists before evaluating it, to prevent deployments resulting in a failed state.



Related to https://github.com/OctopusDeploy/Issues/issues/5489
Related to HPY-54