### PR TITLE
Move resource verification into a separate step if argo rollouts support feature is enabled

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Commands/KubernetesVerifyResourcesCommandFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/KubernetesVerifyResourcesCommandFixture.cs
@@ -1,0 +1,89 @@
+using System;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Kubernetes;
+using Calamari.Kubernetes.Commands;
+using Calamari.Kubernetes.Integration;
+using Calamari.Kubernetes.ResourceStatus;
+using Calamari.Testing.Helpers;
+using Calamari.Tests.Fixtures.Integration.FileSystem;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Calamari.Tests.KubernetesFixtures.Commands
+{
+    [TestFixture]
+    public class KubernetesVerifyResourcesCommandFixture
+    {
+        [Test]
+        public void WhenNoAppliedResourcesVariableIsSet_ShouldDoNothingAndSucceed()
+        {
+            var variables = new CalamariVariables();
+            var statusReporter = Substitute.For<IResourceStatusReportExecutor>();
+            var log = new InMemoryLog();
+            var command = CreateCommand(variables, statusReporter, log);
+
+            var result = command.Execute(new string[] { });
+
+            result.Should().Be(0);
+            statusReporter.ReceivedCalls().Should().BeEmpty();
+            log.MessagesInfoFormatted.Should().Contain("No applied resources found; nothing to verify.");
+        }
+
+        [Test]
+        public void WhenAppliedResourcesIsAnEmptyList_ShouldDoNothingAndSucceed()
+        {
+            var variables = new CalamariVariables
+            {
+                [SpecialVariables.AppliedResources] = "[]"
+            };
+            var statusReporter = Substitute.For<IResourceStatusReportExecutor>();
+            var log = new InMemoryLog();
+            var command = CreateCommand(variables, statusReporter, log);
+
+            var result = command.Execute(new string[] { });
+
+            result.Should().Be(0);
+            statusReporter.ReceivedCalls().Should().BeEmpty();
+            log.MessagesInfoFormatted.Should().Contain("Applied resources list is empty; nothing to verify.");
+        }
+
+        [Test]
+        public void WhenAppliedResourcesIsNotValidJson_ShouldThrowCommandException()
+        {
+            var variables = new CalamariVariables
+            {
+                [SpecialVariables.AppliedResources] = "this is not json"
+            };
+            var statusReporter = Substitute.For<IResourceStatusReportExecutor>();
+            var command = CreateCommand(variables, statusReporter, new InMemoryLog());
+
+            Action execute = () => command.Execute(new string[] { });
+
+            execute.Should()
+                   .Throw<CommandException>()
+                   .WithMessage("Could not parse applied resources output variable:*");
+            statusReporter.ReceivedCalls().Should().BeEmpty();
+        }
+
+        static KubernetesVerifyResourcesCommand CreateCommand(
+            IVariables variables,
+            IResourceStatusReportExecutor statusReporter,
+            InMemoryLog log)
+        {
+            var fileSystem = new TestCalamariPhysicalFileSystem();
+            var commandLineRunner = Substitute.For<ICommandLineRunner>();
+            var kubectl = new Kubectl(variables, log, commandLineRunner);
+
+            return new KubernetesVerifyResourcesCommand(
+                log,
+                variables,
+                fileSystem,
+                commandLineRunner,
+                kubectl,
+                statusReporter);
+        }
+    }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/Commands/KubernetesVerifyResourcesCommandFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Commands/KubernetesVerifyResourcesCommandFixture.cs
@@ -18,18 +18,18 @@ namespace Calamari.Tests.KubernetesFixtures.Commands
     public class KubernetesVerifyResourcesCommandFixture
     {
         [Test]
-        public void WhenNoAppliedResourcesVariableIsSet_ShouldDoNothingAndSucceed()
+        public void WhenNoAppliedResourcesVariableIsSet_ShouldThrowCommandException()
         {
             var variables = new CalamariVariables();
             var statusReporter = Substitute.For<IResourceStatusReportExecutor>();
-            var log = new InMemoryLog();
-            var command = CreateCommand(variables, statusReporter, log);
+            var command = CreateCommand(variables, statusReporter, new InMemoryLog());
 
-            var result = command.Execute(new string[] { });
+            Action execute = () => command.Execute(new string[] { });
 
-            result.Should().Be(0);
+            execute.Should()
+                   .Throw<CommandException>()
+                   .WithMessage("The applied resources variable was not found. This variable is required to verify the deployed resources.");
             statusReporter.ReceivedCalls().Should().BeEmpty();
-            log.MessagesInfoFormatted.Should().Contain("No applied resources found; nothing to verify.");
         }
 
         [Test]

--- a/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesApplyRawYamlCommand.cs
@@ -4,6 +4,7 @@ using Calamari.Common.Commands;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
@@ -44,14 +45,17 @@ namespace Calamari.Kubernetes.Commands
 
         protected override async Task<bool> ExecuteCommand(RunningDeployment runningDeployment)
         {
-            if (!variables.GetFlag(SpecialVariables.ResourceStatusCheck))
+            //When ArgoRollouts support is enabled, status checking is performed by a separate verification action
+            var argoRolloutsEnabled = OctopusFeatureToggles.ArgoRolloutsSupportFeatureToggle.IsEnabled(variables);
+
+            if (argoRolloutsEnabled || !variables.GetFlag(SpecialVariables.ResourceStatusCheck))
             {
                 return await kubernetesApplyExecutor.Execute(runningDeployment);
             }
 
             var timeoutSeconds = variables.GetInt32(SpecialVariables.Timeout) ?? 0;
             var waitForJobs = variables.GetFlag(SpecialVariables.WaitForJobs);
-            
+
             var statusCheck = statusReporter.Start(timeoutSeconds, waitForJobs);
 
             return await kubernetesApplyExecutor.Execute(runningDeployment, (newResources) => statusCheck.AddResources(newResources)) &&

--- a/source/Calamari/Kubernetes/Commands/KubernetesKustomizeCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesKustomizeCommand.cs
@@ -5,6 +5,7 @@ using Calamari.Common.Commands;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.StructuredVariables;
 using Calamari.Common.Features.Substitutions;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Deployment.Journal;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
@@ -52,7 +53,10 @@ namespace Calamari.Kubernetes.Commands
 
         protected override async Task<bool> ExecuteCommand(RunningDeployment runningDeployment)
         {
-            if (!variables.GetFlag(SpecialVariables.ResourceStatusCheck))
+            //When ArgoRollouts support is enabled, status checking is performed by a separate verification action
+            var argoRolloutsEnabled = OctopusFeatureToggles.ArgoRolloutsSupportFeatureToggle.IsEnabled(variables);
+
+            if (argoRolloutsEnabled || !variables.GetFlag(SpecialVariables.ResourceStatusCheck))
             {
                 return await kubernetesApplyExecutor.Execute(runningDeployment);
             }

--- a/source/Calamari/Kubernetes/Commands/KubernetesVerifyResourcesCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesVerifyResourcesCommand.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Calamari.Aws.Integration;
+using Calamari.Commands.Support;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Deployment;
+using Calamari.Deployment.Conventions;
+using Calamari.Kubernetes.Conventions;
+using Calamari.Kubernetes.Integration;
+using Calamari.Kubernetes.ResourceStatus;
+using Calamari.Kubernetes.ResourceStatus.Resources;
+using Newtonsoft.Json;
+
+namespace Calamari.Kubernetes.Commands
+{
+    [Command(Name, Description = "Verifies that resources applied by a Kubernetes deploy step have reached their desired state")]
+    public class KubernetesVerifyResourcesCommand : Command
+    {
+        public const string Name = "kubernetes-verify-resources";
+
+        readonly ILog log;
+        readonly IVariables variables;
+        readonly ICalamariFileSystem fileSystem;
+        readonly ICommandLineRunner commandLineRunner;
+        readonly Kubectl kubectl;
+        readonly IResourceStatusReportExecutor statusReporter;
+
+        public KubernetesVerifyResourcesCommand(
+            ILog log,
+            IVariables variables,
+            ICalamariFileSystem fileSystem,
+            ICommandLineRunner commandLineRunner,
+            Kubectl kubectl,
+            IResourceStatusReportExecutor statusReporter)
+        {
+            this.log = log;
+            this.variables = variables;
+            this.fileSystem = fileSystem;
+            this.commandLineRunner = commandLineRunner;
+            this.kubectl = kubectl;
+            this.statusReporter = statusReporter;
+        }
+
+        public override int Execute(string[] commandLineArguments)
+        {
+            Options.Parse(commandLineArguments);
+
+            var json = variables.Get(SpecialVariables.AppliedResources);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                log.Info($"No applied resources found; nothing to verify.");
+                return 0;
+            }
+
+            List<ResourceIdentifier> resources;
+            try
+            {
+                resources = DeserializeResources(json);
+            }
+            catch (JsonException ex)
+            {
+                throw new CommandException($"Could not parse applied resources output variable: {ex.Message}");
+            }
+
+            if (resources.Count == 0)
+            {
+                log.Info("Applied resources list is empty; nothing to verify.");
+                return 0;
+            }
+
+            WarnForUnverifiableResources(resources);
+
+            AuthenticateKubectl();
+
+            var timeoutSeconds = variables.GetInt32(SpecialVariables.Timeout) ?? 0;
+            var waitForJobs = variables.GetFlag(SpecialVariables.WaitForJobs);
+
+            var statusCheck = statusReporter.Start(timeoutSeconds, waitForJobs, resources);
+            var success = statusCheck.WaitForCompletionOrTimeout(CancellationToken.None).GetAwaiter().GetResult();
+
+            if (!success)
+            {
+                throw new CommandException("Resource verification failed.");
+            }
+
+            return 0;
+        }
+
+        static List<ResourceIdentifier> DeserializeResources(string json)
+        {
+            var raw = JsonConvert.DeserializeObject<List<AppliedResourceDto>>(json) ?? new List<AppliedResourceDto>();
+            return raw
+                   .Select(r => new ResourceIdentifier(
+                                                       new ResourceGroupVersionKind(r.Group ?? string.Empty, r.Version, r.Kind),
+                                                       r.Name,
+                                                       r.Namespace))
+                   .ToList();
+        }
+
+        void WarnForUnverifiableResources(IEnumerable<ResourceIdentifier> resources)
+        {
+            foreach (var resource in resources)
+            {
+                var gvk = resource.GroupVersionKind;
+                if (ResourceFactory.IsVerifiable(gvk))
+                    continue;
+
+                var name = string.IsNullOrEmpty(resource.Namespace) ? resource.Name : $"{resource.Namespace}/{resource.Name}";
+                log.Warn($"Unable to fully verify resource '{gvk}' '{name}'. Calamari does not know the readiness criteria for this resource type; only its existence will be confirmed.");
+            }
+        }
+
+        void AuthenticateKubectl()
+        {
+            var deployment = new RunningDeployment(variables);
+            kubectl.SetWorkingDirectory(deployment.CurrentDirectory);
+            kubectl.SetEnvironmentVariables(deployment.EnvironmentVariables);
+
+            var conventions = new List<IConvention>();
+            if (variables.Get(Deployment.SpecialVariables.Account.AccountType) == "AmazonWebServicesAccount")
+            {
+                conventions.Add(new AwsAuthConvention(log, variables));
+            }
+            conventions.Add(new KubernetesAuthContextConvention(log, commandLineRunner, kubectl, fileSystem));
+
+            new ConventionProcessor(deployment, conventions, log).RunConventions();
+        }
+
+        class AppliedResourceDto
+        {
+            public string Group { get; set; }
+            public string Version { get; set; }
+            public string Kind { get; set; }
+            public string Name { get; set; }
+            public string Namespace { get; set; }
+        }
+    }
+}

--- a/source/Calamari/Kubernetes/Commands/KubernetesVerifyResourcesCommand.cs
+++ b/source/Calamari/Kubernetes/Commands/KubernetesVerifyResourcesCommand.cs
@@ -54,8 +54,7 @@ namespace Calamari.Kubernetes.Commands
             var json = variables.Get(SpecialVariables.AppliedResources);
             if (string.IsNullOrWhiteSpace(json))
             {
-                log.Info($"No applied resources found; nothing to verify.");
-                return 0;
+                throw new CommandException($"The applied resources variable was not found. This variable is required to verify the deployed resources.");
             }
 
             List<ResourceIdentifier> resources;
@@ -86,7 +85,7 @@ namespace Calamari.Kubernetes.Commands
 
             if (!success)
             {
-                throw new CommandException("Resource verification failed.");
+                throw new CommandException("Resource verification failed. Check verbose logs for more details.");
             }
 
             return 0;

--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmUpgradeExecutor.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmUpgradeExecutor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -24,18 +24,21 @@ namespace Calamari.Kubernetes.Conventions.Helm
         readonly HelmTemplateValueSourcesParser templateValueSourcesParser;
         readonly HelmCli helmCli;
         readonly IKubernetesManifestNamespaceResolver namespaceResolver;
+        readonly IManifestReporter manifestReporter;
 
         public HelmUpgradeExecutor(ILog log,
                                    ICalamariFileSystem fileSystem,
                                    HelmTemplateValueSourcesParser templateValueSourcesParser,
                                    HelmCli helmCli,
-                                   IKubernetesManifestNamespaceResolver namespaceResolver)
+                                   IKubernetesManifestNamespaceResolver namespaceResolver,
+                                   IManifestReporter manifestReporter = null)
         {
             this.log = log;
             this.fileSystem = fileSystem;
             this.templateValueSourcesParser = templateValueSourcesParser;
             this.helmCli = helmCli;
             this.namespaceResolver = namespaceResolver;
+            this.manifestReporter = manifestReporter;
         }
 
         public void ExecuteHelmUpgrade(RunningDeployment deployment,
@@ -64,15 +67,15 @@ namespace Calamari.Kubernetes.Conventions.Helm
 
             if (OctopusFeatureToggles.ArgoRolloutsSupportFeatureToggle.IsEnabled(deployment.Variables))
             {
-                SetAppliedResourcesOutputVariable(deployment, releaseName, newRevisionNumber);
+                ReportManifestAndSetAppliedResources(deployment, releaseName, newRevisionNumber);
             }
 
             installCompletedCts.Cancel();
         }
 
-        void SetAppliedResourcesOutputVariable(RunningDeployment deployment, string releaseName, int revisionNumber)
+        void ReportManifestAndSetAppliedResources(RunningDeployment deployment, string releaseName, int revisionNumber)
         {
-            string manifest = null;
+            string manifest;
             try
             {
                 manifest = helmCli.GetManifest(releaseName, revisionNumber);
@@ -89,6 +92,10 @@ namespace Calamari.Kubernetes.Conventions.Helm
                 return;
             }
 
+            //Manifest reporting normally happens inside HelmManifestAndStatusReporter, which is
+            //skipped on this path; emit it inline so the UI still gets the applied manifest.
+            manifestReporter?.ReportManifestApplied(manifest);
+
             var resources = ManifestParser.GetResourcesFromManifest(manifest, namespaceResolver, deployment.Variables, log);
             AppliedResourcesOutputHelper.SetAppliedResourcesOutputVariable(log, deployment, resources);
         }
@@ -104,8 +111,10 @@ namespace Calamari.Kubernetes.Conventions.Helm
             SetValuesParameters(deployment, args);
             var hasAdditionalArgs = SetAdditionalArguments(deployment, args);
 
-            //Adjust args based on KOS
-            if (deployment.Variables.GetFlag(SpecialVariables.ResourceStatusCheck))
+            //Adjust args based on KOS. When ArgoRollouts support is enabled, status checking moves
+            //to a separate verification action, so we don't force --wait on the deploy step.
+            if (deployment.Variables.GetFlag(SpecialVariables.ResourceStatusCheck)
+                && !OctopusFeatureToggles.ArgoRolloutsSupportFeatureToggle.IsEnabled(deployment.Variables))
             {
                 AddKOSArgs(deployment.Variables, hasAdditionalArgs, args);
             }

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeWithKOSConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeWithKOSConvention.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -57,10 +58,20 @@ namespace Calamari.Kubernetes.Conventions
 
             var newRevisionNumber = (currentRevisionNumber ?? 0) + 1;
 
+            //When ArgoRollouts support is enabled, the parallel manifest + KOS reporter is replaced
+            //by a separate verification action that runs after the deploy step. Manifest reporting
+            //and AppliedResources emission are performed inline by HelmUpgradeExecutor instead.
+            if (OctopusFeatureToggles.ArgoRolloutsSupportFeatureToggle.IsEnabled(deployment.Variables))
+            {
+                var executor = new HelmUpgradeExecutor(log, fileSystem, valueSourcesParser, helmCli, namespaceResolver, manifestReporter);
+                executor.ExecuteHelmUpgrade(deployment, releaseName, newRevisionNumber, new CancellationTokenSource(), new CancellationTokenSource());
+                return;
+            }
+
             //This is used to cancel KOS when the helm upgrade has completed
             //It does not cancel the get manifest
             var helmInstallCompletedCts = new CancellationTokenSource();
-            
+
             //This is used to cancel the get manifest when the helm install fails (and we are still trying to retrieve the manifest)
             var helmInstallErrorCts = new CancellationTokenSource();
 
@@ -71,7 +82,7 @@ namespace Calamari.Kubernetes.Conventions
                                                                                       valueSourcesParser,
                                                                                       helmCli,
                                                                                       namespaceResolver);
-                                               
+
                                                executor.ExecuteHelmUpgrade(deployment, releaseName, newRevisionNumber, helmInstallCompletedCts, helmInstallErrorCts);
                                            });
 
