### PR TITLE
Fixes obsolete message warning

### DIFF
--- a/source/Calamari.CloudAccounts/AzureOidcAccountExtensions.cs
+++ b/source/Calamari.CloudAccounts/AzureOidcAccountExtensions.cs
@@ -15,7 +15,7 @@ namespace Calamari.CloudAccounts
             Log.Verbose($"Authentication Context: {authContext}");
 
             var app = ConfidentialClientApplicationBuilder.Create(applicationId)
-                                                          .WithClientAssertion(token)
+                                                          .WithClientAssertion((AssertionRequestOptions _) => Task.FromResult(token))
                                                           .WithAuthority(authContext)
                                                           .WithHttpClientFactory(authClientFactory)
                                                           .Build();


### PR DESCRIPTION
Updates OIDC extensions to get rid of warning message in build log and use recommended method call
