### PR TITLE
fix: null warnings from ResouceGroup project in build output

### DIFF
--- a/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
+++ b/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
@@ -14,126 +14,126 @@ using Newtonsoft.Json.Linq;
 using Polly;
 using Polly.Timeout;
 
-namespace Calamari.AzureResourceGroup
+namespace Calamari.AzureResourceGroup;
+
+class AzureResourceGroupOperator(ILog log)
 {
-    class AzureResourceGroupOperator
+    public async Task<ArmOperation<ArmDeploymentResource>> CreateDeployment(ResourceGroupResource resourceGroupResource,
+                                                                            string deploymentName,
+                                                                            ArmDeploymentMode deploymentMode,
+                                                                            string template,
+                                                                            string? parameters)
     {
-        readonly ILog log;
+        log.Verbose($"Template:\n{template}\n");
+        if (parameters != null)
+            log.Verbose($"Parameters:\n{parameters}\n");
 
-        public AzureResourceGroupOperator(ILog log)
+        try
         {
-            this.log = log;
-        }
-
-        public async Task<ArmOperation<ArmDeploymentResource>> CreateDeployment(ResourceGroupResource resourceGroupResource,
-                                                                                string deploymentName,
-                                                                                ArmDeploymentMode deploymentMode,
-                                                                                string template,
-                                                                                string? parameters)
-        {
-            log.Verbose($"Template:\n{template}\n");
-            if (parameters != null)
-                log.Verbose($"Parameters:\n{parameters}\n");
-
-            try
+            var deploymentContent = new ArmDeploymentContent(new ArmDeploymentProperties(deploymentMode)
             {
-                var deploymentContent = new ArmDeploymentContent(new ArmDeploymentProperties(deploymentMode)
-                {
-                    Template = BinaryData.FromString(template),
-                    Parameters = parameters != null ? BinaryData.FromString(parameters) : null
-                });
-                var createDeploymentResult = await resourceGroupResource.GetArmDeployments().CreateOrUpdateAsync(WaitUntil.Started, deploymentName, deploymentContent);
+                Template = BinaryData.FromString(template),
+                Parameters = parameters != null ? BinaryData.FromString(parameters) : null
+            });
+            var createDeploymentResult = await resourceGroupResource.GetArmDeployments().CreateOrUpdateAsync(WaitUntil.Started, deploymentName, deploymentContent);
 
-                log.Info($"Deployment {deploymentName} created.");
+            log.Info($"Deployment {deploymentName} created.");
 
-                return createDeploymentResult;
-            }
-            catch
+            return createDeploymentResult;
+        }
+        catch
+        {
+            log.Error("Error submitting deployment");
+            throw;
+        }
+    }
+
+    public async Task PollForCompletionWithTimeout(ArmOperation<ArmDeploymentResource> deploymentOperation, IVariables variables)
+    {
+        var pollingTimeout = GetPollingTimeout(variables);
+        var asyncResourceGroupPollingTimeoutPolicy = Policy.TimeoutAsync(pollingTimeout, TimeoutStrategy.Optimistic);
+        await asyncResourceGroupPollingTimeoutPolicy.ExecuteAsync(ct => Poll(deploymentOperation, ct), CancellationToken.None);
+    }
+
+    public async Task PollForCompletion(ArmOperation<ArmDeploymentResource> deploymentOperation)
+    {
+        await Poll(deploymentOperation, CancellationToken.None);
+    }
+
+    async Task Poll(ArmOperation<ArmDeploymentResource> deploymentOperation, CancellationToken cancellationToken)
+    {
+        log.Info("Polling for deployment completion...");
+        try
+        {
+            var delayStrategy = DelayStrategy.CreateExponentialDelayStrategy(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
+            var response = await deploymentOperation.WaitForCompletionAsync(delayStrategy, cancellationToken);
+            log.Info($"Deployment completed with status: {response.Value?.Data.Properties?.ProvisioningState}");
+        }
+        catch
+        {
+            log.Error("Error polling for deployment completion");
+            throw;
+        }
+    }
+
+    public async Task FinalizeDeployment(ArmOperation<ArmDeploymentResource> operation, IVariables variables)
+    {
+        await LogOperationResults(operation);
+        CaptureOutputs(operation.Value.Data.Properties.Outputs?.ToString(), variables);
+    }
+
+    async Task LogOperationResults(ArmOperation<ArmDeploymentResource> operation)
+    {
+        if (!operation.HasValue || !operation.HasCompleted)
+            return;
+
+        var sb = new StringBuilder("Operations details:\n");
+        await foreach (var op in operation.Value.GetDeploymentOperationsAsync())
+        {
+            var properties = op.Properties;
+            sb.AppendLine($"Resource: {properties.TargetResource?.ResourceName}");
+            sb.AppendLine($"Type: {properties.TargetResource?.ResourceType}");
+            sb.AppendLine($"Timestamp: {properties.Timestamp?.ToLocalTime():s}");
+            sb.AppendLine($"Deployment operation: {op.Id}");
+            sb.AppendLine($"Status: {properties.StatusCode}");
+            sb.AppendLine($"Provisioning State: {properties.ProvisioningState}");
+            if (properties.StatusMessage != null)
+                sb.AppendLine($"Status Message: {JsonConvert.SerializeObject(properties.StatusMessage)}");
+            sb.Append(" \n");
+        }
+
+        log.Info(sb.ToString());
+    }
+
+    void CaptureOutputs(string? outputsJson, IVariables variables)
+    {
+        if (string.IsNullOrWhiteSpace(outputsJson))
+            return;
+
+        log.Verbose("Deployment Outputs:");
+        log.Verbose(outputsJson);
+
+        var outputs = JObject.Parse(outputsJson);
+
+
+            
+        foreach (var output in outputs)
+        {
+            if (output.Value?["value"] is not null)
             {
-                log.Error("Error submitting deployment");
-                throw;
+                log.SetOutputVariable($"AzureRmOutputs[{output.Key}]", output.Value["value"]!.ToString(), variables);
             }
         }
+                
+    }
 
-        public async Task PollForCompletionWithTimeout(ArmOperation<ArmDeploymentResource> deploymentOperation, IVariables variables)
+    static TimeSpan GetPollingTimeout(IVariables variables)
+    {
+        var pollingTimeoutVariableValue = variables.GetInt32(SpecialVariables.Action.Azure.ArmDeploymentTimeout);
+        if (pollingTimeoutVariableValue.HasValue && pollingTimeoutVariableValue.Value > 0)
         {
-            var pollingTimeout = GetPollingTimeout(variables);
-            var asyncResourceGroupPollingTimeoutPolicy = Policy.TimeoutAsync(pollingTimeout, TimeoutStrategy.Optimistic);
-            await asyncResourceGroupPollingTimeoutPolicy.ExecuteAsync(ct => Poll(deploymentOperation, ct), CancellationToken.None);
+            return TimeSpan.FromMinutes(pollingTimeoutVariableValue.Value);
         }
-
-        public async Task PollForCompletion(ArmOperation<ArmDeploymentResource> deploymentOperation)
-        {
-            await Poll(deploymentOperation, CancellationToken.None);
-        }
-
-        async Task Poll(ArmOperation<ArmDeploymentResource> deploymentOperation, CancellationToken cancellationToken)
-        {
-            log.Info("Polling for deployment completion...");
-            try
-            {
-                var delayStrategy = DelayStrategy.CreateExponentialDelayStrategy(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
-                var response = await deploymentOperation.WaitForCompletionAsync(delayStrategy, cancellationToken);
-                log.Info($"Deployment completed with status: {response.Value?.Data.Properties?.ProvisioningState}");
-            }
-            catch
-            {
-                log.Error("Error polling for deployment completion");
-                throw;
-            }
-        }
-
-        public async Task FinalizeDeployment(ArmOperation<ArmDeploymentResource> operation, IVariables variables)
-        {
-            await LogOperationResults(operation);
-            CaptureOutputs(operation.Value.Data.Properties.Outputs?.ToString(), variables);
-        }
-
-        async Task LogOperationResults(ArmOperation<ArmDeploymentResource> operation)
-        {
-            if (!operation.HasValue || !operation.HasCompleted)
-                return;
-
-            var sb = new StringBuilder("Operations details:\n");
-            await foreach (var op in operation.Value.GetDeploymentOperationsAsync())
-            {
-                var properties = op.Properties;
-                sb.AppendLine($"Resource: {properties.TargetResource?.ResourceName}");
-                sb.AppendLine($"Type: {properties.TargetResource?.ResourceType}");
-                sb.AppendLine($"Timestamp: {properties.Timestamp?.ToLocalTime():s}");
-                sb.AppendLine($"Deployment operation: {op.Id}");
-                sb.AppendLine($"Status: {properties.StatusCode}");
-                sb.AppendLine($"Provisioning State: {properties.ProvisioningState}");
-                if (properties.StatusMessage != null)
-                    sb.AppendLine($"Status Message: {JsonConvert.SerializeObject(properties.StatusMessage)}");
-                sb.Append(" \n");
-            }
-
-            log.Info(sb.ToString());
-        }
-
-        void CaptureOutputs(string? outputsJson, IVariables variables)
-        {
-            if (string.IsNullOrWhiteSpace(outputsJson))
-                return;
-
-            log.Verbose("Deployment Outputs:");
-            log.Verbose(outputsJson);
-
-            var outputs = JObject.Parse(outputsJson);
-
-            foreach (var output in outputs)
-                log.SetOutputVariable($"AzureRmOutputs[{output.Key}]", output.Value["value"].ToString(), variables);
-        }
-
-        static TimeSpan GetPollingTimeout(IVariables variables)
-        {
-            var pollingTimeoutVariableValue = variables.GetInt32(SpecialVariables.Action.Azure.ArmDeploymentTimeout);
-            if (pollingTimeoutVariableValue.HasValue && pollingTimeoutVariableValue.Value > 0)
-            {
-                return TimeSpan.FromMinutes(pollingTimeoutVariableValue.Value);
-            }
-            return TimeSpan.FromMinutes(30);
-        }
+        return TimeSpan.FromMinutes(30);
     }
 }

--- a/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
+++ b/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
@@ -114,9 +114,6 @@ class AzureResourceGroupOperator(ILog log)
         log.Verbose(outputsJson);
 
         var outputs = JObject.Parse(outputsJson);
-
-
-            
         foreach (var output in outputs)
         {
             if (output.Value?["value"] is not null)
@@ -124,7 +121,6 @@ class AzureResourceGroupOperator(ILog log)
                 log.SetOutputVariable($"AzureRmOutputs[{output.Key}]", output.Value["value"]!.ToString(), variables);
             }
         }
