### PR TITLE
Fix handling of duplicate files in the Calamari package, add tests

### DIFF
--- a/source/Calamari.ConsolidateCalamariPackages.Tests/ConsolidatedPackageTests.cs
+++ b/source/Calamari.ConsolidateCalamariPackages.Tests/ConsolidatedPackageTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NUnit.Framework;
+using Octopus.Calamari.ConsolidatedPackage;
+using Octopus.Calamari.ConsolidatedPackage.Api;
+
+namespace Calamari.ConsolidateCalamariPackages.Tests;
+
+[TestFixture]
+public class ConsolidatedPackageTests
+{
+    [Test]
+    public void ExtractCalamariPackage_ExtractsPlatformFiles()
+    {
+        // Taken from real Calamari index.json
+        var index = new ConsolidatedPackageIndex(new Dictionary<string, IConsolidatedPackageIndex.Package>
+        {
+            ["Calamari"] =
+                new("Calamari",
+                    "2025.4.682",
+                    IsNupkg: true,
+                    new Dictionary<string, IConsolidatedPackageIndex.FileTransfer[]>
+                    {
+                        ["linux-x64"] =
+                        [
+                            new("e53319a5e0ad28139f18abff2a3846a2/Octopus.Calamari.linux-x64.nuspec", "Octopus.Calamari.linux-x64.nuspec"),
+                            new("3103c6689c0c54d1951cd48c91fd07d3/Calamari.Shared.dll", "Calamari.Shared.dll"),
+                            new("9530f39bf5be0d28a050a0d536354840/Calamari.dll", "Calamari.dll"),
+                        ],
+                        ["win-x64"] =
+                        [
+                            new("6f7d961cb2643f9b4676db6c6b2fb050/Octopus.Calamari.win-x64.nuspec", "Octopus.Calamari.win-x64.nuspec"),
+                            new("aa773c55c461d2bc95d3ec23d0c2affc/Calamari.Shared.dll", "Calamari.Shared.dll"),
+                            new("31e6370cd8472603f2082ada35be3cc3/Calamari.dll", "Calamari.dll"),
+                        ],
+                    })
+        });
+
+        var streamProvider =
+            BuildZipArchive(("e53319a5e0ad28139f18abff2a3846a2/Octopus.Calamari.linux-x64.nuspec", "aaa_Octopus.Calamari.linux-x64"),
+                            ("3103c6689c0c54d1951cd48c91fd07d3/Calamari.Shared.dll", "aab_Calamari.Shared.dll"),
+                            ("9530f39bf5be0d28a050a0d536354840/Calamari.dll", "aac_Calamari.dll"),
+                            ("6f7d961cb2643f9b4676db6c6b2fb050/Octopus.Calamari.win-x64.nuspec", "baa_Octopus.Calamari.linux-x64"),
+                            ("aa773c55c461d2bc95d3ec23d0c2affc/Calamari.Shared.dll", "bab_Calamari.Shared.dll"),
+                            ("31e6370cd8472603f2082ada35be3cc3/Calamari.dll", "bac_Calamari.dll"));
+
+        var p = new ConsolidatedPackage(streamProvider, index);
+
+        var linux64 = p.ExtractCalamariPackage("Calamari", "linux-x64").Select(i => i.entryName).ToArray();
+        linux64.Should().Equal("Octopus.Calamari.linux-x64.nuspec", "Calamari.Shared.dll", "Calamari.dll");
+
+        var win64 = p.ExtractCalamariPackage("Calamari", "win-x64").Select(i => i.entryName).ToArray();
+        win64.Should().Equal("Octopus.Calamari.win-x64.nuspec", "Calamari.Shared.dll", "Calamari.dll");
+    }
+
+    [Test]
+    public void ExtractCalamariPackage_ExtractsSameFileContentsToDifferentOutputs()
+    {
+        var index = new ConsolidatedPackageIndex(new Dictionary<string, IConsolidatedPackageIndex.Package>
+        {
+            ["Chicken"] =
+                new("Chicken",
+                    "1",
+                    IsNupkg: true,
+                    new Dictionary<string, IConsolidatedPackageIndex.FileTransfer[]>
+                    {
+                        ["linux-x64"] =
+                        [
+                            new("e53319a5e0ad28139f18abff2a3846a2/Chicken.txt", "Chicken.txt"),
+                            new("e53319a5e0ad28139f18abff2a3846a2/Chicken.txt", "Subfolder/Chicken.txt"),
+                        ],
+                    })
+        });
+
+        var customStreamProvider = BuildZipArchive(("e53319a5e0ad28139f18abff2a3846a2/Chicken.txt", "Crazy chickens jab, peck, and flap while quietly dozing foxes get very humid"));
+
+        var p = new ConsolidatedPackage(customStreamProvider, index);
+
+        // ExtractCalamariPackage returns an IEnumerable containing streams which are closed as we move through the IEnumerable
+        // We can't call ToArray on it or all the streams get closed before we can read them.
+        using var enumerator = p.ExtractCalamariPackage("Chicken", "linux-x64").GetEnumerator();
+
+        enumerator.MoveNext().Should().BeTrue();
+        {
+            var (entryName, size, sourceStream) = enumerator.Current;
+            entryName.Should().Be("Chicken.txt");
+            size.Should().Be(76);
+            new StreamReader(sourceStream).ReadToEnd().Should().Be("Crazy chickens jab, peck, and flap while quietly dozing foxes get very humid");
+        }
+
+        enumerator.MoveNext().Should().BeTrue();
+        {
+            var (entryName, size, sourceStream) = enumerator.Current;
+            entryName.Should().Be("Subfolder/Chicken.txt");
+            size.Should().Be(76);
+            new StreamReader(sourceStream).ReadToEnd().Should().Be("Crazy chickens jab, peck, and flap while quietly dozing foxes get very humid");
+        }
+        
+        enumerator.MoveNext().Should().BeFalse(because: "No more files in the index");
+    }
+
+    class FakeConsolidatedPackageStreamProvider(byte[] zipFileContents) : IConsolidatedPackageStreamProvider
+    {
+        public Stream OpenStream() => new MemoryStream(zipFileContents);
+    }
+
+    static FakeConsolidatedPackageStreamProvider BuildZipArchive(params (string, string)[] filesAndContents)
+    {
+        using var stream = new MemoryStream();
+        using (var z = new ZipArchive(stream, ZipArchiveMode.Create))
+        {
+            foreach (var (file, content) in filesAndContents)
+            {
+                var entry = z.CreateEntry(file, CompressionLevel.NoCompression);
+                using var entryStream = entry.Open();
+                using var writer = new StreamWriter(entryStream);
+                writer.Write(content);
+            }
+        }
+
+        return new(stream.ToArray());
+    }
+}

