### PR TITLE
Change indentation for method args

### DIFF
--- a/source/Calamari.sln.DotSettings
+++ b/source/Calamari.sln.DotSettings
@@ -4,7 +4,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StaticMemberInGenericType/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_INTERNAL_MODIFIER/@EntryValue">Implicit</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_FIRST_ARG_BY_PAREN/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_FIRST_ARG_BY_PAREN/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_LINQ_QUERY/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_ARRAY_AND_OBJECT_INITIALIZER/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_BINARY_EXPRESSIONS_CHAIN/@EntryValue">True</s:Boolean>


### PR DESCRIPTION
The configured indentation of method args is pretty heavily indented. When you take into account some of our long function names it gets pretty wasteful.

## Before

```
var sshConnection = new SshKeyGitConnection(
					                                                            sshCredential.Username,
					                                                            sshCredential.PrivateKey,
					                                                            requestedUrl,
					                                                            GitReference.CreateFromString(targetRevision));
```

## After

```
var sshConnection = new SshKeyGitConnection(
      sshCredential.Username,
      sshCredential.PrivateKey,
      requestedUrl,
      GitReference.CreateFromString(targetRevision));
```