### PR TITLE
Deleting a directory now removes all ReadOnly attributes on files

### DIFF
--- a/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Common/Plumbing/FileSystem/CalamariPhysicalFileSystem.cs
@@ -129,7 +129,7 @@ namespace Calamari.Common.Plumbing.FileSystem
 
         public void DeleteDirectory(string path)
         {
-            Directory.Delete(path, true);
+            DeleteDirectory(path, FailureOptions.ThrowOnFailure);
         }
 
         public void DeleteDirectory(string path, FailureOptions options)
@@ -144,9 +144,18 @@ namespace Calamari.Common.Plumbing.FileSystem
                     if (Directory.Exists(path))
                     {
                         var dir = new DirectoryInfo(path);
+                        
                         //we remove any readonly attributes
                         dir.Attributes &= ~FileAttributes.ReadOnly;
+                        
+                        //Some files might be ReadOnly, clean up properly by removing the ReadOnly attribute
+                        foreach (var file in EnumerateFilesRecursively(path))
+                        {
+                            RemoveReadOnlyAttributeFromFile(file);
+                        }
+                        
                         dir.Delete(true);
+                        
                         EnsureDirectoryDeleted(path, options);
                     }
 
@@ -291,7 +300,7 @@ namespace Calamari.Common.Plumbing.FileSystem
         {
             var fileInfo = new FileInfo(filePath);
             
-            //I'm not sure of any side affects or IO of doing this when not needed, so just doing if required
+            //I'm not sure of any side effects or IO of doing this when not needed, so just doing if required
             if (fileInfo.IsReadOnly)
             {
                 fileInfo.IsReadOnly = false;

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -116,6 +116,13 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             argoCdApplicationManifestParser.ParseManifest(Arg.Any<string>())
                                            .Returns(argoCdApplicationFromYaml);
         }
+        
+        [TearDown]
+        public void Cleanup()
+        {
+            originRepo.Dispose();
+            fileSystem.DeleteDirectory(tempDirectory, FailureOptions.IgnoreFailure);
+        }
 
         [Test]
         public void PluginSourceType_DontUpdate()

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
@@ -103,7 +103,6 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
         public void Cleanup()
         {
             originRepo.Dispose();
-            
             fileSystem.DeleteDirectory(tempDirectory, FailureOptions.IgnoreFailure);
         }
 

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDApplicationManifestsInstallConventionTests.cs
@@ -102,6 +102,8 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
         [TearDown]
         public void Cleanup()
         {
+            originRepo.Dispose();
+            
             fileSystem.DeleteDirectory(tempDirectory, FailureOptions.IgnoreFailure);
         }
 

--- a/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
@@ -43,7 +43,7 @@ public abstract class AuthenticatingRepositoryFactoryTestBase
     [TearDown]
     public void Cleanup()
     {
-        RepositoryHelpers.DeleteRepositoryDirectory(fileSystem, tempDirectory);
+        fileSystem.DeleteDirectory(tempDirectory);
     }
 
     [TestFixture]

--- a/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/AuthenticatingRepositoryFactoryTests.cs
@@ -7,6 +7,7 @@ using Calamari.Integration.Time;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Fixtures.Integration.FileSystem;
 using FluentAssertions;
+using LibGit2Sharp;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Calamari.Contracts.ArgoCD;
@@ -23,13 +24,14 @@ public abstract class AuthenticatingRepositoryFactoryTestBase
     protected string tempDirectory;
     protected string OriginPath => Path.Combine(tempDirectory, "origin");
     protected RepositoryFactory repositoryFactory;
+    Repository bareOrigin;
 
     [SetUp]
     public void Init()
     {
         log = new InMemoryLog();
         tempDirectory = fileSystem.CreateTemporaryDirectory();
-        RepositoryHelpers.CreateBareRepository(OriginPath);
+        bareOrigin = RepositoryHelpers.CreateBareRepository(OriginPath);
         RepositoryHelpers.CreateBranchIn(branchName, OriginPath);
 
         repositoryFactory = new RepositoryFactory(
@@ -43,6 +45,7 @@ public abstract class AuthenticatingRepositoryFactoryTestBase
     [TearDown]
     public void Cleanup()
     {
+        bareOrigin.Dispose();
         fileSystem.DeleteDirectory(tempDirectory);
     }
 

--- a/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/GitHttpSmartSubTransportTests.cs
@@ -45,7 +45,7 @@ public class GitHttpSmartSubTransportTests
     {
         server?.Stop();
         server?.Dispose();
-        RepositoryHelpers.DeleteRepositoryDirectory(fileSystem, tempDirectory);
+        fileSystem.DeleteDirectory(tempDirectory);
     }
 
     [Test]

--- a/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitVendorApiAdapter_PullRequestTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/PullRequests/GitVendorApiAdapter_PullRequestTests.cs
@@ -133,7 +133,8 @@ namespace Calamari.Tests.ArgoCD.Git.GitVendorApiAdapters
                                                                      new GitBranchName(defaultBranch),
                                                                      CancellationToken.None);
                 pullRequest.Number.Should().BeGreaterThan(0);
-            }finally
+            }
+            finally
             {
                 // Attempt to Delete Branch on Remote
                 var pushRefSpec = $":{newBranch.CanonicalName}";
@@ -141,8 +142,6 @@ namespace Calamari.Tests.ArgoCD.Git.GitVendorApiAdapters
                 {
                     CredentialsProvider = credentialsHandler,
                 });