--- a/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackage.cs
+++ b/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackage.cs
@@ -10,7 +10,7 @@ namespace Octopus.Calamari.ConsolidatedPackage
     public class ConsolidatedPackage : IConsolidatedPackage
     {
         readonly IConsolidatedPackageStreamProvider packageStreamProvider;
-        
+
         public ConsolidatedPackage(IConsolidatedPackageStreamProvider packageStreamProvider, IConsolidatedPackageIndex index)
         {
             this.packageStreamProvider = packageStreamProvider;
@@ -28,17 +28,35 @@ namespace Octopus.Calamari.ConsolidatedPackage
                 throw new Exception($"Could not find platform {platform} for {calamariFlavour}");
             }
 
-            var platformFilesLookup = platformFiles.ToDictionary(f => f.Source);
-
-            using var sourceStream = packageStreamProvider.OpenStream();
-            using var source = new ZipArchive(sourceStream, ZipArchiveMode.Read);
-            foreach (var sourceEntry in source.Entries)
+            using (var sourceStream = packageStreamProvider.OpenStream())
             {
-                if (!platformFilesLookup.TryGetValue(sourceEntry.FullName, out var fileTransfer)) continue;
+                using (var source = new ZipArchive(sourceStream, ZipArchiveMode.Read))
+                {
+                    foreach (var fileTransfer in platformFiles)
+                    {
+                        var sourceEntry = source.Entries.FirstOrDefault(e => e.FullName.Equals(fileTransfer.Source));
+                        if (sourceEntry is null) continue;
 
-                using var sourceEntryStream = sourceEntry.Open();
-                yield return (fileTransfer.Destination, sourceEntry.Length, sourceEntryStream);
+                        using (var sourceEntryStream = sourceEntry.Open())
+                        {
+                            yield return (fileTransfer.Destination, sourceEntry.Length, sourceEntryStream);
+                        }
+                    }
+                }
             }
         }
+
+        //
+        // var platformFilesLookup = platformFiles.ToDictionary(f => f.Source);
+        //
+        // using var sourceStream = packageStreamProvider.OpenStream();
+        // using var source = new ZipArchive(sourceStream, ZipArchiveMode.Read);
+        // foreach (var sourceEntry in source.Entries)
+        // {
+        //     if (!platformFilesLookup.TryGetValue(sourceEntry.FullName, out var fileTransfer)) continue;
+        //
+        //     using var sourceEntryStream = sourceEntry.Open();
+        //     yield return (fileTransfer.Destination, sourceEntry.Length, sourceEntryStream);
+        // }
     }
 }

--- a/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackage.cs
+++ b/source/Calamari.ConsolidateCalamariPackages/ConsolidatedPackage.cs
@@ -28,35 +28,20 @@ namespace Octopus.Calamari.ConsolidatedPackage
                 throw new Exception($"Could not find platform {platform} for {calamariFlavour}");
             }
 
