### PR TITLE
Update contracts with SSH credential types

### DIFF
--- a/source/Calamari.Contracts/ArgoCD/ArgoCDCustomPropertiesDto.cs
+++ b/source/Calamari.Contracts/ArgoCD/ArgoCDCustomPropertiesDto.cs
@@ -31,7 +31,7 @@ public record GitCredentialDto(string Url, string Username, string Password) : I
     public string Type => DiscriminatorValue;
 }
 
-public record SshKeyGitCredentialDto(string Name, string Url, string Username, string PrivateKey, SshKnownHost[] KnownHosts) : IGitCredentialDto
+public record SshKeyGitCredentialDto(string Url, string Username, string PrivateKey, SshKnownHost[] KnownHosts) : IGitCredentialDto
 {
     public const string DiscriminatorValue = "SshKey";
     public string Type => DiscriminatorValue;

--- a/source/Calamari.Contracts/ArgoCD/ArgoCDCustomPropertiesDto.cs
+++ b/source/Calamari.Contracts/ArgoCD/ArgoCDCustomPropertiesDto.cs
@@ -30,3 +30,11 @@ public record GitCredentialDto(string Url, string Username, string Password) : I
     public const string DiscriminatorValue = "UsernamePassword";
     public string Type => DiscriminatorValue;
 }
+
+public record SshKeyGitCredentialDto(string Name, string Url, string Username, string PrivateKey, SshKnownHost[] KnownHosts) : IGitCredentialDto
+{
+    public const string DiscriminatorValue = "SshKey";
+    public string Type => DiscriminatorValue;
+}
+
+public record SshKnownHost(string Host, string KeyType, string PublicKey);

--- a/source/Calamari.Contracts/ArgoCD/ArgoCDCustomPropertiesDto.cs
+++ b/source/Calamari.Contracts/ArgoCD/ArgoCDCustomPropertiesDto.cs
@@ -31,10 +31,10 @@ public record GitCredentialDto(string Url, string Username, string Password) : I
     public string Type => DiscriminatorValue;
 }
 
-public record SshKeyGitCredentialDto(string Url, string Username, string PrivateKey, SshKnownHost[] KnownHosts) : IGitCredentialDto
+public record SshKeyGitCredentialDto(string Url, string Username, string PrivateKey, SshKnownHostDto[] KnownHosts) : IGitCredentialDto
 {
     public const string DiscriminatorValue = "SshKey";
     public string Type => DiscriminatorValue;
 }
 
-public record SshKnownHost(string Host, string KeyType, string PublicKey);
+public record SshKnownHostDto(string Host, string PublicKey);

--- a/source/Calamari.Contracts/Git/GitCredentials.cs
+++ b/source/Calamari.Contracts/Git/GitCredentials.cs
@@ -13,10 +13,10 @@ public record UsernamePasswordGitCredentialDto(string Name, string Url, string U
     public string Type => DiscriminatorValue;
 }
 
-public record SshKeyGitCredentialDto(string Name, string Url, string Username, string PrivateKey, SshKnownHost[] KnownHosts) : IGitCredentialDto
+public record SshKeyGitCredentialDto(string Name, string Url, string Username, string PrivateKey, SshKnownHostDto[] KnownHosts) : IGitCredentialDto
 {
     public const string DiscriminatorValue = "SshKey";
     public string Type => DiscriminatorValue;
 }
 
-public record SshKnownHost(string Host, string KeyType, string PublicKey);
+public record SshKnownHostDto(string Host, string PublicKey);

--- a/source/Calamari.Contracts/Git/GitCredentials.cs
+++ b/source/Calamari.Contracts/Git/GitCredentials.cs
@@ -13,8 +13,10 @@ public record UsernamePasswordGitCredentialDto(string Name, string Url, string U
     public string Type => DiscriminatorValue;
 }
 
-public record SshKeyGitCredentialDto(string Name, string Url)
+public record SshKeyGitCredentialDto(string Name, string Url, string Username, string PrivateKey, SshKnownHost[] KnownHosts) : IGitCredentialDto
 {
     public const string DiscriminatorValue = "SshKey";
     public string Type => DiscriminatorValue;
 }
+
+public record SshKnownHost(string Host, string KeyType, string PublicKey);


### PR DESCRIPTION
Updates to contracts before we proceed with the SSH implementation so there are no hard requirements for Server to have certain Calamari versions