### PR TITLE
CommitToGit should strip non-wildcarded section of the input path prior to copy

### DIFF
--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -360,7 +360,7 @@ namespace Calamari.Deployment
                 public const string Username = "Octopus.Action.Git.TargetRepositoryUsername";
                 public const string Password = "Octopus.Action.Git.TargetRepositoryPassword";
                 public const string Reference = "Octopus.Action.Git.TargetRepositoryBranch";
-                public const string DestinationPath = "Octopus.Action.Git.TargetRepositoryDestinationPath";
+                public const string DestinationPath = "Octopus.Action.Git.TargetRepositoryPath";
 
                 public const string InputFileSources = "Octopus.Action.Git.InputFileSources";
 

--- a/source/Calamari.Tests/CommitToGit/CommitToGitDependencyMetadataParserFixture.cs
+++ b/source/Calamari.Tests/CommitToGit/CommitToGitDependencyMetadataParserFixture.cs
@@ -150,13 +150,25 @@ namespace Calamari.Tests.CommitToGit
         [Test]
         public void GetGitRepositoryDependenciesForCopying_WhenGitRepositoryType_ReturnsDependencyWithCorrectFields()
         {
-            SetInputFileSources("[{\"Type\":\"GitRepository\",\"GitDependencyName\":\"my-repo\",\"DestinationSubFolder\":\"output\"}]");
+            SetInputFileSources("[{\"Type\":\"GitRepository\",\"GitDependencyName\":\"my-repo\",\"DestinationSubFolder\":\"output\",\"InputFilePaths\":[\"src/**/*\",\"docs/**/*\"]}]");
 
             var result = sut.GetGitRepositoryDependenciesForCopying(deployment).ToList();
 
             result.Should().HaveCount(1);
             result[0].GitDependencyName.Should().Be("my-repo");
             result[0].DestinationSubFolder.Should().Be("output");
+            result[0].InputFilePaths.Should().BeEquivalentTo("src/**/*", "docs/**/*");
+        }
+
+        [Test]
+        public void GetGitRepositoryDependenciesForCopying_WhenInputFilePathsNotSpecified_DefaultsToWildcard()
+        {
+            SetInputFileSources("[{\"Type\":\"GitRepository\",\"GitDependencyName\":\"my-repo\",\"DestinationSubFolder\":\"\"}]");
+
+            var result = sut.GetGitRepositoryDependenciesForCopying(deployment).ToList();
+
+            result.Should().HaveCount(1);
+            result[0].InputFilePaths.Should().BeEquivalentTo("**/*");
         }
 
         [Test]
@@ -173,12 +185,14 @@ namespace Calamari.Tests.CommitToGit
         public void GetGitRepositoryDependenciesForCopying_EvaluatesVariablesInGitProperties()
         {
             deployment.Variables.Set("RepoNameVar", "resolved-repo");
-            SetInputFileSources("[{\"Type\":\"GitRepository\",\"GitDependencyName\":\"#{RepoNameVar}\",\"DestinationSubFolder\":\"\"}]");
+            deployment.Variables.Set("PathVar", "src/app");
+            SetInputFileSources("[{\"Type\":\"GitRepository\",\"GitDependencyName\":\"#{RepoNameVar}\",\"DestinationSubFolder\":\"\",\"InputFilePaths\":[\"#{PathVar}/**/*\"]}]");
 
             var result = sut.GetGitRepositoryDependenciesForCopying(deployment).ToList();
 
             result.Should().HaveCount(1);
             result[0].GitDependencyName.Should().Be("resolved-repo");
+            result[0].InputFilePaths.Should().BeEquivalentTo("src/app/**/*");
         }
 
         [Test]

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -153,6 +153,33 @@ public class CommitToGitCommandTest
     }
 
     [Test]