@@ -82,7 +93,7 @@ namespace Calamari.Kubernetes.Conventions
                                                           await runner.StartBackgroundMonitoringAndReporting(deployment,
                                                                                releaseName,
                                                                                newRevisionNumber,
-                                                                               helmInstallCompletedCts.Token, 
+                                                                               helmInstallCompletedCts.Token,
                                                                                helmInstallErrorCts.Token);
                                                       },
                                                       helmInstallCompletedCts.Token);

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportScriptWrapper.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.Scripts;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.Integration;
 
@@ -35,13 +34,6 @@ namespace Calamari.Kubernetes.ResourceStatus
 
         public bool IsEnabled(ScriptSyntax syntax)
         {
-            //When ArgoRollouts support is enabled, resource status reporting is performed by a
-            //separate verification action (kubernetes-verify-resources) instead of inline here.
-            if (OctopusFeatureToggles.ArgoRolloutsSupportFeatureToggle.IsEnabled(variables))
-            {
-                return false;
-            }
-
             var isBlueGreen = string.Equals(variables.Get(SpecialVariables.DeploymentStyle), "bluegreen", StringComparison.OrdinalIgnoreCase);
             var isWaitDeployment = string.Equals(variables.Get(SpecialVariables.DeploymentWait) , "wait", StringComparison.OrdinalIgnoreCase);
 

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportScriptWrapper.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportScriptWrapper.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.Features.Scripts;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.Integration;
 
@@ -34,6 +35,13 @@ namespace Calamari.Kubernetes.ResourceStatus
 
         public bool IsEnabled(ScriptSyntax syntax)
         {
+            //When ArgoRollouts support is enabled, resource status reporting is performed by a
+            //separate verification action (kubernetes-verify-resources) instead of inline here.
+            if (OctopusFeatureToggles.ArgoRolloutsSupportFeatureToggle.IsEnabled(variables))
+            {
+                return false;
+            }
+
             var isBlueGreen = string.Equals(variables.Get(SpecialVariables.DeploymentStyle), "bluegreen", StringComparison.OrdinalIgnoreCase);
             var isWaitDeployment = string.Equals(variables.Get(SpecialVariables.DeploymentWait) , "wait", StringComparison.OrdinalIgnoreCase);
 

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
@@ -25,6 +25,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             { SupportedResourceGroupVersionKinds.PersistentVolumeV1, (d, o) => new PersistentVolume(d, o) }
         };
 
+        public static bool IsVerifiable(ResourceGroupVersionKind gvk) => resourceFactories.ContainsKey(gvk);
+
         public static Resource FromJson(string json, Options options) => FromJObject(JObject.Parse(json), options);
 
         public static IEnumerable<Resource> FromListJson(string json, Options options)


### PR DESCRIPTION
Adds a new kubernetes-verify-resources Calamari command and gates inline resource status checking behind the ArgoRolloutsSupport feature toggle. When the toggle is enabled, deploy steps apply resources and emit the AppliedResources output variable, but defer status verification to a separate verification action that runs afterwards.


Relates to [SIE-63](https://linear.app/octopus/issue/SIE-63/extract-calamari-kos-into-standalone-command-and-implement-calamari)
[Related Server PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/43252)
