### PR TITLE
Make CalamariFlavourProgram actually execute asynchronously

### DIFF
--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using Autofac;
 using Autofac.Core;
 using Autofac.Core.Registration;
@@ -32,7 +33,7 @@ namespace Calamari.Common;
 
 public abstract class CalamariFlavourProgram(ILog log)
 {
-    protected int Run(string[] args)
+    protected async Task<int> Run(string[] args)
     {
         try
         {
@@ -67,13 +68,13 @@ public abstract class CalamariFlavourProgram(ILog log)
 
                 while (!Debugger.IsAttached)
                 {
-                    Thread.Sleep(1000);
+                    await Task.Delay(1000);
                 }
             }
 #endif
             var isolation = container.Resolve<IScriptIsolationEnforcer>();
-            using var _ = isolation.Enforce(options.ScriptIsolation);
-            return ResolveAndExecuteCommand(container, options);
+            await using var _ = isolation.Enforce(options.ScriptIsolation);
+            return await ResolveAndExecuteCommand(container, options);
         }
         catch (Exception ex)
         {
@@ -81,31 +82,30 @@ public abstract class CalamariFlavourProgram(ILog log)
         }
     }
 
-    protected abstract int ResolveAndExecuteCommand(IContainer container, CommonOptions options);
+    protected abstract Task<int? ResolveAndExecuteCommand(IContainer container, CommonOptions options);
 
     protected virtual void ConfigureContainer(ContainerBuilder builder, CommonOptions options)
-    {            
+    {
         //register the options into the DI
         builder.RegisterInstance(options).AsSelf();
-            
-            var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-            builder.RegisterInstance(fileSystem).As<ICalamariFileSystem>();
-            builder.RegisterType<ScriptEngine>().As<IScriptEngine>();
-            builder.RegisterType<VariableLogger>().AsSelf();
-            builder.RegisterInstance(log).As<ILog>().SingleInstance();
-            builder.RegisterType<FreeSpaceChecker>().As<IFreeSpaceChecker>().SingleInstance();
-            builder.RegisterType<CommandLineRunner>().As<ICommandLineRunner>().SingleInstance();
-            builder.RegisterType<CombinedPackageExtractor>().As<ICombinedPackageExtractor>();
-            builder.RegisterType<ExtractPackage>().As<IExtractPackage>();
-            builder.RegisterType<CodeGenFunctionsRegistry>().SingleInstance();
-            builder.RegisterType<AssemblyEmbeddedResources>().As<ICalamariEmbeddedResources>();
-            
-            // For Pipeline Commands
-            builder.RegisterType<TransformFileLocator>().As<ITransformFileLocator>();
-            builder.Register(context => ConfigurationTransformer.FromVariables(context.Resolve<IVariables>(), context.Resolve<ILog>())).As<IConfigurationTransformer>();
-            builder.RegisterType<ConfigurationVariablesReplacer>().As<IConfigurationVariablesReplacer>();
 
-            
+        var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+        builder.RegisterInstance(fileSystem).As<ICalamariFileSystem>();
+        builder.RegisterType<ScriptEngine>().As<IScriptEngine>();
+        builder.RegisterType<VariableLogger>().AsSelf();
+        builder.RegisterInstance(log).As<ILog>().SingleInstance();
+        builder.RegisterType<FreeSpaceChecker>().As<IFreeSpaceChecker>().SingleInstance();
+        builder.RegisterType<CommandLineRunner>().As<ICommandLineRunner>().SingleInstance();
+        builder.RegisterType<CombinedPackageExtractor>().As<ICombinedPackageExtractor>();
+        builder.RegisterType<ExtractPackage>().As<IExtractPackage>();
+        builder.RegisterType<CodeGenFunctionsRegistry>().SingleInstance();
+        builder.RegisterType<AssemblyEmbeddedResources>().As<ICalamariEmbeddedResources>();
+
+        // For Pipeline Commands
+        builder.RegisterType<TransformFileLocator>().As<ITransformFileLocator>();
+        builder.Register(context => ConfigurationTransformer.FromVariables(context.Resolve<IVariables>(), context.Resolve<ILog>())).As<IConfigurationTransformer>();
+        builder.RegisterType<ConfigurationVariablesReplacer>().As<IConfigurationVariablesReplacer>();
+
         builder.RegisterModule<VariablesModule>();
         builder.RegisterModule<SubstitutionsModule>();
         builder.RegisterModule<ScriptIsolationModule>();
@@ -119,12 +119,12 @@ public abstract class CalamariFlavourProgram(ILog log)
                .Except<TerminalScriptWrapper>()
                .As<IScriptWrapper>()
                .SingleInstance();
-            
-            // Register Behaviors
-            builder.RegisterAssemblyTypes(assemblies)
-                   .Where(t => t.IsAssignableTo<IBehaviour>() && !t.IsAbstract)
-                   .AsSelf()
-                   .InstancePerDependency();
+
+        // Register Behaviors
+        builder.RegisterAssemblyTypes(assemblies)
+               .Where(t => t.IsAssignableTo<IBehaviour>() && !t.IsAbstract)
+               .AsSelf()
+               .InstancePerDependency();
 
         builder.RegisterInstance(options).AsSelf().SingleInstance();
 
@@ -139,7 +139,7 @@ public abstract class CalamariFlavourProgram(ILog log)
     protected virtual IEnumerable<Assembly> GetAllAssembliesToRegister()
     {
         var programAssembly = GetProgramAssemblyToRegister();
-            
+
         yield return programAssembly; // Calamari Flavour
         yield return typeof(CalamariFlavourProgram).Assembly; // Calamari.Common
     }

--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
+using Autofac.Core;
+using Autofac.Core.Registration;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.ConfigurationTransforms;
 using Calamari.Common.Features.ConfigurationVariables;
@@ -44,7 +46,9 @@ public abstract class CalamariFlavourProgram(ILog log)
             log.Verbose($"Calamari Version: {GetType().Assembly.GetInformationalVersion()}");
 
             if (options.Command.Equals("version", StringComparison.OrdinalIgnoreCase))
+            {
                 return 0;
+            }
 
             var envInfo = string.Join($"{Environment.NewLine}  ",
                                       EnvironmentHelper.SafelyGetEnvironmentInformation());
@@ -81,7 +85,34 @@ public abstract class CalamariFlavourProgram(ILog log)
         }
     }
 
-    protected abstract Task<int> ResolveAndExecuteCommand(IContainer container, CommonOptions options);
+    async Task<int> ResolveAndExecuteCommand(IContainer container, CommonOptions options)
+    {
+        try
+        {
+            if (container.IsRegisteredWithName<PipelineCommand>(options.Command))
+            {
+                try
+                {
+                    var pipeline = container.ResolveNamed<PipelineCommand>(options.Command);
+                    var variables = container.Resolve<IVariables>();
+                    await pipeline.Execute(container, variables);
+                    return 0;
+                }
+                catch (Exception ex)
+                {
+                    return ConsoleFormatter.PrintError(log, ex);
+                }
+            }
+
+            return await ResolveAndExecuteCommandWithArgs(container, options);
+        }
+        catch (Exception e) when (e is ComponentNotRegisteredException or DependencyResolutionException)
+        {
+            throw new CommandException($"Could not find the command {options.Command}");
+        }
+    }
+
+    protected abstract Task<int> ResolveAndExecuteCommandWithArgs(IContainer container, CommonOptions options);
 
     protected virtual void ConfigureContainer(ContainerBuilder builder, CommonOptions options)
     {
@@ -125,20 +156,20 @@ public abstract class CalamariFlavourProgram(ILog log)
                .Where(t => t.IsAssignableTo<IBehaviour>() && !t.IsAbstract)
                .AsSelf()
                .InstancePerDependency();
-        
+
         // Register Pipeline commands
         builder.RegisterAssemblyTypes(assemblies)
                .AssignableTo<PipelineCommand>()
                .WithMetadataFrom<CommandAttribute>()
                .Where(t => t.GetCustomAttribute<CommandAttribute>() is not null)
                .Named<PipelineCommand>(t => t.GetCommandNameFromAttribute());
-        
+
         builder.RegisterModule<StructuredConfigVariablesModule>();
     }
 
     protected virtual IEnumerable<Assembly> GetProgramAssembliesToRegister()
     {
-       yield return GetType().Assembly;
+        yield return GetType().Assembly;
     }
 
     protected virtual IEnumerable<Assembly> GetAllAssembliesToRegister()
@@ -147,7 +178,7 @@ public abstract class CalamariFlavourProgram(ILog log)
 
         foreach (var assembly in programAssemblies)
             yield return assembly; // Calamari Flavour & dependencies
-        
+
         yield return typeof(CalamariFlavourProgram).Assembly; // Calamari.Common
     }
 }

