### PR TITLE
Fix bare NullReferenceException for missing NuGet V3 package version (FD-440)

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3LibDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3LibDownloader.cs
@@ -36,7 +36,11 @@ namespace Calamari.Integration.Packages.NuGet
                 }
 
                 string targetTempNupkg = Path.Combine(targetPath, Path.GetRandomFileName());
-                var packageDownloader =  providers.GetPackageDownloaderAsync(new PackageIdentity(packageId, version.ToNuGetVersion()), sourceCacheContext, logger, CancellationToken.None)
+                var packageIdentity = new PackageIdentity(packageId, version.ToNuGetVersion());
+
+                EnsurePackageVersionExists(sourceRepository, packageIdentity, feedUri, sourceCacheContext, logger);
+
+                var packageDownloader =  providers.GetPackageDownloaderAsync(packageIdentity, sourceCacheContext, logger, CancellationToken.None)
                                                       .GetAwaiter()
                                                       .GetResult();
                 var fileCopied = packageDownloader.CopyNupkgFileToAsync(targetTempNupkg, CancellationToken.None).GetAwaiter().GetResult();
@@ -48,6 +52,26 @@ namespace Calamari.Integration.Packages.NuGet
 
                 File.Move(targetTempNupkg, targetFilePath);
             }
+        }
+
+        // The (forked) NuGet.Commands SourceRepositoryDependencyProvider.GetPackageDownloaderAsync throws a bare
+        // NullReferenceException when the requested version is not present on the feed: the inner FindPackageByIdResource
+        // returns a null downloader, which the provider then dereferences unconditionally (SetThrottle/SetExceptionHandler).
+        // Calamari can't stop the library dereferencing its own null, so we pre-check that the version exists and throw an
+        // actionable error instead. This folds into the existing "could not be downloaded ... make sure the package is
+        // pushed to the feed" retry messaging in InternalNuGetPackageDownloader. See FD-440.
+        static void EnsurePackageVersionExists(SourceRepository sourceRepository, PackageIdentity packageIdentity, Uri feedUri, SourceCacheContext sourceCacheContext, ILogger logger)
+        {
+            var findPackageByIdResource = sourceRepository.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None)
+                                                          .GetAwaiter()
+                                                          .GetResult();
+
+            var packageExists = findPackageByIdResource.DoesPackageExistAsync(packageIdentity.Id, packageIdentity.Version, sourceCacheContext, logger, CancellationToken.None)
+                                                       .GetAwaiter()
+                                                       .GetResult();
+
+            if (!packageExists)
+                throw new Exception($"Package {packageIdentity.Id} version {packageIdentity.Version.ToNormalizedString()} was not found on the NuGet feed '{feedUri}'. Make sure the package version has been pushed to the feed.");
         }
 
         public class NugetLogger : ILogger

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Net;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Integration.Packages.NuGet;
+using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
 using FluentAssertions;
 using NSubstitute;
@@ -63,6 +65,26 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             });
 
             return calledCount;
+        }
+
+        [Test]
+        [RequiresNonFreeBSDPlatform]
+        public void GivesActionableErrorWhenV3FeedIsMissingTheRequestedVersion()
+        {
+            // FD-440: requesting a version that doesn't exist on a NuGet V3 feed used to throw a bare
+            // NullReferenceException from inside the NuGet client. It should give a clear "not found" message instead.
+            var targetFilePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.nupkg");
+
+            var ex = Assert.Throws<Exception>(() =>
+                NuGetV3LibDownloader.DownloadPackage(
+                    "Newtonsoft.Json",
+                    VersionFactory.CreateSemanticVersion("999.999.999"),
+                    new Uri("https://api.nuget.org/v3/index.json"),
+                    null,
+                    targetFilePath));
+
+            ex.Should().NotBeOfType<NullReferenceException>("the missing version should surface an actionable message, not a bare NRE");
+            ex!.Message.Should().Contain("was not found");
         }
     }
 }


### PR DESCRIPTION
## Problem

When Calamari downloads a package from a NuGet **V3** feed and the requested **version does not exist on the feed**, the deployment fails with an opaque `NullReferenceException` instead of a clear "package/version not found" message:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at NuGet.Commands.SourceRepositoryDependencyProvider.GetPackageDownloaderAsync(...)
   at Calamari.Integration.Packages.NuGet.NuGetV3LibDownloader.DownloadPackage(...)
   at Calamari.Integration.Packages.NuGet.InternalNuGetPackageDownloader...
   at Calamari.Integration.Packages.Download.NuGetPackageDownloader.DownloadPackage(...)
   at Calamari.Commands.DownloadPackageCommand.Execute(...)
```

The NRE is thrown **inside the (forked) NuGet client library**, not Calamari. `SourceRepositoryDependencyProvider.GetPackageDownloaderAsync` retrieves a downloader from the inner `FindPackageByIdResource` and then unconditionally calls `SetThrottle`/`SetExceptionHandler` on it — but for a version that isn't on the feed, that downloader is `null`. Calamari calls the API correctly; it just can't stop the library dereferencing its own null.

A customer who selects a version that was never published (CI didn't push it, wrong version selected, etc.) gets a meaningless `NullReferenceException` with no hint that the real issue is a missing package version.

## Scope

- Affects the **"download package on the deployment target"** path (the Calamari `NuGetV3LibDownloader`). The server-side acquisition path (`ExternalHttpNuGetPackageFeed`) already surfaces a clean "NotFound" message — different code path.
- **Independent of feed authentication** — reproduced anonymously against `api.nuget.org`. Bad-credentials (401) is a separate, already-handled case.
- Not a day-one bug: the offending `GetPackageDownloaderAsync` call replaced the older `CopyToAsync` path in commit `ea707ed8c` ("#6965 Updated to latest version of NuGet.Commands", 2021-08-09) and has had no null guard since.

## Reproduction

Reproduced end-to-end in the product: https://main.testoctopus.app/app#/Spaces-203/projects/download-problem/deployments/releases/0.0.3/deployments/Deployments-98822

1. Create a step that uses a package from a NuGet (V3) feed
2. Mark the package as **download on target**
3. Create a release with a package version that doesn't exist
4. Deploy

The added integration test (`GivesActionableErrorWhenV3FeedIsMissingTheRequestedVersion`) reproduces the exact NRE against `api.nuget.org` when the guard is absent, and confirms the actionable message when present.

Fixes FD-440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
