### PR TITLE
CommitToGit prevents copies escaping package being copied

### DIFF
--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -402,6 +402,44 @@ public class CommitToGitCommandTest
     }
 
     [Test]
+    [TestCase("../../../etc/passwd", TestName = "Package_RejectsInputPath_StartingWithDotDot")]
+    [TestCase("/etc/passwd", TestName = "Package_RejectsInputPath_StartingWithSlash")]
+    [TestCase("configs/../../etc/passwd", TestName = "Package_RejectsInputPath_ContainingDotDotSegment")]
+    public void RejectsPackageInputFilePathsThatEscapeSourceDirectory(string maliciousInputPath)
+    {
+        const string packageReferenceName = "my-configs";
+        const string destinationPath = "output-dir";
+
+        var zipPath = CreateZipWithEntry(packageReferenceName, "configs/settings.json", "{}");
+
+        var inputFileSources = $"[{{\"Type\":\"Package\",\"PackageId\":\"{packageReferenceName}\",\"PackageName\":\"{packageReferenceName}\",\"InputFilePaths\":[\"{maliciousInputPath}\"],\"DestinationSubFolder\":\"\"}}]";
+        variables.AddRange([
+            new CalamariExecutionVariable(PackageVariables.IndexedPackageId(packageReferenceName), packageReferenceName, false),
+            new CalamariExecutionVariable(PackageVariables.IndexedOriginalPath(packageReferenceName), zipPath, false),
+            new CalamariExecutionVariable(PackageVariables.IndexedExtract(packageReferenceName), "True", false),
+            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.InputFileSources, inputFileSources, false),
+            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.DestinationPath, destinationPath, false),
+        ]);
+
+        RunCommitToGit().Should().NotBe(0, $"input path '{maliciousInputPath}' should be rejected because it could reference files outside the input source");
+    }
+
+    [Test]
+    [TestCase("../../../etc/passwd", TestName = "GitDep_RejectsInputPath_StartingWithDotDot")]
+    [TestCase("/etc/passwd", TestName = "GitDep_RejectsInputPath_StartingWithSlash")]
+    [TestCase("manifests/../../etc/passwd", TestName = "GitDep_RejectsInputPath_ContainingDotDotSegment")]
+    public void RejectsGitDependencyInputFilePathsThatEscapeSourceDirectory(string maliciousInputPath)
+    {
+        const string gitDependencyName = "my-git-dep";
+        const string destinationPath = "output-dir";
+
+        var zipPath = CreateZipWithEntry(gitDependencyName, "manifests/deployment.yaml", "apiVersion: apps/v1");
+        AddInputGitReferenceVariables(gitDependencyName, zipPath, destinationPath, inputFilePaths: new[] { maliciousInputPath });
+
+        RunCommitToGit().Should().NotBe(0, $"input path '{maliciousInputPath}' should be rejected because it could reference files outside the input source");
+    }
+
+    [Test]
     public void CommitToGitRunsScriptProvidedViaScriptBodyBySyntaxVariable()
     {
         variables.AddRange([

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -415,9 +415,36 @@ public class CommitToGitCommandTest
     [TestCase("../../../etc/passwd", TestName = "Package_RejectsInputPath_StartingWithDotDot")]
     [TestCase("/etc/passwd", TestName = "Package_RejectsInputPath_StartingWithSlash")]
     [TestCase("configs/../../etc/passwd", TestName = "Package_RejectsInputPath_ContainingDotDotSegment")]
+    public void RejectsPackageInputFilePathsThatEscapeSourceDirectory(string maliciousInputPath)
+    {
+        const string packageReferenceName = "my-configs";
+        const string destinationPath = "output-dir";
+
+        var zipPath = CreateZipWithEntry(packageReferenceName, "configs/settings.json", "{}");
+
+        var inputFileSources = SerializeInputFileSources(new PackageDependency
+        {
+            PackageId = packageReferenceName,
+            PackageName = packageReferenceName,
+            InputFilePaths = [maliciousInputPath],
+            DestinationSubFolder = "",
+        });
+        variables.AddRange([
+            new CalamariExecutionVariable(PackageVariables.IndexedPackageId(packageReferenceName), packageReferenceName, false),
+            new CalamariExecutionVariable(PackageVariables.IndexedOriginalPath(packageReferenceName), zipPath, false),
+            new CalamariExecutionVariable(PackageVariables.IndexedExtract(packageReferenceName), "True", false),
+            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.InputFileSources, inputFileSources, false),
+            new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.DestinationPath, destinationPath, false),
+        ]);
+
+        RunCommitToGit().Should().NotBe(0, $"input path '{maliciousInputPath}' should be rejected because it could reference files outside the input source");
+    }
+
+    [Test]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     [TestCase("C:\\Windows\\System32\\config", TestName = "Package_RejectsInputPath_WindowsAbsolutePath")]
     [TestCase("\\\\server\\share\\secret", TestName = "Package_RejectsInputPath_UncPath")]
-    public void RejectsPackageInputFilePathsThatEscapeSourceDirectory(string maliciousInputPath)
+    public void RejectsPackageInputFilePathsThatEscapeSourceDirectory_Windows(string maliciousInputPath)
     {
         const string packageReferenceName = "my-configs";
         const string destinationPath = "output-dir";
@@ -446,9 +473,22 @@ public class CommitToGitCommandTest
     [TestCase("../../../etc/passwd", TestName = "GitDep_RejectsInputPath_StartingWithDotDot")]
     [TestCase("/etc/passwd", TestName = "GitDep_RejectsInputPath_StartingWithSlash")]
     [TestCase("manifests/../../etc/passwd", TestName = "GitDep_RejectsInputPath_ContainingDotDotSegment")]
+    public void RejectsGitDependencyInputFilePathsThatEscapeSourceDirectory(string maliciousInputPath)
+    {
+        const string gitDependencyName = "my-git-dep";
+        const string destinationPath = "output-dir";
+
+        var zipPath = CreateZipWithEntry(gitDependencyName, "manifests/deployment.yaml", "apiVersion: apps/v1");
+        AddInputGitReferenceVariables(gitDependencyName, zipPath, destinationPath, inputFilePaths: new[] { maliciousInputPath });
+
+        RunCommitToGit().Should().NotBe(0, $"input path '{maliciousInputPath}' should be rejected because it could reference files outside the input source");
+    }
+
+    [Test]
+    [Category(TestCategory.CompatibleOS.OnlyWindows)]
     [TestCase("C:\\Windows\\System32\\config", TestName = "GitDep_RejectsInputPath_WindowsAbsolutePath")]
     [TestCase("\\\\server\\share\\secret", TestName = "GitDep_RejectsInputPath_UncPath")]
-    public void RejectsGitDependencyInputFilePathsThatEscapeSourceDirectory(string maliciousInputPath)
+    public void RejectsGitDependencyInputFilePathsThatEscapeSourceDirectory_Windows(string maliciousInputPath)
     {
         const string gitDependencyName = "my-git-dep";
         const string destinationPath = "output-dir";

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using Calamari.ArgoCD.Git;
 using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.CommitToGit;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.ArgoCD.Git;
 using Calamari.Tests.Fixtures.Integration.FileSystem;
@@ -167,7 +167,13 @@ public class CommitToGitCommandTest
 
         var zipPath = CreateZipWithEntry(packageReferenceName, packageEntryPath, "irrelevant");
 
-        var inputFileSources = $"[{{\"Type\":\"Package\",\"PackageId\":\"{packageReferenceName}\",\"PackageName\":\"{packageReferenceName}\",\"InputFilePaths\":[\"{inputGlob}\"],\"DestinationSubFolder\":\"\"}}]";
+        var inputFileSources = SerializeInputFileSources(new PackageDependency
+        {
+            PackageId = packageReferenceName,
+            PackageName = packageReferenceName,
+            InputFilePaths = [inputGlob],
+            DestinationSubFolder = "",
+        });
         variables.AddRange([
             new CalamariExecutionVariable(PackageVariables.IndexedPackageId(packageReferenceName), packageReferenceName, false),
             new CalamariExecutionVariable(PackageVariables.IndexedOriginalPath(packageReferenceName), zipPath, false),
@@ -295,11 +301,9 @@ public class CommitToGitCommandTest
         var zip1Path = CreateZipWithEntry(package1Name, "configs/settings.json", "{}");
         var zip2Path = CreateZipWithEntry(package2Name, "configs/template.yaml", "apiVersion: apps/v1");
 
-        var inputFileSources =
-            $"[" +
-            $"{{\"Type\":\"Package\",\"PackageId\":\"{package1Name}\",\"PackageName\":\"{package1Name}\",\"InputFilePaths\":[\"configs/**/*\"],\"DestinationSubFolder\":\"\"}}," +
-            $"{{\"Type\":\"Package\",\"PackageId\":\"{package2Name}\",\"PackageName\":\"{package2Name}\",\"InputFilePaths\":[\"configs/**/*\"],\"DestinationSubFolder\":\"\"}}" +
-            $"]";
+        var inputFileSources = SerializeInputFileSources(
+            new PackageDependency { PackageId = package1Name, PackageName = package1Name, InputFilePaths = ["configs/**/*"], DestinationSubFolder = "" },
+            new PackageDependency { PackageId = package2Name, PackageName = package2Name, InputFilePaths = ["configs/**/*"], DestinationSubFolder = "" });
 
         variables.AddRange([
             new CalamariExecutionVariable(PackageVariables.IndexedPackageId(package1Name), package1Name, false),
@@ -326,7 +330,13 @@ public class CommitToGitCommandTest
 
         var zipPath = CreateZipWithEntry(packageReferenceName, "configs/settings.json", "{\"setting\": \"value\"}");
 
-        var inputFileSources = $"[{{\"Type\":\"Package\",\"PackageId\":\"{packageReferenceName}\",\"PackageName\":\"{packageReferenceName}\",\"InputFilePaths\":[\"configs/**/*\"],\"DestinationSubFolder\":\"{destinationSubFolder}\"}}]";
+        var inputFileSources = SerializeInputFileSources(new PackageDependency
+        {
+            PackageId = packageReferenceName,
+            PackageName = packageReferenceName,
+            InputFilePaths = ["configs/**/*"],
+            DestinationSubFolder = destinationSubFolder,
+        });
         variables.AddRange([
             new CalamariExecutionVariable(PackageVariables.IndexedPackageId(packageReferenceName), packageReferenceName, false),
             new CalamariExecutionVariable(PackageVariables.IndexedOriginalPath(packageReferenceName), zipPath, false),
@@ -414,7 +424,13 @@ public class CommitToGitCommandTest
 
         var zipPath = CreateZipWithEntry(packageReferenceName, "configs/settings.json", "{}");
 
-        var inputFileSources = $"[{{\"Type\":\"Package\",\"PackageId\":\"{packageReferenceName}\",\"PackageName\":\"{packageReferenceName}\",\"InputFilePaths\":[\"{maliciousInputPath}\"],\"DestinationSubFolder\":\"\"}}]";
+        var inputFileSources = SerializeInputFileSources(new PackageDependency
+        {
+            PackageId = packageReferenceName,
+            PackageName = packageReferenceName,
+            InputFilePaths = [maliciousInputPath],
+            DestinationSubFolder = "",
+        });
         variables.AddRange([
             new CalamariExecutionVariable(PackageVariables.IndexedPackageId(packageReferenceName), packageReferenceName, false),
             new CalamariExecutionVariable(PackageVariables.IndexedOriginalPath(packageReferenceName), zipPath, false),
@@ -569,7 +585,13 @@ public class CommitToGitCommandTest
 
     void AddInputPackageVariables(string packageReferenceName, string zipPath, string destinationPath)
     {
-        var inputFileSources = $"[{{\"Type\":\"Package\",\"PackageId\":\"{packageReferenceName}\",\"PackageName\":\"{packageReferenceName}\",\"InputFilePaths\":[\"configs/**/*\"],\"DestinationSubFolder\":\"\"}}]";
+        var inputFileSources = SerializeInputFileSources(new PackageDependency
+        {
+            PackageId = packageReferenceName,
+            PackageName = packageReferenceName,
+            InputFilePaths = ["configs/**/*"],
+            DestinationSubFolder = "",
+        });
         variables.AddRange([
             // Package to copy into the repository, declared via InputFileSources
             new CalamariExecutionVariable(PackageVariables.IndexedPackageId(packageReferenceName), packageReferenceName, false),
@@ -585,10 +607,12 @@ public class CommitToGitCommandTest
 
     void AddInputGitReferenceVariables(string gitDependencyName, string zipPath, string destinationPath, string destinationSubFolder = "", string[] inputFilePaths = null)
     {
-        var inputFilePathsJson = inputFilePaths != null
-            ? "[" + string.Join(",", inputFilePaths.Select(p => $"\"{p}\"")) + "]"
-            : "[\"**/*\"]";
-        var inputFileSources = $"[{{\"Type\":\"GitRepository\",\"GitDependencyName\":\"{gitDependencyName}\",\"DestinationSubFolder\":\"{destinationSubFolder}\",\"InputFilePaths\":{inputFilePathsJson}}}]";
+        var inputFileSources = SerializeInputFileSources(new GitRepositoryDependency
+        {
+            GitDependencyName = gitDependencyName,
+            DestinationSubFolder = destinationSubFolder,
+            InputFilePaths = inputFilePaths ?? ["**/*"],
+        });
         variables.AddRange([
             new CalamariExecutionVariable(Deployment.SpecialVariables.GitResources.Extract(gitDependencyName), "true", false),
             new CalamariExecutionVariable(Deployment.SpecialVariables.GitResources.OriginalPath(gitDependencyName), zipPath, false),
@@ -596,6 +620,9 @@ public class CommitToGitCommandTest
             new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.DestinationPath, destinationPath, false),
         ]);
     }
+
+    static string SerializeInputFileSources(params CommitToGitDependency[] sources)
+        => JsonConvert.SerializeObject(sources);
 
     string GetCommittedFileContent(string repoFilePath)
     {

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -405,6 +405,8 @@ public class CommitToGitCommandTest
     [TestCase("../../../etc/passwd", TestName = "Package_RejectsInputPath_StartingWithDotDot")]
     [TestCase("/etc/passwd", TestName = "Package_RejectsInputPath_StartingWithSlash")]
     [TestCase("configs/../../etc/passwd", TestName = "Package_RejectsInputPath_ContainingDotDotSegment")]
+    [TestCase("C:\\Windows\\System32\\config", TestName = "Package_RejectsInputPath_WindowsAbsolutePath")]
+    [TestCase("\\\\server\\share\\secret", TestName = "Package_RejectsInputPath_UncPath")]
     public void RejectsPackageInputFilePathsThatEscapeSourceDirectory(string maliciousInputPath)
     {
         const string packageReferenceName = "my-configs";
@@ -428,6 +430,8 @@ public class CommitToGitCommandTest
     [TestCase("../../../etc/passwd", TestName = "GitDep_RejectsInputPath_StartingWithDotDot")]
     [TestCase("/etc/passwd", TestName = "GitDep_RejectsInputPath_StartingWithSlash")]
     [TestCase("manifests/../../etc/passwd", TestName = "GitDep_RejectsInputPath_ContainingDotDotSegment")]
+    [TestCase("C:\\Windows\\System32\\config", TestName = "GitDep_RejectsInputPath_WindowsAbsolutePath")]
+    [TestCase("\\\\server\\share\\secret", TestName = "GitDep_RejectsInputPath_UncPath")]
     public void RejectsGitDependencyInputFilePathsThatEscapeSourceDirectory(string maliciousInputPath)
     {
         const string gitDependencyName = "my-git-dep";

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -195,7 +195,7 @@ public class CommitToGitCommand : Command
     {
         foreach (var glob in globPatterns)
         {
-            EnsureInputPathIsSafe(glob);
+            EnsureInputPathIsSafe(sourceDir, glob);
 
             var prefix = GetNonWildcardPrefix(glob);
             foreach (var sourceFile in fileSystem.EnumerateFilesWithGlob(sourceDir, glob))
@@ -209,21 +209,16 @@ public class CommitToGitCommand : Command
         }
     }
 
-    static void EnsureInputPathIsSafe(string inputPath)
+    static void EnsureInputPathIsSafe(string sourceDir, string inputPath)
     {
         if (string.IsNullOrEmpty(inputPath))
             return;
 
-        // Normalize Windows separators so that Path.IsPathRooted reliably detects
-        // UNC paths (\\server\share) and drive-letter paths (C:\...) on all platforms.
-        var normalized = inputPath.Replace('\\', '/');
+        var sourceDirFull = Path.GetFullPath(sourceDir).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        var resolvedFull = Path.GetFullPath(Path.Combine(sourceDir, inputPath));
 
-        if (Path.IsPathRooted(normalized) || (normalized.Length >= 2 && normalized[1] == ':'))
-            throw new CommandException($"InputFilePath '{inputPath}' is not allowed because it is an absolute path. Input paths must be relative to the package or git repository source.");
-
-        var segments = normalized.Split('/');
-        if (segments.Any(s => s == ".."))
-            throw new CommandException($"InputFilePath '{inputPath}' is not allowed because it contains a '..' path segment that could reference files outside the input source.");
+        if (!resolvedFull.StartsWith(sourceDirFull, StringComparison.Ordinal))
+            throw new CommandException($"InputFilePath '{inputPath}' is not allowed because it resolves to a path outside the input source directory.");
     }
 
     static string GetNonWildcardPrefix(string globPattern)

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -214,11 +214,10 @@ public class CommitToGitCommand : Command
         if (string.IsNullOrEmpty(inputPath))
             return;
 
-        var normalized = inputPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-        if (normalized.StartsWith(Path.AltDirectorySeparatorChar))
+        if (Path.IsPathRooted(inputPath))
             throw new CommandException($"InputFilePath '{inputPath}' is not allowed because it is an absolute path. Input paths must be relative to the package or git repository source.");
 
+        var normalized = inputPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var segments = normalized.Split(Path.AltDirectorySeparatorChar);
         if (segments.Any(s => s == ".."))
             throw new CommandException($"InputFilePath '{inputPath}' is not allowed because it contains a '..' path segment that could reference files outside the input source.");

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -214,10 +214,10 @@ public class CommitToGitCommand : Command
         if (string.IsNullOrEmpty(inputPath))
             return;
 
-        var sourceDirFull = Path.GetFullPath(sourceDir).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
-        var resolvedFull = Path.GetFullPath(Path.Combine(sourceDir, inputPath));
+        var absoluteSourceDir = Path.GetFullPath(sourceDir).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        var absoluteInputSubPath = Path.GetFullPath(Path.Combine(sourceDir, inputPath));
 
-        if (!resolvedFull.StartsWith(sourceDirFull, StringComparison.Ordinal))
+        if (!absoluteInputSubPath.StartsWith(absoluteSourceDir, StringComparison.Ordinal))
             throw new CommandException($"InputFilePath '{inputPath}' is not allowed because it resolves to a path outside the input source directory.");
     }
 

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -214,11 +214,14 @@ public class CommitToGitCommand : Command
         if (string.IsNullOrEmpty(inputPath))
             return;
 
-        if (Path.IsPathRooted(inputPath))
+        // Normalize Windows separators so that Path.IsPathRooted reliably detects
+        // UNC paths (\\server\share) and drive-letter paths (C:\...) on all platforms.
+        var normalized = inputPath.Replace('\\', '/');
+
+        if (Path.IsPathRooted(normalized) || (normalized.Length >= 2 && normalized[1] == ':'))
             throw new CommandException($"InputFilePath '{inputPath}' is not allowed because it is an absolute path. Input paths must be relative to the package or git repository source.");
 
-        var normalized = inputPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var segments = normalized.Split(Path.AltDirectorySeparatorChar);
+        var segments = normalized.Split('/');
         if (segments.Any(s => s == ".."))
             throw new CommandException($"InputFilePath '{inputPath}' is not allowed because it contains a '..' path segment that could reference files outside the input source.");
     }

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -195,6 +195,8 @@ public class CommitToGitCommand : Command
     {
         foreach (var glob in globPatterns)
         {
+            EnsureInputPathIsSafe(glob);
+
             var prefix = GetNonWildcardPrefix(glob);
             foreach (var sourceFile in fileSystem.EnumerateFilesWithGlob(sourceDir, glob))
             {
@@ -205,6 +207,21 @@ public class CommitToGitCommand : Command
                 yield return (sourceFile, destRelative);
             }
         }
+    }
+
+    static void EnsureInputPathIsSafe(string inputPath)
+    {
+        if (string.IsNullOrEmpty(inputPath))
+            return;
+
+        var normalized = inputPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        if (normalized.StartsWith(Path.AltDirectorySeparatorChar))
+            throw new CommandException($"InputFilePath '{inputPath}' is not allowed because it is an absolute path. Input paths must be relative to the package or git repository source.");
+
+        var segments = normalized.Split(Path.AltDirectorySeparatorChar);
+        if (segments.Any(s => s == ".."))
+            throw new CommandException($"InputFilePath '{inputPath}' is not allowed because it contains a '..' path segment that could reference files outside the input source.");
     }
 
     static string GetNonWildcardPrefix(string globPattern)


### PR DESCRIPTION
During testing it was found that a user _could_ specify an inputpath for a given source which escaped the source's root directory - meaning the copy operation would/could pull in files from anywhere in the worker's filesystem.

This change checks if an input source defines a path which is within its directory structure before executing the copy 

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
