### PR TITLE
CommitToGit: Handle missing destination Path

### DIFF
--- a/source/Calamari.Tests/CommitToGit/CommitToGitConfigFactoryTests.cs
+++ b/source/Calamari.Tests/CommitToGit/CommitToGitConfigFactoryTests.cs
@@ -52,4 +52,18 @@ public class CommitToGitConfigFactoryTests
         httpsGitConnection.Password.Should().Be("pwd-from-file");
         httpsGitConnection.Uri.Value.Should().Be(new Uri("https://example.invalid/repo.git"));
     }
+
+    [Test]
+    public void CreateRepositoryConfig_WhenDestinationPathIsMissing_DefaultsToEmptyString()
+    {
+        loader.Load<CommitToGitCustomPropertiesDto>()
+              .Returns(new CommitToGitCustomPropertiesDto(new UsernamePasswordGitCredentialDto("MyCred", "https://example.invalid/repo.git", "user", "pwd")));
+        variables.Get(SpecialVariables.Action.Git.DestinationPath).Returns((string)null);
+
+        var deployment = new RunningDeployment(null, variables);
+
+        var config = factory.CreateRepositoryConfig(deployment, loader);
+
+        config.DestinationPath.Should().Be(string.Empty);
+    }
 }

--- a/source/Calamari.Tests/CommitToGit/CommitToGitConfigFactoryTests.cs
+++ b/source/Calamari.Tests/CommitToGit/CommitToGitConfigFactoryTests.cs
@@ -56,6 +56,8 @@ public class CommitToGitConfigFactoryTests
     [Test]
     public void CreateRepositoryConfig_WhenDestinationPathIsMissing_DefaultsToEmptyString()
     {
+        //Octopus server removes variables containing empty strings, thus a missing property should default to an empty string.
+        //Thus the TargetRepositorydestinationPath could validly be missing from the variable set, in such case, it should default to an empty string.
         loader.Load<CommitToGitCustomPropertiesDto>()
               .Returns(new CommitToGitCustomPropertiesDto(new UsernamePasswordGitCredentialDto("MyCred", "https://example.invalid/repo.git", "user", "pwd")));
         variables.Get(SpecialVariables.Action.Git.DestinationPath).Returns((string)null);

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -165,7 +165,7 @@ public class CommitToGitCommand : Command
         [
             new DelegateInstallConvention(d =>
                                           {
-                                              var destinationPath = repositoryConfig!.DestinationPath;
+                                              var destinationPath = repositoryConfig.DestinationPath;
                                               var destBase = Path.Combine(clonedRepository.WorkingDirectory, destinationPath);
 
                                               foreach (var package in metadataParser.GetPackageDependenciesForCopying(d))

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -165,7 +165,7 @@ public class CommitToGitCommand : Command
         [
             new DelegateInstallConvention(d =>
                                           {
-                                              var destinationPath = repositoryConfig!.DestinationPath ?? string.Empty;
+                                              var destinationPath = repositoryConfig!.DestinationPath;
                                               var destBase = Path.Combine(clonedRepository.WorkingDirectory, destinationPath);
 
                                               foreach (var package in metadataParser.GetPackageDependenciesForCopying(d))

--- a/source/Calamari/CommitToGit/CommitToGitConfigFactory.cs
+++ b/source/Calamari/CommitToGit/CommitToGitConfigFactory.cs
@@ -45,7 +45,7 @@ namespace Calamari.CommitToGit
 
             return new CommitToGitRepositorySettings(connection,
                                                      commitParameters,
-                                                     variables.Get(SpecialVariables.Action.Git.DestinationPath));
+                                                     variables.Get(SpecialVariables.Action.Git.DestinationPath) ?? string.Empty);
         }
 
         string EvaluateNonsensitiveExpression(string expression)

--- a/source/Calamari/CommitToGit/CommitToGitConfigFactory.cs
+++ b/source/Calamari/CommitToGit/CommitToGitConfigFactory.cs
@@ -43,6 +43,7 @@ namespace Calamari.CommitToGit
                                             _ => throw new NotSupportedException($"An unrecognised credential type '{properties.GitCredential.GetType().Name}' was found for '{uriAsString}'"),
                                         };
 
+            //Note: Octopus server removes variables containing empty strings, thus a missing property should default to an empty string.
             return new CommitToGitRepositorySettings(connection,
                                                      commitParameters,
                                                      variables.Get(SpecialVariables.Action.Git.DestinationPath) ?? string.Empty);


### PR DESCRIPTION
Turns out Server will remove empty strings from properties/variables - given the destinationPath is (now) allowed to be empty, Calamari needs to expect that it may be missing.

If it is missing, Calamari should assume an empty string.

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
