### PR TITLE
Use Octopus.LibGit2Sharp

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -16,6 +16,8 @@
       <package pattern="Octopus.Data" />
       <package pattern="Octopus.Dependencies.*" />
       <package pattern="Octopus.Globfish" />
+      <package pattern="Octopus.LibGit2Sharp" />
+      <package pattern="Octopus.LibGit2Sharp.NativeBinaries" />
       <package pattern="Octopus.Ocl" />
       <package pattern="Octopus.Server.Extensibility" />
       <package pattern="Octopus.Server.MessageContracts*" />

--- a/build/Build.CalamariTesting.cs
+++ b/build/Build.CalamariTesting.cs
@@ -31,8 +31,13 @@ partial class Build
                               .Execute();
                       });
 
+    // Temporary redirect so I can merge this PR without breaking Teamcity builds
     [PublicAPI]
     Target LinuxSpecificTestingWithoutOpenSsl3 =>
+        target => target.DependsOn(LinuxSpecificTestingWithoutWithoutOpenSsl11OrOpenSsl3);
+
+    [PublicAPI]
+    Target LinuxSpecificTestingWithoutWithoutOpenSsl11OrOpenSsl3 =>
         target => target
             .Executes(async () =>
                       {
@@ -40,7 +45,7 @@ partial class Build
 
                           CreateTestRun("Binaries/Calamari.Tests.dll")
                               .WithDotNetPath(dotnetPath)
-                              .WithFilter("TestCategory != Windows & TestCategory != PlatformAgnostic & TestCategory != RunOnceOnWindowsAndLinux & TestCategory != RequiresOpenSsl3")
+                              .WithFilter("TestCategory != Windows & TestCategory != PlatformAgnostic & TestCategory != RunOnceOnWindowsAndLinux & TestCategory != RequiresOpenSsl1_1OrOpenSsl3")
                               .Execute();
                       });
 
@@ -54,19 +59,6 @@ partial class Build
                           CreateTestRun("Binaries/Calamari.Tests.dll")
                               .WithDotNetPath(dotnetPath)
                               .WithFilter("(TestCategory != Windows & TestCategory != PlatformAgnostic) | TestCategory = RunOnceOnWindowsAndLinux")
-                              .Execute();
-                      });
-
-    [PublicAPI]
-    Target OncePerWindowsOrLinuxTestingWithoutOpenSsl3 =>
-        target => target
-            .Executes(async () =>
-                      {
-                          var dotnetPath = await LocateOrInstallDotNetSdk();
-
-                          CreateTestRun("Binaries/Calamari.Tests.dll")
-                              .WithDotNetPath(dotnetPath)
-                              .WithFilter("((TestCategory != Windows & TestCategory != PlatformAgnostic) | TestCategory = RunOnceOnWindowsAndLinux) & TestCategory != RequiresOpenSsl3")
                               .Execute();
                       });
 

--- a/source/Calamari.Testing/Helpers/TestCategory.cs
+++ b/source/Calamari.Testing/Helpers/TestCategory.cs
@@ -24,6 +24,6 @@ namespace Calamari.Testing.Helpers
 
         public const string RunOnceOnWindowsAndLinux = "RunOnceOnWindowsAndLinux";
 
