### PR TITLE
Add extra logging to update ECS step

### DIFF
--- a/source/Calamari.Aws/Deployment/Conventions/UpdateEcsServiceConvention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UpdateEcsServiceConvention.cs
@@ -49,6 +49,7 @@ public class UpdateEcsServiceConvention(
             throw new CommandException($"Template task definition '{templateTaskDefinitionName}' not found.");
         }
         var template = templateResp.TaskDefinition;
+        log.Info($"Found task definition template \"{templateTaskDefinitionName}\".");
 
         // SPF behavior to check if the target task definition family exists before applying the update
         // Only needed if the target is different from the source
@@ -68,8 +69,10 @@ public class UpdateEcsServiceConvention(
 
         var taskDefTags = EcsDefaultTags.MergeAndDeduplicateTags(deployment.Variables, tags, templateResp.Tags);
         var registerRequest = RegisterTaskDefinitionRequestFactory.FromTaskDefinition(template, targetTaskDefinitionName, containers, taskDefTags, deployment.Variables);
+        log.Info($"Container image(s) to be updated: {string.Join(", ", containers.Select(c => c.ContainerName))}.");
         var registerResp = await ecs.RegisterTaskDefinitionAsync(registerRequest, ct);
         var registeredTaskDef = registerResp.TaskDefinition;
+        log.Info($"New revision for task definition \"{registeredTaskDef.Family}\" created. Revision number: {registeredTaskDef.Revision}.");
 
         var serviceResp = await ecs.DescribeServicesAsync(new DescribeServicesRequest
         {
@@ -88,6 +91,7 @@ public class UpdateEcsServiceConvention(
             ForceNewDeployment = true
         }, ct);
         var updatedService = updateResp.Service;
+        log.Info($"ECS Service \"{serviceName}\" has been updated successfully.");
 
         var serviceTags = EcsDefaultTags.MergeAndDeduplicateTags(deployment.Variables, tags, existingService.Tags);
         if (serviceTags.Count > 0)


### PR DESCRIPTION
After reviewing some SPF logging for this step this adds a few log lines missing

Note that our native step port does not have the task definition diff that SPF had.

Logging sample after changes

```
Wed, May 27th 2026 14:19:26 +10:00  Info        The version 2026.99.0-sk-improve-logging-20260527141524 of the Calamari.linux-x64 tool has not been extracted, it will be extracted automatically.
Wed, May 27th 2026 14:19:34 +10:00  Info        Version 2026.99.0-sk-improve-logging-20260527141524 of the Calamari.linux-x64 tool has been extracted successfully
Wed, May 27th 2026 14:19:36 +10:00  Info        Running the step as the AWS role skumar-octo-account
Wed, May 27th 2026 14:19:36 +10:00  Info        Found task definition template "test-sk-task".
Wed, May 27th 2026 14:19:37 +10:00  Info        Container image(s) to be updated: test-sk-nginx.
Wed, May 27th 2026 14:19:37 +10:00  Info        New revision for task definition "test-sk-task" created. Revision number: 24.
Wed, May 27th 2026 14:19:37 +10:00  Info        ECS Service "test-sk-stack-ServicetestSkTask-BvO1npPY94iF" has been updated successfully.
Wed, May 27th 2026 14:19:37 +10:00  Info        Saving variable "Octopus.Action[Update ECS service].Output.TaskDefinitionFamily"
Wed, May 27th 2026 14:19:37 +10:00  Info        Saving variable "Octopus.Action[Update ECS service].Output.TaskDefinitionRevision"
Wed, May 27th 2026 14:19:37 +10:00  Info        Saving variable "Octopus.Action[Update ECS service].Output.ClusterName"
Wed, May 27th 2026 14:19:37 +10:00  Info        Saving variable "Octopus.Action[Update ECS service].Output.ServiceName"
Wed, May 27th 2026 14:19:37 +10:00  Info        Saving variable "Octopus.Action[Update ECS service].Output.Region"
Wed, May 27th 2026 14:19:37 +10:00  Info        Waiting for ECS service 'test-sk-stack-ServicetestSkTask-BvO1npPY94iF' deployment to reach COMPLETED.
Wed, May 27th 2026 14:19:37 +10:00  Info        Service rollout state: IN_PROGRESS.
Wed, May 27th 2026 14:24:39 +10:00  Info        Recent ECS service events:
Wed, May 27th 2026 14:24:39 +10:00  Info        [2026-05-27T04:22:01.9230000Z] (service test-sk-stack-ServicetestSkTask-BvO1npPY94iF) was unable to place a task. Reason: ResourceInitializationError: failed to download env files: file download command: non empty error stream: service call has been retried 1 time(s): operation error S3: HeadObject, https response error StatusCode: 403, RequestID: QJPJY4MSJ2GBNNTB, HostID: JkH/kG0t7hqJDv51I+CgKXc6B8lvbQFMu6Eisg50lmJ2ateeXlKJT1tuc7Ti4q//BhadjqNJd5VwBXTQ2V/2F5ypHYjvy2Oj, api error Forbidden: Forbidden.
Wed, May 27th 2026 14:24:39 +10:00  Info        [2026-05-27T04:21:33.3770000Z] (service test-sk-stack-ServicetestSkTask-BvO1npPY94iF) has started 1 tasks: (task 77c40dcd81d54d9e9eb6420a34e8dbfa).
Wed, May 27th 2026 14:24:39 +10:00  Info        [2026-05-27T04:21:01.3550000Z] (service test-sk-stack-ServicetestSkTask-BvO1npPY94iF) was unable to place a task. Reason: ResourceInitializationError: failed to download env files: file download command: non empty error stream: service call has been retried 1 time(s): operation error S3: HeadObject, https response error StatusCode: 403, RequestID: V0KNPKP3Y5WZ43YV, HostID: 82yzLauirILxe31hK2PmGOKJAOzgJwusEw+rlwYyYml/rQkvFDvzBM8r/tIyQRT18E60gRnzYxnEuDXGh4FtdyyRB+KlzInj, api error Forbidden: Forbidden.
Wed, May 27th 2026 14:24:39 +10:00  Info        [2026-05-27T04:20:31.0680000Z] (service test-sk-stack-ServicetestSkTask-BvO1npPY94iF) has started 1 tasks: (task c298a753efb04ba08c2a639d60b4f352).
Wed, May 27th 2026 14:24:39 +10:00  Info        [2026-05-27T04:19:49.9409999Z] (service test-sk-stack-ServicetestSkTask-BvO1npPY94iF) stopped 1 pending tasks.
Wed, May 27th 2026 14:24:39 +10:00  Error       Timed out waiting for ECS service deployment.
Wed, May 27th 2026 14:24:39 +10:00  Fatal       The remote script failed with exit code 1
Wed, May 27th 2026 14:24:39 +10:00  Fatal       The action Update ECS service on spf-deprecation-cluster failed
```