### PR TITLE
fix(KustomizeUpdater): non `docker.io` image registries were ignored for image updates

### DIFF
--- a/source/Calamari.Tests/ArgoCD/KustomizeUpdaterTests.cs
+++ b/source/Calamari.Tests/ArgoCD/KustomizeUpdaterTests.cs
@@ -293,6 +293,44 @@ spec:
         }
 
         [Test]
+        public void Process_WithImageOnNonDefaultRegistry_ProducesPatchSoChangesAreCommitted()
+        {
+            // Regression test: an image whose registry differs from the default (e.g. GAR/GCR/ECR)
+            // must still produce a JSON patch. Previously the recorded image reference had its
+            // registry stripped, so CreateJsonPatch re-parsed it, defaulted the registry to
+            // docker.io, failed to match, and returned no patch — meaning HasChanges() was false
+            // and the working-copy edit was silently discarded (never committed).
+            const string kustomizationContent = @"apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld
+  newTag: ""latest""
+";
+
+            var garImages = new List<ContainerImageReferenceAndHelmReference>
+            {
+                new(ContainerImageReference.FromReferenceString(
+                        "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2",
+                        ArgoCDConstants.DefaultContainerRegistry)),
+            };
+
+            var sourceWithMetadata = new ApplicationSourceWithMetadata(
+                new ApplicationSource { Path = "." },
+                SourceType.Kustomize,
+                0);
+
+            CreateKustomizationFile(kustomizationContent);
+
+            var updater = new KustomizeUpdater(CreateMockDeploymentConfig(garImages), ArgoCDConstants.DefaultContainerRegistry, log, fileSystem);
+
+            var result = updater.Process(sourceWithMetadata, tempDir);
+
+            result.UpdatedImages.Should().Contain("shared-gke-dev-gqtrxy/argo-test/helloworld:v2");
+            result.HasChanges().Should().BeTrue("a JSON patch must be produced so the commit/push is not skipped");
+            result.PatchedFiles.Should().NotBeEmpty();
+        }
+
+        [Test]
         public void Process_WithNoKustomizationFile_ReturnsEmptyResult()
         {
             var sourceWithMetadata = new ApplicationSourceWithMetadata(

--- a/source/Calamari/ArgoCD/Conventions/UpdateImageTag/BaseUpdater.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateImageTag/BaseUpdater.cs
@@ -121,12 +121,14 @@ public abstract class BaseUpdater : ISourceUpdater
     // The tag should always be present — ContainerImageReference objects are created by
     // DeploymentConfigFactory which ensures a tag is set. The no-tag fallback appends the
     // placeholder anyway so the replacer can still match.
+    protected const string PlaceholderTag = "__CALAMARI_PLACEHOLDER__";
+
     protected static string MakePlaceholderRef(string imageRef)
     {
         var colonIdx = imageRef.LastIndexOf(':');
         return colonIdx >= 0
-            ? imageRef[..colonIdx] + ":__CALAMARI_PLACEHOLDER__"
-            : imageRef + ":__CALAMARI_PLACEHOLDER__";
+            ? imageRef[..colonIdx] + ":" + PlaceholderTag
+            : imageRef + ":" + PlaceholderTag;
     }
 
     protected static JsonPatchDocument CreateJsonPatchFromDiff(string originalContent, string updatedContent)

--- a/source/Calamari/ArgoCD/Conventions/UpdateImageTag/KustomizeUpdater.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateImageTag/KustomizeUpdater.cs
@@ -45,13 +45,16 @@ public class KustomizeUpdater : BaseUpdater
         // For kustomization resources, name and tag are separate YAML fields (name + newTag),
         // so naive string replacement of "name:tag" won't find a match.
         // Instead, run the replacer with placeholder tags to produce the "before" content.
-        var placeholderImages = targetedImages
-                                .Select(imageRef =>
-                                {
-                                    var placeholderRef = MakePlaceholderRef(imageRef);
-                                    return new ContainerImageReferenceAndHelmReference(
-                                        ContainerImageReference.FromReferenceString(placeholderRef, defaultRegistry));
-                                })
+        //
+        // The targeted image strings have their registry stripped (ImageName:Tag), so we must NOT
+        // re-parse them — doing so loses the registry for images on a non-default registry (e.g.
+        // GAR/GCR/ECR), causing the placeholder match to fail and the patch to come back empty.
+        // Instead, recover the original references (which retain registry + default registry) and
+        // only swap the tag for the placeholder.
+        var placeholderImages = imagesToUpdate
+                                .Where(i => targetedImages.Contains($"{i.ContainerReference.ImageName}:{i.ContainerReference.Tag}"))
+                                .Select(i => new ContainerImageReferenceAndHelmReference(
+                                            i.ContainerReference.WithReplacedTag(PlaceholderTag)))
                                 .ToList();
 
         var placeholderReplacer = new KustomizeContainerImageReplacer(content, defaultRegistry, updateKustomizePatches, log);

--- a/source/Calamari/ArgoCD/Models/ContainerImageReference.cs
+++ b/source/Calamari/ArgoCD/Models/ContainerImageReference.cs
@@ -100,6 +100,16 @@ namespace Calamari.ArgoCD.Models
             return $"{ToOriginalFormatName()}:{tag}";
         }
 
+        /// <summary>
+        /// Returns a copy of this reference with a different tag, preserving the registry,
+        /// image name and the originating default registry. Unlike re-parsing a string via
+        /// <see cref="FromReferenceString"/>, this never loses registry information.
+        /// </summary>
+        public ContainerImageReference WithReplacedTag(string tag)
+        {
+            return new ContainerImageReference(Registry, ImageName, tag, DefaultRegistry);
+        }
+
         static bool RegistriesMatch(ContainerImageReference reference1, ContainerImageReference reference2)
         {
             return string.Equals(NormalizeRegistry(reference1), NormalizeRegistry(reference2), StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
Fix for issue:
Update Argo CD Application Image Tags for kustomize apps does commit any changes during deployment if **image pushed to non-default registry** ( `docker.io` )

```yaml
images:
  - name: vplakydatestregistry.azurecr.io/xeonalex/guesbook-unprivileged
    newTag: "latest"
```



:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