+    [TestCase("manifests/**/*", "manifests/sub/app.yaml", "sub/app.yaml", TestName = "DeepGlob_StripsNonWildcardPrefix")]
+    [TestCase("manifests/*.yaml", "manifests/app.yaml", "app.yaml", TestName = "SingleStarGlob_StripsNonWildcardPrefix")]
+    [TestCase("manifests/sub/app.yaml", "manifests/sub/app.yaml", "app.yaml", TestName = "ExactPath_StripsDirectoryKeepsFilename")]
+    [TestCase("**/*.yaml", "manifests/sub/app.yaml", "manifests/sub/app.yaml", TestName = "RootGlob_NothingToStripPreservesMatchedRelativePath")]
+    public void DestinationPathStripsNonWildcardPrefixOfInputGlob(string inputGlob, string packageEntryPath, string expectedRepoPath)
+    {
+        const string packageReferenceName = "my-configs";
+        const string destinationPath = "output-dir";
+
+        var zipPath = CreateZipWithEntry(packageReferenceName, packageEntryPath, "irrelevant");
+
+        var inputFileSources = $"[{{\"Type\":\"Package\",\"PackageId\":\"{packageReferenceName}\",\"PackageName\":\"{packageReferenceName}\",\"InputFilePaths\":[\"{inputGlob}\"],\"DestinationSubFolder\":\"\"}}]";
+        variables.AddRange([
+            new CalamariExecutionVariable(PackageVariables.IndexedPackageId(packageReferenceName), packageReferenceName, false),
+            new CalamariExecutionVariable(PackageVariables.IndexedOriginalPath(packageReferenceName), zipPath, false),
+            new CalamariExecutionVariable(PackageVariables.IndexedExtract(packageReferenceName), "True", false),
+            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.InputFileSources, inputFileSources, false),
+            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.DestinationPath, destinationPath, false),
+        ]);
+
+        RunCommitToGit().Should().Be(0);
+
+        GetCommittedFileContent($"{destinationPath}/{expectedRepoPath}")
+            .Should().NotBeNull($"file matched by '{inputGlob}' should land at '{destinationPath}/{expectedRepoPath}'");
+    }
+
+    [Test]
     public void OnlyCopiesFilesMatchingInputPathsFromPackageIntoGitRepository()
     {
         const string packageReferenceName = "my-configs";
@@ -169,7 +196,7 @@ public class CommitToGitCommandTest
 
         GetCommittedFileContent($"{destinationPath}/configs/settings.json")
             .Should().NotBeNull("files matching the InputFilePaths glob should be copied");
-        GetCommittedFileContent($"{destinationPath}/scripts/setup.sh")
+        GetCommittedFileContent($"{destinationPath}/configs/setup.sh")
             .Should().BeNull("files not matching the InputFilePaths glob should not be copied");
     }
 
@@ -263,7 +290,7 @@ public class CommitToGitCommandTest
         var zip1Path = CreateZipWithEntry(package1Name, "configs/settings.json", "{}");
         var zip2Path = CreateZipWithEntry(package2Name, "configs/template.yaml", "apiVersion: apps/v1");
 
-        var templateValueSources =
+        var inputFileSources =
             $"[" +
             $"{{\"Type\":\"Package\",\"PackageId\":\"{package1Name}\",\"PackageName\":\"{package1Name}\",\"InputFilePaths\":[\"configs/**/*\"],\"DestinationSubFolder\":\"\"}}," +
             $"{{\"Type\":\"Package\",\"PackageId\":\"{package2Name}\",\"PackageName\":\"{package2Name}\",\"InputFilePaths\":[\"configs/**/*\"],\"DestinationSubFolder\":\"\"}}" +
@@ -276,13 +303,13 @@ public class CommitToGitCommandTest
             new CalamariExecutionVariable(PackageVariables.IndexedPackageId(package2Name), package2Name, false),
             new CalamariExecutionVariable(PackageVariables.IndexedOriginalPath(package2Name), zip2Path, false),
             new CalamariExecutionVariable(PackageVariables.IndexedExtract(package2Name), "True", false),
-            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.InputFileSources, templateValueSources, false),
+            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.InputFileSources, inputFileSources, false),
             new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.DestinationPath, destinationPath, false),
         ]);
 
         RunCommitToGit().Should().Be(0);
