### PR TITLE
fix: Resolve Obsolete warnings in Calamari.Common

### DIFF
--- a/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/AesEncryption.cs
@@ -98,14 +98,13 @@ namespace Calamari.Common.Plumbing.Extensions
 
         Aes GetCryptoProvider(byte[]? iv = null)
         {
-            var provider = new AesCryptoServiceProvider
-            {
-                Mode = CipherMode.CBC,
-                Padding = PaddingMode.PKCS7,
-                KeySize = keySizeBits,
-                BlockSize = BlockSizeBits,
-                Key = EncryptionKey
-            };
+            var provider = Aes.Create();
+            provider.Mode = CipherMode.CBC;
+            provider.Padding = PaddingMode.PKCS7;
+            provider.KeySize = keySizeBits;
+            provider.BlockSize = BlockSizeBits;
+            provider.Key = EncryptionKey;
+            
             if (iv != null)
                 provider.IV = iv;
             
@@ -135,7 +134,7 @@ namespace Calamari.Common.Plumbing.Extensions
 
         static byte[] GetEncryptionKey(string encryptionPassword, int keySizeBits)
         {
-            var passwordGenerator = new Rfc2898DeriveBytes(encryptionPassword, PasswordPaddingSalt, PasswordSaltIterations);
+            var passwordGenerator = new Rfc2898DeriveBytes(encryptionPassword, PasswordPaddingSalt, PasswordSaltIterations, HashAlgorithmName.SHA1);
             return passwordGenerator.GetBytes(keySizeBits / 8);
         }
 

--- a/source/Calamari.Common/Plumbing/Extensions/AssemblyExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/AssemblyExtensions.cs
@@ -16,7 +16,7 @@ namespace Calamari
 
         public static string FullLocalPath(this Assembly assembly)
         {
-            var codeBase = assembly.CodeBase;
+            var codeBase = assembly.Location;
             var uri = new UriBuilder(codeBase);
             var root = Uri.UnescapeDataString(uri.Path);
             root = root.Replace('/', Path.DirectorySeparatorChar);

--- a/source/Calamari.Common/Plumbing/Extensions/AssemblyExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/AssemblyExtensions.cs
@@ -16,7 +16,8 @@ namespace Calamari
 
         public static string FullLocalPath(this Assembly assembly)
         {
-            var codeBase = assembly.Location;
+            // Old call returned a file URL
+            var codeBase = $"file://{assembly.Location}";
             var uri = new UriBuilder(codeBase);
             var root = Uri.UnescapeDataString(uri.Path);
             root = root.Replace('/', Path.DirectorySeparatorChar);


### PR DESCRIPTION
Remove some more Build log noise by updating methods flagged as Obsolete in Calamari.Common
