### PR TITLE
Default to url username for ssh git ops

### DIFF
--- a/source/Calamari/ArgoCD/Git/LibGit2SharpCredentialsHandlerExtensionMethods.cs
+++ b/source/Calamari/ArgoCD/Git/LibGit2SharpCredentialsHandlerExtensionMethods.cs
@@ -45,7 +45,7 @@ public static class LibGit2SharpCredentialsHandlerExtensionMethods
 
                    return new SshKeyMemoryCredentials
                    {
-                       Username = connection.Username ?? userFromUrl,
+                       Username = string.IsNullOrWhiteSpace(connection.Username) ? userFromUrl : connection.Username,
                        PrivateKey = connection.PrivateKey,
                    };
                };


### PR DESCRIPTION
Relates to MD-1876

We previously put in handling for null usernames, but since our Server => Calamari contracts are non-nullable at the moment this is a way to effectively allow empty usernames to pass through as they should as well.

Backporting into 2026.2 because I'll do the same on server side. Currently Server defaults to "git" which will accumulate in the database for users who don't have this fix. Very unlikely to cause an issue, but it's a good safety net.