### PR TITLE
pin v9 of System.Security.Cryptography.Pkcs

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -16,6 +16,7 @@
     <ItemGroup>
         <PackageReference Include="NuGet.Commands" Version="7.0.3" />
         <PackageReference Include="NuGet.Packaging" Version="7.4.0-octopus-release.17001" />
+        <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
         <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
         <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
     <PackageReference Include="Polly" Version="8.3.1" />
     <PackageReference Include="NuGet.Commands" Version="7.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
     <PackageReference Include="Markdown" Version="2.1.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />


### PR DESCRIPTION
Build Warnings related to conflicting versions of PkCS Assembly.

<img width="2744" height="358" alt="CleanShot 2026-05-14 at 16 47 16@2x" src="https://github.com/user-attachments/assets/605698c6-67fc-4abf-b00a-f3494657d599" />


This pins the higher version in Calamari.Shared and Calamari..Common to resolve.