-        GetCommittedFileContent($"{destinationPath}/configs/settings.json").Should().NotBeNull("files from the first package should be copied");
-        GetCommittedFileContent($"{destinationPath}/configs/template.yaml").Should().NotBeNull("files from the second package should be copied");
+        GetCommittedFileContent($"{destinationPath}/settings.json").Should().NotBeNull("files from the first package should be copied (with the non-wildcard glob prefix stripped)");
+        GetCommittedFileContent($"{destinationPath}/template.yaml").Should().NotBeNull("files from the second package should be copied (with the non-wildcard glob prefix stripped)");
     }
 
     [Test]
@@ -294,20 +321,20 @@ public class CommitToGitCommandTest
 
         var zipPath = CreateZipWithEntry(packageReferenceName, "configs/settings.json", "{\"setting\": \"value\"}");
 
-        var templateValueSources = $"[{{\"Type\":\"Package\",\"PackageId\":\"{packageReferenceName}\",\"PackageName\":\"{packageReferenceName}\",\"InputFilePaths\":[\"configs/**/*\"],\"DestinationSubFolder\":\"{destinationSubFolder}\"}}]";
+        var inputFileSources = $"[{{\"Type\":\"Package\",\"PackageId\":\"{packageReferenceName}\",\"PackageName\":\"{packageReferenceName}\",\"InputFilePaths\":[\"configs/**/*\"],\"DestinationSubFolder\":\"{destinationSubFolder}\"}}]";
         variables.AddRange([
             new CalamariExecutionVariable(PackageVariables.IndexedPackageId(packageReferenceName), packageReferenceName, false),
             new CalamariExecutionVariable(PackageVariables.IndexedOriginalPath(packageReferenceName), zipPath, false),
             new CalamariExecutionVariable(PackageVariables.IndexedExtract(packageReferenceName), "True", false),
-            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.InputFileSources, templateValueSources, false),
+            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.InputFileSources, inputFileSources, false),
             new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.DestinationPath, destinationPath, false),
         ]);
 
         RunCommitToGit().Should().Be(0);
 
-        GetCommittedFileContent($"{destinationPath}/{destinationSubFolder}/configs/settings.json")
-            .Should().NotBeNull("package files should be placed under the DestinationSubFolder from the source metadata");
-        GetCommittedFileContent($"{destinationPath}/configs/settings.json")
+        GetCommittedFileContent($"{destinationPath}/{destinationSubFolder}/settings.json")
+            .Should().NotBeNull("package files should be placed under the DestinationSubFolder from the source metadata (with the non-wildcard glob prefix stripped)");
+        GetCommittedFileContent($"{destinationPath}/settings.json")
             .Should().BeNull("package files should not be placed directly under the top-level DestinationPath when a DestinationSubFolder is specified");
     }
 
