### PR TITLE
Remove references to ansi-colors feature toggle

### DIFF
--- a/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
@@ -6,13 +6,11 @@ namespace Calamari.Common.FeatureToggles
     {
         public static class KnownSlugs
         {
-            public const string AnsiColorsInTaskLogFeatureToggle = "ansi-colors";
             public const string ArgoCDHelmReplacePathFromContainerReferenceFeatureToggle = "argo-cd-helm-replace-path-from-container-reference";
             public const string KustomizePatchImageUpdatesFeatureToggle = "kustomize-patch-image-updates";
             public const string ArgoRolloutsSupportFeatureToggle = "argo-rollouts-support";
         };
 
-        public static readonly OctopusFeatureToggle AnsiColorsInTaskLogFeatureToggle = new(KnownSlugs.AnsiColorsInTaskLogFeatureToggle);
         public static readonly OctopusFeatureToggle ArgoCDHelmReplacePathFromContainerReferenceFeatureToggle = new(KnownSlugs.ArgoCDHelmReplacePathFromContainerReferenceFeatureToggle);
         public static readonly OctopusFeatureToggle KustomizePatchImageUpdatesFeatureToggle = new(KnownSlugs.KustomizePatchImageUpdatesFeatureToggle);
         public static readonly OctopusFeatureToggle ArgoRolloutsSupportFeatureToggle = new(KnownSlugs.ArgoRolloutsSupportFeatureToggle);

--- a/source/Calamari.Terraform.Tests/CommandsFixture.cs
+++ b/source/Calamari.Terraform.Tests/CommandsFixture.cs
@@ -248,7 +248,7 @@ namespace Calamari.Terraform.Tests
                                           _.Variables.Add(TerraformSpecialVariables.Action.Terraform.AdditionalInitParams, additionalParams),
                                       "Simple")
                 .Should()
-                .Contain($"init -no-color -get-plugins=true {additionalParams}");
+                .Contain($"init -get-plugins=true {additionalParams}");
         }
 
         [Test]
@@ -263,7 +263,7 @@ namespace Calamari.Terraform.Tests
                                       },
                                       "Simple")
                 .Should()
-                .Contain("init -no-color -get-plugins=false");
+                .Contain("init -get-plugins=false");
         }
 
         [Test]
@@ -280,10 +280,10 @@ namespace Calamari.Terraform.Tests
         }
 
         [Test]
-        [TestCase(typeof(PlanCommand), "plan -no-color -detailed-exitcode -var my_var=\"Hello world\"")]
-        [TestCase(typeof(ApplyCommand), "apply -no-color -auto-approve -var my_var=\"Hello world\"")]
-        [TestCase(typeof(DestroyPlanCommand), "plan -no-color -detailed-exitcode -destroy -var my_var=\"Hello world\"")]
-        [TestCase(typeof(DestroyCommand), "destroy -auto-approve -no-color -var my_var=\"Hello world\"")]
+        [TestCase(typeof(PlanCommand), "plan -detailed-exitcode -var my_var=\"Hello world\"")]
+        [TestCase(typeof(ApplyCommand), "apply -auto-approve -var my_var=\"Hello world\"")]
+        [TestCase(typeof(DestroyPlanCommand), "plan -detailed-exitcode -destroy -var my_var=\"Hello world\"")]
+        [TestCase(typeof(DestroyCommand), "destroy -auto-approve -var my_var=\"Hello world\"")]
         public void AdditionalActionParams(Type commandType, string expected)
         {
             var command = GetCommandFromType(commandType);
@@ -299,10 +299,10 @@ namespace Calamari.Terraform.Tests
         }
 
         [Test]
