### PR TITLE
feat: stub Health Check to Conventional ECS Targets

### DIFF
--- a/source/Calamari.Aws/Commands/EcsClusterHealthCheck.cs
+++ b/source/Calamari.Aws/Commands/EcsClusterHealthCheck.cs
@@ -1,0 +1,14 @@
+using System;
+using Calamari.Commands.Support;
+using Calamari.Common.Commands;
+
+namespace Calamari.Aws.Commands;
+
+[Command("aws-ecs-health-check", Description = "Run a health check on an AWS ECS Cluster")]
+public class HealthCheckCommand : Command
+{
+    public override int Execute(string[] commandLineArguments)
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
Conventional ECS targets were created to replace the versions in SPF.

The initial implementation did not have a HealthCheck implemented. This stubs the method (and always returns "healthy"). A future PR will provide an actual implementation.

Note: Conventional Targets are still Feature toggled off until migration is complete.