-        public const string RequiresOpenSsl3 = "RequiresOpenSsl3";
+        public const string RequiresOpenSsl1_1OrOpenSsl3 = "RequiresOpenSsl1_1OrOpenSsl3";
     }
 }

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
@@ -29,7 +29,7 @@ using Octopus.Calamari.Contracts.ArgoCD;
 
 namespace Calamari.Tests.ArgoCD.Commands.Conventions
 {
-    [Category(TestCategory.RequiresOpenSsl3)]
+    [Category(TestCategory.RequiresOpenSsl1_1OrOpenSsl3)]
     public class UpdateArgoCDAppImagesInstallConventionHelmTests
     {
         const string ProjectSlug = "TheProject";

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -29,7 +29,7 @@ using Octopus.Calamari.Contracts.ArgoCD;
 namespace Calamari.Tests.ArgoCD.Commands.Conventions
 {
     [TestFixture]
-    [Category(TestCategory.RequiresOpenSsl3)]
+    [Category(TestCategory.RequiresOpenSsl1_1OrOpenSsl3)]
     public class UpdateArgoCDAppImagesInstallConventionTests
     {
         const string ProjectSlug = "TheProject";

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
@@ -28,7 +28,7 @@ using Octopus.Calamari.Contracts.ArgoCD;
 namespace Calamari.Tests.ArgoCD.Commands.Conventions
 {
     [TestFixture]
-    [Category(TestCategory.RequiresOpenSsl3)]
+    [Category(TestCategory.RequiresOpenSsl1_1OrOpenSsl3)]
     public class UpdateArgoCDApplicationManifestsInstallConventionTests
     {
         const string ProjectSlug = "TheProject";

--- a/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
@@ -13,7 +13,7 @@ using Octopus.Calamari.Contracts.ArgoCD;
 
 namespace Calamari.Tests.ArgoCD.Git;
 
-[Category(TestCategory.RequiresOpenSsl3)]
+[Category(TestCategory.RequiresOpenSsl1_1OrOpenSsl3)]
 public abstract class AuthenticatingRepositoryFactoryTestBase
 {
     protected readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();

--- a/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
@@ -17,7 +17,7 @@ using WireMock.Server;
 namespace Calamari.Tests.ArgoCD.Git;
 
 [TestFixture]
-[Category(TestCategory.RequiresOpenSsl3)]
+[Category(TestCategory.RequiresOpenSsl1_1OrOpenSsl3)]
 public class GitHttpSmartSubTransportTests
 {
     readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();

--- a/source/Calamari.Tests/ArgoCD/Git/LibGit2SharpTransportRegistrationTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/LibGit2SharpTransportRegistrationTests.cs
@@ -1,0 +1,32 @@
+using System;
+using Calamari.ArgoCD.Git;
+using Calamari.Common.Commands;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.ArgoCD.Git;
+
+[TestFixture]
+public class LibGit2SharpTransportRegistrationTests
+{
+    [Test]
+    public void RegisterWith_WhenDelegateThrowsTypeInitializationExceptionWithDllNotFoundException_ThrowsCommandExceptionWithOpenSslGuidance()
+    {
+        var dllNotFoundException = new DllNotFoundException("libcrypto.so.3");
+        var typeInitEx = new TypeInitializationException("SomeType", dllNotFoundException);
+
+        Action act = () => LibGit2SharpTransportRegistration.RegisterWith(() => throw typeInitEx);
+
+        act.Should().Throw<CommandException>()
+           .WithMessage("*OpenSSL 3*")
+           .WithMessage("*end-of-life*");
+    }
+
+    [Test]
+    public void RegisterWith_WhenDelegateSucceeds_ReturnsTrue()
+    {
+        var result = LibGit2SharpTransportRegistration.RegisterWith(() => { });
+
+        result.Should().BeTrue();
+    }
+}

--- a/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitVendorApiAdapter_PullRequestTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitVendorApiAdapter_PullRequestTests.cs
@@ -23,7 +23,7 @@ using Repository = LibGit2Sharp.Repository;
 namespace Calamari.Tests.ArgoCD.Git.GitVendorApiAdapters
 {
     [TestFixture]
-    [Category(TestCategory.RequiresOpenSsl3)]
+    [Category(TestCategory.RequiresOpenSsl1_1OrOpenSsl3)]
     public class GitHubPullRequestClientTests
     {
         [Test]

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
@@ -16,7 +16,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.ArgoCD.Git
 {
     [TestFixture]
-    [Category(TestCategory.RequiresOpenSsl3)]
+    [Category(TestCategory.RequiresOpenSsl1_1OrOpenSsl3)]
     public class RepositoryFactoryTests
     {
         readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
@@ -19,7 +19,7 @@ using NUnit.Framework;
 namespace Calamari.Tests.ArgoCD.Git
 {
     [TestFixture]
-    [Category(TestCategory.RequiresOpenSsl3)]
+    [Category(TestCategory.RequiresOpenSsl1_1OrOpenSsl3)]
     public class RepositoryWrapperTest
     {
         readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -22,6 +22,7 @@ namespace Calamari.Tests;
 
 [TestFixture]
 [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
+[Category(TestCategory.RequiresOpenSsl1_1OrOpenSsl3)]
 public class CommitToGitCommandTest
 {
     readonly ICalamariFileSystem fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();

--- a/source/Calamari/ArgoCD/Git/LibGit2SharpTransportRegistration.cs
+++ b/source/Calamari/ArgoCD/Git/LibGit2SharpTransportRegistration.cs
@@ -1,4 +1,5 @@
 using System;
+using Calamari.Common.Commands;
 using LibGit2Sharp;
 
 namespace Calamari.ArgoCD.Git;
@@ -7,19 +8,42 @@ namespace Calamari.ArgoCD.Git;
 /// Lazily registers custom smart sub-transports for libgit2sharp so that the native
 /// library is only loaded when git operations are actually needed, rather than during
 /// startup.
-/// The only reason not to do it during startup is that we have a new dependency on
-/// OpenSSL3 that older (now unsupported) OS versions may not fulfill. Instead of
-/// breaking everyone if they are running older systems, we will only break them
-/// if they use git functionality.
+/// Out git library supports workers that have either OpenSSL 3 (<c>libcrypto.so.3</c>) or
+/// OpenSSL 1.1 (<c>libcrypto.so.1.1</c>) installed.
 /// </summary>
 static class LibGit2SharpTransportRegistration
 {
-    static readonly Lazy<bool> Registered = new(() =>
-        {
-            GlobalSettings.RegisterSmartSubtransport<GitHttpSmartSubTransport>("http");
-            GlobalSettings.RegisterSmartSubtransport<GitHttpSmartSubTransport>("https");
-            return true;
-        });
+    static readonly Lazy<bool> Registered = new(Register);
 
     public static void EnsureRegistered() => _ = Registered.Value;
+
+    static bool Register() => RegisterWith(() =>
+    {
+        GlobalSettings.RegisterSmartSubtransport<GitHttpSmartSubTransport>("http");
+        GlobalSettings.RegisterSmartSubtransport<GitHttpSmartSubTransport>("https");
+    });
+
+    internal static bool RegisterWith(Action registerTransports)
+    {
+        try
+        {
+            registerTransports();
+        }
+        catch (TypeInitializationException ex) when (ex.InnerException is DllNotFoundException dllEx)
+        {
+            var message = $"""
+                           Failed to load the native libgit2 library required for Git operations.
+
+                           On Linux, libgit2 requires OpenSSL 3 (libcrypto.so.3). Install it according to your distribution's guidance or update to a supported OS.
+                           If you are running a legacy distribution that does not provide OpenSSL 3, OpenSSL 1.1 (libcrypto.so.1.1) may be used as a transitional fallback, but note that OpenSSL 1.1 is end-of-life and should not be relied upon long-term.
+
+                           Original exception:
+                           {dllEx.Message}
+                           """;
+
+            throw new CommandException(message, ex);
+        }
+
+        return true;
+    }
 }

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="Autofac" Version="4.8.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="KubernetesClient" Version="17.0.14" />
-    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
+    <PackageReference Include="Octopus.LibGit2Sharp" Version="0.31.1-octopus.2" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Kubernetes\Scripts\AzurePowershellContext.ps1" />


### PR DESCRIPTION
Updates to use our fork of LibGit2Sharp that includes the libssh2 support.

No functional changes, but I've added a test to ensure the error message is nice for users who don't have a correct version of OpenSSL installed on their linux target.

Test category changes are for clarity, once this is merged I'll follow up and remove `LinuxSpecificTestingWithoutOpenSsl3`