### PR TITLE
Fix SYSLIB0004: remove obsolete PrepareConstrainedRegions calls

### DIFF
--- a/source/Calamari.Shared/Integration/Certificates/CryptoKeySecurityAccessRules.cs
+++ b/source/Calamari.Shared/Integration/Certificates/CryptoKeySecurityAccessRules.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Calamari.Integration.Certificates.WindowsNative;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security;

--- a/source/Calamari.Shared/Integration/Certificates/CryptoKeySecurityAccessRules.cs
+++ b/source/Calamari.Shared/Integration/Certificates/CryptoKeySecurityAccessRules.cs
@@ -184,10 +184,8 @@ namespace Calamari.Integration.Certificates
       {
         AccessControlSections accessControlSections = AccessControlSections.None;
         bool flag = false;
-        RuntimeHelpers.PrepareConstrainedRegions();
         try
         {
-          RuntimeHelpers.PrepareConstrainedRegions();
           try
           {
           }

--- a/source/Calamari.Shared/Integration/Certificates/WindowsNative/SafeCspHandle.cs
+++ b/source/Calamari.Shared/Integration/Certificates/WindowsNative/SafeCspHandle.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Microsoft.Win32.SafeHandles;
@@ -24,14 +23,12 @@ namespace Calamari.Integration.Certificates.WindowsNative
     public SafeCspHandle Duplicate()
     {
       bool success = false;
-      RuntimeHelpers.PrepareConstrainedRegions();
       try
       {
         this.DangerousAddRef(ref success);
         IntPtr handle = this.DangerousGetHandle();
         int hr = 0;
         SafeCspHandle safeCspHandle = new SafeCspHandle();
-        RuntimeHelpers.PrepareConstrainedRegions();
         try
         {
         }


### PR DESCRIPTION
Constrained Execution Regions are a .NET Framework-only feature - see https://learn.microsoft.com/en-us/dotnet/framework/performance/constrained-execution-regions.

<img width="371" height="135" alt="image" src="https://github.com/user-attachments/assets/445c9522-aee9-4ff7-aa6c-a9921b24a8c0" />

`RuntimeHelpers.PrepareConstrainedRegions()` is a no-op on .NET 5+ and is marked obsolete (SYSLIB0004). Now we dont have to support netfx, we can drop these.

This PR removes the obsolete calls - 2 less warnings :winning: