### PR TITLE
Use file creation time for GetNearestPackages when version is non-SemVer

### DIFF
--- a/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
@@ -693,6 +693,11 @@ namespace Calamari.Common.Plumbing.FileSystem
             return File.GetCreationTime(filePath);
         }
 
+        public DateTime GetLastWriteTime(string filePath)
+        {
+            return File.GetLastWriteTime(filePath);
+        }
+
         public string GetFileName(string filePath)
         {
             return new FileInfo(filePath).Name;

--- a/source/Calamari.Common/Plumbing/FileSystem/FileOperations.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/FileOperations.cs
@@ -15,6 +15,7 @@ namespace Calamari.Common.Plumbing.FileSystem
         void Move(string sourceFile, string destination);
         void SetAttributes(string path, FileAttributes normal);
         DateTime GetCreationTime(string filePath);
+        DateTime GetLastWriteTime(string filePath);
         Stream Open(string filePath, FileMode fileMode, FileAccess fileAccess, FileShare none);
     }
 
@@ -71,6 +72,11 @@ namespace Calamari.Common.Plumbing.FileSystem
         public DateTime GetCreationTime(string path)
         {
             return File.GetCreationTime(path);
+        }
+
+        public DateTime GetLastWriteTime(string path)
+        {
+            return File.GetLastWriteTime(path);
         }
 
         public Stream Open(string path, FileMode mode, FileAccess access, FileShare share)

--- a/source/Calamari.Common/Plumbing/FileSystem/ICalamariFileSystem.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/ICalamariFileSystem.cs
@@ -51,6 +51,7 @@ namespace Calamari.Common.Plumbing.FileSystem
         string GetRelativePath(string fromFile, string toFile);
         Stream OpenFileExclusively(string filePath, FileMode fileMode, FileAccess fileAccess);
         DateTime GetCreationTime(string filePath);
+        DateTime GetLastWriteTime(string filePath);
         string GetFileName(string filePath);
         string GetDirectoryName(string directoryPath);
         byte[] ReadAllBytes(string filePath);

--- a/source/Calamari.Shared/Integration/Certificates/FileSystem/PackageStore.cs
+++ b/source/Calamari.Shared/Integration/Certificates/FileSystem/PackageStore.cs
@@ -71,12 +71,21 @@ namespace Calamari.Integration.FileSystem
         {
             fileSystem.EnsureDirectoryExists(GetPackagesDirectory());
 
-            var zipPackages =
+            var allMatchingPackages =
                 from filePath in PackageFiles(packageId)
                 let zip = PackageMetadata(filePath)
-                where zip != null && string.Equals(zip.PackageId, packageId, StringComparison.OrdinalIgnoreCase) && zip.Version.CompareTo(version) <= 0
-                orderby zip.Version descending
-                select new {zip, filePath};
+                where zip != null && string.Equals(zip.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
+                select new { zip, filePath };
+
+            // For SemVer versions, find packages with version <= target ordered by version descending (closest lower version first).
+            // For non-SemVer versions (Docker tags, build numbers etc.) SemVer comparison is meaningless, so fall back to
+            // ordering by file creation time — the most recently cached package is the best delta candidate.
+            var zipPackages = version.Format == VersionFormat.Semver
+                ? allMatchingPackages
+                    .Where(x => x.zip.Version.CompareTo(version) <= 0)
+                    .OrderByDescending(x => x.zip.Version)
+                : allMatchingPackages
+                    .OrderByDescending(x => fileSystem.GetCreationTime(x.filePath));
 
             return
                 from zipPackage in zipPackages.Take(take)

--- a/source/Calamari.Shared/Integration/Certificates/FileSystem/PackageStore.cs
+++ b/source/Calamari.Shared/Integration/Certificates/FileSystem/PackageStore.cs
@@ -85,7 +85,7 @@ namespace Calamari.Integration.FileSystem
                     .Where(x => x.zip.Version.CompareTo(version) <= 0)
                     .OrderByDescending(x => x.zip.Version)
                 : allMatchingPackages
-                    .OrderByDescending(x => fileSystem.GetCreationTime(x.filePath));
+                    .OrderByDescending(x => fileSystem.GetLastWriteTime(x.filePath));
 
             return
                 from zipPackage in zipPackages.Take(take)

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
@@ -92,14 +92,18 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         }
 
         [Test]
-        public void NonSemVerVersionsReturnPackagesOrderedByCreationTime()
+        public void NonSemVerVersionsReturnPackagesOrderedByLastWriteTime()
         {
             // For non-SemVer tags (Docker tags, build numbers etc.) version comparison is unreliable.
-            // GetNearestPackages should fall back to file creation time so the most recently
+            // GetNearestPackages should fall back to file last-write time so the most recently
             // cached package is offered as the delta candidate.
-            var v1Path = CreatePackageWithDockerTag("feature-login-100");
-            var v2Path = CreatePackageWithDockerTag("main-9999");
-            var v3Path = CreatePackageWithDockerTag("feature-signup-42");
+            //
+            // We bypass PackageBuilder.BuildSamplePackage here because `dotnet pack /p:Version=...`
+            // rejects non-SemVer versions. We also use .zip rather than .nupkg so PackageName.FromFile
+            // does not try to read NuGet metadata from the file content.
+            var v1Path = CreateDummyCachedFile("feature-login-100");
+            var v2Path = CreateDummyCachedFile("main-9999");
+            var v3Path = CreateDummyCachedFile("feature-signup-42");
 
             // Set deterministic last-write times: v2 is most recent, then v3, then v1.
             // Using SetLastWriteTimeUtc rather than SetCreationTimeUtc because creation time
@@ -120,7 +124,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
                 var target = VersionFactory.TryCreateDockerTag("feature-new-99");
                 var packages = store.GetNearestPackages("Acme.Web", target).ToList();
 
-                // All three are returned (no version filter), ordered by creation time descending
+                // All three are returned (no version filter), ordered by last-write time descending
                 Assert.That(packages.Count, Is.EqualTo(3));
                 Assert.That(packages[0].Version.ToString(), Is.EqualTo("main-9999"));
                 Assert.That(packages[1].Version.ToString(), Is.EqualTo("feature-signup-42"));
@@ -128,16 +132,14 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             }
         }
 
-        private string CreatePackageWithDockerTag(string version)
+        private string CreateDummyCachedFile(string version)
         {
             var dockerVersion = VersionFactory.TryCreateDockerTag(version)!;
-            var sourcePackage = PackageBuilder.BuildSamplePackage("Acme.Web", version, true);
-            var destinationPath = Path.Combine(PackagePath, PackageName.ToCachedFileName("Acme.Web", dockerVersion, ".nupkg"));
-
-            if (File.Exists(destinationPath))
-                File.Delete(destinationPath);
-
-            File.Move(sourcePackage, destinationPath);
+            // Use .zip rather than .nupkg — .nupkg files trigger NuGet metadata parsing inside
+            // PackageName.FromFile, which would fail on these dummy files. The PackageStore only
+            // reads file metadata (hash, size, last-write time), not the file contents themselves.
+            var destinationPath = Path.Combine(PackagePath, PackageName.ToCachedFileName("Acme.Web", dockerVersion, ".zip"));
+            File.WriteAllText(destinationPath, "dummy content for " + version);
             return destinationPath;
         }
 

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
@@ -101,10 +101,12 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
             var v2Path = CreatePackageWithDockerTag("main-9999");
             var v3Path = CreatePackageWithDockerTag("feature-signup-42");
 
-            // Set deterministic creation times: v2 is most recent, then v3, then v1
-            File.SetCreationTimeUtc(v1Path, DateTime.UtcNow.AddMinutes(-30));
-            File.SetCreationTimeUtc(v3Path, DateTime.UtcNow.AddMinutes(-15));
-            File.SetCreationTimeUtc(v2Path, DateTime.UtcNow.AddMinutes(-5));
+            // Set deterministic last-write times: v2 is most recent, then v3, then v1.
+            // Using SetLastWriteTimeUtc rather than SetCreationTimeUtc because creation time
+            // is read-only on Linux filesystems.
+            File.SetLastWriteTimeUtc(v1Path, DateTime.UtcNow.AddMinutes(-30));
+            File.SetLastWriteTimeUtc(v3Path, DateTime.UtcNow.AddMinutes(-15));
+            File.SetLastWriteTimeUtc(v2Path, DateTime.UtcNow.AddMinutes(-5));
 
             using (new TemporaryFile(v1Path))
             using (new TemporaryFile(v2Path))

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs
@@ -8,6 +8,7 @@ using Calamari.Integration.FileSystem;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Fixtures.Deployment.Packages;
 using NUnit.Framework;
+using Octopus.Versioning;
 using Octopus.Versioning.Semver;
 
 namespace Calamari.Tests.Fixtures.Integration.FileSystem
@@ -88,6 +89,54 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
 
                 CollectionAssert.AreEquivalent(new[] { "1.0.0.1" }, packages.Select(c => c.Version.ToString()));
             }
