### PR TITLE
Remove unused parameter from DeployAwsCloudFormationConvention

### DIFF
--- a/source/Calamari.Aws/Commands/CreateAwsS3Command.cs
+++ b/source/Calamari.Aws/Commands/CreateAwsS3Command.cs
@@ -69,7 +69,6 @@ namespace Calamari.Aws.Commands
                                                       TemplateFactory,
                                                       stackEventLogger,
                                                       StackProvider,
-                                                      _ => null,
                                                       true,
                                                       stackName,
                                                       environment,

--- a/source/Calamari.Aws/Commands/DeployAwsCloudFormationCommand.cs
+++ b/source/Calamari.Aws/Commands/DeployAwsCloudFormationCommand.cs
@@ -141,7 +141,6 @@ namespace Calamari.Aws.Commands
                                                                                           TemplateFactory,
                                                                                           stackEventLogger,
                                                                                           StackProvider,
-                                                                                          RoleArnProvider,
                                                                                           waitForComplete,
                                                                                           stackName,
                                                                                           environment,

--- a/source/Calamari.Aws/Commands/DeployEcsServiceCommand.cs
+++ b/source/Calamari.Aws/Commands/DeployEcsServiceCommand.cs
@@ -59,7 +59,6 @@ public class DeployEcsServiceCommand : Command
                                                                           TemplateFactory,
                                                                           new StackEventLogger(log),
                                                                           _ => stackArn,
-                                                                          _ => null,
                                                                           inputs.WaitForComplete,
                                                                           inputs.StackName,
                                                                           environment,

--- a/source/Calamari.Aws/Deployment/Conventions/DeployAwsCloudFormationConvention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/DeployAwsCloudFormationConvention.cs
@@ -31,7 +31,6 @@ public class DeployAwsCloudFormationConvention : CloudFormationInstallationConve
     readonly Func<IAmazonCloudFormation> clientFactory;
     readonly Func<ICloudFormationRequestBuilder> templateFactory;
     readonly Func<RunningDeployment, StackArn> stackProvider;
-    readonly Func<RunningDeployment, string> roleArnProvider;
     readonly bool waitForComplete;
     readonly string stackName;
     readonly TimeSpan? waitTimeout;
@@ -44,7 +43,6 @@ public class DeployAwsCloudFormationConvention : CloudFormationInstallationConve
         Func<ICloudFormationRequestBuilder> templateFactory,
         StackEventLogger stackEventLogger,
         Func<RunningDeployment, StackArn> stackProvider,
-        Func<RunningDeployment, string> roleArnProvider,
         bool waitForComplete,
         string stackName,
         AwsEnvironmentGeneration awsEnvironmentGeneration,
@@ -54,7 +52,6 @@ public class DeployAwsCloudFormationConvention : CloudFormationInstallationConve
         this.clientFactory = clientFactory;
         this.templateFactory = templateFactory;
         this.stackProvider = stackProvider;
-        this.roleArnProvider = roleArnProvider;
         this.waitForComplete = waitForComplete;
         this.stackName = stackName;
         this.awsEnvironmentGeneration = awsEnvironmentGeneration;


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

Despite previous ill-informed comments to the contrary (https://github.com/OctopusDeploy/Calamari/pull/1897/changes/BASE..0c73b6ac4354a422881c1b72e503720a14b2d81f#r3144641228) The `RoleArnProvider` is not actually used and was only a thin layerfor eading a variable. 

Submitting this as clean up, with apoligies to @sathvikkumar-octo for my missing this when he did it correctly the first time.