### PR TITLE
Don't include the dotnet-script.*.zip in built packages

### DIFF
--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -29,19 +29,6 @@
     <ProjectReference Include="..\Calamari.Azure\Calamari.Azure.csproj" />
     <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
   </ItemGroup>
-
-  <!-- Extract dotnet-script zip files to support C# script execution -->
-  <Target Name="RunResolvePackageDependencies" Condition="'$(RunResolvePackageDependencies)' != ''" />
-  <Target Name="GetToolFiles" DependsOnTargets="RunResolvePackageDependencies">
-    <ItemGroup>
-      <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip"/>
-    </ItemGroup>
-  </Target>
-<Target Name="CopyDotnetScriptFilesAfterBuild" AfterTargets="Build" DependsOnTargets="GetToolFiles">
-  <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(OutputPath)/" />
-</Target>
-
-<Target Name="CopyDotnetScriptFilesAfterPublish" AfterTargets="Publish" DependsOnTargets="GetToolFiles">
-  <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(PublishDir)/" />
-</Target>
+  
+  <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -30,5 +30,5 @@
     <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
   </ItemGroup>
   
-  <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
+  <Import Project="$(MSBuildProjectDirectory)/../IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
+++ b/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
@@ -22,18 +22,5 @@
         <ProjectReference Include="..\Calamari.Azure\Calamari.Azure.csproj"/>
     </ItemGroup>
 
-    <!-- Extract dotnet-script zip files to support C# script execution -->
-    <Target Name="RunResolvePackageDependencies" Condition="'$(RunResolvePackageDependencies)' != ''" />
-    <Target Name="GetToolFiles" DependsOnTargets="RunResolvePackageDependencies">
-        <ItemGroup>
-            <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip"/>
-        </ItemGroup>
-    </Target>
-<Target Name="CopyDotnetScriptFilesAfterBuild" AfterTargets="Build" DependsOnTargets="GetToolFiles">
-  <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(OutputPath)/" />
-</Target>
-
-<Target Name="CopyDotnetScriptFilesAfterPublish" AfterTargets="Publish" DependsOnTargets="GetToolFiles">
-  <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(PublishDir)/" />
-</Target>
+    <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
+++ b/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
@@ -22,5 +22,5 @@
         <ProjectReference Include="..\Calamari.Azure\Calamari.Azure.csproj"/>
     </ItemGroup>
 
-    <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
+    <Import Project="$(MSBuildProjectDirectory)/../IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari.AzureScripting/Calamari.AzureScripting.csproj
+++ b/source/Calamari.AzureScripting/Calamari.AzureScripting.csproj
@@ -27,18 +27,5 @@
         <ProjectReference Include="..\Calamari.CloudAccounts\Calamari.CloudAccounts.csproj" />
     </ItemGroup>
 
-    <!-- Extract dotnet-script zip files to support C# script execution -->
-    <Target Name="RunResolvePackageDependencies" Condition="'$(RunResolvePackageDependencies)' != ''" />
-    <Target Name="GetToolFiles" DependsOnTargets="RunResolvePackageDependencies">
-        <ItemGroup>
-            <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip"/>
-        </ItemGroup>
-    </Target>
-<Target Name="CopyDotnetScriptFilesAfterBuild" AfterTargets="Build" DependsOnTargets="GetToolFiles">
-  <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(OutputPath)/" />
-</Target>
-
-<Target Name="CopyDotnetScriptFilesAfterPublish" AfterTargets="Publish" DependsOnTargets="GetToolFiles">
-  <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(PublishDir)/" />
-</Target>
+    <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari.AzureScripting/Calamari.AzureScripting.csproj
+++ b/source/Calamari.AzureScripting/Calamari.AzureScripting.csproj
@@ -27,5 +27,5 @@
         <ProjectReference Include="..\Calamari.CloudAccounts\Calamari.CloudAccounts.csproj" />
     </ItemGroup>
 
-    <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
+    <Import Project="$(MSBuildProjectDirectory)/../IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
+++ b/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
@@ -62,18 +62,5 @@
     <Unzip SourceFiles="@(NetCoreShimFiles)" DestinationFolder="$(PublishDir)/netcoreshim" />
   </Target>
 
-  <!-- Extract dotnet-script zip files to support C# script execution -->
-  <Target Name="RunResolvePackageDependencies" Condition="'$(RunResolvePackageDependencies)' != ''" />
-  <Target Name="GetToolFiles" DependsOnTargets="RunResolvePackageDependencies">
-    <ItemGroup>
-      <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip"/>
-    </ItemGroup>
-  </Target>
-  <Target Name="CopyDotnetScriptFilesAfterBuild" AfterTargets="Build" DependsOnTargets="GetToolFiles">
-    <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(OutputPath)/" />
-  </Target>
-  
-  <Target Name="CopyDotnetScriptFilesAfterPublish" AfterTargets="Publish" DependsOnTargets="GetToolFiles">
-    <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(PublishDir)/" />
-  </Target>
+  <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
+++ b/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
@@ -62,5 +62,5 @@
     <Unzip SourceFiles="@(NetCoreShimFiles)" DestinationFolder="$(PublishDir)/netcoreshim" />
   </Target>
 
