### PR TITLE
Fix nullability warnings for CS8765/CS8610/CS8764

### DIFF
--- a/source/Calamari.Common/Plumbing/Deployment/PackageRetention/TinyTypeTypeConverter.cs
+++ b/source/Calamari.Common/Plumbing/Deployment/PackageRetention/TinyTypeTypeConverter.cs
@@ -7,12 +7,12 @@ namespace Calamari.Common.Plumbing.Deployment.PackageRetention
 {
     public class TinyTypeTypeConverter<T> : TypeConverter where T : CaseInsensitiveStringTinyType
     {
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             return sourceType == typeof(string);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
         {
             if (value == null) throw new ArgumentNullException(nameof(value));
 

--- a/source/Calamari.Common/Plumbing/Deployment/PackageRetention/VersionConverter.cs
+++ b/source/Calamari.Common/Plumbing/Deployment/PackageRetention/VersionConverter.cs
@@ -12,7 +12,7 @@ namespace Calamari.Common.Plumbing.Deployment.PackageRetention
 
         public override bool CanConvert(Type objectType) => objectType == typeof(IVersion);
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             var version = value as IVersion ?? throw new Exception("Type must implement IVersion to use this converter.");
             var outputVersion = new { Version = version.ToString(), Format = version.Format.ToString() };
@@ -20,7 +20,7 @@ namespace Calamari.Common.Plumbing.Deployment.PackageRetention
             serializer.Serialize(writer, outputVersion);
         }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             var jsonObject = JObject.Load(reader);
             var versionString = jsonObject["Version"].Value<string>();

--- a/source/Calamari.Common/Plumbing/IndentedTextWriter.cs
+++ b/source/Calamari.Common/Plumbing/IndentedTextWriter.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -81,6 +82,7 @@ namespace Calamari.Common.Plumbing
         ///     Gets or sets the new line character to use.
         ///     </para>
         /// </devdoc>
+        [AllowNull]
         public override string NewLine
         {
             get => InnerWriter.NewLine;
@@ -151,7 +153,7 @@ namespace Calamari.Common.Plumbing
         ///     to the text stream.
         ///     </para>
         /// </devdoc>
-        public override void Write(string s)
+        public override void Write(string? s)
         {
             OutputTabs();
             InnerWriter.Write(s);
@@ -185,7 +187,7 @@ namespace Calamari.Common.Plumbing
         ///     character array to the text stream.
         ///     </para>
         /// </devdoc>
-        public override void Write(char[] buffer)
+        public override void Write(char[]? buffer)
         {
             OutputTabs();
             InnerWriter.Write(buffer);
@@ -255,7 +257,7 @@ namespace Calamari.Common.Plumbing
         ///     to the text stream.
         ///     </para>
         /// </devdoc>
-        public override void Write(object value)
+        public override void Write(object? value)
         {
             OutputTabs();
             InnerWriter.Write(value);
@@ -266,7 +268,7 @@ namespace Calamari.Common.Plumbing
         ///     Writes out a formatted string, using the same semantics as specified.
         ///     </para>
         /// </devdoc>
-        public override void Write(string format, object arg0)
+        public override void Write(string format, object? arg0)
         {
             OutputTabs();
             InnerWriter.Write(format, arg0);
@@ -278,7 +280,7 @@ namespace Calamari.Common.Plumbing
         ///     using the same semantics as specified.
         ///     </para>
         /// </devdoc>
-        public override void Write(string format, object arg0, object arg1)
+        public override void Write(string format, object? arg0, object? arg1)
         {
             OutputTabs();
             InnerWriter.Write(format, arg0, arg1);
@@ -290,7 +292,7 @@ namespace Calamari.Common.Plumbing
         ///     using the same semantics as specified.
         ///     </para>
         /// </devdoc>
-        public override void Write(string format, params object[] arg)
+        public override void Write(string format, params object?[] arg)
         {
             OutputTabs();
             InnerWriter.Write(format, arg);
@@ -313,7 +315,7 @@ namespace Calamari.Common.Plumbing
         ///     a line terminator to the text stream.
         ///     </para>
         /// </devdoc>
-        public override void WriteLine(string s)
+        public override void WriteLine(string? s)
         {
             OutputTabs();
             InnerWriter.WriteLine(s);
@@ -358,7 +360,7 @@ namespace Calamari.Common.Plumbing
         /// <devdoc>
         ///     <para>[To be supplied.]</para>
         /// </devdoc>
-        public override void WriteLine(char[] buffer)
+        public override void WriteLine(char[]? buffer)
         {
             OutputTabs();
             InnerWriter.WriteLine(buffer);
@@ -418,7 +420,7 @@ namespace Calamari.Common.Plumbing
         /// <devdoc>
         ///     <para>[To be supplied.]</para>
         /// </devdoc>
-        public override void WriteLine(object value)
+        public override void WriteLine(object? value)
         {
             OutputTabs();
             InnerWriter.WriteLine(value);
@@ -428,7 +430,7 @@ namespace Calamari.Common.Plumbing
         /// <devdoc>
         ///     <para>[To be supplied.]</para>
         /// </devdoc>
-        public override void WriteLine(string format, object arg0)
+        public override void WriteLine(string format, object? arg0)
         {
             OutputTabs();
             InnerWriter.WriteLine(format, arg0);
@@ -438,7 +440,7 @@ namespace Calamari.Common.Plumbing
         /// <devdoc>
         ///     <para>[To be supplied.]</para>
         /// </devdoc>
-        public override void WriteLine(string format, object arg0, object arg1)
+        public override void WriteLine(string format, object? arg0, object? arg1)
         {
             OutputTabs();
             InnerWriter.WriteLine(format, arg0, arg1);
@@ -448,7 +450,7 @@ namespace Calamari.Common.Plumbing
         /// <devdoc>
         ///     <para>[To be supplied.]</para>
         /// </devdoc>
-        public override void WriteLine(string format, params object[] arg)
+        public override void WriteLine(string format, params object?[] arg)
         {
             OutputTabs();
             InnerWriter.WriteLine(format, arg);

--- a/source/Calamari.Shared/Serialization/InheritedClassConverter.cs
+++ b/source/Calamari.Shared/Serialization/InheritedClassConverter.cs
@@ -10,8 +10,10 @@ namespace Calamari.Serialization
 {
     public abstract class InheritedClassConverter<TBaseResource, TEnumType> : JsonConverter
     {
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+
             writer.WriteStartObject();
             var contractResolver = serializer.ContractResolver;
 
@@ -39,7 +41,7 @@ namespace Calamari.Serialization
         }
 
 
-        public override object? ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             if (reader.TokenType == JsonToken.Null)
                 return null;


### PR DESCRIPTION
Fixes nullability warnings for

CS8765 - Nullability of type of parameter doesn't match overridden member
CS8610 - Nullability of reference types in type of parameter doesn't match overridden member. 
CS8764 - Nullability of return type doesn't match overridden member

Purely a mechanical refactoring.

Was 195 warnings in build [2026.3.117](https://build.octopushq.com/buildConfiguration/TeamModernDeployments_Calamari_VNext_Build_BuildCompile/22771598?buildTab=log&focusLine=3048&logView=flowAware&linesState=2060.2160.2237.2252.7353.7490.7655), now is 173 in build [2026.3.126-mattr-fix-nullabili](https://build.octopushq.com/buildConfiguration/TeamModernDeployments_Calamari_VNext_Build_BuildCompile/22792086?buildTab=log&focusLine=2970&logView=flowAware&linesState=2070.2262.7285.7422)