@@ -455,25 +482,27 @@ public class CommitToGitCommandTest
 
     void AddInputPackageVariables(string packageReferenceName, string zipPath, string destinationPath)
     {
-        var templateValueSources = $"[{{\"Type\":\"Package\",\"PackageId\":\"{packageReferenceName}\",\"PackageName\":\"{packageReferenceName}\",\"InputFilePaths\":[\"configs/**/*\"],\"DestinationSubFolder\":\"\"}}]";
+        var inputFileSources = $"[{{\"Type\":\"Package\",\"PackageId\":\"{packageReferenceName}\",\"PackageName\":\"{packageReferenceName}\",\"InputFilePaths\":[\"configs/**/*\"],\"DestinationSubFolder\":\"\"}}]";
         variables.AddRange([
-            // Package to copy into the repository, declared via TemplateValuesSources
+            // Package to copy into the repository, declared via InputFileSources
             new CalamariExecutionVariable(PackageVariables.IndexedPackageId(packageReferenceName), packageReferenceName, false),
             new CalamariExecutionVariable(PackageVariables.IndexedOriginalPath(packageReferenceName), zipPath, false),
             new CalamariExecutionVariable(PackageVariables.IndexedExtract(packageReferenceName), "True", false),
-            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.InputFileSources, templateValueSources, false),
-            // Override the destination path set in setUp
-            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.DestinationPath, destinationPath, false),
+            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.InputFileSources, inputFileSources, false),
+            // Override the destination path set in setUp. Suffix with "configs" so the prefix that the new
+            // strip-non-wildcard behaviour removes from `configs/**/*` is reintroduced — keeps the helper's
+            // committed paths aligned with the package layout.
+            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.DestinationPath, Path.Combine(destinationPath, "configs"), false),
         ]);
     }
 
     void AddInputGitReferenceVariables(string gitDependencyName, string zipPath, string destinationPath, string destinationSubFolder = "")
     {
-        var templateValueSources = $"[{{\"Type\":\"GitRepository\",\"GitDependencyName\":\"{gitDependencyName}\",\"DestinationSubFolder\":\"{destinationSubFolder}\"}}]";
+        var inputFileSources = $"[{{\"Type\":\"GitRepository\",\"GitDependencyName\":\"{gitDependencyName}\",\"DestinationSubFolder\":\"{destinationSubFolder}\"}}]";
         variables.AddRange([
             new CalamariExecutionVariable(Deployment.SpecialVariables.GitResources.Extract(gitDependencyName), "true", false),
             new CalamariExecutionVariable(Deployment.SpecialVariables.GitResources.OriginalPath(gitDependencyName), zipPath, false),
-            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.InputFileSources, templateValueSources, false),
+            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.InputFileSources, inputFileSources, false),
             new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.DestinationPath, destinationPath, false),
         ]);
     }

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using Calamari.ArgoCD.Git;
 using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing.Extensions;

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -359,6 +359,46 @@ public class CommitToGitCommandTest
     }
 
     [Test]
+    [TestCase("manifests/**/*", "manifests/sub/app.yaml", "sub/app.yaml", TestName = "GitDep_DeepGlob_StripsNonWildcardPrefix")]
+    [TestCase("manifests/*.yaml", "manifests/app.yaml", "app.yaml", TestName = "GitDep_SingleStarGlob_StripsNonWildcardPrefix")]
+    [TestCase("manifests/sub/app.yaml", "manifests/sub/app.yaml", "app.yaml", TestName = "GitDep_ExactPath_StripsDirectoryKeepsFilename")]
+    [TestCase("**/*.yaml", "manifests/sub/app.yaml", "manifests/sub/app.yaml", TestName = "GitDep_RootGlob_NothingToStripPreservesMatchedRelativePath")]
+    public void GitDependencyDestinationPathStripsNonWildcardPrefixOfInputGlob(string inputGlob, string entryPath, string expectedRepoPath)
+    {
+        const string gitDependencyName = "my-git-dep";
+        const string destinationPath = "output-dir";
+
+        var zipPath = CreateZipWithEntry(gitDependencyName, entryPath, "apiVersion: apps/v1");
+        AddInputGitReferenceVariables(gitDependencyName, zipPath, destinationPath, inputFilePaths: new[] { inputGlob });
+
+        RunCommitToGit().Should().Be(0);
+
+        GetCommittedFileContent($"{destinationPath}/{expectedRepoPath}")
+            .Should().NotBeNull($"file matched by '{inputGlob}' should land at '{destinationPath}/{expectedRepoPath}'");
+    }
+
+    [Test]
+    public void OnlyCopiesFilesMatchingInputPathsFromGitDependencyIntoGitRepository()
+    {
+        const string gitDependencyName = "my-git-dep";
+        const string destinationPath = "output-dir";
+
+        var zipPath = CreateZipWithEntries(gitDependencyName, new Dictionary<string, string>
+        {
+            ["manifests/deployment.yaml"] = "apiVersion: apps/v1",
+            ["scripts/setup.sh"] = "#!/bin/bash",
+        });
+        AddInputGitReferenceVariables(gitDependencyName, zipPath, destinationPath, inputFilePaths: new[] { "manifests/**/*" });
+
+        RunCommitToGit().Should().Be(0);
+
+        GetCommittedFileContent($"{destinationPath}/deployment.yaml")
+            .Should().NotBeNull("files matching the InputFilePaths glob should be copied");
+        GetCommittedFileContent($"{destinationPath}/scripts/setup.sh")
+            .Should().BeNull("files not matching the InputFilePaths glob should not be copied");
+    }
+
+    [Test]
     public void CommitToGitRunsScriptProvidedViaScriptBodyBySyntaxVariable()
     {
         variables.AddRange([
@@ -498,9 +538,12 @@ public class CommitToGitCommandTest
         ]);
     }
 