-  <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
+  <Import Project="$(MSBuildProjectDirectory)/../IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari.GoogleCloudScripting/Calamari.GoogleCloudScripting.csproj
+++ b/source/Calamari.GoogleCloudScripting/Calamari.GoogleCloudScripting.csproj
@@ -17,18 +17,5 @@
         <ProjectReference Include="..\Calamari.Scripting\Calamari.Scripting.csproj" />
     </ItemGroup>
 
-    <!-- Extract dotnet-script zip files to support C# script execution -->
-    <Target Name="RunResolvePackageDependencies" Condition="'$(RunResolvePackageDependencies)' != ''" />
-    <Target Name="GetToolFiles" DependsOnTargets="RunResolvePackageDependencies">
-        <ItemGroup>
-            <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip"/>
-        </ItemGroup>
-    </Target>
-    <Target Name="CopyDotnetScriptFilesAfterBuild" AfterTargets="Build" DependsOnTargets="GetToolFiles">
-        <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(OutputPath)/" />
-    </Target>
-
-    <Target Name="CopyDotnetScriptFilesAfterPublish" AfterTargets="Publish" DependsOnTargets="GetToolFiles">
-        <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(PublishDir)/" />
-    </Target>
+    <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari.GoogleCloudScripting/Calamari.GoogleCloudScripting.csproj
+++ b/source/Calamari.GoogleCloudScripting/Calamari.GoogleCloudScripting.csproj
@@ -17,5 +17,5 @@
         <ProjectReference Include="..\Calamari.Scripting\Calamari.Scripting.csproj" />
     </ItemGroup>
 
-    <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
+    <Import Project="$(MSBuildProjectDirectory)/../IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -10,18 +10,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
-
-    <ItemGroup>
-        <Content Include="DotnetScript/*.*">
-            <LinkBase>DotnetScript</LinkBase>
-            <Pack>true</Pack>
-            <Visible>false</Visible>
-            <PackagePath>contentFiles/any/any/DotnetScript/</PackagePath>
-            <PackageCopyToOutput>true</PackageCopyToOutput>
-            <PackageFlatten>false</PackageFlatten>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </Content>
-    </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
     </ItemGroup>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -245,42 +245,6 @@
         <None Remove="KubernetesFixtures\Scripts\KubernetesHealthCheck.ps1"/>
         <None Remove="KubernetesFixtures\Scripts\KubernetesHealthCheck.sh"/>
     </ItemGroup>