-                
     }
 
     static TimeSpan GetPollingTimeout(IVariables variables)

--- a/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
+++ b/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
@@ -39,7 +39,7 @@ namespace Calamari.AzureResourceGroup
 
             var variables = context.Variables;
             var hasAccessToken = !variables.Get(AccountVariables.Jwt).IsNullOrEmpty();
-            var account = hasAccessToken ? (IAzureAccount)new AzureOidcAccount(variables) : new AzureServicePrincipalAccount(variables);
+            IAzureAccount account = hasAccessToken ? new AzureOidcAccount(variables) : new AzureServicePrincipalAccount(variables);
 
             var armClient = account.CreateArmClient();
 

--- a/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
+++ b/source/Calamari.AzureResourceGroup/DeployAzureResourceGroupBehaviour.cs
@@ -1,3 +1,4 @@
+// ReSharper disable ClassNeverInstantiated.Global
 using System;
 using System.Threading.Tasks;
 using Azure.ResourceManager.Resources;
@@ -11,76 +12,66 @@ using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Variables;
 using Octopus.CoreUtilities.Extensions;
 
-namespace Calamari.AzureResourceGroup
+namespace Calamari.AzureResourceGroup;
+
+class DeployAzureResourceGroupBehaviour(
+    TemplateService templateService,
+    IResourceGroupTemplateNormalizer parameterNormalizer,
+    ILog log,
+    AzureResourceGroupOperator azureResourceGroupOperator)
+    : IDeployBehaviour
 {
-    class DeployAzureResourceGroupBehaviour : IDeployBehaviour
+    public bool IsEnabled(RunningDeployment context) => true;
+
+    public async Task Execute(RunningDeployment context)
     {
-        readonly TemplateService templateService;
-        readonly IResourceGroupTemplateNormalizer parameterNormalizer;
-        readonly ILog log;
-        readonly AzureResourceGroupOperator azureResourceGroupOperator;
+        log.Verbose("Using Modern Azure SDK behaviour.");
 
-        public DeployAzureResourceGroupBehaviour(TemplateService templateService,
-                                                 IResourceGroupTemplateNormalizer parameterNormalizer,
-                                                 ILog log,
-                                                 AzureResourceGroupOperator azureResourceGroupOperator)
+        var variables = context.Variables;
+        var hasAccessToken = !variables.Get(AccountVariables.Jwt).IsNullOrEmpty();
+        IAzureAccount account = hasAccessToken ? new AzureOidcAccount(variables) : new AzureServicePrincipalAccount(variables);
+
+        var armClient = account.CreateArmClient();
+
+        var resourceGroupName = variables.GetRequiredVariable(SpecialVariables.Action.Azure.ResourceGroupName);
+        var subscriptionId = variables.GetRequiredVariable(AzureAccountVariables.SubscriptionId);
+
+        var deploymentNameVariable = variables[SpecialVariables.Action.Azure.ResourceGroupDeploymentName];
+        var deploymentName = !string.IsNullOrWhiteSpace(deploymentNameVariable)
+            ? deploymentNameVariable
+            : DeploymentName.FromStepName(variables[ActionVariables.Name]);
+
+        var deploymentModeVariable = variables.GetRequiredVariable(SpecialVariables.Action.Azure.ResourceGroupDeploymentMode);
+        var deploymentMode = (ArmDeploymentMode)Enum.Parse(typeof(ArmDeploymentMode), deploymentModeVariable);
+
+        var templateParametersFile = variables.Get(SpecialVariables.Action.Azure.TemplateParameters, "parameters.json");
+        var templateSource = variables.Get(SpecialVariables.Action.Azure.TemplateSource, string.Empty);
+
+        var filesInPackageOrRepository = templateSource is "Package" or "GitRepository";
+
+        var templateFile = filesInPackageOrRepository
+            ? variables.GetMandatoryVariable(SpecialVariables.Action.Azure.ResourceGroupTemplate) // For now, we know that Server enforces a template when reading from a Package or Git so we treat it as mandatory
+            : variables.Get(SpecialVariables.Action.Azure.Template, "template.json");
+        if (filesInPackageOrRepository)
         {
-            this.templateService = templateService;
-            this.parameterNormalizer = parameterNormalizer;
-            this.log = log;
-            this.azureResourceGroupOperator = azureResourceGroupOperator;
+            templateParametersFile = variables.Get(SpecialVariables.Action.Azure.ResourceGroupTemplateParameters);
         }
 
-        public bool IsEnabled(RunningDeployment context) => true;
+        var template = templateService.GetSubstitutedTemplateContent(templateFile, filesInPackageOrRepository, variables);
+        var parameters = !string.IsNullOrWhiteSpace(templateParametersFile)
+            ? parameterNormalizer.Normalize(templateService.GetSubstitutedTemplateContent(templateParametersFile, filesInPackageOrRepository, variables))
+            : null;
 
-        public async Task Execute(RunningDeployment context)
-        {
-            log.Verbose("Using Modern Azure SDK behaviour.");
-
-            var variables = context.Variables;
-            var hasAccessToken = !variables.Get(AccountVariables.Jwt).IsNullOrEmpty();
-            IAzureAccount account = hasAccessToken ? new AzureOidcAccount(variables) : new AzureServicePrincipalAccount(variables);
-
-            var armClient = account.CreateArmClient();
-
-            var resourceGroupName = variables.GetRequiredVariable(SpecialVariables.Action.Azure.ResourceGroupName);
-            var subscriptionId = variables.GetRequiredVariable(AzureAccountVariables.SubscriptionId);
-
-            var deploymentNameVariable = variables[SpecialVariables.Action.Azure.ResourceGroupDeploymentName];
-            var deploymentName = !string.IsNullOrWhiteSpace(deploymentNameVariable)
-                ? deploymentNameVariable
-                : DeploymentName.FromStepName(variables[ActionVariables.Name]);
-
-            var deploymentModeVariable = variables.GetRequiredVariable(SpecialVariables.Action.Azure.ResourceGroupDeploymentMode);
-            var deploymentMode = (ArmDeploymentMode)Enum.Parse(typeof(ArmDeploymentMode), deploymentModeVariable);
-
-            var templateFile = variables.Get(SpecialVariables.Action.Azure.Template, "template.json");
-            var templateParametersFile = variables.Get(SpecialVariables.Action.Azure.TemplateParameters, "parameters.json");
-            var templateSource = variables.Get(SpecialVariables.Action.Azure.TemplateSource, string.Empty);
-
-            var filesInPackageOrRepository = templateSource == "Package" || templateSource == "GitRepository";
-            if (filesInPackageOrRepository)
-            {
-                templateFile = variables.Get(SpecialVariables.Action.Azure.ResourceGroupTemplate);
-                templateParametersFile = variables.Get(SpecialVariables.Action.Azure.ResourceGroupTemplateParameters);
-            }
-
-            var template = templateService.GetSubstitutedTemplateContent(templateFile, filesInPackageOrRepository, variables);
-            var parameters = !string.IsNullOrWhiteSpace(templateParametersFile)
-                ? parameterNormalizer.Normalize(templateService.GetSubstitutedTemplateContent(templateParametersFile, filesInPackageOrRepository, variables))
-                : null;
-
-            var resourceGroupResource = armClient.GetResourceGroupResource(ResourceGroupResource.CreateResourceIdentifier(subscriptionId, resourceGroupName));
+        var resourceGroupResource = armClient.GetResourceGroupResource(ResourceGroupResource.CreateResourceIdentifier(subscriptionId, resourceGroupName));
             
-            log.Info($"Deploying Resource Group {resourceGroupName} in subscription {subscriptionId}.\nDeployment name: {deploymentName}\nDeployment mode: {deploymentMode}");
+        log.Info($"Deploying Resource Group {resourceGroupName} in subscription {subscriptionId}.\nDeployment name: {deploymentName}\nDeployment mode: {deploymentMode}");
             
-            var deploymentOperation = await azureResourceGroupOperator.CreateDeployment(resourceGroupResource,
-                                                                                        deploymentName,
-                                                                                        deploymentMode,
-                                                                                        template,
-                                                                                        parameters);
-            await azureResourceGroupOperator.PollForCompletionWithTimeout(deploymentOperation, variables);
-            await azureResourceGroupOperator.FinalizeDeployment(deploymentOperation, variables);
-        }
+        var deploymentOperation = await azureResourceGroupOperator.CreateDeployment(resourceGroupResource,
+                                                                                    deploymentName,
+                                                                                    deploymentMode,
+                                                                                    template,
+                                                                                    parameters);
+        await azureResourceGroupOperator.PollForCompletionWithTimeout(deploymentOperation, variables);
+        await azureResourceGroupOperator.FinalizeDeployment(deploymentOperation, variables);
     }
 }