-    void AddInputGitReferenceVariables(string gitDependencyName, string zipPath, string destinationPath, string destinationSubFolder = "")
+    void AddInputGitReferenceVariables(string gitDependencyName, string zipPath, string destinationPath, string destinationSubFolder = "", string[] inputFilePaths = null)
     {
-        var inputFileSources = $"[{{\"Type\":\"GitRepository\",\"GitDependencyName\":\"{gitDependencyName}\",\"DestinationSubFolder\":\"{destinationSubFolder}\"}}]";
+        var inputFilePathsJson = inputFilePaths != null
+            ? "[" + string.Join(",", inputFilePaths.Select(p => $"\"{p}\"")) + "]"
+            : "[\"**/*\"]";
+        var inputFileSources = $"[{{\"Type\":\"GitRepository\",\"GitDependencyName\":\"{gitDependencyName}\",\"DestinationSubFolder\":\"{destinationSubFolder}\",\"InputFilePaths\":{inputFilePathsJson}}}]";
         variables.AddRange([
             new CalamariExecutionVariable(Deployment.SpecialVariables.GitResources.Extract(gitDependencyName), "true", false),
             new CalamariExecutionVariable(Deployment.SpecialVariables.GitResources.OriginalPath(gitDependencyName), zipPath, false),

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -196,6 +196,8 @@ public class CommitToGitCommandTest
 
         GetCommittedFileContent($"{destinationPath}/configs/settings.json")
             .Should().NotBeNull("files matching the InputFilePaths glob should be copied");
+        GetCommittedFileContent($"{destinationPath}/scripts/setup.sh")
+            .Should().BeNull("files not matching the InputFilePaths glob should not be copied");
         GetCommittedFileContent($"{destinationPath}/configs/setup.sh")
             .Should().BeNull("files not matching the InputFilePaths glob should not be copied");
     }
@@ -308,8 +310,8 @@ public class CommitToGitCommandTest
         ]);
 
         RunCommitToGit().Should().Be(0);
-        GetCommittedFileContent($"{destinationPath}/settings.json").Should().NotBeNull("files from the first package should be copied (with the non-wildcard glob prefix stripped)");
-        GetCommittedFileContent($"{destinationPath}/template.yaml").Should().NotBeNull("files from the second package should be copied (with the non-wildcard glob prefix stripped)");
+        GetCommittedFileContent($"{destinationPath}/settings.json").Should().NotBeNull("files from the first package should be copied");
+        GetCommittedFileContent($"{destinationPath}/template.yaml").Should().NotBeNull("files from the second package should be copied");
     }
 
     [Test]

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -194,9 +194,6 @@ public class CommitToGitCommand : Command
 
     IEnumerable<(string SourceFile, string DestRelativePath)> EnumerateGlobMatchesWithStrippedPrefix(string sourceDir, string[] globPatterns)
     {
-        if (globPatterns == null)
-            yield break;
-
         foreach (var glob in globPatterns)
         {
             var prefix = GetNonWildcardPrefix(glob);

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -174,7 +174,7 @@ public class CommitToGitCommand : Command
                                                       "Package",
                                                       package.PackageName,
                                                       package.DestinationSubFolder,
-                                                      dir => fileSystem.EnumerateFilesWithGlob(dir, package.InputFilePaths)));
+                                                      dir => EnumerateGlobMatchesWithStrippedPrefix(dir, package.InputFilePaths)));
                                               }
 
                                               foreach (var gitDep in metadataParser.GetGitRepositoryDependenciesForCopying(d))