-                
-                RepositoryHelpers.DeleteRepositoryDirectory(CalamariPhysicalFileSystem.GetPhysicalFileSystem(), temporaryFolder.DirectoryPath);
             }
         }
     }

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
@@ -39,12 +39,17 @@ namespace Calamari.Tests.ArgoCD.Git
             bareOrigin = RepositoryHelpers.CreateBareRepository(OriginPath);
             RepositoryHelpers.CreateBranchIn(branchName, OriginPath);
 
-            repositoryFactory = new RepositoryFactory(log, fileSystem, tempDirectory, new GitVendorPullRequestClientResolver(Array.Empty<IGitVendorPullRequestClientFactory>()), new SystemClock());
+            repositoryFactory = new RepositoryFactory(log,
+                fileSystem,
+                tempDirectory,
+                new GitVendorPullRequestClientResolver(Array.Empty<IGitVendorPullRequestClientFactory>()),
+                new SystemClock());
         }
 
         [TearDown]
         public void Cleanup()
         {
+            bareOrigin.Dispose();
             fileSystem.DeleteDirectory(tempDirectory);
         }
 
@@ -52,9 +57,9 @@ namespace Calamari.Tests.ArgoCD.Git
         public void ThrowsExceptionIfUrlDoesNotExist()
         {
             var connection = new HttpsGitConnection("username",
-                                               "password",
-                                               "file://doesNotExist",
-                                               branchName);
+                "password",
+                "file://doesNotExist",
+                branchName);
 
             Action action = () => repositoryFactory.CloneRepository("name", connection);
 
@@ -105,7 +110,11 @@ namespace Calamari.Tests.ArgoCD.Git
             CreateCommitOnOrigin(branchName, filename, content);
 
             var mockResolver = Substitute.For<IGitVendorPullRequestClientResolver>();
-            var factoryWithMockedResolver = new RepositoryFactory(log, fileSystem, tempDirectory, mockResolver, new SystemClock());
+            var factoryWithMockedResolver = new RepositoryFactory(log,
+                fileSystem,
+                tempDirectory,
+                mockResolver,
+                new SystemClock());
 
             var sshConnection = new SshKeyGitConnection(
                 Username: "git",
@@ -121,7 +130,8 @@ namespace Calamari.Tests.ArgoCD.Git
             mockResolver.DidNotReceive().TryResolve(Arg.Any<IHttpsGitConnection>(), Arg.Any<ILog>(), Arg.Any<System.Threading.CancellationToken>());
 
             log.MessagesVerboseFormatted
-               .Should().Contain(s => s.Contains("SSH authentication") && s.Contains("PR creation will not be available"));
+               .Should()
+               .Contain(s => s.Contains("SSH authentication") && s.Contains("PR creation will not be available"));
         }
 
         void CreateCommitOnOrigin(GitBranchName branchName, string fileName, string content)
@@ -136,12 +146,12 @@ namespace Calamari.Tests.ArgoCD.Git
 
             var tree = bareOrigin.ObjectDatabase.CreateTree(treeDefinition);
             var commit = bareOrigin.ObjectDatabase.CreateCommit(
-                                                                signature,
-                                                                signature,
-                                                                message,
-                                                                tree,
-                                                                new[] { branch.Tip },
-                                                                false);
+                signature,
+                signature,
+                message,
+                tree,
+                new[] { branch.Tip },
+                false);
             bareOrigin.Refs.UpdateTarget(branch.Reference, commit.Id);
         }
     }

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryFactoryTests.cs
@@ -45,7 +45,7 @@ namespace Calamari.Tests.ArgoCD.Git
         [TearDown]
         public void Cleanup()
         {
-            RepositoryHelpers.DeleteRepositoryDirectory(fileSystem, tempDirectory);
+            fileSystem.DeleteDirectory(tempDirectory);
         }
 
         [Test]

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryHelpers.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryHelpers.cs
@@ -56,23 +56,11 @@ namespace Calamari.Tests.ArgoCD.Git
             var subPath = Guid.NewGuid().ToString();
             var resultPath = Path.Combine(tempDirectory, subPath);
             Repository.Clone(originPath, resultPath);
