### PR TITLE
feature: Add Newtonsoft serialization settings for contract sharing

### DIFF
--- a/source/Calamari.Contracts/Calamari.Contracts.csproj
+++ b/source/Calamari.Contracts/Calamari.Contracts.csproj
@@ -14,4 +14,8 @@
             This package contains the contracts for types shared between Octopus Server and Calamari.
         </Description>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    </ItemGroup>
 </Project>

--- a/source/Calamari.Contracts/Serialization/JsonSerializationSettings.cs
+++ b/source/Calamari.Contracts/Serialization/JsonSerializationSettings.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Octopus.Calamari.Contracts.Serialization;
+
+public static class JsonSerializationSettings
+{
+    public static JsonSerializerSettings NewtonsoftSerializationSettings =>
+        new()
+        {
+            Formatting = Formatting.None,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            TypeNameHandling = TypeNameHandling.None,
+            DateParseHandling = DateParseHandling.None,
+        };
+}


### PR DESCRIPTION
With contracts being shared across Octopus/Calamari I thoguht it might be useful to share the serialization settings to that they could be used for (de)Serialization on both sides of the wire to ensure consistency.

Had a reservation about taking a dep on Newtonsoft for the Contract library and potential future issues of them getting out of sync - to be discussed.
