### PR TITLE
preserve inherited AWS_REGION when Terraform step has no region

### DIFF
--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -174,8 +174,17 @@ namespace Calamari.CloudAccounts
         /// </summary>
         void PopulateCommonSettings()
         {
-            EnvironmentVars["AWS_DEFAULT_REGION"] = region;
-            EnvironmentVars["AWS_REGION"] = region;
+            // When the step has no Octopus.Action.Aws.Region, `region` is null. Writing null into
+            // EnvironmentVars used to wipe the parent process's AWS_REGION in any spawned child
+            // (because SilentProcessRunner overlays the dict on ProcessStartInfo.EnvironmentVariables,
+            // where null means 'remove the var'). For Terraform steps on EKS Pods with IRSA, this
+            // erased the Pod's inherited region and broke `terraform plan` with 'invalid AWS Region:'.
+            // See Issues #8337.
+            if (!string.IsNullOrWhiteSpace(region))
+            {
+                EnvironmentVars["AWS_DEFAULT_REGION"] = region;
+                EnvironmentVars["AWS_REGION"] = region;
+            }
         }
 
         /// <summary>

--- a/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
+++ b/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
@@ -103,5 +103,126 @@ namespace Calamari.Tests.AWS
             var envGeneration = new AwsEnvironmentGeneration(Substitute.For<ILog>(), variables);
             envGeneration.AwsRegion.SystemName.Should().Be("aws-global");
         }
