### PR TITLE
Fix opaque NullReferenceException when a NuGet V3 package version is missing (FD-440)

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3LibDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3LibDownloader.cs
@@ -8,7 +8,6 @@ using NuGet.Protocol.Core.Types;
 using System.IO;
 using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Extensions;
-using NuGet.Commands;
 using NuGet.Packaging.Core;
 using Octopus.Versioning;
 
@@ -28,17 +27,32 @@ namespace Calamari.Integration.Packages.NuGet
 
             using (var sourceCacheContext = new SourceCacheContext() { NoCache = true })
             {
-                var providers = new SourceRepositoryDependencyProvider(sourceRepository, logger, sourceCacheContext, sourceCacheContext.IgnoreFailedSources, false);
                 var targetPath = Directory.GetParent(targetFilePath).FullName;
                 if (!Directory.Exists(targetPath))
                 {
                     Directory.CreateDirectory(targetPath);
                 }
 
+                // Resolve the downloader from FindPackageByIdResource directly rather than going through
+                // SourceRepositoryDependencyProvider. The provider unconditionally dereferences the downloader returned
+                // here, which is null when the requested version isn't on the feed, producing a bare NullReferenceException
+                // (FD-440). Calling the resource directly lets us null-check it and surface an actionable error. The
+                // provider's throttle / ignore-failed-sources behaviour isn't relevant here: Calamari passes no throttle
+                // and downloads from a single source.
+                var findPackageByIdResource = sourceRepository.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None)
+                                                              .GetAwaiter()
+                                                              .GetResult();
+
+                var packageIdentity = new PackageIdentity(packageId, version.ToNuGetVersion());
+
                 string targetTempNupkg = Path.Combine(targetPath, Path.GetRandomFileName());
-                var packageDownloader =  providers.GetPackageDownloaderAsync(new PackageIdentity(packageId, version.ToNuGetVersion()), sourceCacheContext, logger, CancellationToken.None)
-                                                      .GetAwaiter()
-                                                      .GetResult();
+                var packageDownloader = findPackageByIdResource.GetPackageDownloaderAsync(packageIdentity, sourceCacheContext, logger, CancellationToken.None)
+                                                               .GetAwaiter()
+                                                               .GetResult();
+
+                if (packageDownloader == null)
+                    throw new Exception($"Package {packageId} version {version} was not found on the NuGet feed '{feedUri}'. Make sure the package version has been pushed to the feed.");
+
                 var fileCopied = packageDownloader.CopyNupkgFileToAsync(targetTempNupkg, CancellationToken.None).GetAwaiter().GetResult();
                 
                 if (!fileCopied) //I would expect any actual standard exception to be thrown above and not returned as a bool

--- a/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3LibDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/NuGet/NuGetV3LibDownloader.cs
@@ -43,6 +43,12 @@ namespace Calamari.Integration.Packages.NuGet
                                                               .GetAwaiter()
                                                               .GetResult();
 
+                // GetResourceAsync returns null (rather than throwing) when no provider can supply the resource for this
+                // feed, so guard it explicitly — otherwise the dereference below would resurface the very
+                // NullReferenceException this change exists to eliminate (FD-440).
+                if (findPackageByIdResource == null)
+                    throw new Exception($"The NuGet feed '{feedUri}' did not return a package lookup resource (FindPackageByIdResource). Make sure the feed URL is a valid NuGet V3 feed.");
+
                 var packageIdentity = new PackageIdentity(packageId, version.ToNuGetVersion());
 
                 string targetTempNupkg = Path.Combine(targetPath, Path.GetRandomFileName());

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/NuGetPackageDownloaderFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Net;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Variables;
@@ -63,6 +64,26 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             });
 
             return calledCount;
+        }
+
+        [Test]
+        [RequiresNonFreeBSDPlatform]
+        public void GivesActionableErrorWhenV3FeedIsMissingTheRequestedVersion()
+        {
+            // FD-440: requesting a version that doesn't exist on a NuGet V3 feed used to throw a bare
+            // NullReferenceException from inside the NuGet client. It should give a clear "not found" message instead.
+            var targetFilePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.nupkg");
+
+            var ex = Assert.Throws<Exception>(() =>
+                NuGetV3LibDownloader.DownloadPackage(
+                    "Newtonsoft.Json",
+                    VersionFactory.CreateSemanticVersion("999.999.999"),
+                    new Uri("https://api.nuget.org/v3/index.json"),
+                    null,
+                    targetFilePath));
+
+            ex.Should().NotBeOfType<NullReferenceException>("the missing version should surface an actionable message, not a bare NRE");
+            ex!.Message.Should().Contain("was not found");
         }
     }
 }


### PR DESCRIPTION
## Background

Deploying with a package set to **download on the target**, from a NuGet **V3** feed, for a **version that doesn't exist on the feed**, failed with an opaque `NullReferenceException` — no hint that the real problem is a missing/unpublished version:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at NuGet.Commands.SourceRepositoryDependencyProvider.GetPackageDownloaderAsync(...)
   at Calamari.Integration.Packages.NuGet.NuGetV3LibDownloader.DownloadPackage(...)
   ...
   at Calamari.Commands.DownloadPackageCommand.Execute(...)
```

Customer-facing context and the end-to-end product repro are in **FD-440**.

The problem is described in [this PR](https://github.com/OctopusDeploy/NuGet.Client/pull/25) for NuGet.Client. But since we don't want to add more things ot it, and the likelyhood of this getting fixed upstream in a timely manner are low, this PR avoids the problem.

## Verification

Reproduced and fixed end-to-end on a local Octopus Server: a `Run a Script` step running on a worker pool, referencing `Newtonsoft.Json` version `9999.9.9` (which doesn't exist) from a NuGet V3 feed (`https://api.nuget.org/v3/index.json`), with the package acquired on the worker.

**Before (stock Calamari)** — bare NRE wrapped by the retry message:

```
Error | The package Newtonsoft.Json version 9999.9.9 could not be downloaded from the external feed
        'https://api.nuget.org/v3/index.json' after making 5 attempts over 101s...
Error | System.NullReferenceException: Object reference not set to an instance of an object.
Error |   at NuGet.Commands.SourceRepositoryDependencyProvider.GetPackageDownloaderAsync(...)
Error |   at Calamari...NuGetV3LibDownloader.DownloadPackage(...) NuGetV3LibDownloader.cs:line 39
```

**After (this change)** — clear, actionable message, no `NullReferenceException` anywhere in the log:

```
Verbose | Attempt 1 of 5: Package Newtonsoft.Json version 9999.9.9 was not found on the NuGet feed
          'https://api.nuget.org/v3/index.json'. Make sure the package version has been pushed to the feed.
```

Automated coverage: integration test `GivesActionableErrorWhenV3FeedIsMissingTheRequestedVersion` downloads a missing version from `api.nuget.org` — fails with the exact NRE above without this change, passes with it.

**On the retries:** the download still retries all attempts before the deployment fails — left as-is intentionally. A version that's absent right now may legitimately be published to the feed mid-window (e.g. a lagging CI push), so retrying is the desired behaviour. This change only improves the *message*; it doesn't alter the retry policy.

Fixes FD-440
