### PR TITLE
Remove lsof command diagnostic

### DIFF
--- a/source/Calamari.Common/Features/Processes/CommandLineRunner.cs
+++ b/source/Calamari.Common/Features/Processes/CommandLineRunner.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Runtime.InteropServices;
 using Calamari.Common.Plumbing.Commands;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.ServiceMessages;
@@ -55,12 +54,7 @@ namespace Calamari.Common.Features.Processes
             catch (Exception ex)
             {
                 if (ex.InnerException is Win32Exception)
-                {
                     commandOutput.WriteError(ConstructWin32ExceptionMessage(invocation.Executable));
-                    
-                    //todo: @robert.erez  - Remove this check if/when we can confirm that the issue is fixed.
-                    LogOpenFileStats(invocation, ex, commandOutput);
-                }
 
                 commandOutput.WriteError(ex.ToString());
                 commandOutput.WriteError("The command that caused the exception was: " + invocation);
@@ -70,33 +64,6 @@ namespace Calamari.Common.Features.Processes
                     -1,
                     ex.ToString(),
                     invocation.WorkingDirectory);
-            }
-        }
-
-        // Variable used for temporarily evaluating a potential bug with file handles being left open.
-        static void LogOpenFileStats(CommandLineInvocation invocation, Exception ex, SplitCommandInvocationOutputSink commandOutput)
-        {
-            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEAMCITY_VERSION")))
-                return; // Only log in our CI environment.
-
-            if (ex.InnerException == null || !ex.InnerException.Message.Contains("Text file busy"))
-                return; // "Text file busy" is the error that indicates a file is open.
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return; // lsof is not available on Windows.
-
-            try
-            {
-                SilentProcessRunner.ExecuteCommand(
-                                                   "lsof",
-                                                   "",
-                                                   invocation.WorkingDirectory,
-                                                   commandOutput.WriteError,
-                                                   commandOutput.WriteError);
-            }
-            catch (Exception e)
-            {
-                commandOutput.WriteInfo("Something really wrong happened when trying to log open file handles: " + e.Message);
             }
         }
 


### PR DESCRIPTION
This reverts #1683.

My understanding is that the diagnostic information provided by `lsof` hasn't proven useful in diagnosing the underlying issue. Executing this command produces hundreds of megabytes of output in task logs, the handling of which impacts test execution performance. If it's not providing value then it'd be best to remove it.

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
