### PR TITLE
Backport fixes for handling "unstructured" text in 2026.1

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -24,7 +24,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="NuGet.CommandLine" Version="7.0.1">
+        <PackageReference Include="NuGet.CommandLine" Version="7.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -17,7 +17,9 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="8.3.1" />
-    <PackageReference Include="SharpCompress" Version="0.37.2" />
+    <PackageReference Include="SharpCompress" Version="0.37.2">
+      <NoWarn>NU1902</NoWarn>
+    </PackageReference>
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>

--- a/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
@@ -15,7 +15,9 @@
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 
-        <PackageReference Include="SharpCompress" Version="0.37.2" />
+        <PackageReference Include="SharpCompress" Version="0.37.2">
+            <NoWarn>NU1902</NoWarn>
+        </PackageReference>
         <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
     </ItemGroup>
     <ItemGroup>

--- a/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
@@ -19,7 +19,9 @@
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Serilog" Version="2.10.0" />
-      <PackageReference Include="SharpCompress" Version="0.37.2" />
+        <PackageReference Include="SharpCompress" Version="0.37.2">
+            <NoWarn>NU1902</NoWarn>
+        </PackageReference>
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Calamari.ConsolidateCalamariPackages.Api\Calamari.ConsolidateCalamariPackages.Api.csproj" />

--- a/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using Calamari.ArgoCD;
+using Calamari.ArgoCD.Conventions;
+using Calamari.ArgoCD.Models;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NUnit.Framework;
+
+namespace Calamari.Tests.ArgoCD.Helm;
+
+public class HelmValuesImageReplaceStepVariablesTests
+{
+    const string DefaultRegistry = "docker.io";
+    readonly InMemoryLog log = new();
+
+    [Test]
+    public void UnstructuredValue_UpdatesTag_TracksWithFriendlyName()
+    {
+        const string yaml = @"
+image:
+  tag: 1.0
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "image.tag")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEquivalentTo(["nginx:1.27.1"]);
+        result.UpdatedContents.Should().Contain("tag: 1.27.1");
+    }
+
+    [Test]
+    public void UnstructuredValue_AlreadyAtTarget_TracksWithFriendlyName()
+    {
+        const string yaml = @"
+image:
+  tag: 1.27.1
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "image.tag")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEmpty();
+        result.AlreadyUpToDateImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
+    }
+
+    [Test]
+    public void StructuredValue_UpdatesFullRef()
+    {
+        const string yaml = @"
+image:
+  name: nginx:1.0
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "image.name")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().HaveCount(1);
+        result.UpdatedContents.Should().Contain("name: nginx:1.27.1");
+    }
+
+    [Test]
+    public void StructuredValue_AlreadyAtTarget_TracksWithFriendlyName()
+    {
+        const string yaml = @"
+image:
+  name: nginx:1.27.1
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "image.name")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEmpty();
+        result.AlreadyUpToDateImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
+    }
+
+    [Test]
+    public void TwoImagesWithSameTag_OnlyUpdatesConfiguredPath()
+    {
+        const string yaml = @"
+nginx:
+  tag: 1.0
+redis:
+  tag: 1.0
+";
+        
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "nginx.tag")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEquivalentTo(["nginx:1.27.1"]);
+        result.UpdatedContents.Should().Contain($"nginx:{Environment.NewLine}  tag: 1.27.1");
+        result.UpdatedContents.Should().Contain($"redis:{Environment.NewLine}  tag: 1.0");
+    }
+
+    [Test]
+    public void NoHelmReference_SkipsImage()
+    {
+        const string yaml = @"
+image:
+  tag: 1.0
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry))
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEmpty();
+        result.AlreadyUpToDateImages.Should().BeEmpty();
+    }
+
+    [Test]
+    public void PathNotFoundInYaml_SkipsImage()
+    {
+        const string yaml = @"
+image:
+  tag: 1.0
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "nonexistent.path")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEmpty();
+        result.UpdatedContents.Should().Be(yaml);
+    }
+
+    [Test]
+    public void StructuredValue_MismatchedImageName_DoesNotUpdate()
+    {
+        const string yaml = @"
+image:
+  name: alpine:3.18
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString("nginx:1.27.1", DefaultRegistry), "image.name")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEmpty();
+        result.UpdatedContents.Should().Contain("name: alpine:3.18");
+    }
+}

--- a/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
@@ -52,7 +52,6 @@ image:
 
         using var scope = new AssertionScope();
         result.UpdatedImageReferences.Should().BeEmpty();
-        result.AlreadyUpToDateImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
     }
 
     [Test]
@@ -92,7 +91,6 @@ image:
 
         using var scope = new AssertionScope();
         result.UpdatedImageReferences.Should().BeEmpty();
-        result.AlreadyUpToDateImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
     }
 
     [Test]
@@ -136,7 +134,6 @@ image:
 
         using var scope = new AssertionScope();
         result.UpdatedImageReferences.Should().BeEmpty();
-        result.AlreadyUpToDateImages.Should().BeEmpty();
     }
 
     [Test]

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -15,7 +15,7 @@
         <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="NuGet.CommandLine" Version="7.0.1">
+        <PackageReference Include="NuGet.CommandLine" Version="7.0.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppDeploymentConfig.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppDeploymentConfig.cs
@@ -18,7 +18,7 @@ namespace Calamari.ArgoCD.Conventions
 
         public bool HasStepBasedHelmValueReferences()
         {
-            return ImageReferences.Any(ir => ir.HelmReference is not null) && UseHelmReferenceFromContainer;
+            return ImageReferences.Any(ir => !ir.HelmReference.IsNullOrEmpty()) && UseHelmReferenceFromContainer;
         }
     }
 }

--- a/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppDeploymentConfig.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateArgoCDAppDeploymentConfig.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.ArgoCD.Conventions
 {

--- a/source/Calamari/ArgoCD/HelmValuesImageReplaceStepVariables.cs
+++ b/source/Calamari/ArgoCD/HelmValuesImageReplaceStepVariables.cs
@@ -33,13 +33,17 @@ public class HelmValuesImageReplaceStepVariables : IContainerImageReplacer
             var valueToUpdate = flattenedYamlPathDictionary.GetRaw(helmReference);
             if (valueToUpdate == null)
             {
-                log.Verbose($"{helmReference} for image {newImageTag.ContainerReference.ToString()} was not found in your values file.");
+                log.Verbose($"{helmReference} for image {newImageTag.ContainerReference.FriendlyName()} was not found in your values file.");
                 continue;
             }
                 
             if (IsUnstructuredText(valueToUpdate))
             {
-                HelmValuesEditor.UpdateNodeValue(updatedYaml, helmReference, newImageTag.ContainerReference.Tag);
+                if (valueToUpdate != newImageTag.ContainerReference.Tag)
+                {
+                    updatedYaml = HelmValuesEditor.UpdateNodeValue(updatedYaml, helmReference, newImageTag.ContainerReference.Tag);
+                    imagesUpdated.Add(newImageTag.ContainerReference.FriendlyName());
+                }
             }
             else
             {

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -41,7 +41,9 @@
     <PackageReference Include="Octopus.Versioning" Version="5.1.883" />
     <PackageReference Include="Octopus.TinyTypes" Version="2.2.1156" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
-    <PackageReference Include="SharpCompress" Version="0.37.2" />
+    <PackageReference Include="SharpCompress" Version="0.37.2">
+      <NoWarn>NU1902</NoWarn>
+    </PackageReference>
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
2026.1 has issues with updating unstructured Tags - this attempts to backport the fixes made in 2026.2. It has not been tested, but is just a proposal for the work requried.


:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
