### PR TITLE
Consolidate how we load kubectl versioning

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Authentication/SetupKubectlAuthenticationAwsFixture.cs
@@ -5,6 +5,7 @@ using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes;
 using Calamari.Kubernetes.Authentication;
+using Calamari.Kubernetes.Integration;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -86,7 +87,7 @@ namespace Calamari.Tests.KubernetesFixtures.Authentication
             AddLogForWhichAws();
             AddLogForAwsVersion(CurrentAwsVersion);
 
-            kubectl.GetVersion().Returns(Maybe<SemanticVersion>.Some(new SemanticVersion(1, 29, 7)));
+            kubectl.GetVersion().Returns(new KubectlVersionOutput(new SemanticVersion(1, 29, 7), null));
 
             variables.SetStrings(KnownVariables.EnabledFeatureToggles,
                                  new[]

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/Executors/KustomizeExecutorTests.cs
@@ -156,10 +156,10 @@ namespace Calamari.Tests.KubernetesFixtures.Commands.Executors
             var result = await executor.Execute(runningDeployment, RecordingCallback);
 
             // Assert
-            result.Should().BeTrue();
+            result.Should().BeTrue();   
             commandLineRunner.ReceivedCalls().Count().Should().Be(3);
             var commandLineArgs = commandLineRunner.ReceivedCalls().SelectMany(call => call.GetArguments().Select(arg => arg.ToString())).ToArray();
-            commandLineArgs[0].Should().Contain("version").And.Contain("--client").And.Contain("-o json");
+            commandLineArgs[0].Should().Contain("version").And.Contain("--client").And.Contain("--output=json");
             commandLineArgs[1].Should().Contain("kustomize").And.Contain(OverlayPath).And.Contain("-o").And.Contain(KustomizeExecutor.HydratedKustomizeManifestFilename);
             commandLineArgs[2].Should().Contain("apply -f").And.Contain(KustomizeExecutor.HydratedKustomizeManifestFilename).And.Contain("-o json");
             receivedCallbacks.Should()

--- a/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/AwsCliAuth.cs
@@ -126,10 +126,10 @@ namespace Calamari.Kubernetes.Authentication
 
         string GetKubeCtlAuthApiVersion()
         {
-            var kubectlVersion = kubectl.GetVersion();
+            var versionOutput = kubectl.GetVersion();
 
             //v1alpha1 was deprecated in 1.24 of K8s
-            return kubectlVersion.Some() && kubectlVersion.Value > new SemanticVersion("1.23.6")
+            return versionOutput != null && versionOutput.KubectlVersion > new SemanticVersion("1.23.6")
                 ? "client.authentication.k8s.io/v1beta1"
                 : "client.authentication.k8s.io/v1alpha1";
         }

--- a/source/Calamari/Kubernetes/Authentication/GoogleKubernetesEngineAuth.cs
+++ b/source/Calamari/Kubernetes/Authentication/GoogleKubernetesEngineAuth.cs
@@ -1,4 +1,4 @@
-﻿using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.Integration;
 using Octopus.CoreUtilities;
@@ -68,8 +68,8 @@ namespace Calamari.Kubernetes.Authentication
         /// </remarks>
         void WarnCustomersAboutAuthToolingRequirements()
         {
-            var kubeCtlVersion = kubectlCli.GetVersion();
-            if (kubeCtlVersion.None() || kubeCtlVersion.Value < new SemanticVersion("1.26.0"))
+            var versionOutput = kubectlCli.GetVersion();
+            if (versionOutput == null || versionOutput.KubectlVersion < new SemanticVersion("1.26.0"))
                 return;
 
             if (!authPluginCli.ExistsOnPath())

--- a/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
+++ b/source/Calamari/Kubernetes/Commands/Executors/KustomizeExecutor.cs
@@ -8,7 +8,7 @@ using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Kubernetes.Integration;
 using Calamari.Kubernetes.ResourceStatus.Resources;
-using Newtonsoft.Json.Linq;
+using Octopus.Versioning.Semver;
 
 namespace Calamari.Kubernetes.Commands.Executors
 {
@@ -19,8 +19,7 @@ namespace Calamari.Kubernetes.Commands.Executors
     class KustomizeExecutor : BaseKubernetesApplyExecutor, IKustomizeKubernetesApplyExecutor
     {
         public const string HydratedKustomizeManifestFilename = "hydrated-kustomize-manifest.yaml";
-        const int MinimumKubectlVersionMajor = 1;
-        const int MinimumKubectlVersionMinor = 24;
+        static readonly SemanticVersion MinimumKubectlVersion = new SemanticVersion("1.24.0");
         readonly ILog log;
         readonly Kubectl kubectl;
         readonly IManifestReporter manifestReporter;
@@ -46,7 +45,7 @@ namespace Calamari.Kubernetes.Commands.Executors
             }
 
             log.Verbose("Validating kubectl version");
-            ValidateKubectlVersion(deployment.CurrentDirectory);
+            var versionOutput = ValidateKubectlVersion();
             
             log.Info("Building kustomization");
             BuildKustomization(deployment.CurrentDirectory, overlayPath);
@@ -86,50 +85,17 @@ namespace Calamari.Kubernetes.Commands.Executors
             }
         }
 
-        void ValidateKubectlVersion(string currentDirectory)
+        KubectlVersionOutput ValidateKubectlVersion()
         {
-            var commandResult = kubectl.ExecuteCommandAndReturnOutput("version", "--client", "-o", "json");
-            commandResult.LogErrorsWithSanitizedDirectory(log, currentDirectory);
-            if (commandResult.Result.ExitCode != 0)
-            {
-                throw new KubectlException("Failed to check kubectl version");
-            }
-            
-            var outputJson = commandResult.Output.InfoLogs.Join(Environment.NewLine);
-
-            if (!TryParseVersion(outputJson, out var major, out var minor))
+            var versionOutput = kubectl.GetVersion();
+            if (versionOutput == null)
                 throw new KubectlException("Could not determine the kubectl version.");
 
-            if (major < MinimumKubectlVersionMajor || minor < MinimumKubectlVersionMinor)
-                throw new KubectlException($"kubectl is on version v{major}.{minor}, it needs to be v{MinimumKubectlVersionMajor}.{MinimumKubectlVersionMinor} or higher to run Kustomize.");
-            log.Verbose($"kubectl version: {major}.{minor}");
-        }
+            if (versionOutput.KubectlVersion < MinimumKubectlVersion)
+                throw new KubectlException($"kubectl is on version {versionOutput.KubectlVersion}, it needs to be v{MinimumKubectlVersion} or higher to run Kustomize.");
 
-        bool TryParseVersion(string kubectlClientVersionJson, out int major, out int minor)
-        {
-            try
-            {
-                var outer = JToken.Parse(kubectlClientVersionJson);
-                major = GetVersion(outer, "clientVersion.major");
-                minor = GetVersion(outer, "clientVersion.minor");
-                return true;
-            }
-            catch
-            {
-                major = -1;
-                minor = -1;
-                return false;
-            }
-        }
-
-        static int GetVersion(JToken root, string jsonPathToVersion)
-        {
-            var clientVersionToken = root.SelectToken($"{jsonPathToVersion}");
-
-            if (clientVersionToken != null && int.TryParse(clientVersionToken.ToString(), out var version))
-                return version;
-
-            return -1;
+            log.Verbose($"kubectl version: {versionOutput.KubectlVersion}");
+            return versionOutput;
         }
     }
 }

