### PR TITLE
Fix CA2200: preserve stack trace on rethrow

### DIFF
--- a/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
@@ -529,7 +529,7 @@ namespace Calamari.Common.Plumbing.FileSystem
                 LogFileAccess(temporaryReplacement);
                 LogFileAccess(backup);
 
-                throw unauthorizedAccessException;
+                throw;
             }
 
             File.Delete(temporaryReplacement);


### PR DESCRIPTION
## What

Changes the rethrow in `CalamariPhysicalFileSystem.MoveFile`'s `UnauthorizedAccessException` handler from `throw unauthorizedAccessException;` to a bare `throw;`.

## Why

`throw unauthorizedAccessException;` reset the exception's stack trace to the catch block, discarding where the `UnauthorizedAccessException` actually originated (the `File.Replace`/`File.Copy` call). 

A bare `throw;` re-throws the in-flight exception with its original stack trace intact — same exception type and message, better diagnostics.

## Impact

- Clears the CA2200 warning (the entire override/rethrow-correctness category in the solution).
- No behavioural change beyond the preserved stack trace; the caught variable is still referenced for logging, so no unused-variable warning.