--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -6,10 +6,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
-using Autofac.Core;
-using Autofac.Core.Registration;
 using Calamari.Common.Commands;
-using Calamari.Common.Features.Behaviours;
 using Calamari.Common.Features.ConfigurationTransforms;
 using Calamari.Common.Features.ConfigurationVariables;
 using Calamari.Common.Features.EmbeddedResources;
@@ -29,6 +26,7 @@ using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Proxies;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.Common.Util;
 
 namespace Calamari.Common;
 
@@ -74,7 +72,7 @@ public abstract class CalamariFlavourProgram(ILog log)
             }
 #endif
             var isolation = container.Resolve<IScriptIsolationEnforcer>();
-            await using var _ = isolation.Enforce(options.ScriptIsolation);
+            await using var _ = await isolation.EnforceAsync(options.ScriptIsolation, CancellationToken.None);
             return await ResolveAndExecuteCommand(container, options);
         }
         catch (Exception ex)
@@ -83,7 +81,7 @@ public abstract class CalamariFlavourProgram(ILog log)
         }
     }
 
-    protected abstract Task<int? ResolveAndExecuteCommand(IContainer container, CommonOptions options);
+    protected abstract Task<int> ResolveAndExecuteCommand(IContainer container, CommonOptions options);
 
     protected virtual void ConfigureContainer(ContainerBuilder builder, CommonOptions options)
     {
@@ -127,20 +125,29 @@ public abstract class CalamariFlavourProgram(ILog log)
                .Where(t => t.IsAssignableTo<IBehaviour>() && !t.IsAbstract)
                .AsSelf()
                .InstancePerDependency();
-
+        
+        // Register Pipeline commands
+        builder.RegisterAssemblyTypes(assemblies)
+               .AssignableTo<PipelineCommand>()
+               .WithMetadataFrom<CommandAttribute>()
+               .Where(t => t.GetCustomAttribute<CommandAttribute>() is not null)
+               .Named<PipelineCommand>(t => t.GetCommandNameFromAttribute());
+        
         builder.RegisterModule<StructuredConfigVariablesModule>();
     }
 
-    protected virtual Assembly GetProgramAssemblyToRegister()
+    protected virtual IEnumerable<Assembly> GetProgramAssembliesToRegister()
     {
-        return GetType().Assembly;
+       yield return GetType().Assembly;
     }
 
     protected virtual IEnumerable<Assembly> GetAllAssembliesToRegister()
     {
-        var programAssembly = GetProgramAssemblyToRegister();
+        var programAssemblies = GetProgramAssembliesToRegister();
 
-        yield return programAssembly; // Calamari Flavour
+        foreach (var assembly in programAssemblies)
+            yield return assembly; // Calamari Flavour & dependencies
+        
         yield return typeof(CalamariFlavourProgram).Assembly; // Calamari.Common
     }
 }

--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -22,6 +22,7 @@ using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Commands;
+using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
@@ -104,6 +105,7 @@ public abstract class CalamariFlavourProgram(ILog log)
         // For Pipeline Commands
         builder.RegisterType<TransformFileLocator>().As<ITransformFileLocator>();
         builder.Register(context => ConfigurationTransformer.FromVariables(context.Resolve<IVariables>(), context.Resolve<ILog>())).As<IConfigurationTransformer>();
+        builder.RegisterType<DeploymentJournalWriter>().As<IDeploymentJournalWriter>().SingleInstance();
         builder.RegisterType<ConfigurationVariablesReplacer>().As<IConfigurationVariablesReplacer>();
 
         builder.RegisterModule<VariablesModule>();
@@ -125,8 +127,6 @@ public abstract class CalamariFlavourProgram(ILog log)
                .Where(t => t.IsAssignableTo<IBehaviour>() && !t.IsAbstract)
                .AsSelf()
                .InstancePerDependency();
-
-        builder.RegisterInstance(options).AsSelf().SingleInstance();
 
         builder.RegisterModule<StructuredConfigVariablesModule>();
     }

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -67,7 +67,7 @@ public abstract class CalamariFlavourProgramAsync(ILog log)
             if (CalamariEnvironment.ShouldWaitForDebugger(container.Resolve<IVariables>()))
             {
                 using var proc = Process.GetCurrentProcess();
-                Log.Info($"Waiting for debugger to attach... (PID: {proc.Id})");
+                log.Info($"Waiting for debugger to attach... (PID: {proc.Id})");
 
                 while (!Debugger.IsAttached)
                 {
@@ -82,7 +82,7 @@ public abstract class CalamariFlavourProgramAsync(ILog log)
         }
         catch (Exception ex)
         {
-            return ConsoleFormatter.PrintError(ConsoleLog.Instance, ex);
+            return ConsoleFormatter.PrintError(log, ex);
         }
     }
 
@@ -139,12 +139,6 @@ public abstract class CalamariFlavourProgramAsync(ILog log)
                .Except<TerminalScriptWrapper>()
                .As<IScriptWrapper>()
                .SingleInstance();
-
-        builder.RegisterAssemblyTypes(assemblies)
-               .AssignableTo<ICommandAsync>()
-               .Where(t => t.GetCommandNameFromAttribute()
-                            .Equals(options.Command, StringComparison.OrdinalIgnoreCase))
-               .Named<ICommandAsync>(t => t.GetCommandNameFromAttribute());
 
         builder.RegisterAssemblyTypes(assemblies)
                .Where(t => t.IsAssignableTo<IBehaviour>() && !t.IsAbstract)

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -77,8 +77,8 @@ public abstract class CalamariFlavourProgramAsync(ILog log)
 #endif
             var isolation = container.Resolve<IScriptIsolationEnforcer>();
             await using var _ = await isolation.EnforceAsync(options.ScriptIsolation, CancellationToken.None);
-            await ResolveAndExecuteCommand(container, options);
-            return 0;
+            return await ResolveAndExecuteCommand(container, options);
+            
         }
         catch (Exception ex)
         {
@@ -86,7 +86,7 @@ public abstract class CalamariFlavourProgramAsync(ILog log)
         }
     }
 
