### PR TITLE
Block SSH on windows

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
@@ -81,6 +81,8 @@ public abstract class AuthenticatingRepositoryFactoryTestBase
     public class SshUrlTests : AuthenticatingRepositoryFactoryTestBase
     {
         [Test]
+        // SSH not currently functional on Windows
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void SshCredentialBranch_IsSelectedAndDispatchesSshKeyGitConnection()
         {
             // Use an ssh:// URL so the new strict validation allows it, and mock the factory
@@ -108,6 +110,8 @@ public abstract class AuthenticatingRepositoryFactoryTestBase
         }
 
         [Test]
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
+        // SSH not currently functional on Windows
         public void KnownHostsFromDtoAreCarriedOntoSshKeyGitConnection()
         {
             const string sshUrl = "ssh://git@github.com/org/repo.git";

--- a/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
@@ -110,8 +110,8 @@ public abstract class AuthenticatingRepositoryFactoryTestBase
         }
 
         [Test]
-        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         // SSH not currently functional on Windows
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void KnownHostsFromDtoAreCarriedOntoSshKeyGitConnection()
         {
             const string sshUrl = "ssh://git@github.com/org/repo.git";

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
@@ -96,6 +96,8 @@ namespace Calamari.Tests.ArgoCD.Git
         }
 
         [Test]
+        // SSH not currently functional on Windows
+        [Category(TestCategory.CompatibleOS.OnlyNixOrMac)]
         public void CloningSshKeyGitConnectionDoesNotResolveAPullRequestClientAndLogsVerboseMessage()
         {
             var filename = "sshTest.txt";

--- a/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
@@ -32,6 +32,9 @@ public class AuthenticatingRepositoryFactory
     {
         var gitCredential = gitCredentials.GetValueOrDefault(requestedUrl);
 
+        var isSsh = gitCredential is SshKeyGitCredentialDto ? "isSshKey" : "notSsh";
+        log.Info($"DEBUG - running on {Environment.OSVersion.Platform} ({CalamariEnvironment.IsRunningOnWindows}) ({isSsh})");
+
         if (gitCredential is SshKeyGitCredentialDto && CalamariEnvironment.IsRunningOnWindows)
         {
             throw new CommandException(

--- a/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Calamari.Common.Commands;
-using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Logging;
 using Octopus.Calamari.Contracts.ArgoCD;
 

--- a/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
@@ -31,18 +31,6 @@ public class AuthenticatingRepositoryFactory
     public RepositoryWrapper CloneRepository(string requestedUrl, string targetRevision)
     {
         var gitCredential = gitCredentials.GetValueOrDefault(requestedUrl);
-
-        var isSsh = gitCredential is SshKeyGitCredentialDto ? "isSshKey" : "notSsh";
-        log.Info($"DEBUG - running on {Environment.OSVersion.Platform} ({CalamariEnvironment.IsRunningOnWindows}) ({isSsh})");
-
-        if (gitCredential is SshKeyGitCredentialDto && CalamariEnvironment.IsRunningOnWindows)
-        {
-            throw new CommandException(
-                $"Cannot clone '{requestedUrl}' using an SSH key credential: "
-                + "SSH git credentials are not supported when Calamari is running on Windows. "
-                + "Supply a username/password credential for this repository, or run the deployment on a Linux worker.");
-        }
-
         switch (gitCredential)
         {
             case GitCredentialDto passwordCredential:

--- a/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/AuthenticatingRepositoryFactory.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Logging;
 using Octopus.Calamari.Contracts.ArgoCD;
 
@@ -29,6 +31,15 @@ public class AuthenticatingRepositoryFactory
     public RepositoryWrapper CloneRepository(string requestedUrl, string targetRevision)
     {
         var gitCredential = gitCredentials.GetValueOrDefault(requestedUrl);
+
+        if (gitCredential is SshKeyGitCredentialDto && CalamariEnvironment.IsRunningOnWindows)
+        {
+            throw new CommandException(
+                $"Cannot clone '{requestedUrl}' using an SSH key credential: "
+                + "SSH git credentials are not supported when Calamari is running on Windows. "
+                + "Supply a username/password credential for this repository, or run the deployment on a Linux worker.");
+        }
+
         switch (gitCredential)
         {
             case GitCredentialDto passwordCredential:

--- a/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryFactory.cs
@@ -1,10 +1,10 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using Calamari.ArgoCD.Git.PullRequests;
 using Calamari.Common.Commands;
+using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
@@ -48,6 +48,8 @@ namespace Calamari.ArgoCD.Git
 
         public RepositoryWrapper CloneRepository(string repositoryName, IGitConnection gitConnection)
         {
+            WindowsSshKeys.AssertSupported(gitConnection);
+
             var repositoryPath = Path.Combine(repositoryParentDirectory, repositoryName);
             fileSystem.CreateDirectory(repositoryPath);
 

--- a/source/Calamari/ArgoCD/Git/WindowsSshKeys.cs
+++ b/source/Calamari/ArgoCD/Git/WindowsSshKeys.cs
@@ -1,0 +1,20 @@
+using System;
+using Calamari.Common.Plumbing;
+using NuGet.Commands;
+
+namespace Calamari.ArgoCD.Git;
+
+// Our fork LibGit2Sharp uses WinCNG for it's SSH support, and WinCNG does not support some keys.
+// This first implementation blocks on all as we want to get the feature out for Linux first and
+// we'll come back to attempt to handle it more gracefully at a later date.
+public class WindowsSshKeys
+{
+    public static void AssertSupported(IGitConnection? connection)
+    {
+        if (!CalamariEnvironment.IsRunningOnWindows) return;
+        if (connection is not SshKeyGitConnection) return;
+
+        throw new CommandException(
+            "SSH credentials are not currently supported for Git operations running on Windows. Use HTTPS credentials (username + password or PAT) instead or run the deployment on a Linux worker.");
+    }
+}


### PR DESCRIPTION
Windows uses WinCNG for it's libssh2 crypto backend which is finicky about which SSH keys it accepts, and the failure mode is to hang indefinitely.

For now, we've [documented that Windows doesn't work](https://github.com/OctopusDeploy/docs/pull/3190) and we'll fail fast with a message when users try. If it's worthwhile, we'll come back and figure out how to best check for the key type in use and fail if it's unsupported.

Relates to MD-1957

Failure for windows worker
<img width="1676" height="518" alt="image" src="https://github.com/user-attachments/assets/66654c2d-6f90-4cfc-9109-37674a3fcb20" />