+        }
+
+        [Test]
+        public void NonSemVerVersionsReturnPackagesOrderedByCreationTime()
+        {
+            // For non-SemVer tags (Docker tags, build numbers etc.) version comparison is unreliable.
+            // GetNearestPackages should fall back to file creation time so the most recently
+            // cached package is offered as the delta candidate.
+            var v1Path = CreatePackageWithDockerTag("feature-login-100");
+            var v2Path = CreatePackageWithDockerTag("main-9999");
+            var v3Path = CreatePackageWithDockerTag("feature-signup-42");
+
+            // Set deterministic creation times: v2 is most recent, then v3, then v1
+            File.SetCreationTimeUtc(v1Path, DateTime.UtcNow.AddMinutes(-30));
+            File.SetCreationTimeUtc(v3Path, DateTime.UtcNow.AddMinutes(-15));
+            File.SetCreationTimeUtc(v2Path, DateTime.UtcNow.AddMinutes(-5));
+
+            using (new TemporaryFile(v1Path))
+            using (new TemporaryFile(v2Path))
+            using (new TemporaryFile(v3Path))
+            {
+                var store = new PackageStore(
+                    CreatePackageExtractor(),
+                    CalamariPhysicalFileSystem.GetPhysicalFileSystem()
+                );
+
+                var target = VersionFactory.TryCreateDockerTag("feature-new-99");
+                var packages = store.GetNearestPackages("Acme.Web", target).ToList();
+
+                // All three are returned (no version filter), ordered by creation time descending
+                Assert.That(packages.Count, Is.EqualTo(3));
+                Assert.That(packages[0].Version.ToString(), Is.EqualTo("main-9999"));
+                Assert.That(packages[1].Version.ToString(), Is.EqualTo("feature-signup-42"));
+                Assert.That(packages[2].Version.ToString(), Is.EqualTo("feature-login-100"));
+            }
+        }
+
+        private string CreatePackageWithDockerTag(string version)
+        {
+            var dockerVersion = VersionFactory.TryCreateDockerTag(version)!;
+            var sourcePackage = PackageBuilder.BuildSamplePackage("Acme.Web", version, true);
+            var destinationPath = Path.Combine(PackagePath, PackageName.ToCachedFileName("Acme.Web", dockerVersion, ".nupkg"));
+
+            if (File.Exists(destinationPath))
+                File.Delete(destinationPath);
+
+            File.Move(sourcePackage, destinationPath);
+            return destinationPath;
         }
 
         private string CreateEmptyFile(string version)

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/TestFile.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/TestFile.cs
@@ -15,6 +15,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         public bool Exists(string path) => File.Exists(WithBase(path));
         public byte[] ReadAllBytes(string path) => File.ReadAllBytes(WithBase(path));
         public DateTime GetCreationTime(string filePath) => File.GetCreationTime(WithBase(filePath));
+        public DateTime GetLastWriteTime(string filePath) => File.GetLastWriteTime(WithBase(filePath));
         public Stream Open(string filePath, FileMode fileMode, FileAccess fileAccess, FileShare none) =>
             File.Open(WithBase(filePath), fileMode, fileAccess, none);
         


### PR DESCRIPTION
## Summary

Follow-up to [OctopusDeploy/OctopusDeploy#43750](https://github.com/OctopusDeploy/OctopusDeploy/pull/43750) which adds a `MostRecentlyPublished` ordering strategy for Channel Package Version Rules.

`PackageStore.GetNearestPackages` is called when a package is not already cached on a Tentacle. It finds up to 5 locally cached packages to offer as delta bases for compressed transfer.

**Before:** The method filtered with `version.CompareTo(target) <= 0` and ordered by version descending — both operations are unreliable for non-SemVer version strings (Docker tags, build numbers, date-stamps). Calamari would find no useful delta candidates, causing the full package to be downloaded instead of a delta.

**After:** When `version.Format != VersionFormat.Semver`, the method skips the version filter and instead orders all cached packages for the same package ID by file creation time descending. The most recently cached package is the best delta candidate.

SemVer behaviour is **unchanged**.

## Changes

- `Calamari.Shared/Integration/Certificates/FileSystem/PackageStore.cs` — branch on `version.Format` in `GetNearestPackages`
- `Calamari.Tests/Fixtures/Integration/FileSystem/PackageStoreFixture.cs` — new test with Docker tag versions and deterministic creation times

## Test plan
- [x] Existing `FiltersPackagesWithHigherVersion`, `OldFormatsAreIgnored`, `IgnoresInvalidFiles` tests unchanged
- [x] New `NonSemVerVersionsReturnPackagesOrderedByCreationTime` test verifies creation-time ordering for Docker tags
- [x] `dotnet build` clean