### PR TITLE
chmod the docker-credential helper binary

### DIFF
--- a/build/Build.Docker.cs
+++ b/build/Build.Docker.cs
@@ -12,6 +12,12 @@ public partial class Build
         d =>
             d.Executes(() =>
                        {
+                           if (OperatingSystem.IsWindows())
+                           {
+                               Log.Error("The Docker images can not be built on Windows");
+                               return;
+                           }
+
                            var flavours = GetCalamariFlavours();
                            string[] supportedPlatforms = ["linux/amd64", "linux/arm64", "linux/arm"];
                            var dockerBuildPlatform = string.Join(",", supportedPlatforms);
@@ -33,18 +39,22 @@ public partial class Build
                                                                 flavourFolder / "linux-amd64");
                                                             Log.Information("Renamed 'linux-x64' folder to 'linux-amd64'");
 
-                                                            //a known list of binaries to chmod +x
                                                             string[] binariesToChmodX = ["docker-credential-octopus", flavour];
 
                                                             foreach (var supportedPlatform in supportedPlatforms)
                                                             {
                                                                 var platformFolder = supportedPlatform.Replace("/", "-");
+                                                                
                                                                 // change the native binaries to be executable in each platform
                                                                 foreach (var binary in binariesToChmodX)
                                                                 {
-                                                                    PowerShellTasks.PowerShell(_ => _
-                                                                                                    .EnableNoProfile()
-                                                                                                    .SetCommand($"chmod +x '{flavourFolder / platformFolder / binary}'"));
+                                                                    string binaryPath = flavourFolder / platformFolder / binary;
+                                                                    
+                                                                    //Not all binaries exist in all flavours (The extra win check skips the CA1416 issues)
+                                                                    if (File.Exists(binaryPath) && !OperatingSystem.IsWindows())
+                                                                    {
+                                                                        File.SetUnixFileMode(binaryPath, UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+                                                                    }
                                                                 }
                                                             }
 

--- a/build/Build.Docker.cs
+++ b/build/Build.Docker.cs
@@ -53,7 +53,8 @@ public partial class Build
                                                                     //Not all binaries exist in all flavours (The extra win check skips the CA1416 issues)
                                                                     if (File.Exists(binaryPath) && !OperatingSystem.IsWindows())
                                                                     {
-                                                                        File.SetUnixFileMode(binaryPath, UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+                                                                        var mode = File.GetUnixFileMode(binaryPath);
+                                                                        File.SetUnixFileMode(binaryPath, mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
                                                                     }
                                                                 }
                                                             }

--- a/build/Build.Docker.cs
+++ b/build/Build.Docker.cs
@@ -32,13 +32,20 @@ public partial class Build
                                                             Directory.Move(flavourFolder / "linux-x64",
                                                                 flavourFolder / "linux-amd64");
                                                             Log.Information("Renamed 'linux-x64' folder to 'linux-amd64'");
+
+                                                            //a known list of binaries to chmod +x
+                                                            string[] binariesToChmodX = ["docker-credential-octopus", flavour];
+
                                                             foreach (var supportedPlatform in supportedPlatforms)
                                                             {
                                                                 var platformFolder = supportedPlatform.Replace("/", "-");
-                                                                // change the native binary to be executable in each platform
-                                                                PowerShellTasks.PowerShell(_ => _
-                                                                                                .EnableNoProfile()
-                                                                                                .SetCommand($"chmod +x '{flavourFolder / platformFolder / flavour}'"));
+                                                                // change the native binaries to be executable in each platform
+                                                                foreach (var binary in binariesToChmodX)
+                                                                {
+                                                                    PowerShellTasks.PowerShell(_ => _
+                                                                                                    .EnableNoProfile()
+                                                                                                    .SetCommand($"chmod +x '{flavourFolder / platformFolder / binary}'"));
+                                                                }
                                                             }
 
                                                             var tag = $"octopusdeploy/{flavour}:{NugetVersion.Value}".ToLowerInvariant();


### PR DESCRIPTION
We are packaging a new binary, `docker-credential-octopus` (introduced in #1981)

However, when loading calamari as a Kubernetes image volume as a read-only filesystem, this needs to be made executable.

We now perform a `chmod +x` on an array of binary names

<img width="691" height="61" alt="image" src="https://github.com/user-attachments/assets/1dae4afc-7a16-42ad-8f4d-bb164188fd05" />

<img width="837" height="30" alt="image" src="https://github.com/user-attachments/assets/11791239-8f5b-4b4e-901c-4da7f7bf041b" />