-    <!--
-      In netcore 2.1.3, the framework stopped calculating package definitions automatically "for perf"
-      (see https://github.com/dotnet/sdk/issues/2342)
-      So, we need to add a dependency onto `GetToolFiles` to calculate them first.
-      Unfortunately, RunResolvePackageDependencies doesn't exist for the full fat framework, so we
-      define a new empty target if it's not already defined to keep it happy.
-    -->
-    <Target Name="RunResolvePackageDependencies" Condition="'$(RunResolvePackageDependencies)' != ''"/>
 
-    <Target Name="GetToolFiles" DependsOnTargets="RunResolvePackageDependencies">
-        <ItemGroup>
-            <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip"/>
-        </ItemGroup>
-    </Target>
-
-    <Target Name="CopyToolsAfterBuild" AfterTargets="Build" DependsOnTargets="GetToolFiles">
-        <ItemGroup>
-            <DotnetScriptFilesExe Include="$(OutputPath)/dotnet-script/*.sh;$(OutputPath)/dotnet-script/*.exe"/>
-        </ItemGroup>
-        <Copy SourceFiles="@(NuGetFiles)" DestinationFolder="$(OutputPath)/NuGet/" SkipUnchangedFiles="true" Condition="'$(TargetFramework)' == 'net462'"/>
-        <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true"/>
-        <Exec Command="chmod +x %(DotnetScriptFilesExe.Identity)" IgnoreExitCode="true" Condition="!$([MSBuild]::IsOSPlatform('Windows'))"/>
-
-        <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(OutDir)/" SkipUnchangedFiles="true"/>
-        <Exec Command="chmod +x %(DotnetScriptFilesExe.Identity)" IgnoreExitCode="true"/>
-    </Target>
-
-    <Target Name="CopyToolsAfterPublish" AfterTargets="Publish" DependsOnTargets="GetToolFiles">
-        <ItemGroup>
-            <DotnetScriptFilesExe Include="$(PublishDir)/dotnet-script/*.sh;$(PublishDir)/dotnet-script/*.exe"/>
-        </ItemGroup>
-        <Copy SourceFiles="@(NuGetFiles)" DestinationFolder="$(PublishDir)/NuGet/" SkipUnchangedFiles="true" Condition="'$(TargetFramework)' == 'net462'"/>
-        <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="true"/>
-        <Exec Command="chmod +x %(DotnetScriptFilesExe.Identity)" IgnoreExitCode="true" Condition="!$([MSBuild]::IsOSPlatform('Windows'))"/>
-
-        <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(PublishDir)/" SkipUnchangedFiles="true"/>
-        <Exec Command="chmod +x %(DotnetScriptFilesExe.Identity)" IgnoreExitCode="true"/>
-    </Target>
+    <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -246,5 +246,5 @@
         <None Remove="KubernetesFixtures\Scripts\KubernetesHealthCheck.sh"/>
     </ItemGroup>
 
-    <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
+    <Import Project="$(MSBuildProjectDirectory)/../IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -61,5 +61,5 @@
     </None>
   </ItemGroup>
   
-  <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
+  <Import Project="$(MSBuildProjectDirectory)/../IncludeDotNetScript.targets"/>
 </Project>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -60,24 +60,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <!--
-    In netcore 2.1.3, the framework stopped calculating package definitions automatically "for perf"
-    (see https://github.com/dotnet/sdk/issues/2342)
-    So, we need to add a dependency onto `GetToolFiles` to calculate them first.
-    Unfortunately, RunResolvePackageDependencies doesn't exist for the full fat framework, so we
-    define a new empty target if it's not already defined to keep it happy.
-  -->
-  <Target Name="RunResolvePackageDependencies" Condition="'$(RunResolvePackageDependencies)' != ''" />
-  <Target Name="GetToolFiles" DependsOnTargets="RunResolvePackageDependencies">
-    <ItemGroup>
-      <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip"/>
-    </ItemGroup>
-  </Target>
-<Target Name="CopyDotnetScriptFilesAfterBuild" AfterTargets="Build" DependsOnTargets="GetToolFiles">
-  <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(OutputPath)/" />
-</Target>
-
-<Target Name="CopyDotnetScriptFilesAfterPublish" AfterTargets="Publish" DependsOnTargets="GetToolFiles">
-  <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(PublishDir)/" />
-</Target>
+  
+  <Import Project="$(SolutionDir)\IncludeDotNetScript.targets"/>
 </Project>

--- a/source/IncludeDotNetScript.targets
+++ b/source/IncludeDotNetScript.targets
@@ -1,0 +1,23 @@
+<Project>
+    <!-- Extract dotnet-script zip files to support C# script execution -->
+    <Target Name="GetToolFiles" DependsOnTargets="RunResolvePackageDependencies">
+        <ItemGroup>
+            <DotnetScriptFiles Include="$(MSBuildProjectDirectory)/../Calamari.Scripting/DotnetScript/dotnet-script.*.zip"/>
+        </ItemGroup>
+    </Target>
+    <Target Name="CopyDotnetScriptFilesAfterBuild" AfterTargets="Build" DependsOnTargets="GetToolFiles">
+        <ItemGroup>
+            <DotnetScriptFilesExe Include="$(OutputPath)/dotnet-script/*.sh;$(OutputPath)/dotnet-script/*.exe"/>
+        </ItemGroup>
+        <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(OutputPath)/" />
+        <Exec Command="chmod +x %(DotnetScriptFilesExe.Identity)" IgnoreExitCode="true" Condition="!$([MSBuild]::IsOSPlatform('Windows'))"/>
+    </Target>
+
+    <Target Name="CopyDotnetScriptFilesAfterPublish" AfterTargets="Publish" DependsOnTargets="GetToolFiles">
+        <ItemGroup>
+            <DotnetScriptFilesExe Include="$(PublishDir)/dotnet-script/*.sh;$(PublishDir)/dotnet-script/*.exe"/>
+        </ItemGroup>
+        <Unzip SourceFiles="@(DotnetScriptFiles)" DestinationFolder="$(PublishDir)/" />
+        <Exec Command="chmod +x %(DotnetScriptFilesExe.Identity)" IgnoreExitCode="true" Condition="!$([MSBuild]::IsOSPlatform('Windows'))"/>
+    </Target>
+</Project>


### PR DESCRIPTION
We are unintentionally building the `dotnet-script.*.zip` source zip file into the released packages. This is ~7mb in size and completely unnecessary as we unzip it anyway