### PR TITLE
feature: Add default contract serialization settings

### DIFF
--- a/source/Calamari.Common/Plumbing/Variables/CalamariContractSerializationSettings.cs
+++ b/source/Calamari.Common/Plumbing/Variables/CalamariContractSerializationSettings.cs
@@ -8,7 +8,7 @@ public static class CalamariContractSerializationSettings
 
     // NOTE: Values here should match Octopus.Variables/CalamariContractSerializationSettings.cs
     // changes in one should be reflected in the other
-    public static JsonSerializerSettings Default => new JsonSerializerSettings
+    public static JsonSerializerSettings Default => new()
     {
         Formatting = Formatting.None,
         NullValueHandling = NullValueHandling.Ignore,

--- a/source/Calamari.Common/Plumbing/Variables/CalamariContractSerializationSettings.cs
+++ b/source/Calamari.Common/Plumbing/Variables/CalamariContractSerializationSettings.cs
@@ -12,6 +12,7 @@ public static class CalamariContractSerializationSettings
     {
         Formatting = Formatting.None,
         NullValueHandling = NullValueHandling.Ignore,
-        ContractResolver = new CamelCasePropertyNamesContractResolver()
+        ContractResolver = new CamelCasePropertyNamesContractResolver(),
+        MissingMemberHandling = MissingMemberHandling.Error,
     };
 }

--- a/source/Calamari.Common/Plumbing/Variables/CalamariContractSerializationSettings.cs
+++ b/source/Calamari.Common/Plumbing/Variables/CalamariContractSerializationSettings.cs
@@ -1,0 +1,17 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Calamari.Common.Plumbing.Variables;
+
+public static class CalamariContractSerializationSettings
+{
+
+    // NOTE: Values here should match Octopus.Variables/CalamariContractSerializationSettings.cs
+    // changes in one should be reflected in the other
+    public static JsonSerializerSettings Default => new JsonSerializerSettings
+    {
+        Formatting = Formatting.None,
+        NullValueHandling = NullValueHandling.Ignore,
+        ContractResolver = new CamelCasePropertyNamesContractResolver()
+    };
+}

--- a/source/Calamari.Common/Plumbing/Variables/VariablesDeserialisationExtensions.cs
+++ b/source/Calamari.Common/Plumbing/Variables/VariablesDeserialisationExtensions.cs
@@ -1,20 +1,13 @@
 using System;
 using Calamari.Common.Commands;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Calamari.Common.Plumbing.Variables;
 
-public static class CalamariVariableDeserilisationExtensions
+public static class VariablesDeserialisationExtensions
 {
-    public static readonly JsonSerializerSettings DefaultSerializationSettings = new()
-    {
-        Formatting = Formatting.None,
-        ContractResolver = new CamelCasePropertyNamesContractResolver(),
-        MissingMemberHandling = MissingMemberHandling.Error,
-    };
     
-    public static T GetValueDeserilisedAs<T>(this CalamariVariables variables, string name)
+    public static T GetValueDeserialisedAs<T>(this IVariables variables, string name)
     {
 
         var variableJson = variables.Get(name);
@@ -26,7 +19,7 @@ public static class CalamariVariableDeserilisationExtensions
 
         try
         {
-            var output = JsonConvert.DeserializeObject<T>(variableJson, DefaultSerializationSettings);
+            var output = JsonConvert.DeserializeObject<T>(variableJson, CalamariContractSerializationSettings.Default);
             return output ?? throw new CommandException($"Variable {name} was deserialized as null ");
         }
         catch (JsonSerializationException)

--- a/source/Calamari.Tests/Common/Plumbing/Variables/VariablesDeserialisationExtensionsTests.cs
+++ b/source/Calamari.Tests/Common/Plumbing/Variables/VariablesDeserialisationExtensionsTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 
 namespace Calamari.Tests.Common.Plumbing.Variables;
 
-public class CalamariVariableDeserilisationExtensionsTests
+public class VariablesDeserialisationExtensionsTests
 {
     const string TestKey = "TestKey";
     
@@ -18,7 +18,7 @@ public class CalamariVariableDeserilisationExtensionsTests
             { TestKey,  "" }
         };
 
-        var action = () => variables.GetValueDeserilisedAs<TestVariableClass>(TestKey);
+        var action = () => variables.GetValueDeserialisedAs<TestVariableClass>(TestKey);
 
         action.Should().Throw<CommandException>();
     }
@@ -28,7 +28,7 @@ public class CalamariVariableDeserilisationExtensionsTests
     {
         var variables = new CalamariVariables();
 
-        var action = () => variables.GetValueDeserilisedAs<TestVariableClass>(TestKey);
+        var action = () => variables.GetValueDeserialisedAs<TestVariableClass>(TestKey);
 
         action.Should().Throw<CommandException>();
     }
@@ -41,7 +41,7 @@ public class CalamariVariableDeserilisationExtensionsTests
             { TestKey,  "No valid JSON to be found here" }
         };
 