@@ -184,12 +184,45 @@ public class CommitToGitCommand : Command
                                                       "Git dependency",
                                                       gitDep.GitDependencyName,
                                                       gitDep.DestinationSubFolder,
-                                                      dir => fileSystem.EnumerateFilesRecursively(dir)));
+                                                      dir => fileSystem.EnumerateFilesRecursively(dir).Select(f => (f, Path.GetRelativePath(dir, f)))));
                                                   if (copiedTo != null)
                                                       log.Verbose($"Copied files for git dependency '{gitDep.GitDependencyName}' to {copiedTo}");
                                               }
                                           })
         ];
+    }
+
+    IEnumerable<(string SourceFile, string DestRelativePath)> EnumerateGlobMatchesWithStrippedPrefix(string sourceDir, string[] globPatterns)
+    {
+        if (globPatterns == null)
+            yield break;
+
+        foreach (var glob in globPatterns)
+        {
+            var prefix = GetNonWildcardPrefix(glob);
+            foreach (var sourceFile in fileSystem.EnumerateFilesWithGlob(sourceDir, glob))
+            {
+                var relativePath = Path.GetRelativePath(sourceDir, sourceFile).Replace('\\', '/');
+                var destRelative = !string.IsNullOrEmpty(prefix) && relativePath.StartsWith(prefix, StringComparison.Ordinal)
+                    ? relativePath[prefix.Length..]
+                    : relativePath;
+                yield return (sourceFile, destRelative);
+            }
+        }
+    }
+
+    static string GetNonWildcardPrefix(string globPattern)
+    {
+        if (string.IsNullOrEmpty(globPattern))
+            return string.Empty;
+
+        var segments = globPattern.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Split(Path.AltDirectorySeparatorChar);
+        var firstWildcard = Array.FindIndex(segments, s => s.Contains('*'));
+        // No wildcard at all: treat the final segment as the filename, prefix is its directory.
+        var prefixSegmentCount = firstWildcard == -1 ? segments.Length - 1 : firstWildcard;
+        return prefixSegmentCount <= 0
+            ? string.Empty
+            : string.Join("/", segments.Take(prefixSegmentCount)) + "/";
     }
 
     string CopyDependencyToRepository(RunningDeployment deployment, RepositoryWrapper clonedRepository, string destBase, CopyDependencySpec spec)
@@ -203,21 +236,20 @@ public class CommitToGitCommand : Command
         }
 
         var filesToTarget = spec.EnumerateFiles(sourceDir).ToList();
-        nonSensitiveSubstituteInFiles.Substitute(deployment.CurrentDirectory, filesToTarget);
+        nonSensitiveSubstituteInFiles.Substitute(deployment.CurrentDirectory, filesToTarget.Select(f => f.SourceFile).ToList());
 
         var depDestBase = Path.Combine(destBase, spec.DestinationSubFolder ?? string.Empty);
         EnsurePathInsideWorkingDirectory(clonedRepository.WorkingDirectory, depDestBase, $"DestinationSubFolder for {spec.Kind.ToLowerInvariant()} '{spec.Name}'");
-        foreach (var sourceFile in filesToTarget)
+        foreach (var (sourceFile, destRelativePath) in filesToTarget)
         {
-            var relativePath = Path.GetRelativePath(sourceDir, sourceFile);
-            var destFile = Path.Combine(depDestBase, relativePath);
+            var destFile = Path.Combine(depDestBase, destRelativePath);
             fileSystem.EnsureDirectoryExists(Path.GetDirectoryName(destFile)!);
             fileSystem.CopyFile(sourceFile, destFile);
         }
         return depDestBase;
     }
 