+
+        // Repros the Terraform-step-on-EKS scenario from Issues #8337
+        // worker Pod has IRSA env vars set, step is configured with UseInstanceRole=true and no explicit account.
+        // PopulateKeysFromWebRole should win the fallback chain and populate session credentials from STS.
+        [Test]
+        public async Task UsesWebIdentityFromEksPodWhenInstanceRoleSelected()
+        {
+            IVariables variables = new CalamariVariables();
+            variables.Add("Octopus.Action.AwsAccount.UseInstanceRole", "True");
+            variables.Add("Octopus.Action.Aws.Region", "us-east-1");
+
+            var roleArn = "arn:aws:iam::123456789012:role/eks-octopus-worker";
+            var accessKeyId = Randomizer.CreateRandomizer().GetString(20, "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+            var secretAccessKey = Randomizer.CreateRandomizer().GetString(40, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+");
+            var sessionToken = Randomizer.CreateRandomizer().GetString(1120, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
+
+            var stsResponse = $@"<?xml version=""1.0""?>
+<AssumeRoleWithWebIdentityResponse xmlns=""https://sts.amazonaws.com/doc/2011-06-15/"">
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>{accessKeyId}</AccessKeyId>
+      <SecretAccessKey>{secretAccessKey}</SecretAccessKey>
+      <SessionToken>{sessionToken}</SessionToken>
+      <Expiration>{DateTime.UtcNow.AddHours(1):yyyy-MM-ddTHH:mm:ssZ}</Expiration>
+    </Credentials>
+    <SubjectFromWebIdentityToken>system:serviceaccount:default:octopus-worker</SubjectFromWebIdentityToken>
+    <AssumedRoleUser>
+      <Arn>{roleArn}/octopus-aws-sdk-session</Arn>
+      <AssumedRoleId>AROAEXAMPLE:octopus-aws-sdk-session</AssumedRoleId>
+    </AssumedRoleUser>
+  </AssumeRoleWithWebIdentityResult>
+  <ResponseMetadata>
+    <RequestId>00000000-0000-0000-0000-000000000000</RequestId>
+  </ResponseMetadata>
+</AssumeRoleWithWebIdentityResponse>";
+
+            using var server = WireMockServer.Start();
+            server
+                .Given(Request.Create()
+                              .UsingPost()
+                              .WithBody(new RegexMatcher("Action=AssumeRoleWithWebIdentity")))
+                .RespondWith(Response.Create()
+                                     .WithStatusCode(200)
+                                     .WithHeader("Content-Type", "text/xml")
+                                     .WithBody(stsResponse));
+
+            // Snapshot env so we don't bleed into subsequent tests (the existing
+            // UsesGenericContainerCredentialsWhenAvailable test leaves CONTAINER_* set;
+            // we must clear those or PopulateKeysFromContainerIdentity wins the fallback chain).
+            var preserved = new Dictionary<string, string>
+            {
+                ["AWS_ROLE_ARN"] = Environment.GetEnvironmentVariable("AWS_ROLE_ARN"),
+                ["AWS_WEB_IDENTITY_TOKEN_FILE"] = Environment.GetEnvironmentVariable("AWS_WEB_IDENTITY_TOKEN_FILE"),
+                ["AWS_ENDPOINT_URL_STS"] = Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL_STS"),
+                ["AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"] = Environment.GetEnvironmentVariable("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"),
+                ["AWS_CONTAINER_CREDENTIALS_FULL_URI"] = Environment.GetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_FULL_URI"),
+            };
+
+            AwsEnvironmentGeneration awsEnvironmentGenerator;
+            try
+            {
+                Environment.SetEnvironmentVariable("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", null);
+                Environment.SetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_FULL_URI", null);
+
+                using var tokenPath = new TemporaryFile(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+                File.WriteAllText(tokenPath.FilePath, "eyJhbGciOiJSUzI1NiIsImtpZCI6ImV4YW1wbGUifQ.fake-irsa-jwt.signature");
+
+                Environment.SetEnvironmentVariable("AWS_ROLE_ARN", roleArn);
+                Environment.SetEnvironmentVariable("AWS_WEB_IDENTITY_TOKEN_FILE", tokenPath.FilePath);
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL_STS", $"http://127.0.0.1:{server.Port}/");
+
+                awsEnvironmentGenerator = await AwsEnvironmentGeneration.Create(Substitute.For<ILog>(), variables);
+            }
+            finally
+            {
+                foreach (var kvp in preserved)
+                    Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+            }
+
+            awsEnvironmentGenerator.EnvironmentVars.Should().Contain(new KeyValuePair<string, string>("AWS_ACCESS_KEY_ID", accessKeyId));
+            awsEnvironmentGenerator.EnvironmentVars.Should().Contain(new KeyValuePair<string, string>("AWS_SECRET_ACCESS_KEY", secretAccessKey));
+            awsEnvironmentGenerator.EnvironmentVars.Should().Contain(new KeyValuePair<string, string>("AWS_SESSION_TOKEN", sessionToken));
+        }
+
+        // Regression test for Issues #8337: when the step has no Octopus.Action.Aws.Region,
+        // PopulateCommonSettings used to do EnvironmentVars["AWS_REGION"] = null. SilentProcessRunner
+        // then overlays the dict onto ProcessStartInfo.EnvironmentVariables — and in .NET, setting
+        // a dict value to null means 'remove the var' from the child env. That wiped the EKS Pod's
+        // inherited AWS_REGION in the spawned terraform process, which errored with 'invalid AWS Region:'.
+        //
+        // Verified end-to-end on a real EKS+IRSA Pod (Calamari 2026.2.x): Test 5 in that harness
+        // (Calamari-style env with no region) failed with that exact error; same harness's Test 4
+        // (region set) succeeded. The fix is to skip the assignment when region is null/empty so the
+        // parent env's value passes through unchanged.
+        [Test]
+        public async Task DoesNotOverwriteRegionWhenStepHasNoRegionConfigured()
+        {
+            IVariables variables = new CalamariVariables();
+            variables.Add("Octopus.Account.AccountType", "AmazonWebServicesAccount");
+            variables.Add("Octopus.Action.AwsAccount.Variable", "AWSAccount");
+            variables.Add("AWSAccount.AccessKey", "AKIAIOSFODNN7EXAMPLE");
+            variables.Add("AWSAccount.SecretKey", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+            // Deliberately NOT setting Octopus.Action.Aws.Region.
+
+            // Stub verifyLogin so TryPopulateKeysDirectly succeeds without hitting STS.
+            Func<Task<bool>> verifyLoginStub = () => Task.FromResult(true);
+            var gen = await AwsEnvironmentGeneration.Create(Substitute.For<ILog>(), variables, verifyLoginStub);
+
+            // Both keys must either be absent OR have a non-empty value. They must NOT exist with
+            // null/empty values, because that's what SilentProcessRunner treats as 'remove the var'.
+            foreach (var key in new[] { "AWS_REGION", "AWS_DEFAULT_REGION" })
+            {
+                if (gen.EnvironmentVars.TryGetValue(key, out var value))
+                {
+                    value.Should().NotBeNullOrWhiteSpace(
+                        $"{key} must not be overlaid with null/empty when the step has no region — " +
+                        "SilentProcessRunner treats a null dict value as 'remove the var' and wipes the " +
+                        "parent process's region inherited from the EKS Pod, breaking the Terraform AWS provider");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Discussion on [slack](https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1695006795522649?thread_ts=1694578009.851649&cid=CNHBHV2BX).

## Details

__The actual bug is the region overlay, not IRSA (_IAM Roles for Service Accounts_).__ When a Terraform step runs on an EKS Pod worker with no `Octopus.Action.Aws.Region` configured, `AwsEnvironmentGeneration.PopulateCommonSettings` writes `EnvironmentVars["AWS_REGION"] = null` and `["AWS_DEFAULT_REGION"] = null`. `SilentProcessRunner` then overlays that dict onto `ProcessStartInfo.EnvironmentVariables` when spawning `terraform` — and in .NET, a null dict value means "remove this key from the child env."

The flip side: the EKS Pod's IRSA-injected `AWS_REGION` (e.g. `ap-southeast-2`) that Calamari itself inherited from the Pod gets wiped for the `terraform` child process. The Terraform AWS provider then hard-errors before any credential resolution kicks in.

Bug report shape: "AWS Script step works but Terraform step fails on EKS for non-obvious reasons." Worth being honest about why it looked non-obvious — same parent env, different tolerance. The AWS CLI falls back to global STS and reads from `~/.aws/config` when region is missing; the Terraform AWS provider doesn't tolerate it at all.

## Before

`Error: invalid AWS Region: with provider["registry.terraform.io/hashicorp/aws"]`

## After

1. Only assign region into `EnvironmentVars` __when it is actually set.__
2. When the step has no region, leave the inherited parent env alone.

## Testing

Local repro.

The IRSA / web-identity path through `PopulateKeysFromWebRole` (added in #961) itself works correctly today — it was the region-overlay step downstream of it that broke the env handed to `terraform`.

Closes [#8337](https://github.com/OctopusDeploy/Issues/issues/8337).

Does this change require a corresponding Server Change?
- No