-            var resultRepo = new Repository(resultPath);
+            
+            using var resultRepo = new Repository(resultPath);
             LibGit2Sharp.Commands.Checkout(resultRepo, branchName.ToFriendlyName());
 
             return resultPath;
         }
-        
-        public static void DeleteRepositoryDirectory(ICalamariFileSystem fileSystem, string path)
-        {
-            //Some files might be ReadOnly, clean up properly by removing the ReadOnly attribute
-            foreach (var file in fileSystem.EnumerateFilesRecursively(path))
-            {
-                fileSystem.RemoveReadOnlyAttributeFromFile(file);
-            }
-
-            fileSystem.DeleteDirectory(path, FailureOptions.IgnoreFailure);
-        }
     }
-    
-    
 }

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
@@ -62,6 +62,8 @@ namespace Calamari.Tests.ArgoCD.Git
         [TearDown]
         public void Cleanup()
         {
+            bareOrigin.Dispose();
+            repository.Dispose();
             fileSystem.DeleteDirectory(tempDirectory);
         }
 

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
@@ -62,7 +62,7 @@ namespace Calamari.Tests.ArgoCD.Git
         [TearDown]
         public void Cleanup()
         {
-            RepositoryHelpers.DeleteRepositoryDirectory(fileSystem, tempDirectory);
+            fileSystem.DeleteDirectory(tempDirectory);
         }
 
         string RepositoryRootPath => Path.Combine(tempDirectory, repositoryPath);

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -61,6 +61,7 @@ public class CommitToGitCommandTest
         originalCwd = Directory.GetCurrentDirectory();
         Directory.SetCurrentDirectory(executionDirectory);
     }
+    
     [TearDown]
     public void Cleanup()
     {

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -37,13 +37,14 @@ public class CommitToGitCommandTest
     readonly GitBranchName targetBranchName = GitBranchName.CreateFromFriendlyName(targetBranchFriendlyName);
 
     CalamariExecutionVariableCollection variables;
+    Repository bareOrigin;
 
     [SetUp]
     public void setUp()
     {
         executionDirectory = fileSystem.CreateTemporaryDirectory();
 
-        RepositoryHelpers.CreateBareRepository(OriginPath);
+        bareOrigin = RepositoryHelpers.CreateBareRepository(OriginPath);
         RepositoryHelpers.CreateBranchIn(targetBranchName, OriginPath);
 
         variables = new();
@@ -57,6 +58,12 @@ public class CommitToGitCommandTest
         ]);
 
         Directory.SetCurrentDirectory(executionDirectory);
+    }
+    [TearDown]
+    public void Cleanup()
+    {
+        bareOrigin.Dispose();
+        fileSystem.DeleteDirectory(executionDirectory);
     }
 
     [Test]

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -38,9 +38,10 @@ public class CommitToGitCommandTest
 
     CalamariExecutionVariableCollection variables;
     Repository bareOrigin;
+    string originalCwd;
 
     [SetUp]
-    public void setUp()
+    public void SetUp()
     {
         executionDirectory = fileSystem.CreateTemporaryDirectory();
 
@@ -57,12 +58,14 @@ public class CommitToGitCommandTest
             new CalamariExecutionVariable(Deployment.SpecialVariables.Action.Git.CommitMessageSummary, "Git Commit Summary", false),
         ]);
 
+        originalCwd = Directory.GetCurrentDirectory();
         Directory.SetCurrentDirectory(executionDirectory);
     }
     [TearDown]
     public void Cleanup()
     {
         bareOrigin.Dispose();
+        Directory.SetCurrentDirectory(originalCwd);
         fileSystem.DeleteDirectory(executionDirectory);
     }
 

--- a/source/Calamari.Tests/Fixtures/Integration/FileSystem/TestCalamariPhysicalFileSystem.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/FileSystem/TestCalamariPhysicalFileSystem.cs
@@ -19,7 +19,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         }
 
         public void SetFileBasePath(string basePath) => File = new TestFile(basePath);