-    record CopyDependencySpec(string Kind, string Name, string DestinationSubFolder, Func<string, IEnumerable<string>> EnumerateFiles);
+    record CopyDependencySpec(string Kind, string Name, string DestinationSubFolder, Func<string, IEnumerable<(string SourceFile, string DestRelativePath)>> EnumerateFiles);
 
     // Execute the transform script over the repository from its 'base directory'
     IEnumerable<IConvention> BuildTransformRepositoryConventions()

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -179,12 +179,11 @@ public class CommitToGitCommand : Command
 
                                               foreach (var gitDep in metadataParser.GetGitRepositoryDependenciesForCopying(d))
                                               {
-                                                  //no input-globs are required as only the relevant files were transmitted to Calamari
                                                   var copiedTo = CopyDependencyToRepository(d, clonedRepository, destBase, new CopyDependencySpec(
                                                       "Git dependency",
                                                       gitDep.GitDependencyName,
                                                       gitDep.DestinationSubFolder,
-                                                      dir => fileSystem.EnumerateFilesRecursively(dir).Select(f => (f, Path.GetRelativePath(dir, f)))));
+                                                      dir => EnumerateGlobMatchesWithStrippedPrefix(dir, gitDep.InputFilePaths)));
                                                   if (copiedTo != null)
                                                       log.Verbose($"Copied files for git dependency '{gitDep.GitDependencyName}' to {copiedTo}");
                                               }

--- a/source/Calamari/CommitToGit/CommitToGitDependencyMetadataParser.cs
+++ b/source/Calamari/CommitToGit/CommitToGitDependencyMetadataParser.cs
@@ -106,7 +106,7 @@ namespace Calamari.CommitToGit
     {
         public string PackageId { get; set; }
         public string PackageName { get; set; }
-        public string[] InputFilePaths { get; set; }
+        public string[] InputFilePaths { get; set; } = ["**/*"];
         public string DestinationSubFolder { get; set; }
 
         public override string GetName()
@@ -127,7 +127,7 @@ namespace Calamari.CommitToGit
             {
                 PackageId = variables.Evaluate(packageDependency.PackageId),
                 PackageName = variables.Evaluate(packageDependency.PackageName),
-                InputFilePaths = packageDependency.InputFilePaths?.Select(p => variables.Evaluate(p)).ToArray(),
+                InputFilePaths = packageDependency.InputFilePaths?.Select(p => variables.Evaluate(p)).ToArray() ?? new[] { "**/*" },
                 DestinationSubFolder = variables.Evaluate(packageDependency.DestinationSubFolder),
             };
         }

--- a/source/Calamari/CommitToGit/CommitToGitDependencyMetadataParser.cs
+++ b/source/Calamari/CommitToGit/CommitToGitDependencyMetadataParser.cs
@@ -137,6 +137,7 @@ namespace Calamari.CommitToGit
     {
         public string GitDependencyName { get; set; }
         public string DestinationSubFolder { get; set; }
+        public string[] InputFilePaths { get; set; } = ["**/*"];
 
         public override string GetName()
         {
@@ -150,12 +151,13 @@ namespace Calamari.CommitToGit
 
         public static GitRepositoryDependency FromJTokenWithEvaluation(JToken jToken, IVariables variables)
         {
-            var gitRepositoryTvs = jToken.ToObject<GitRepositoryDependency>();
+            var gitRepository = jToken.ToObject<GitRepositoryDependency>();
 
             return new GitRepositoryDependency
             {
-                GitDependencyName = variables.Evaluate(gitRepositoryTvs.GitDependencyName),
-                DestinationSubFolder = variables.Evaluate(gitRepositoryTvs.DestinationSubFolder)
+                GitDependencyName = variables.Evaluate(gitRepository.GitDependencyName),
+                DestinationSubFolder = variables.Evaluate(gitRepository.DestinationSubFolder),
+                InputFilePaths = gitRepository.InputFilePaths?.Select(p => variables.Evaluate(p)).ToArray() ?? new[] { "**/*" },
             };
         }
     }


### PR DESCRIPTION
As per the upload-artefact operations, the non-wildcarded segment of the input-path should stripped prior to copying.

i.e. only the directory structure from wildcard onwards is maintained.

eg. **/* would results in the WHOLE directory structure being maintained.

The only difference between this and the upload-artefact is that a FULLY-SCOPED filename will be copied flat to the destination path.
Otherwise, the specific file would be required to maintain the same pathing in the destination as in the input.