-    static Task ResolveAndExecuteCommand(ILifetimeScope container, CommonOptions options)
+    static async Task<int> ResolveAndExecuteCommand(ILifetimeScope container, CommonOptions options)
     {
         try
         {
@@ -94,7 +94,8 @@ public abstract class CalamariFlavourProgramAsync(ILog log)
             {
                 var pipeline = container.ResolveNamed<PipelineCommand>(options.Command);
                 var variables = container.Resolve<IVariables>();
-                return pipeline.Execute(container, variables);
+                await pipeline.Execute(container, variables);
+                return 0;
             }
             
             throw new CommandException($"Could not find the command {options.Command}");

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -34,60 +34,6 @@ namespace Calamari.Common;
 
 public abstract class CalamariFlavourProgramAsync(ILog log)
 {
-    protected virtual void ConfigureContainer(ContainerBuilder builder, CommonOptions options)
-    {
-        //register the options into the DI
-        builder.RegisterInstance(options).AsSelf();
-            
-        var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
-        builder.RegisterInstance(fileSystem).As<ICalamariFileSystem>();
-        builder.RegisterType<ScriptEngine>().As<IScriptEngine>();
-        builder.RegisterType<VariableLogger>().AsSelf();
-        builder.RegisterInstance(log).As<ILog>().SingleInstance();
-        builder.RegisterType<FreeSpaceChecker>().As<IFreeSpaceChecker>().SingleInstance();
-        builder.RegisterType<CommandLineRunner>().As<ICommandLineRunner>().SingleInstance();
-        builder.RegisterType<CombinedPackageExtractor>().As<ICombinedPackageExtractor>();
-        builder.RegisterType<ExtractPackage>().As<IExtractPackage>();
-        builder.RegisterType<AssemblyEmbeddedResources>().As<ICalamariEmbeddedResources>();
-        builder.RegisterType<ConfigurationVariablesReplacer>().As<IConfigurationVariablesReplacer>();
-        builder.RegisterType<TransformFileLocator>().As<ITransformFileLocator>();
-        builder.Register(context => ConfigurationTransformer.FromVariables(context.Resolve<IVariables>(), context.Resolve<ILog>())).As<IConfigurationTransformer>();
-        builder.RegisterType<DeploymentJournalWriter>().As<IDeploymentJournalWriter>().SingleInstance();
-        builder.RegisterType<CodeGenFunctionsRegistry>().SingleInstance();
-            
-        builder.RegisterModule<VariablesModule>();
-        builder.RegisterModule<SubstitutionsModule>();
-        builder.RegisterModule<ScriptIsolationModule>();
-
-        var assemblies = GetAllAssembliesToRegister().ToArray();
-
-        builder.RegisterAssemblyTypes(assemblies).AssignableTo<ICodeGenFunctions>().As<ICodeGenFunctions>().SingleInstance();
-
-        builder.RegisterAssemblyTypes(assemblies)
-               .AssignableTo<IScriptWrapper>()
-               .Except<TerminalScriptWrapper>()
-               .As<IScriptWrapper>()
-               .SingleInstance();
-
-        builder.RegisterAssemblyTypes(assemblies)
-               .Where(t => t.IsAssignableTo<IBehaviour>() && !t.IsAbstract)
-               .AsSelf()
-               .InstancePerDependency();
-
-        builder.RegisterAssemblyTypes(assemblies)
-               .AssignableTo<PipelineCommand>()
-               .Where(t => t.GetCommandNameFromAttribute()
-                            .Equals(options.Command, StringComparison.OrdinalIgnoreCase))
-               .Named<PipelineCommand>(t => t.GetCommandNameFromAttribute());
-
-        builder.RegisterModule<StructuredConfigVariablesModule>();
-    }
-
-    protected virtual IEnumerable<Assembly> GetProgramAssembliesToRegister()
-    {
-        yield return GetType().Assembly;
-    }
-
     protected async Task<int> Run(string[] args)
     {
         try
@@ -140,16 +86,6 @@ public abstract class CalamariFlavourProgramAsync(ILog log)
         }
     }
 
-    IEnumerable<Assembly> GetAllAssembliesToRegister()
-    {
-        var programAssemblies = GetProgramAssembliesToRegister();
-
-        foreach (var assembly in programAssemblies)
-            yield return assembly; // Calamari Flavour & dependencies
-
-        yield return typeof(CalamariFlavourProgramAsync).Assembly; // Calamari.Common
-    }
-
     static Task ResolveAndExecuteCommand(ILifetimeScope container, CommonOptions options)
     {
         try
@@ -167,5 +103,76 @@ public abstract class CalamariFlavourProgramAsync(ILog log)
         {
             throw new CommandException($"Could not find the command {options.Command}");
         }
+    }
+    
+    protected virtual void ConfigureContainer(ContainerBuilder builder, CommonOptions options)
+    {
+        //register the options into the DI
+        builder.RegisterInstance(options).AsSelf();
+            
+        var fileSystem = CalamariPhysicalFileSystem.GetPhysicalFileSystem();
+        builder.RegisterInstance(fileSystem).As<ICalamariFileSystem>();
+        builder.RegisterType<ScriptEngine>().As<IScriptEngine>();
+        builder.RegisterType<VariableLogger>().AsSelf();
+        builder.RegisterInstance(log).As<ILog>().SingleInstance();
+        builder.RegisterType<FreeSpaceChecker>().As<IFreeSpaceChecker>().SingleInstance();
+        builder.RegisterType<CommandLineRunner>().As<ICommandLineRunner>().SingleInstance();
+        builder.RegisterType<CombinedPackageExtractor>().As<ICombinedPackageExtractor>();
+        builder.RegisterType<ExtractPackage>().As<IExtractPackage>();
+        builder.RegisterType<CodeGenFunctionsRegistry>().SingleInstance();
+        builder.RegisterType<AssemblyEmbeddedResources>().As<ICalamariEmbeddedResources>();
+        builder.RegisterType<TransformFileLocator>().As<ITransformFileLocator>();
+        builder.Register(context => ConfigurationTransformer.FromVariables(context.Resolve<IVariables>(), context.Resolve<ILog>())).As<IConfigurationTransformer>();
+        builder.RegisterType<DeploymentJournalWriter>().As<IDeploymentJournalWriter>().SingleInstance();
+        builder.RegisterType<ConfigurationVariablesReplacer>().As<IConfigurationVariablesReplacer>();
+            
+        builder.RegisterModule<VariablesModule>();
+        builder.RegisterModule<SubstitutionsModule>();
+        builder.RegisterModule<ScriptIsolationModule>();
+
+        var assemblies = GetAllAssembliesToRegister().ToArray();
+
+        builder.RegisterAssemblyTypes(assemblies).AssignableTo<ICodeGenFunctions>().As<ICodeGenFunctions>().SingleInstance();
+
+        builder.RegisterAssemblyTypes(assemblies)
+               .AssignableTo<IScriptWrapper>()
+               .Except<TerminalScriptWrapper>()
+               .As<IScriptWrapper>()
+               .SingleInstance();
+
+        builder.RegisterAssemblyTypes(assemblies)
+               .AssignableTo<ICommandAsync>()
+               .Where(t => t.GetCommandNameFromAttribute()
+                            .Equals(options.Command, StringComparison.OrdinalIgnoreCase))
+               .Named<ICommandAsync>(t => t.GetCommandNameFromAttribute());
+
+        builder.RegisterAssemblyTypes(assemblies)
+               .Where(t => t.IsAssignableTo<IBehaviour>() && !t.IsAbstract)
+               .AsSelf()
+               .InstancePerDependency();
+
+        builder.RegisterAssemblyTypes(assemblies)
+               .AssignableTo<PipelineCommand>()
+               .Where(t => t.GetCommandNameFromAttribute()
+                            .Equals(options.Command, StringComparison.OrdinalIgnoreCase))
+               .Named<PipelineCommand>(t => t.GetCommandNameFromAttribute());
+
+        builder.RegisterModule<StructuredConfigVariablesModule>();
+    }
+
+    protected virtual IEnumerable<Assembly> GetProgramAssembliesToRegister()
+    {
+        yield return GetType().Assembly;
+    }
+
+
+    IEnumerable<Assembly> GetAllAssembliesToRegister()
+    {
+        var programAssemblies = GetProgramAssembliesToRegister();
+
+        foreach (var assembly in programAssemblies)
+            yield return assembly; // Calamari Flavour & dependencies
+
+        yield return typeof(CalamariFlavourProgramAsync).Assembly; // Calamari.Common
     }
 }

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Threading.Tasks;
 using Calamari.ArgoCD.Git;
 using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing.Extensions;
@@ -36,7 +37,7 @@ public class CommitToGitCommandTest
     CalamariExecutionVariableCollection variables;
 
     [SetUp]
-    public void setUp()
+    public void SetUp()
     {
         executionDirectory = fileSystem.CreateTemporaryDirectory();
 
@@ -57,19 +58,19 @@ public class CommitToGitCommandTest
     }
 
     [Test]
-    public void CommitToGitRunsScriptWithNoDependenciesToCreateFileWhichIsCommitedToRepository()
+    public async Task CommitToGitRunsScriptWithNoDependenciesToCreateFileWhichIsCommitedToRepository()
     {
         variables.AddRange([
             new CalamariExecutionVariable(ScriptVariables.ScriptBody, "touch \"$(get_octopusvariable 'Octopus.Calamari.Git.RepositoryPath')/proof.txt\"", false),
             new CalamariExecutionVariable(ScriptVariables.Syntax, ScriptSyntax.Bash.ToString(), false),
         ]);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
         GetCommittedFileContent("proof.txt").Should().NotBeNull("the transform script should have created and committed the file to the repository");
     }
 
     [Test]
-    public void CommitToGitRunsInlineScriptWithPackageDependencyToCreateFileWhichIsCommitedToRepository()
+    public async Task CommitToGitRunsInlineScriptWithPackageDependencyToCreateFileWhichIsCommitedToRepository()
     {
         const string packageReferenceName = "my-scripts";
 
@@ -83,12 +84,12 @@ public class CommitToGitCommandTest
             new CalamariExecutionVariable(PackageVariables.IndexedExtract(packageReferenceName), "True", false),
         ]);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
         GetCommittedFileContent("proof.txt").Should().NotBeNull("the helper script should have created and committed the file to the repository");
     }
 
     [Test]
-    public void CommitToGitRunsPackageBasedScriptWithNoDependenciesToCreateFileWhichIsCommitedToRepository()
+    public async Task CommitToGitRunsPackageBasedScriptWithNoDependenciesToCreateFileWhichIsCommitedToRepository()
     {
         var zipPath = CreateZipWithEntry("transform-script", "script.sh", "touch \"$(get_octopusvariable 'Octopus.Calamari.Git.RepositoryPath')/proof.txt\"");
 
@@ -96,12 +97,12 @@ public class CommitToGitCommandTest
             new CalamariExecutionVariable(ScriptVariables.ScriptFileName, "script.sh", false),
         ]);
 
-        RunCommitToGit("--package", zipPath).Should().Be(0);
+        (await RunCommitToGit("--package", zipPath)).Should().Be(0);
         GetCommittedFileContent("proof.txt").Should().NotBeNull("the package-based script should have created and committed the file to the repository");
     }
 
     [Test]