-            using (var sourceStream = packageStreamProvider.OpenStream())
-            {
-                using (var source = new ZipArchive(sourceStream, ZipArchiveMode.Read))
-                {
-                    foreach (var fileTransfer in platformFiles)
-                    {
-                        var sourceEntry = source.Entries.FirstOrDefault(e => e.FullName.Equals(fileTransfer.Source));
-                        if (sourceEntry is null) continue;
+            using var sourceStream = packageStreamProvider.OpenStream();
+            using var source = new ZipArchive(sourceStream, ZipArchiveMode.Read);
 
-                        using (var sourceEntryStream = sourceEntry.Open())
-                        {
-                            yield return (fileTransfer.Destination, sourceEntry.Length, sourceEntryStream);
-                        }
-                    }
+            var entriesLookup = source.Entries.ToDictionary(e => e.FullName);
+            foreach (var fileTransfer in platformFiles)
+            {
+                if (!entriesLookup.TryGetValue(fileTransfer.Source, out var sourceEntry))
+                {
+                    continue;
                 }
+
+                using var sourceEntryStream = sourceEntry.Open();
+                yield return (fileTransfer.Destination, sourceEntry.Length, sourceEntryStream);
             }
         }
-
-        //
-        // var platformFilesLookup = platformFiles.ToDictionary(f => f.Source);
-        //
-        // using var sourceStream = packageStreamProvider.OpenStream();
-        // using var source = new ZipArchive(sourceStream, ZipArchiveMode.Read);
-        // foreach (var sourceEntry in source.Entries)
-        // {
-        //     if (!platformFilesLookup.TryGetValue(sourceEntry.FullName, out var fileTransfer)) continue;
-        //
-        //     using var sourceEntryStream = sourceEntry.Open();
-        //     yield return (fileTransfer.Destination, sourceEntry.Length, sourceEntryStream);
-        // }
     }
 }


### PR DESCRIPTION
# Background

Previously in [ConsolidatePackages: Use System.IO.Compression and slightly tweak extraction loop](https://github.com/OctopusDeploy/Calamari/pull/1913) I updated the code to use System.IO.Compression instead of SharpCompress when extracting the calamari package.

Foolishly I also altered the algorithm, using dictionary-lookups instead of linear scans inside a nested loop. The algorithm did not handle the case where a file might exist one time within the Calamari archive, but be extracted to more than one file on the destination filesystem.

Leading to these errors when used inside Octopus

```
unning this script in the Octopus Server security context (jt)
Acquiring isolation mutex RunningScript with NoIsolation in ServerTasks-6001
Executable directory is '/bin'
Executable name or full path: '/bin/bash'
No user context provided. Running as current user.
Starting '/bin/bash' in working directory '/Users/jt/OctopusDev/main/Server/Work/20260511050132-6001-4' using 'Unicode (UTF-8)' encoding running as 'jt' with the same environment variables as the launching process
Process '/bin/bash' in '/Users/jt/OctopusDev/main/Server/Work/20260511050132-6001-4' exited with code 0
An item with the same key has already been added. Key: f45226e320f41097397b1ba7468c2d1c/Microsoft.Extensions.Primitives.dll
An item with the same key has already been added. Key: f45226e320f41097397b1ba7468c2d1c/Microsoft.Extensions.Primitives.dll System.ArgumentException: An item with the same key has already been added. Key: f45226e320f41097397b1ba7468c2d1c/Microsoft.Extensions.Primitives.dll
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at System.Linq.Enumerable.SpanToDictionary[TSource,TKey](ReadOnlySpan`1 source, Func`2 keySelector, IEqualityComparer`1 comparer)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey](IEnumerable`1 source, Func`2 keySelector, IEqualityComparer`1 comparer)
   at Octopus.Calamari.ConsolidatedPackage.ConsolidatedPackage.ExtractCalamariPackage(String calamariFlavour, String platform)+MoveNext()
   at Octopus.Server.Orchestration.Targets.Common.BundledPackages.ConsolidatedPackageBundledPackageSource.PopulateArchive(CalamariPackage package, Action`3 write) in /Users/jt/Developer/Octopus/OctopusDeploy/source/Octopus.Server/Orchestration/Targets/Common/BundledPackages/ConsolidatedPackageBundledPackageSource.cs:line 96
   at Octopus.Server.Orchestration.Targets.Common.BundledPackages.ConsolidatedPackageBundledPackageSource.CreateArchive(CalamariPackage calamariPackage, Stream stream, CompressionType compressionType) in /Users/jt/Developer/Octopus/OctopusDeploy/source/Octopus.Server/Orchestration/Targets/Common/BundledPackages/ConsolidatedPackageBundledPackageSource.cs:line 70
```

# Results / How to review this PR

- The first commit reverts the algorithm to the original nested loop using sharpcompress, and adds some unit tests to cover both the basic case, and the duplicate case.
- The second commit re-introduces a dictionary optimization, but in a smaller way which does not break the algorithm.