--- a/source/Calamari.AzureResourceGroup/TemplateService.cs
+++ b/source/Calamari.AzureResourceGroup/TemplateService.cs
@@ -4,31 +4,23 @@ using Calamari.Common.Plumbing.Variables;
 using Calamari.Common.Util;
 using Octopus.CoreUtilities.Extensions;
 
-namespace Calamari.AzureResourceGroup
+namespace Calamari.AzureResourceGroup;
+
+class TemplateService(ICalamariFileSystem fileSystem, ITemplateResolver resolver)
 {
-    class TemplateService
+    public string GetSubstitutedTemplateContent(string relativePath, bool inPackage, IVariables variables)
     {
-        readonly ICalamariFileSystem fileSystem;
-        readonly ITemplateResolver resolver;
+        return ResolveAndSubstituteFile(() => resolver.Resolve(relativePath, inPackage, variables).Value,
+                                        fileSystem.ReadFile,
+                                        variables);
+    }
 
-        public TemplateService(ICalamariFileSystem fileSystem, ITemplateResolver resolver)
-        {
-            this.fileSystem = fileSystem;
-            this.resolver = resolver;
-        }
-
-        public string GetSubstitutedTemplateContent(string relativePath, bool inPackage, IVariables variables)
-        {
-            return ResolveAndSubstituteFile(() => resolver.Resolve(relativePath, inPackage, variables).Value,
-                                            fileSystem.ReadFile,
-                                            variables);
-        }
-
-        string ResolveAndSubstituteFile(Func<string> resolvePath, Func<string, string> readContent, IVariables variables)
-        {
-            return resolvePath()
-                   .Map(readContent)
-                   .Map(variables.Evaluate);
-        }
+    static string ResolveAndSubstituteFile(Func<string> resolvePath, Func<string, string> readContent, IVariables variables)
+    {
+        return resolvePath()
+               .Map(readContent)
+               .Map(variables.Evaluate)
+               // Evaluate can return null - while unlikely we should handle gracefully
+               ?? string.Empty;
     }
 }


### PR DESCRIPTION
Add safe null handling to remove noise from the buill log about potentilly null values.

Did some tidy while I was in the files.