-        
+
         public override bool GetDiskFreeSpace(string directoryPath, out ulong totalNumberOfFreeBytes)
         {
             throw new NotImplementedException("*testing* this is in TestCalamariPhysicalFileSystem");
@@ -29,6 +29,7 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
         {
             throw new NotImplementedException("*testing* this is in TestCalamariPhysicalFileSystem");
         }
+
         private class TestNixCalamariPhysicalFileSystem : NixCalamariPhysicalFileSystem, ICalamariFileSystem
         {
             public new string CreateTemporaryDirectory()
@@ -43,20 +44,16 @@ namespace Calamari.Tests.Fixtures.Integration.FileSystem
                 return path;
             }
         }
+
         private class TestWindowsPhysicalFileSystem : WindowsPhysicalFileSystem, ICalamariFileSystem
         {
             public new string CreateTemporaryDirectory()
             {
-               var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);
 
-                path = Path.Combine(path, Assembly.GetEntryAssembly()?.GetName().Name ?? Guid.NewGuid().ToString());
+                path = Path.Combine(path, Assembly.GetEntryAssembly()?.GetName().Name ?? Guid.NewGuid().ToString(), "Temp", Guid.NewGuid().ToString());
 
-                path = Path.Combine(path, Guid.NewGuid().ToString());
-
-                if (!Directory.Exists(path))
-                {
-                    Directory.CreateDirectory(path);
-                }
+                Directory.CreateDirectory(path);
 
                 return path;
             }

--- a/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitLab/SelfHostedGitLabInspector.cs
+++ b/source/Calamari/ArgoCD/Git/PullRequests/Vendors/GitLab/SelfHostedGitLabInspector.cs
@@ -14,12 +14,12 @@ public class SelfHostedGitLabInspector(IMemoryCache cache)
     readonly IMemoryCache cache = cache;
     readonly SemaphoreSlim semaphoreSlim = new(1, 1);
 
-    public static string GetSelfHostedBaseRepositoryUrl(Uri repositoryUri) => repositoryUri.GetLeftPart(UriPartial.Authority);//this elides the path & query
+    public static string GetSelfHostedBaseRepositoryUrl(Uri repositoryUri) => repositoryUri.GetLeftPart(UriPartial.Authority); //this elides the path & query
 
     public async Task<bool> IsSelfHostedGitLabInstance(Uri repositoryUri, CancellationToken cancellationToken)
     {
         var selfHostedUri = GetSelfHostedBaseRepositoryUrl(repositoryUri);
-        var key = $"gitlab_{selfHostedUri}";    
+        var key = $"gitlab_{selfHostedUri}";
 
         //we only want one piece of code checking this at once
         await semaphoreSlim.WaitAsync(cancellationToken);
@@ -31,16 +31,16 @@ public class SelfHostedGitLabInspector(IMemoryCache cache)
             }
 
             var httpClient = new HttpClient();
-
-            //we can make an anonymous HTTP call to `/api/v4` and inspect the headers for `X-GitLab-Meta`
-            var apiUrl = new UriBuilder(selfHostedUri)
-            {
-                Path = "/api/v4"
-            };
-
+            
             bool hasGitLabHeader;
             try
             {
+                //we can make an anonymous HTTP call to `/api/v4` and inspect the headers for `X-GitLab-Meta`
+                var apiUrl = new UriBuilder(selfHostedUri)
+                {
+                    Path = "/api/v4"
+                };
+
                 var response = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, apiUrl.Uri),
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken);

--- a/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
@@ -268,13 +268,6 @@ namespace Calamari.ArgoCD.Git
             log.Verbose("Deleting local repository");
             try
             {
-                //some files in the .git folder can/are ReadOnly which makes them impossible to delete
-                //so just remove the ReadOnly attribute from all files (if they are ReadOnly)
-                foreach (var gitFile in calamariFileSystem.EnumerateFilesRecursively(Path.Combine(repoCheckoutDirectoryPath, ".git")))
-                {
-                    calamariFileSystem.RemoveReadOnlyAttributeFromFile(gitFile);
-                }
-
                 calamariFileSystem.DeleteDirectory(repoCheckoutDirectoryPath);
                 log.Verbose("Deleted local repository");
             }


### PR DESCRIPTION
Certain tests were taking up to 1min because they couldn't delete a cloned test git repository as there was ReadOnly files in the `.git` folder.

Added logic for removing ReadOnly attribute on all files recursively before deleting the folder. This will _very_ slightly slow down folder deletion, but it's more likely to succeed now