### PR TITLE
chmod the binary to executable before building docker image

### DIFF
--- a/build/Build.Docker.cs
+++ b/build/Build.Docker.cs
@@ -28,6 +28,12 @@ public partial class Build
                                                             compressedArtifactPath.UncompressTo(flavourFolder);
                                                             Log.Information("Uncompressed {ZipPath} to {FolderPath}", compressedArtifactPath, flavourFolder);
 
+                                                            // change the native binary to be executable
+                                                            PowerShellTasks.PowerShell(_ => _
+                                                                                            .EnableNoProfile()
+                                                                                            .SetCommand($"chmod +x '{flavourFolder / flavour}'"));
+
+
                                                             //Rename any `linux-x64` folders to `linux-amd64`
                                                             Directory.Move(flavourFolder / "linux-x64",
                                                                 flavourFolder / "linux-amd64");

--- a/build/Build.Docker.cs
+++ b/build/Build.Docker.cs
@@ -23,21 +23,23 @@ public partial class Build
                                Logging.InBlock(flavour, () =>
                                                         {
                                                             var flavourFolder = KnownPaths.OutputsDirectory / flavour;
-                                                            
+
                                                             var compressedArtifactPath = KnownPaths.OutputsDirectory / $"{flavour}.zip";
                                                             compressedArtifactPath.UncompressTo(flavourFolder);
                                                             Log.Information("Uncompressed {ZipPath} to {FolderPath}", compressedArtifactPath, flavourFolder);
-
-                                                            // change the native binary to be executable
-                                                            PowerShellTasks.PowerShell(_ => _
-                                                                                            .EnableNoProfile()
-                                                                                            .SetCommand($"chmod +x '{flavourFolder / flavour}'"));
-
 
                                                             //Rename any `linux-x64` folders to `linux-amd64`
                                                             Directory.Move(flavourFolder / "linux-x64",
                                                                 flavourFolder / "linux-amd64");
                                                             Log.Information("Renamed 'linux-x64' folder to 'linux-amd64'");
+                                                            foreach (var supportedPlatform in supportedPlatforms)
+                                                            {
+                                                                var platformFolder = supportedPlatform.Replace("/", "-");
+                                                                // change the native binary to be executable in each platform
+                                                                PowerShellTasks.PowerShell(_ => _
+                                                                                                .EnableNoProfile()
+                                                                                                .SetCommand($"chmod +x '{flavourFolder / platformFolder / flavour}'"));
+                                                            }
 
                                                             var tag = $"octopusdeploy/{flavour}:{NugetVersion.Value}".ToLowerInvariant();
 


### PR DESCRIPTION
When these docker images are loaded into Kubernetes agent script pods, they are loaded as readonly file systems, which means the permissions cannot be changed and we need the `Calamari`/`Calamari.XXX` binary to be executable.

Related to MD-2016