-        [TestCase(typeof(PlanCommand), "plan -no-color -detailed-exitcode -var-file=\"example.tfvars\"")]
-        [TestCase(typeof(ApplyCommand), "apply -no-color -auto-approve -var-file=\"example.tfvars\"")]
-        [TestCase(typeof(DestroyPlanCommand), "plan -no-color -detailed-exitcode -destroy -var-file=\"example.tfvars\"")]
-        [TestCase(typeof(DestroyCommand), "destroy -auto-approve -no-color -var-file=\"example.tfvars\"")]
+        [TestCase(typeof(PlanCommand), "plan -detailed-exitcode -var-file=\"example.tfvars\"")]
+        [TestCase(typeof(ApplyCommand), "apply -auto-approve -var-file=\"example.tfvars\"")]
+        [TestCase(typeof(DestroyPlanCommand), "plan -detailed-exitcode -destroy -var-file=\"example.tfvars\"")]
+        [TestCase(typeof(DestroyCommand), "destroy -auto-approve -var-file=\"example.tfvars\"")]
         public void VarFiles(Type commandType, string actual)
         {
             ExecuteAndReturnLogOutput(GetCommandFromType(commandType), _ => { _.Variables.Add(TerraformSpecialVariables.Action.Terraform.VarFiles, "example.tfvars"); }, "WithVariables")
@@ -635,7 +635,7 @@ namespace Calamari.Terraform.Tests
 
             output = await ExecuteAndReturnResult(applyCommand, PopulateVariables, "PlanDetailedExitCode");
             output.FullLog.Should()
-                  .Contain("apply -no-color -auto-approve");
+                  .Contain("apply -auto-approve");
 
             output = await ExecuteAndReturnResult(planCommand, PopulateVariables, "PlanDetailedExitCode");
             output.OutputVariables.ContainsKey("TerraformPlanDetailedExitCode").Should().BeTrue();

--- a/source/Calamari.Terraform.Tests/TerraformCliExecutorFixture.cs
+++ b/source/Calamari.Terraform.Tests/TerraformCliExecutorFixture.cs
@@ -20,6 +20,7 @@ namespace Calamari.Terraform.Tests
         public void Setup()
         {
             variables = Substitute.For<IVariables>();
+            variables.GetStrings(KnownVariables.EnabledFeatureToggles).Returns(new List<string>());
             var commandLineRunner = Substitute.For<ICommandLineRunner>();
             commandLineRunner.Execute(Arg.Do<CommandLineInvocation>(invocation => invocation.AdditionalInvocationOutputSink.WriteInfo("Terraform v0.15.0")))
                              .Returns(new CommandResult("foo", 0));
@@ -67,6 +68,7 @@ namespace Calamari.Terraform.Tests
         public void InitializePlugins_RetriesOnTransient502Error()
         {
             var testVariables = Substitute.For<IVariables>();
+            testVariables.GetStrings(KnownVariables.EnabledFeatureToggles).Returns(new List<string>());
             var commandLineRunner = Substitute.For<ICommandLineRunner>();
             var callCount = 0;
             commandLineRunner.Execute(Arg.Do<CommandLineInvocation>(invocation =>
@@ -90,6 +92,7 @@ namespace Calamari.Terraform.Tests
         public void InitializePlugins_DoesNotRetryNonTransientError()
         {
             var testVariables = Substitute.For<IVariables>();
+            testVariables.GetStrings(KnownVariables.EnabledFeatureToggles).Returns(new List<string>());
             var commandLineRunner = Substitute.For<ICommandLineRunner>();
             var callCount = 0;
             commandLineRunner.Execute(Arg.Do<CommandLineInvocation>(invocation =>
@@ -114,6 +117,7 @@ namespace Calamari.Terraform.Tests
         public void InitializePlugins_ThrowsAfterRetriesExhausted()
         {
             var testVariables = Substitute.For<IVariables>();
+            testVariables.GetStrings(KnownVariables.EnabledFeatureToggles).Returns(new List<string>());
             var commandLineRunner = Substitute.For<ICommandLineRunner>();
             var callCount = 0;
             commandLineRunner.Execute(Arg.Do<CommandLineInvocation>(invocation =>

--- a/source/Calamari.Terraform.Tests/TerraformCliExecutorFixture.cs
+++ b/source/Calamari.Terraform.Tests/TerraformCliExecutorFixture.cs
@@ -20,7 +20,6 @@ namespace Calamari.Terraform.Tests
         public void Setup()
         {
             variables = Substitute.For<IVariables>();
-            variables.GetStrings(KnownVariables.EnabledFeatureToggles).Returns(new List<string>());
             var commandLineRunner = Substitute.For<ICommandLineRunner>();
             commandLineRunner.Execute(Arg.Do<CommandLineInvocation>(invocation => invocation.AdditionalInvocationOutputSink.WriteInfo("Terraform v0.15.0")))
                              .Returns(new CommandResult("foo", 0));
@@ -68,7 +67,6 @@ namespace Calamari.Terraform.Tests
         public void InitializePlugins_RetriesOnTransient502Error()
         {
             var testVariables = Substitute.For<IVariables>();
-            testVariables.GetStrings(KnownVariables.EnabledFeatureToggles).Returns(new List<string>());
             var commandLineRunner = Substitute.For<ICommandLineRunner>();
             var callCount = 0;
             commandLineRunner.Execute(Arg.Do<CommandLineInvocation>(invocation =>
@@ -92,7 +90,6 @@ namespace Calamari.Terraform.Tests
         public void InitializePlugins_DoesNotRetryNonTransientError()
         {
             var testVariables = Substitute.For<IVariables>();
-            testVariables.GetStrings(KnownVariables.EnabledFeatureToggles).Returns(new List<string>());
             var commandLineRunner = Substitute.For<ICommandLineRunner>();
             var callCount = 0;
             commandLineRunner.Execute(Arg.Do<CommandLineInvocation>(invocation =>
@@ -117,7 +114,6 @@ namespace Calamari.Terraform.Tests
         public void InitializePlugins_ThrowsAfterRetriesExhausted()
         {
             var testVariables = Substitute.For<IVariables>();
-            testVariables.GetStrings(KnownVariables.EnabledFeatureToggles).Returns(new List<string>());
             var commandLineRunner = Substitute.For<ICommandLineRunner>();
             var callCount = 0;
             commandLineRunner.Execute(Arg.Do<CommandLineInvocation>(invocation =>

--- a/source/Calamari.Terraform/Behaviours/ApplyBehaviour.cs
+++ b/source/Calamari.Terraform/Behaviours/ApplyBehaviour.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
@@ -70,16 +69,12 @@ namespace Calamari.Terraform.Behaviours
         static IEnumerable<string> GetOutputArgs(RunningDeployment deployment)
         {
             yield return "output";
-            if (!OctopusFeatureToggles.AnsiColorsInTaskLogFeatureToggle.IsEnabled(deployment.Variables))
-                yield return "-no-color";
             yield return "-json";
         }
 
         static IEnumerable<string> GetApplyArgs(RunningDeployment deployment, TerraformCliExecutor cli)
         {
             yield return "apply";
-            if (!OctopusFeatureToggles.AnsiColorsInTaskLogFeatureToggle.IsEnabled(deployment.Variables))
-                yield return "-no-color";
             yield return "-auto-approve";
             yield return cli.TerraformVariableFiles;
             yield return cli.ActionParams;

--- a/source/Calamari.Terraform/Behaviours/DestroyBehaviour.cs
+++ b/source/Calamari.Terraform/Behaviours/DestroyBehaviour.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
@@ -34,8 +33,6 @@ namespace Calamari.Terraform.Behaviours
                 var args = new List<string>();
                 args.Add("destroy");
                 args.Add("-auto-approve");
-                if (!OctopusFeatureToggles.AnsiColorsInTaskLogFeatureToggle.IsEnabled(deployment.Variables))
-                    args.Add("-no-color");
                 args.Add(cli.TerraformVariableFiles);
                 args.Add(cli.ActionParams);
                 cli.ExecuteCommand(args.ToArray())

--- a/source/Calamari.Terraform/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari.Terraform/Behaviours/PlanBehaviour.cs
@@ -4,7 +4,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
@@ -58,8 +57,6 @@ namespace Calamari.Terraform.Behaviours
 
                 var args = new List<string>();
                 args.Add("plan");
-                if (!OctopusFeatureToggles.AnsiColorsInTaskLogFeatureToggle.IsEnabled(deployment.Variables))
-                    args.Add("-no-color");
                 args.Add("-detailed-exitcode");
                 args.Add(GetOutputParameter(deployment, cli.Version));
                 args.Add(ExtraParameter);

--- a/source/Calamari.Terraform/TerraformCliExecutor.cs
+++ b/source/Calamari.Terraform/TerraformCliExecutor.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.Extensions;
@@ -215,8 +214,6 @@ namespace Calamari.Terraform
             var allowPluginDownloads = variables.GetFlag(TerraformSpecialVariables.Action.Terraform.AllowPluginDownloads, true);
 
             var initCommand = "init";
-            if (!OctopusFeatureToggles.AnsiColorsInTaskLogFeatureToggle.IsEnabled(deployment.Variables))
-                initCommand += " -no-color";
             if (Version?.IsLessThan("0.15.0") == true)
                 initCommand += $" -get-plugins={allowPluginDownloads.ToString().ToLower()}";
             initCommand += $" {initParams}";


### PR DESCRIPTION
# Background

[[FFT-504](https://linear.app/octopus/issue/FFT-504/remove-references-to-ansi-colors-feature-toggle-in-calamari)]

The `ansi-colors` feature toggle had been defaulting to `true` for about a month, so I [removed it from the OctopusDeploy codebase](https://github.com/OctopusDeploy/OctopusDeploy/pull/43201). What I hadn't realised is that there are references to that feature toggle in Calamari, which means the colors aren't working for certain scenarios anymore.

# Results

The references to the `ansi-colors` feature toggle have been removed.