-    public void CommitToGitRunsPackageBasedScriptWithScriptParameters()
+    public async Task CommitToGitRunsPackageBasedScriptWithScriptParameters()
     {
         var proofFile = Path.Combine(executionDirectory, "script_ran.txt");
         var zipPath = CreateZipWithEntry("transform-script", "script.sh",
@@ -111,12 +112,12 @@ public class CommitToGitCommandTest
             new CalamariExecutionVariable(ScriptVariables.ScriptFileName, "script.sh", false),
         ]);
 
-        RunCommitToGit("--package", zipPath, "--scriptParameters", "expected-arg").Should().Be(0);
+        (await RunCommitToGit("--package", zipPath, "--scriptParameters", "expected-arg")).Should().Be(0);
         File.Exists(proofFile).Should().BeTrue("the transform script should have run with the expected argument");
     }
 
     [Test]
-    public void CanCopyPackageFilesIntoGitRepository()
+    public async Task CanCopyPackageFilesIntoGitRepository()
     {
         const string packageReferenceName = "my-configs";
         const string destinationPath = "output-dir";
@@ -124,14 +125,14 @@ public class CommitToGitCommandTest
         var zipPath = CreateZipWithEntry(packageReferenceName, "configs/settings.json", "{\"setting\": \"value\"}");
         AddInputPackageVariables(packageReferenceName, zipPath, destinationPath);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
 
         GetCommittedFileContent($"{destinationPath}/configs/settings.json")
             .Should().NotBeNull("the package files should have been copied into the repository under the destination path");
     }
 
     [Test]
-    public void SubstitutesNonSensitiveVariablesIntoAnExpandedPackageThenCopiesToGitRepository()
+    public async Task SubstitutesNonSensitiveVariablesIntoAnExpandedPackageThenCopiesToGitRepository()
     {
         const string packageReferenceName = "my-configs";
         const string destinationPath = "output-dir";
@@ -144,7 +145,7 @@ public class CommitToGitCommandTest
             new CalamariExecutionVariable("MyVar", "production-value", false),
         ]);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
 
         var content = GetCommittedFileContent($"{destinationPath}/configs/settings.json");
         content.Should().NotBeNull("the package file should have been copied into the repository");
@@ -153,7 +154,7 @@ public class CommitToGitCommandTest
     }
 
     [Test]
-    public void OnlyCopiesFilesMatchingInputPathsFromPackageIntoGitRepository()
+    public async Task OnlyCopiesFilesMatchingInputPathsFromPackageIntoGitRepository()
     {
         const string packageReferenceName = "my-configs";
         const string destinationPath = "output-dir";
@@ -165,7 +166,7 @@ public class CommitToGitCommandTest
         });
         AddInputPackageVariables(packageReferenceName, zipPath, destinationPath);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
 
         GetCommittedFileContent($"{destinationPath}/configs/settings.json")
             .Should().NotBeNull("files matching the InputFilePaths glob should be copied");
@@ -174,7 +175,7 @@ public class CommitToGitCommandTest
     }
 
     [Test]
-    public void CopiesAllGitReferenceFilesIntoGitRepository()
+    public async Task CopiesAllGitReferenceFilesIntoGitRepository()
     {
         const string gitDependencyName = "my-git-dep";
         const string destinationPath = "output-dir";
@@ -182,14 +183,14 @@ public class CommitToGitCommandTest
         var zipPath = CreateZipWithEntry(gitDependencyName, "manifests/deployment.yaml", "apiVersion: apps/v1");
         AddInputGitReferenceVariables(gitDependencyName, zipPath, destinationPath);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
 
         GetCommittedFileContent($"{destinationPath}/manifests/deployment.yaml")
             .Should().NotBeNull("git reference files should be copied into the repository under the destination path");
     }
 
     [Test]
-    public void FailsWhenSensitiveVariableTemplatesAreEncounteredDuringSubstitution()
+    public async Task FailsWhenSensitiveVariableTemplatesAreEncounteredDuringSubstitution()
     {
         const string packageReferenceName = "my-configs";
         const string destinationPath = "output-dir";
@@ -202,14 +203,14 @@ public class CommitToGitCommandTest
             new CalamariExecutionVariable("MySecret", "super-secret-value", true),
         ]);
 
-        RunCommitToGit().Should().NotBe(0);
+        (await RunCommitToGit()).Should().NotBe(0);
 
         var content = GetCommittedFileContent($"{destinationPath}/configs/settings.json");
         content.Should().BeNull("the package file should not be committed when sensitive variable substitution throws");
     }
 
     [Test]
-    public void CommitMessageSummaryIsUsedAsCommitMessage()
+    public async Task CommitMessageSummaryIsUsedAsCommitMessage()
     {
         const string packageReferenceName = "my-configs";
         const string destinationPath = "output-dir";
@@ -217,25 +218,25 @@ public class CommitToGitCommandTest
         var zipPath = CreateZipWithEntry(packageReferenceName, "configs/settings.json", "{}");
         AddInputPackageVariables(packageReferenceName, zipPath, destinationPath);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
 
         using var repo = new Repository(OriginPath);
         repo.Branches[targetBranchFriendlyName].Tip.Message.Should().StartWith("Git Commit Summary");
     }
 
     [Test]
-    public void FailingScriptResultsInNonZeroExitCode()
+    public async Task FailingScriptResultsInNonZeroExitCode()
     {
         variables.AddRange([
             new CalamariExecutionVariable(ScriptVariables.ScriptBody, "exit 1", false),
-            new CalamariExecutionVariable(ScriptVariables.Syntax, ScriptSyntax.Bash.ToString(), false),
+            new CalamariExecutionVariable(ScriptVariables.Syntax, nameof(ScriptSyntax.Bash), false),
         ]);
 
-        RunCommitToGit().Should().NotBe(0);
+        (await RunCommitToGit()).Should().NotBe(0);
     }
 
     [Test]
-    public void BothPackageCopyAndScriptTransformProduceFilesInRepository()
+    public async Task BothPackageCopyAndScriptTransformProduceFilesInRepository()
     {
         const string packageReferenceName = "my-configs";
         const string destinationPath = "output-dir";
@@ -245,16 +246,16 @@ public class CommitToGitCommandTest
 
         variables.AddRange([
             new CalamariExecutionVariable(ScriptVariables.ScriptBody, "touch \"$(get_octopusvariable 'Octopus.Calamari.Git.RepositoryPath')/script-output.txt\"", false),
-            new CalamariExecutionVariable(ScriptVariables.Syntax, ScriptSyntax.Bash.ToString(), false),
+            new CalamariExecutionVariable(ScriptVariables.Syntax, nameof(ScriptSyntax.Bash), false),
         ]);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
         GetCommittedFileContent($"{destinationPath}/configs/settings.json").Should().NotBeNull("package files should be copied to the repository");
         GetCommittedFileContent("script-output.txt").Should().NotBeNull("the script should have created and committed the file");
     }
 
     [Test]
-    public void MultiplePackagesAreAllCopiedToGitRepository()
+    public async Task MultiplePackagesAreAllCopiedToGitRepository()
     {
         const string package1Name = "configs-package";
         const string package2Name = "templates-package";
@@ -280,13 +281,13 @@ public class CommitToGitCommandTest
             new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.DestinationPath, destinationPath, false),
         ]);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
         GetCommittedFileContent($"{destinationPath}/configs/settings.json").Should().NotBeNull("files from the first package should be copied");
         GetCommittedFileContent($"{destinationPath}/configs/template.yaml").Should().NotBeNull("files from the second package should be copied");
     }
 
     [Test]
-    public void PackageFilesAreCopiedToDestinationSubFolderDefinedInMetadata()
+    public async Task PackageFilesAreCopiedToDestinationSubFolderDefinedInMetadata()
     {
         const string packageReferenceName = "my-configs";
         const string destinationPath = "base-dir";
@@ -303,7 +304,7 @@ public class CommitToGitCommandTest
             new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.DestinationPath, destinationPath, false),
         ]);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
 
         GetCommittedFileContent($"{destinationPath}/{destinationSubFolder}/configs/settings.json")
             .Should().NotBeNull("package files should be placed under the DestinationSubFolder from the source metadata");
@@ -312,7 +313,7 @@ public class CommitToGitCommandTest
     }
 
     [Test]
-    public void GitDependencyFilesAreCopiedToDestinationSubFolderDefinedInMetadata()
+    public async Task GitDependencyFilesAreCopiedToDestinationSubFolderDefinedInMetadata()
     {
         const string gitDependencyName = "my-git-dep";
         const string destinationPath = "base-dir";
@@ -321,7 +322,7 @@ public class CommitToGitCommandTest
         var zipPath = CreateZipWithEntry(gitDependencyName, "deployment.yaml", "apiVersion: apps/v1");
         AddInputGitReferenceVariables(gitDependencyName, zipPath, destinationPath, destinationSubFolder);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
 
         GetCommittedFileContent($"{destinationPath}/{destinationSubFolder}/deployment.yaml")
             .Should().NotBeNull("git dependency files should be placed under the DestinationSubFolder from the source metadata");
@@ -330,24 +331,24 @@ public class CommitToGitCommandTest
     }
 
     [Test]
