### PR TITLE
Revert https://github.com/OctopusDeploy/Calamari/pull/1913

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -10,6 +10,7 @@
         <Owners>Octopus Deploy</Owners>        
         <Title>Calamari.Common</Title>
         <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>
+        <PackageLicenseUrl>https://github.com/OctopusDeploy/Calamari/blob/main/LICENSE.txt</PackageLicenseUrl>        
         <PackageLicenseUrl>https://github.com/OctopusDeploy/Calamari/blob/main/LICENSE.txt</PackageLicenseUrl>
     </PropertyGroup>
 

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -10,7 +10,6 @@
         <Owners>Octopus Deploy</Owners>        
         <Title>Calamari.Common</Title>
         <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>
-        <PackageLicenseUrl>https://github.com/OctopusDeploy/Calamari/blob/main/LICENSE.txt</PackageLicenseUrl>        
         <PackageLicenseUrl>https://github.com/OctopusDeploy/Calamari/blob/main/LICENSE.txt</PackageLicenseUrl>
     </PropertyGroup>
 

--- a/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
@@ -19,7 +19,7 @@
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Serilog" Version="2.10.0" />
-      <PackageReference Include="SharpCompress" Version="0.37.2" />
+      <PackageReference Include="SharpCompress" Version="0.37.2" ><NoWarn>NU1902</NoWarn></PackageReference>
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Calamari.ConsolidateCalamariPackages.Api\Calamari.ConsolidateCalamariPackages.Api.csproj" />

--- a/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
@@ -19,6 +19,7 @@
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Serilog" Version="2.10.0" />
+      <PackageReference Include="SharpCompress" Version="0.37.2" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Calamari.ConsolidateCalamariPackages.Api\Calamari.ConsolidateCalamariPackages.Api.csproj" />

--- a/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackage.cs
+++ b/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackage.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using Octopus.Calamari.ConsolidatedPackage.Api;
+using SharpCompress.Archives.Zip;
 
 namespace Octopus.Calamari.ConsolidatedPackage
 {
@@ -28,16 +28,21 @@ namespace Octopus.Calamari.ConsolidatedPackage
                 throw new Exception($"Could not find platform {platform} for {calamariFlavour}");
             }
 
-            var platformFilesLookup = platformFiles.ToDictionary(f => f.Source);
-
-            using var sourceStream = packageStreamProvider.OpenStream();
-            using var source = new ZipArchive(sourceStream, ZipArchiveMode.Read);
-            foreach (var sourceEntry in source.Entries)
+            using (var sourceStream = packageStreamProvider.OpenStream())
             {
-                if (!platformFilesLookup.TryGetValue(sourceEntry.FullName, out var fileTransfer)) continue;
-
-                using var sourceEntryStream = sourceEntry.Open();
-                yield return (fileTransfer.Destination, sourceEntry.Length, sourceEntryStream);
+                using (var source = ZipArchive.Open(sourceStream))
+                {
+                    foreach (var fileTransfer in platformFiles)
+                    {
+                        var sourceEntry = source.Entries.FirstOrDefault(e => e.Key is not null && e.Key.Equals(fileTransfer.Source));
+                        if(sourceEntry is null) continue;
+                    
+                        using (var sourceEntryStream = sourceEntry.OpenEntryStream())
+                        {
+                            yield return (fileTransfer.Destination, sourceEntry.Size, sourceEntryStream);
+                        }
+                    }
+                }
             }
         }
     }

--- a/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackageIndexLoader.cs
+++ b/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackageIndexLoader.cs
@@ -1,8 +1,9 @@
 using System;
 using System.IO;
-using System.IO.Compression;
+using System.Linq;
 using Newtonsoft.Json;
 using Octopus.Calamari.ConsolidatedPackage.Api;
+using SharpCompress.Archives.Zip;
 
 namespace Octopus.Calamari.ConsolidatedPackage
 {
@@ -10,14 +11,14 @@ namespace Octopus.Calamari.ConsolidatedPackage
     {
         public IConsolidatedPackageIndex Load(Stream zipStream)
         {
-            using var zip = new ZipArchive(zipStream, ZipArchiveMode.Read);
-            var entry = zip.GetEntry("index.json");
+            using var zip = ZipArchive.Open(zipStream);
+            var entry = zip.Entries.First(e => e.Key == "index.json");
             if (entry == null)
             {
                 throw new Exception($"index.json not found in supplied stream.");
             }
 
-            using var entryStream = entry.Open();
+            using var entryStream = entry.OpenEntryStream();
             return From(entryStream);
         }
 


### PR DESCRIPTION
Changes in [https://github.com/OctopusDeploy/Calamari/pull/1913](https://github.com/OctopusDeploy/Calamari/pull/1913) we causing execution failures. This PR removes them until a path forward can be determined and have them re-added

This reverts commit 81363b6ff1440f1a19c83a3899b33ad18d4d7caa, reversing changes made to 6c820fd47b5246cea2e36afe719a6d74754d6970.

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

Reverts changes that caused Calamari failures