### PR TITLE
chore: Bump System.Text.Json installs for v9.0.16

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -32,6 +32,7 @@
         <PackageReference Include="Octopus.1Password.Sdk" Version="0.0.127" />
         <PackageReference Include="AzureSignTool" Version="6.0.1" ExcludeAssets="all" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="System.Text.Json" Version="9.0.16" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\source\Calamari.ConsolidateCalamariPackages\Calamari.ConsolidateCalamariPackages.csproj" />

--- a/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
+++ b/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="Polly" Version="8.3.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="9.0.16" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />
   </ItemGroup>
 

--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -21,7 +21,7 @@
       <NoWarn>NU1902</NoWarn>
     </PackageReference>
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="9.0.16" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari.AzureScripting\Calamari.AzureScripting.csproj" />

--- a/source/Calamari.Testing/Calamari.Testing.csproj
+++ b/source/Calamari.Testing/Calamari.Testing.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="Octopus.1Password.Sdk" Version="0.0.127"/>
         <PackageReference Include="Serilog" Version="3.1.1" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.6" />
+        <PackageReference Include="System.Text.Json" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -21,7 +21,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.7.0"/>
-        <PackageReference Include="System.Text.Json" Version="8.0.6"/>
+        <PackageReference Include="System.Text.Json" Version="9.0.16" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41"/>
         <PackageReference Include="WireMock.Net" Version="1.6.9"/>
         <PackageReference Include="XPath2" Version="1.1.5"/>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="SharpCompress" Version="0.37.2">
       <NoWarn>NU1902</NoWarn>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="9.0.16" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Autofac" Version="4.8.0" />


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

Later version is required to avoid conflicts with AWS `Amazon.CDK.Lib` in upcoming SPF Deprecation PR