-    public void CommitToGitRunsScriptProvidedViaScriptBodyBySyntaxVariable()
+    public async Task CommitToGitRunsScriptProvidedViaScriptBodyBySyntaxVariable()
     {
         variables.AddRange([
             new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Script.ScriptBodyBySyntax(ScriptSyntax.Bash), "touch \"$(get_octopusvariable 'Octopus.Calamari.Git.RepositoryPath')/proof.txt\"", false),
         ]);
 
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
         GetCommittedFileContent("proof.txt").Should().NotBeNull("script provided via syntax-specific variable should run and commit the file");
     }
 
     [Test]
-    public void WhenNoScriptAndNoPackagesCommandSucceedsWithZeroExitCode()
+    public async Task WhenNoScriptAndNoPackagesCommandSucceedsWithZeroExitCode()
     {
-        RunCommitToGit().Should().Be(0);
+        (await RunCommitToGit()).Should().Be(0);
     }
 
     [Test]
-    public void WhenBothScriptParametersArgAndVariableAreSetVariableTakesPrecedence()
+    public async Task WhenBothScriptParametersArgAndVariableAreSetVariableTakesPrecedence()
     {
         var proofFile = Path.Combine(executionDirectory, "arg_check.txt");
         var zipPath = CreateZipWithEntry("transform-script", "script.sh",
@@ -358,46 +359,46 @@ public class CommitToGitCommandTest
             new CalamariExecutionVariable(ScriptVariables.ScriptParameters, "from-variable", false),
         ]);
 
-        RunCommitToGit("--package", zipPath, "--scriptParameters", "from-arg").Should().Be(0);
+       (await RunCommitToGit("--package", zipPath, "--scriptParameters", "from-arg")).Should().Be(0);
         File.Exists(proofFile).Should().BeTrue("the variable value should take precedence over the --scriptParameters arg");
     }
 
     [Test]
-    public void CommitToGit_FailsWithCommandException_WhenCustomPropertiesFileOptionIsMissing()
+    public async Task CommitToGit_FailsWithCommandException_WhenCustomPropertiesFileOptionIsMissing()
     {
-        RunCommitToGit(includeCustomProperties: false)
+        (await RunCommitToGit(includeCustomProperties: false))
             .Should().NotBe(0, "the command must reject runs that do not supply --customPropertiesFile");
     }
 
     [Test]
-    public void CommitToGit_FailsWithCommandException_WhenCustomPropertiesPasswordOptionIsMissing()
+    public async Task CommitToGit_FailsWithCommandException_WhenCustomPropertiesPasswordOptionIsMissing()
     {
         var propsPath = WriteCustomPropertiesFile("n", OriginPath, "u", "p");
 
-        RunCommitToGit(includeCustomProperties: false, "--customPropertiesFile", propsPath)
+        (await RunCommitToGit(includeCustomProperties: false, "--customPropertiesFile", propsPath))
             .Should().NotBe(0, "the command must reject runs that do not supply --customPropertiesPassword");
     }
 
     [Test]
-    public void CommitToGit_FailsWithCommandException_WhenCustomPropertiesFileDoesNotExist()
+    public async Task CommitToGit_FailsWithCommandException_WhenCustomPropertiesFileDoesNotExist()
     {
         var missingPath = Path.Combine(executionDirectory, "does-not-exist.json");
 
-        RunCommitToGit(includeCustomProperties: false,
+        (await RunCommitToGit(includeCustomProperties: false,
                        "--customPropertiesFile", missingPath,
-                       "--customPropertiesPassword", customPropertiesPassword)
+                       "--customPropertiesPassword", customPropertiesPassword))
             .Should().NotBe(0, "the command must reject runs whose --customPropertiesFile path does not exist");
     }
 
     // --- Helpers ---
 
-    int RunCommitToGit(params string[] extraArgs)
-        => RunCommitToGit(includeCustomProperties: true, extraArgs);
+    async Task<int> RunCommitToGit(params string[] extraArgs)
+        => await RunCommitToGit(includeCustomProperties: true, extraArgs);
 