--- a/source/Calamari/Kubernetes/Integration/Kubectl.cs
+++ b/source/Calamari/Kubernetes/Integration/Kubectl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -119,17 +119,21 @@ namespace Calamari.Kubernetes.Integration
         public CommandResultWithOutput ExecuteCommandAndReturnOutput(params string[] arguments) =>
             base.ExecuteCommandAndReturnOutput(ExecutableLocation, arguments);
 
-        public Maybe<SemanticVersion> GetVersion()
+        public KubectlVersionOutput? GetVersion()
         {
             var kubectlVersionOutput = ExecuteCommandAndReturnOutput("version", "--client", "--output=json").Output.InfoLogs;
             var kubeCtlVersionJson = string.Join(" ", kubectlVersionOutput);
             try
             {
-                var clientVersion = JsonConvert.DeserializeAnonymousType(kubeCtlVersionJson, new { clientVersion = new { gitVersion = "1.0.0" } });
-                var kubectlVersionString = clientVersion?.clientVersion?.gitVersion;
+                var versionInfo = JsonConvert.DeserializeAnonymousType(kubeCtlVersionJson, new { clientVersion = new { gitVersion = "" }, kustomizeVersion = "" });
+                var kubectlVersionString = versionInfo?.clientVersion?.gitVersion;
                 if (kubectlVersionString != null)
                 {
-                    return Maybe<SemanticVersion>.Some(SemVerFactory.CreateVersion(kubectlVersionString));
+                    var kubectlVersion = SemVerFactory.CreateVersion(kubectlVersionString);
+                    var kustomizeVersion = versionInfo?.kustomizeVersion != null
+                        ? SemVerFactory.CreateVersion(versionInfo.kustomizeVersion)
+                        : null;
+                    return new KubectlVersionOutput(kubectlVersion, kustomizeVersion);
                 }
             }
             catch (Exception e)
@@ -137,7 +141,7 @@ namespace Calamari.Kubernetes.Integration
                 log.Verbose($"Unable to determine kubectl version. Failed with error message: {e.Message}");
             }
 
-            return Maybe<SemanticVersion>.None;
+            return null;
         }
 
         public void DisableRequestTimeoutArgument()
@@ -156,8 +160,10 @@ namespace Calamari.Kubernetes.Integration
         CommandResult ExecuteCommandWithVerboseLoggingOnly(params string[] arguments);
         void ExecuteCommandAndAssertSuccess(params string[] arguments);
         CommandResultWithOutput ExecuteCommandAndReturnOutput(params string[] arguments);
-        Maybe<SemanticVersion> GetVersion();
+        KubectlVersionOutput? GetVersion();
         string ExecutableLocation { get; }
         void DisableRequestTimeoutArgument();
     }
+
+    public record KubectlVersionOutput(SemanticVersion KubectlVersion, SemanticVersion? KustomizeVersion);
 }


### PR DESCRIPTION
Found we were extracting kubectl information out in a bunch of different ways and I want to use it in a later commit.to 
