### PR TITLE
Drop timeout from Bicep step

### DIFF
--- a/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
+++ b/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
@@ -24,7 +24,7 @@ namespace Calamari.AzureResourceGroup
         {
             this.log = log;
         }
-        
+
         public async Task<ArmOperation<ArmDeploymentResource>> CreateDeployment(ResourceGroupResource resourceGroupResource,
                                                                                 string deploymentName,
                                                                                 ArmDeploymentMode deploymentMode,
@@ -55,22 +55,26 @@ namespace Calamari.AzureResourceGroup
             }
         }
 
-        public async Task PollForCompletion(ArmOperation<ArmDeploymentResource> deploymentOperation, IVariables variables)
+        public async Task PollForCompletionWithTimeout(ArmOperation<ArmDeploymentResource> deploymentOperation, IVariables variables)
         {
             var pollingTimeout = GetPollingTimeout(variables);
-            var asyncResourceGroupPollingTimeoutPolicy = Policy.TimeoutAsync<ArmDeploymentResource>(pollingTimeout, TimeoutStrategy.Optimistic);
+            var asyncResourceGroupPollingTimeoutPolicy = Policy.TimeoutAsync(pollingTimeout, TimeoutStrategy.Optimistic);
+            await asyncResourceGroupPollingTimeoutPolicy.ExecuteAsync(ct => Poll(deploymentOperation, ct), CancellationToken.None);
+        }
 
+        public async Task PollForCompletion(ArmOperation<ArmDeploymentResource> deploymentOperation)
+        {
+            await Poll(deploymentOperation, CancellationToken.None);
+        }
+
+        async Task Poll(ArmOperation<ArmDeploymentResource> deploymentOperation, CancellationToken cancellationToken)
+        {
             log.Info("Polling for deployment completion...");
             try
             {
-                var deploymentResult = await asyncResourceGroupPollingTimeoutPolicy.ExecuteAsync(async timeoutCancellationToken =>
-                                                                                                 {
-                                                                                                     var delayStrategy = DelayStrategy.CreateExponentialDelayStrategy(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
-                                                                                                     var result = await deploymentOperation.WaitForCompletionAsync(delayStrategy, timeoutCancellationToken);
-                                                                                                     return result;
-                                                                                                 },
-                                                                                                 CancellationToken.None);
-                log.Info($"Deployment completed with status: {deploymentResult.Data.Properties?.ProvisioningState}");
+                var delayStrategy = DelayStrategy.CreateExponentialDelayStrategy(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
+                var response = await deploymentOperation.WaitForCompletionAsync(delayStrategy, cancellationToken);
+                log.Info($"Deployment completed with status: {response.Value?.Data.Properties?.ProvisioningState}");
             }
             catch
             {
@@ -121,7 +125,7 @@ namespace Calamari.AzureResourceGroup
             foreach (var output in outputs)
                 log.SetOutputVariable($"AzureRmOutputs[{output.Key}]", output.Value["value"].ToString(), variables);
         }
-        
+
         static TimeSpan GetPollingTimeout(IVariables variables)
         {
             var pollingTimeoutVariableValue = variables.GetInt32(SpecialVariables.Action.Azure.ArmDeploymentTimeout);

--- a/source/Calamari.AzureResourceGroup/Bicep/DeployBicepTemplateBehaviour.cs
+++ b/source/Calamari.AzureResourceGroup/Bicep/DeployBicepTemplateBehaviour.cs
@@ -16,7 +16,7 @@ using Calamari.Common.Plumbing.Variables;
 namespace Calamari.AzureResourceGroup.Bicep;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-class DeployBicepTemplateBehaviour(ICommandLineRunner commandLineRunner, TemplateService templateService, AzureResourceGroupOperator resourceGroupOperator, IResourceGroupTemplateNormalizer parameterNormalizer, ILog log)
+class DeployBicepTemplateBehaviour(ICommandLineRunner commandLineRunner, TemplateService templateService, AzureResourceGroupOperator resourceGroupOperator, ILog log)
     : IDeployBehaviour
 {
     public bool IsEnabled(RunningDeployment context)
@@ -90,12 +90,12 @@ class DeployBicepTemplateBehaviour(ICommandLineRunner commandLineRunner, Templat
         log.Info("Bicep file processed");
 
         var template = templateService.GetSubstitutedTemplateContent(armTemplateFile, filesInPackageOrRepository, context.Variables);
-        
+
 
         var parametersValue = context.Variables.GetRaw(SpecialVariables.Action.Azure.BicepTemplateParameters) ?? string.Empty;
-        
+
         var parameters = BicepToArmParameterMapper.Map(parametersValue, template, context.Variables);
-        
+
         return (template, parameters);
     }
 }

--- a/source/Calamari.AzureResourceGroup/Bicep/DeployBicepTemplateBehaviour.cs
+++ b/source/Calamari.AzureResourceGroup/Bicep/DeployBicepTemplateBehaviour.cs
@@ -50,7 +50,7 @@ class DeployBicepTemplateBehaviour(ICommandLineRunner commandLineRunner, Templat
                                                                                deploymentMode,
                                                                                template,
                                                                                parameters);
-        await resourceGroupOperator.PollForCompletion(deploymentOperation, context.Variables);
+        await resourceGroupOperator.PollForCompletion(deploymentOperation);
         await resourceGroupOperator.FinalizeDeployment(deploymentOperation, context.Variables);
     }
 

--- a/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
+++ b/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
@@ -79,7 +79,7 @@ namespace Calamari.AzureResourceGroup
                                                                                         deploymentMode,
                                                                                         template,
                                                                                         parameters);
-            await azureResourceGroupOperator.PollForCompletion(deploymentOperation, variables);
+            await azureResourceGroupOperator.PollForCompletionWithTimeout(deploymentOperation, variables);
             await azureResourceGroupOperator.FinalizeDeployment(deploymentOperation, variables);
         }
     }


### PR DESCRIPTION
The [SPF source](https://github.com/OctopusDeploy/step-package-bicep/blob/main/steps/deploy-a-bicep-template-v2/src/executor.ts#L210) for this never had timeouts and adding timeouts inside the step overlaps with generic step level timeouts.

The ARM step probably doesn't need this timeout which was added in [this PR](https://github.com/OctopusDeploy/Calamari/pull/1366) but leaving that alone for now.

Ref MD-1872