-    int RunCommitToGit(bool includeCustomProperties, params string[] extraArgs)
+    async Task<int> RunCommitToGit(bool includeCustomProperties, params string[] extraArgs)
     {
         var absPathToVariables = Path.Combine(executionDirectory, variableFileName);
-        File.WriteAllBytes(absPathToVariables, AesEncryption.ForServerVariables(variablePassword).Encrypt(variables.ToJsonString()));
+        await File.WriteAllBytesAsync(absPathToVariables, AesEncryption.ForServerVariables(variablePassword).Encrypt(variables.ToJsonString()));
 
         var args = new List<string>
         {
@@ -414,7 +415,7 @@ public class CommitToGitCommandTest
 
         args.AddRange(extraArgs);
 
-        return Program.Main(args.ToArray());
+        return await Program.Main(args.ToArray());
     }
 
     string WriteCustomPropertiesFile(string credentialName, string repositoryUrl, string username, string password)

--- a/source/Calamari.Tests/Fixtures/Certificates/ImportCertificateCommandFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Certificates/ImportCertificateCommandFixture.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
@@ -25,20 +26,20 @@ namespace Calamari.Tests.Fixtures.Certificates
         readonly SampleCertificate cert = SampleCertificate.CapiWithPrivateKey;
 
         [Test]
-        public void AddingCertToRoot_ThrowsError()
+        public async Task AddingCertToRoot_ThrowsError()
         {
             var variables = CreateInitialVariables();
             variables.Add(SpecialVariables.Action.Certificate.StoreName, StoreName.Root.ToString());
             variables.Add(SpecialVariables.Action.Certificate.StoreLocation, StoreLocation.CurrentUser.ToString());
 
-            var result = Invoke(variables);
+            var result = await Invoke(variables);
 
             result.AssertFailure();
             result.AssertErrorOutput("When importing certificate into Root store, location must be 'LocalMachine'. Windows security restrictions prevent importing into the Root store for a user.");
         }
         
         [Test]
-        public void AddingCertToStore_AddsCert()
+        public async Task AddingCertToStore_AddsCert()
         {
             var certificateStoreLocation = StoreLocation.LocalMachine;
             var storeName = StoreName.My.ToString();
@@ -47,7 +48,7 @@ namespace Calamari.Tests.Fixtures.Certificates
             variables.Add(SpecialVariables.Action.Certificate.StoreLocation, certificateStoreLocation.ToString());
             cert.EnsureCertificateNotInStore(storeName, certificateStoreLocation);
 
-            var result = Invoke(variables);
+            var result = await Invoke(variables);
 
             result.AssertSuccess();
             result.AssertOutputContains($"Importing certificate '{randomSubject}' with thumbprint '{cert.Thumbprint}' into store 'LocalMachine\\My'");
@@ -59,7 +60,7 @@ namespace Calamari.Tests.Fixtures.Certificates
         }
 
         [Test]
-        public void NoStoreLocationProvided_StoresInUserName()
+        public async Task NoStoreLocationProvided_StoresInUserName()
         {
             var storeName = StoreName.My.ToString();
             var storeLocation = StoreLocation.CurrentUser;
@@ -69,7 +70,7 @@ namespace Calamari.Tests.Fixtures.Certificates
             variables.Add(SpecialVariables.Action.Certificate.StoreUser, userName);
             cert.EnsureCertificateNotInStore(storeName, storeLocation);
             
-            var result = Invoke(variables);
+            var result = await Invoke(variables);
 
             result.AssertSuccess();
             result.AssertOutputContains($"Importing certificate '{randomSubject}' with thumbprint '{cert.Thumbprint}' into store 'My' for user '{userName}'");
@@ -80,13 +81,13 @@ namespace Calamari.Tests.Fixtures.Certificates
             cert.EnsureCertificateNotInStore(storeName, storeLocation);
         }
 
-        CalamariResult Invoke(VariableDictionary variables)
+        async Task<CalamariResult> Invoke(VariableDictionary variables)
         {
             using (var variablesFile = new TemporaryFile(Path.GetTempFileName()))
             {
                 var encryptionKey = variables.SaveAsEncryptedExecutionVariables(variablesFile.FilePath);
                 
-                return InvokeInProcess(Calamari()
+                return await InvokeInProcess(Calamari()
                               .Action("import-certificate")
                               .VariablesFileArguments(variablesFile.FilePath, encryptionKey));
             }

--- a/source/Calamari.Tests/Fixtures/ProgramFixture.cs
+++ b/source/Calamari.Tests/Fixtures/ProgramFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Calamari.Common;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Extensions;
@@ -20,20 +21,20 @@ namespace Calamari.Tests.Fixtures
             Assert.AreEqual(1, retCode);
         }
 
-        static int RunProgram()
-            => Program.Main(new[] {"run-script"});
+        static async Task<int> RunProgram()
+            => await Program.Main(["run-script"]);
 
         [Test]
-        public void OctopusCalamariWorkingDirectoryEnvironmentVariableIsSet()
+        public async Task OctopusCalamariWorkingDirectoryEnvironmentVariableIsSet()
         {
             EnvironmentHelper.SetEnvironmentVariable("OctopusCalamariWorkingDirectory", null);
-            RunProgram();
+            await RunProgram();
             // This usage of Environment.GetEnvironmentVariable is fine as it's not accessing a test dependency variable
             Environment.GetEnvironmentVariable("OctopusCalamariWorkingDirectory").Should().NotBeNullOrWhiteSpace();
         }
         
         [Test]
-        public void ProxyIsInitialized()
+        public async Task ProxyIsInitialized()
         {
             var existingProxy = WebRequest.DefaultWebProxy;
             try
@@ -41,7 +42,7 @@ namespace Calamari.Tests.Fixtures
                 EnvironmentHelper.SetEnvironmentVariable("TentacleProxyHost", "localhost");
 
                 WebRequest.DefaultWebProxy = null;
-                RunProgram();
+                await RunProgram();
                 WebRequest.DefaultWebProxy.Should().NotBeNull();
             }
             finally
@@ -52,9 +53,9 @@ namespace Calamari.Tests.Fixtures
         }
 
         [Test]
-        public void DefaultRegexMatchTimeoutIsSet()
+        public async Task DefaultRegexMatchTimeoutIsSet()
         {
-            RunProgram();
+            await RunProgram();
             var regexTimeout = AppDomain.CurrentDomain.GetData("REGEX_DEFAULT_MATCH_TIMEOUT");
             regexTimeout.Should().Be(AppDomainConfiguration.DefaultRegexMatchTimeout);
         }

--- a/source/Calamari.Tests/Fixtures/Variables/VariablesFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Variables/VariablesFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Helpers;
@@ -12,7 +13,7 @@ namespace Calamari.Tests.Fixtures.Variables
     {
 
         [Test]
-        public void ShouldLogVariables()
+        public async Task ShouldLogVariables()
         {
             var variables = new CalamariVariables();
             variables.Set(KnownVariables.PrintVariables, true.ToString());
@@ -26,7 +27,7 @@ namespace Calamari.Tests.Fixtures.Variables
             {
                 VariablesOverride = variables
             };
-            program.RunStubCommand();
+            await program.RunStubCommand();
 
             var messages = program.TestLog.Messages;
             var messagesAsString = string.Join(Environment.NewLine, program.TestLog.Messages.Select(m => m.FormattedMessage));

--- a/source/Calamari.Tests/Helpers/CalamariFixture.cs
+++ b/source/Calamari.Tests/Helpers/CalamariFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Calamari.Commands; //Required when NETFX is defined
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing;
@@ -40,21 +41,14 @@ namespace Calamari.Tests.Helpers
             return new CommandLine(calamariFullPath).UseDotnet().OutputToLog(false);
         }
 
-        protected CommandLine OctoDiff()
-        {
-            var octoDiffExe = OctoDiffCommandLineRunner.FindOctoDiffExecutable();
-
-            return new CommandLine(octoDiffExe);
-        }
-
-        protected CalamariResult InvokeInProcess(CommandLine command, IVariables variables = null)
+        protected async Task<CalamariResult> InvokeInProcess(CommandLine command, IVariables variables = null)
         {
             var args = command.GetRawArgs();
             var program = new TestProgram(Log);
             int exitCode;
             try
             {
-                exitCode = program.RunWithArgs(args);
+                exitCode = await program.RunWithArgs(args);
             }
             catch (Exception ex)
             {

--- a/source/Calamari.Tests/Helpers/TestProgram.cs
+++ b/source/Calamari.Tests/Helpers/TestProgram.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Autofac;
 using Calamari.Commands.Support;
 using Calamari.Common.Commands;
@@ -10,6 +11,7 @@ using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing.Helpers;
+using JetBrains.Annotations;
 
 namespace Calamari.Tests.Helpers
 {
@@ -27,21 +29,21 @@ namespace Calamari.Tests.Helpers
         public bool StubWasCalled { get; set; }
         public IVariables VariablesOverride { get; set; }
 
-        public int RunWithArgs(string[] args)
+        public async Task<int> RunWithArgs(string[] args)
         {
-            return Run(args);
+            return await Run(args);
         }
 
-        public int RunStubCommand()
+        public async Task<int> RunStubCommand()
         {
             registerTestAssembly = false;
             CommandOverride  = new StubCommand(() => StubWasCalled = true);
-            return Run(new [] {"stub"});
+            return await Run(["stub"]);
         }
 
-        protected override Assembly GetProgramAssemblyToRegister()
+        protected override IEnumerable<Assembly> GetProgramAssembliesToRegister()
         {
-            return typeof(Program).Assembly;
+            yield return typeof(Program).Assembly;
         }
 
         protected override IEnumerable<Assembly> GetAllAssembliesToRegister()

--- a/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Helm3UpgradeFixture.cs
@@ -17,9 +17,9 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void Upgrade_Succeeds()
+        public async Task Upgrade_Succeeds()
         {
-            var result = DeployPackage();
+            var result = await DeployPackage();
 
             result.AssertSuccess();
             result.AssertOutputMatches($"NAMESPACE: {Namespace}");
@@ -43,12 +43,12 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void HelmVersionNewerThanMinimumVersion_ReportsObjectStatus()
+        public async Task HelmVersionNewerThanMinimumVersion_ReportsObjectStatus()
         {
             Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
             Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
-            var result = DeployPackage();
+            var result = await DeployPackage();
 
             result.AssertSuccess();
             result.AssertOutputMatches($"NAMESPACE: {Namespace}");
@@ -87,7 +87,7 @@ namespace Calamari.Tests.KubernetesFixtures
                 Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
                 Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
-                var result = DeployPackage();
+                var result =await  DeployPackage();
 
                 result.AssertSuccess();
                 result.AssertOutputMatches($"NAMESPACE: {Namespace}");
@@ -109,12 +109,12 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void HooksOnlyPackage_RetrievesEmptyManifestButDoesNotReportObjectStatus()
+        public async Task HooksOnlyPackage_RetrievesEmptyManifestButDoesNotReportObjectStatus()
         {
             Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
             Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
-            var result = DeployPackage("hooks-only-1.0.0.tgz");
+            var result = await DeployPackage("hooks-only-1.0.0.tgz");
 
             result.AssertSuccess();
             result.AssertOutputMatches($"NAMESPACE: {Namespace}");
@@ -137,12 +137,12 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void EmptyChart_RetrievesEmptyManifestButDoesNotReportObjectStatus()
+        public async Task EmptyChart_RetrievesEmptyManifestButDoesNotReportObjectStatus()
         {
             Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
             Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
 
-            var result = DeployPackage("empty-chart-1.0.0.tgz");
+            var result =await  DeployPackage("empty-chart-1.0.0.tgz");
 
             result.AssertSuccess();
             result.AssertOutputMatches($"NAMESPACE: {Namespace}");
@@ -166,13 +166,13 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNon32BitWindows]
         [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
-        public void TargetingANamespaceThatDoesNotExistAbortsTheManifestSearchingLoop()
+        public async Task TargetingANamespaceThatDoesNotExistAbortsTheManifestSearchingLoop()
         {
             Variables.AddFlag(SpecialVariables.ResourceStatusCheck, true);
             Variables.Set(SpecialVariables.Helm.Timeout, "2m30s");
             Variables.Set(SpecialVariables.Helm.Namespace, "this-namespace-does-not-exist");
 
-            var result = DeployPackage();
+            var result = await DeployPackage();
 
             result.AssertFailure();
             result.AssertOutputMatches($"Retrieving manifest for {ReleaseName}");

--- a/source/Calamari.Tests/KubernetesFixtures/HelmInstalledVersionUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmInstalledVersionUpgradeFixture.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
 using NUnit.Framework;
@@ -12,9 +13,9 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNon32BitWindows]
         [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
-        public void Upgrade_Succeeds()
+        public async Task Upgrade_Succeeds()
         {
-            var result = DeployPackage();
+            var result =await  DeployPackage();
 
             result.AssertSuccess();
             result.AssertNoOutput("Using custom helm executable at");

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -139,9 +139,9 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void NoValues_EmbeddedValuesUsed()
+        public async Task NoValues_EmbeddedValuesUsed()
         {
-            var result = DeployPackage();
+            var result = await DeployPackage();
 
             result.AssertSuccess();
 
@@ -152,13 +152,13 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void MismatchPackageIDAndHelmArchivePathWorks()
+        public async Task MismatchPackageIDAndHelmArchivePathWorks()
         {
             var packageName = $"{Variables.Get(PackageVariables.PackageId)}-{Variables.Get(PackageVariables.PackageVersion)}.tgz";
             Variables.Set(PackageVariables.PackageId, "thisisnotamatch");
             Variables.Set(PackageVariables.PackageVersion, "0.3.7");
 
-            var result = DeployPackage(packageName);
+            var result =await  DeployPackage(packageName);
 
             result.AssertSuccess();
 
@@ -169,12 +169,12 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void ExplicitValues_NewValuesUsed()
+        public async Task ExplicitValues_NewValuesUsed()
         {
             //Helm Config
             Variables.Set(Kubernetes.SpecialVariables.Helm.KeyValues, "{\"SpecialMessage\": \"FooBar\"}");
 
-            var result = DeployPackage();
+            var result = await DeployPackage();
             result.AssertSuccess();
             Assert.AreEqual("Hello FooBar", result.CapturedOutput.OutputVariables["Message"]);
         }
@@ -183,7 +183,7 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void ValuesFromPackage_NewValuesUsed()
+        public async Task ValuesFromPackage_NewValuesUsed()
         {
             //Additional Package
             Variables.Set(PackageVariables.IndexedPackageId("Pack-1"), "CustomValues");
@@ -194,7 +194,7 @@ namespace Calamari.Tests.KubernetesFixtures
             //Variable that will replace packaged value in package
             Variables.Set("MySecretMessage", "Variable Replaced In Package");
 
-            var result = DeployPackage();
+            var result = await DeployPackage();
             result.AssertSuccess();
             Assert.AreEqual("Hello Variable Replaced In Package", result.CapturedOutput.OutputVariables["Message"]);
         }
@@ -203,12 +203,12 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void ValuesFromChartPackage_NewValuesUsed()
+        public async Task ValuesFromChartPackage_NewValuesUsed()
         {
             //Additional Package
             Variables.Set(Kubernetes.SpecialVariables.Helm.Packages.ValuesFilePath(""), Path.Combine("mychart", "secondary.Development.yaml"));
 
-            var result = DeployPackage();
+            var result =await  DeployPackage();
             result.AssertSuccess();
             Assert.AreEqual("Hello I am in a secondary", result.CapturedOutput.OutputVariables["Message"]);
         }
@@ -217,12 +217,12 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void ValuesFromChartPackage_GetSubstituted()
+        public async Task ValuesFromChartPackage_GetSubstituted()
         {
             Variables.Set(PackageVariables.PackageVersion, "0.3.8");
             Variables.Set("SpecialMessage", "octostache is working");
 
-            var result = DeployPackage();
+            var result = await DeployPackage();
             result.AssertSuccess();
             Assert.AreEqual("Hello octostache is working", result.CapturedOutput.OutputVariables["Message"]);
         }
@@ -231,12 +231,12 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void ValuesFromChartPackageWithoutSubDirectory_NewValuesUsed()
+        public async Task ValuesFromChartPackageWithoutSubDirectory_NewValuesUsed()
         {
             //Additional Package
             Variables.Set(Kubernetes.SpecialVariables.Helm.Packages.ValuesFilePath(""), "secondary.Development.yaml");
 
-            var result = DeployPackage();
+            var result =await  DeployPackage();
             result.AssertSuccess();
             Assert.AreEqual("Hello I am in a secondary", result.CapturedOutput.OutputVariables["Message"]);
         }
@@ -245,7 +245,7 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void ValuesFromPackageAndExplicit_ExplicitTakesPrecedence()
+        public async Task ValuesFromPackageAndExplicit_ExplicitTakesPrecedence()
         {
             //Helm Config (lets make sure Explicit values take precedence
             Variables.Set(Kubernetes.SpecialVariables.Helm.KeyValues, "{\"SpecialMessage\": \"FooBar\"}");
@@ -260,7 +260,7 @@ namespace Calamari.Tests.KubernetesFixtures
             //Variable that will replace packaged value in package
             Variables.Set("MySecretMessage", "From A Variable Replaced In Package");
 
-            var result = DeployPackage();
+            var result =await  DeployPackage();
             result.AssertSuccess();
             Assert.AreEqual("Hello FooBar", result.CapturedOutput.OutputVariables["Message"]);
         }
@@ -269,11 +269,11 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void ValuesFromRawYaml_ValuesAdded()
+        public async Task ValuesFromRawYaml_ValuesAdded()
         {
             Variables.Set(Kubernetes.SpecialVariables.Helm.YamlValues, "\"SpecialMessage\": \"YAML\"");
 
-            var result = DeployPackage();
+            var result =await  DeployPackage();
             result.AssertSuccess();
             Assert.AreEqual("Hello YAML", result.CapturedOutput.OutputVariables["Message"]);
         }
@@ -284,7 +284,7 @@ namespace Calamari.Tests.KubernetesFixtures
             {
                 AddPostDeployMessageCheckAndCleanup();
 
-                var result = DeployPackage();
+                var result = await DeployPackage();
                 result.AssertSuccess();
                 result.AssertOutput($"Using custom helm executable at {HelmOsPlatform}\\helm from inside package. Full path at");
             }
@@ -314,13 +314,13 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void Namespace_Override_Used()
+        public async Task Namespace_Override_Used()
         {
             const string @namespace = "calamari-testing-foo";
             Variables.Set(Kubernetes.SpecialVariables.Helm.Namespace, @namespace);
             AddPostDeployMessageCheckAndCleanup(@namespace);
 
-            var result = DeployPackage();
+            var result = await DeployPackage();
             result.AssertSuccess();
             Assert.AreEqual("Hello Embedded Variables", result.CapturedOutput.OutputVariables["Message"]);
         }
@@ -329,12 +329,12 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void AdditionalArgumentsPassed()
+        public async Task AdditionalArgumentsPassed()
         {
             Variables.Set(Kubernetes.SpecialVariables.Helm.AdditionalArguments, "--dry-run");
             AddPostDeployMessageCheckAndCleanup(explicitNamespace: null, dryRun: true);
 
-            var result = DeployPackage();
+            var result = await DeployPackage();
             result.AssertSuccess();
             result.AssertOutputMatches("[helm|\\\\helm\"] upgrade (.*) --dry-run");
         }
@@ -343,13 +343,13 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void DoesNotReportManifestsWhenDryRunIsSet()
+        public async Task DoesNotReportManifestsWhenDryRunIsSet()
         {
             Variables.Set(Kubernetes.SpecialVariables.Helm.AdditionalArguments, "--dry-run");
             Variables.Set(Kubernetes.SpecialVariables.ResourceStatusCheck, "true");
             AddPostDeployMessageCheckAndCleanup(explicitNamespace: null, dryRun: true);
 
-            var result = DeployPackage();
+            var result = await DeployPackage();
             result.AssertSuccess();
             result.AssertOutputMatches("[helm|\\\\helm\"] upgrade (.*) --dry-run");
             result.AssertOutputContains("Helm --dry-run is enabled, no object statuses will be reported");
@@ -360,10 +360,10 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNon32BitWindows]
         [RequiresNonMac]
         [Category(TestCategory.PlatformAgnostic)]
-        public void WhenTheChartDirectoryVariableIsSet_TheChartAtThatLocationIsUsed()
+        public async Task WhenTheChartDirectoryVariableIsSet_TheChartAtThatLocationIsUsed()
         {
             Variables.Set(Kubernetes.SpecialVariables.Helm.ChartDirectory, "specific/location/for/my/chart");
-            var result = DeployPackage("mychart-with-specific-location-0.3.8.tar.gz");
+            var result =await  DeployPackage("mychart-with-specific-location-0.3.8.tar.gz");
             result.AssertSuccess();
         }
 
@@ -371,10 +371,10 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void WhenTheChartDirectoryVariableIsSet_AndTheChartDoesNotExist_AnErrorIsReturned()
+        public async Task WhenTheChartDirectoryVariableIsSet_AndTheChartDoesNotExist_AnErrorIsReturned()
         {
             Variables.Set(Kubernetes.SpecialVariables.Helm.ChartDirectory, "specific/location/for/my/chart");
-            var result = DeployPackage(); // This package doesn't have the specific location, should go :boom:
+            var result =await  DeployPackage(); // This package doesn't have the specific location, should go :boom:
             result.AssertFailure();
             result.AssertOutputContains("Chart was not found in 'specific/location/for/my/chart'");
         }
@@ -383,9 +383,9 @@ namespace Calamari.Tests.KubernetesFixtures
         [RequiresNonFreeBSDPlatform]
         [RequiresNon32BitWindows]
         [Category(TestCategory.PlatformAgnostic)]
-        public void WhenChartIsInRootOfPackage_ShouldUseTheRootStagingDirectory()
+        public async Task WhenChartIsInRootOfPackage_ShouldUseTheRootStagingDirectory()
         {
-            var result = DeployPackage("mychart-with-no-root-folder-0.3.8.tgz");
+            var result = await DeployPackage("mychart-with-no-root-folder-0.3.8.tgz");
             result.AssertSuccess();
         }
 
@@ -421,7 +421,7 @@ namespace Calamari.Tests.KubernetesFixtures
         static string DeleteCommand(string @namespace, string releaseName)
             => $"uninstall {releaseName} --namespace {@namespace}";
 
-        protected CalamariResult DeployPackage(string packageName = null)
+        protected async Task<CalamariResult> DeployPackage(string packageName = null)
         {
             using (var variablesFile = new TemporaryFile(Path.GetTempFileName()))
             {
@@ -435,7 +435,7 @@ namespace Calamari.Tests.KubernetesFixtures
 
                var encryptionKey = Variables.SaveAsEncryptedExecutionVariables(variablesFile.FilePath);
 
-                return InvokeInProcess(Calamari()
+                return await InvokeInProcess(Calamari()
                                        .Action("helm-upgrade")
                                        .Argument("package", pkg)
                                        .VariablesFileArguments(variablesFile.FilePath, encryptionKey));

--- a/source/Calamari.Tests/TestProgramWrapper.cs
+++ b/source/Calamari.Tests/TestProgramWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Tests.Helpers;
 
@@ -8,9 +9,10 @@ namespace Calamari.Tests
     {
         //This is a shell around Calamari.exe so we can use it in .net core testing, since in .net core when we reference the
         //Calamari project we only get the dll, not the exe
-        public static int Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
-            return new TestProgram(ConsoleLog.Instance).Execute(args);
+            var program = new TestProgram(ConsoleLog.Instance);
+            return await program.Execute(args);
         }
     }
 }

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -48,7 +48,7 @@ namespace Calamari
         public static async Task<int> Main(string[] args)
         {
             var program = new Program(ConsoleLog.Instance);
-                return await program.Execute(args);
+            return await program.Execute(args);
         }
 
         public async Task<int> Execute(params string[] args)
@@ -59,35 +59,20 @@ namespace Calamari
             return await Run(args);
         }
 
-        protected override async Task<int> ResolveAndExecuteCommand(IContainer container, CommonOptions options)
+        protected override async Task<int> ResolveAndExecuteCommandWithArgs(IContainer container, CommonOptions options)
         {
-            // Handle Pipeline commands such as Target Discovery
-            if (container.IsRegisteredWithName<PipelineCommand>(options.Command))
-            {
-                try
-                {                
-                    var pipeline = container.ResolveNamed<PipelineCommand>(options.Command);
-                    var variables = container.Resolve<IVariables>();
-                    await pipeline.Execute(container, variables);
-                    return 0;
-                }
-                catch (Exception ex)
-                {
-                    return ConsoleFormatter.PrintError(ConsoleLog.Instance, ex);
-                }
-            }
-
+            await Task.CompletedTask;
 
             var commands = container.Resolve<IEnumerable<Meta<Lazy<ICommandWithArgs>, CommandMeta>>>();
 
             var commandCandidates = commands.Where(x => x.Metadata.Name.Equals(options.Command, StringComparison.OrdinalIgnoreCase)).ToArray();
 
-            if (commandCandidates.Length == 0)
-                throw new CommandException($"Could not find the command {options.Command}");
-            if (commandCandidates.Length > 1)
-                throw new CommandException($"Multiple commands found with the name {options.Command}");
-
-            return commandCandidates[0].Value.Value.Execute(options.RemainingArguments.ToArray());
+            return commandCandidates.Length switch
+                   {
+                       0 => throw new CommandException($"Could not find the command {options.Command}"),
+                       1 => commandCandidates[0].Value.Value.Execute(options.RemainingArguments.ToArray()),
+                       _ => throw new CommandException($"Multiple commands found with the name {options.Command}")
+                   };
         }
 
         protected override void ConfigureContainer(ContainerBuilder builder, CommonOptions options)
@@ -112,12 +97,12 @@ namespace Calamari
             builder.RegisterType<HelmTemplateValueSourcesParser>().AsSelf().SingleInstance();
             if (OperatingSystem.IsWindows())
                 builder.RegisterType<WindowsX509CertificateStore>().As<IWindowsX509CertificateStore>().SingleInstance();
-            else 
+            else
                 builder.RegisterType<NoOpWindowsX509CertificateStore>().As<IWindowsX509CertificateStore>().SingleInstance();
-                
+
             builder.RegisterType<ApiResourceScopeLookup>().As<IApiResourceScopeLookup>().SingleInstance();
             builder.RegisterType<KubernetesManifestNamespaceResolver>().As<IKubernetesManifestNamespaceResolver>().InstancePerLifetimeScope();
-            
+
             builder.RegisterType<KubernetesDiscovererFactory>()
                    .As<IKubernetesDiscovererFactory>()
                    .SingleInstance();

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -144,15 +144,7 @@ namespace Calamari
                    .WithMetadataFrom<CommandAttribute>()
                    .As<ICommandWithInputs>();
 
-            // Register Pipeline commands
-            builder.RegisterAssemblyTypes(assembliesToRegister)
-                   .AssignableTo<PipelineCommand>()
-                   .WithMetadataFrom<CommandAttribute>()
-                   .Where(t => t.GetCustomAttribute<CommandAttribute>() is not null)
-                   .Named<PipelineCommand>(t => t.GetCustomAttribute<CommandAttribute>()!.Name);
-            
-
-            builder.RegisterAssemblyTypes(GetProgramAssemblyToRegister())
+            builder.RegisterAssemblyTypes(GetProgramAssembliesToRegister().ToArray())
                    .Where(x => typeof(ILaunchTool).IsAssignableFrom(x) && !x.IsAbstract && !x.IsInterface)
                    .WithMetadataFrom<LaunchToolAttribute>()
                    .As<ILaunchTool>();

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Autofac.Features.Metadata;
 using Calamari.ArgoCD;
 using Calamari.ArgoCD.Conventions;
@@ -44,20 +45,21 @@ namespace Calamari
         {
         }
 
-        public static int Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
-            return new Program(ConsoleLog.Instance).Execute(args);
+            var program = new Program(ConsoleLog.Instance);
+                return await program.Execute(args);
         }
 
-        public int Execute(params string[] args)
+        public async Task<int> Execute(params string[] args)
         {
             // Backward compatibility fix for v4 collections to ensure they are not null
             // from https://docs.aws.amazon.com/sdk-for-net/v4/developer-guide/net-dg-v4.html#net-dg-v4-collections
             Amazon.AWSConfigs.InitializeCollections = true;
-            return Run(args);
+            return await Run(args);
         }
 
-        protected override int ResolveAndExecuteCommand(IContainer container, CommonOptions options)
+        protected override async Task<int> ResolveAndExecuteCommand(IContainer container, CommonOptions options)
         {
             // Handle Pipeline commands such as Target Discovery
             if (container.IsRegisteredWithName<PipelineCommand>(options.Command))
@@ -66,7 +68,7 @@ namespace Calamari
                 {                
                     var pipeline = container.ResolveNamed<PipelineCommand>(options.Command);
                     var variables = container.Resolve<IVariables>();
-                    pipeline.Execute(container, variables).GetAwaiter().GetResult();
+                    await pipeline.Execute(container, variables);
                     return 0;
                 }
                 catch (Exception ex)

--- a/source/Calamari/Program.cs
+++ b/source/Calamari/Program.cs
@@ -95,7 +95,6 @@ namespace Calamari
             base.ConfigureContainer(builder, options);
 
             builder.RegisterType<CalamariCertificateStore>().As<ICertificateStore>().SingleInstance();
-            builder.RegisterType<DeploymentJournalWriter>().As<IDeploymentJournalWriter>().SingleInstance();
             builder.RegisterType<PackageStore>().As<IPackageStore>().SingleInstance();
             builder.RegisterType<ResourceRetriever>().As<IResourceRetriever>().SingleInstance();
             builder.RegisterType<RunningResourceStatusCheck>().As<IRunningResourceStatusCheck>().SingleInstance();


### PR DESCRIPTION
Individual commands are not run asynchronously (except pipeline commands), but this aligns the behaviour and structure with `CalamariProgramAsync` so we can compare and remove the non-async version