-        var action = () => variables.GetValueDeserilisedAs<TestVariableClass>(TestKey);
+        var action = () => variables.GetValueDeserialisedAs<TestVariableClass>(TestKey);
 
         action.Should().Throw<CommandException>();
     }
@@ -54,7 +54,7 @@ public class CalamariVariableDeserilisationExtensionsTests
             { TestKey,  """{ "isWalrus": true }""" }
         };
 
-        var action = () => variables.GetValueDeserilisedAs<TestVariableClass>(TestKey);
+        var action = () => variables.GetValueDeserialisedAs<TestVariableClass>(TestKey);
 
         action.Should().Throw<CommandException>();
     }
@@ -67,7 +67,7 @@ public class CalamariVariableDeserilisationExtensionsTests
             { TestKey,  """{ "name": "Some Random Object", "numericValue": 18 }""" }
         };
 
-        var result = variables.GetValueDeserilisedAs<TestVariableClass>(TestKey);
+        var result = variables.GetValueDeserialisedAs<TestVariableClass>(TestKey);
 
        result.Should().NotBeNull();
        result.Name.Should().Be("Some Random Object");
@@ -82,13 +82,13 @@ public class CalamariVariableDeserilisationExtensionsTests
             Name = "Input Object",
             NumericValue = 42
         };
-        var inputObjectString = JsonConvert.SerializeObject(inputObject, CalamariVariableDeserilisationExtensions.DefaultSerializationSettings);
+        var inputObjectString = JsonConvert.SerializeObject(inputObject, CalamariContractSerializationSettings.Default);
         var variables = new CalamariVariables
         {
             { TestKey,  inputObjectString }
         };
         
-        var result = variables.GetValueDeserilisedAs<TestVariableClass>(TestKey);
+        var result = variables.GetValueDeserialisedAs<TestVariableClass>(TestKey);
 
         result.Should().BeEquivalentTo(inputObject);
     }

--- a/source/Calamari.Tests/Common/Plumbing/Variables/VariablesDeserialisationExtensionsTests.cs
+++ b/source/Calamari.Tests/Common/Plumbing/Variables/VariablesDeserialisationExtensionsTests.cs
@@ -75,7 +75,7 @@ public class VariablesDeserialisationExtensionsTests
     }
 
     [Test]
-    public void VaribleSeriliseedAndDeserialised_AppearsTheSame()
+    public void VariableSerialisedAndDeserialised_AppearsTheSame()
     {
         var inputObject = new TestVariableClass
         {
@@ -92,10 +92,35 @@ public class VariablesDeserialisationExtensionsTests
 
         result.Should().BeEquivalentTo(inputObject);
     }
+
+    [Test]
+    public void VariableSerialisedAndDeserialisedWithNullableProperty_AppearsTheSame()
+    {
+        var inputObject = new TestVariableClassWithNullableProperty
+        {
+            Name = "Input Object",
+        };
+        
+        var inputObjectString = JsonConvert.SerializeObject(inputObject, CalamariContractSerializationSettings.Default);
+        var variables = new CalamariVariables
+        {
+            { TestKey,  inputObjectString }
+        };
+        
+        var result = variables.GetValueDeserialisedAs<TestVariableClassWithNullableProperty>(TestKey);
+
+        result.Should().BeEquivalentTo(inputObject);
+    }
 }
 
 public class TestVariableClass
 {
     public string Name { get; set; }
     public int NumericValue { get; set; }
+}
+
+public class TestVariableClassWithNullableProperty
+{
+    public string Name { get; set; }
+    public int? NumericValue { get; set; }
 }


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

Adding a class to represent the default serialization optiuons for Calamari contracts.

Also reworks extension to handle IVariables insted of just CalamariVariables.

Fixes spelling

Related Server PR: https://github.com/OctopusDeploy/OctopusDeploy/pull/43479