### PR TITLE
fix(KustomizeUpdater): non docker.io image registries were ignored for image updates

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -785,7 +785,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             results.Should().NotBeNull();
             var actual = results.Single();
             actual.Updated.Should().BeTrue();
-            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1"]);
+            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
             actual.TrackedSourceDetails.Should().HaveCount(1);
 
             var sourceDetails = actual.TrackedSourceDetails.First();
@@ -855,7 +855,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             results.Should().NotBeNull();
             var actual = results.Single();
             actual.Updated.Should().BeTrue();
-            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1", "index.docker.io/redis:7.0"]);
+            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1", "redis:7.0"]);
             actual.TrackedSourceDetails.Should().HaveCount(1);
 
             var sourceDetails = actual.TrackedSourceDetails.First();
@@ -1146,7 +1146,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             results.Should().NotBeNull();
             var actual = results.Single();
             actual.Updated.Should().BeTrue("source 0 had an outdated image");
-            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1"]);
+            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
             actual.TrackedSourceDetails.Should().HaveCount(2, "both sources should be tracked regardless of whether they made a commit");
 
             var singleContainerPatch = SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"));

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -557,7 +557,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             var results = getResults();
             results.Should().NotBeNull();
             var actual = results.Single();
-            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
+            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1"]);
             actual.GitReposUpdated.Should().HaveCount(1);
             actual.TrackedSourceDetails.Should().HaveCount(1);
 
@@ -644,7 +644,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             results.Should().NotBeNull();
             var actual = results.Single();
             actual.Updated.Should().BeTrue();
-            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
+            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1"]);
             actual.TrackedSourceDetails.Should().HaveCount(1);
 
             var sourceDetails = actual.TrackedSourceDetails.First();
@@ -717,7 +717,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             results.Should().NotBeNull();
             var actual = results.Single();
             actual.Updated.Should().BeTrue();
-            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1"], "only nginx needed updating");
+            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1"], "only nginx needed updating");
             actual.TrackedSourceDetails.Should().HaveCount(1);
 
             var sourceDetails = actual.TrackedSourceDetails.First();

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -1141,7 +1141,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             updater.Install(runningDeployment);
 
             // Assert
-            //using var scope = new AssertionScope();
+            using var scope = new AssertionScope();
             var results = getResults();
             results.Should().NotBeNull();
             var actual = results.Single();

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -785,7 +785,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             results.Should().NotBeNull();
             var actual = results.Single();
             actual.Updated.Should().BeTrue();
-            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
+            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1"]);
             actual.TrackedSourceDetails.Should().HaveCount(1);
 
             var sourceDetails = actual.TrackedSourceDetails.First();
@@ -855,7 +855,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             results.Should().NotBeNull();
             var actual = results.Single();
             actual.Updated.Should().BeTrue();
-            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1", "redis:7.0"]);
+            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1", "index.docker.io/redis:7.0"]);
             actual.TrackedSourceDetails.Should().HaveCount(1);
 
             var sourceDetails = actual.TrackedSourceDetails.First();
@@ -1141,12 +1141,12 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             updater.Install(runningDeployment);
 
             // Assert
-            using var scope = new AssertionScope();
+            //using var scope = new AssertionScope();
             var results = getResults();
             results.Should().NotBeNull();
             var actual = results.Single();
             actual.Updated.Should().BeTrue("source 0 had an outdated image");
-            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
+            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1"]);
             actual.TrackedSourceDetails.Should().HaveCount(2, "both sources should be tracked regardless of whether they made a commit");
 
             var singleContainerPatch = SerializeReplacePatch(("/0/spec/template/spec/containers/0/image", "nginx:1.27.1"));

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionTest.cs
@@ -557,7 +557,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             var results = getResults();
             results.Should().NotBeNull();
             var actual = results.Single();
-            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1"]);
+            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
             actual.GitReposUpdated.Should().HaveCount(1);
             actual.TrackedSourceDetails.Should().HaveCount(1);
 
@@ -644,7 +644,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             results.Should().NotBeNull();
             var actual = results.Single();
             actual.Updated.Should().BeTrue();
-            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1"]);
+            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1"]);
             actual.TrackedSourceDetails.Should().HaveCount(1);
 
             var sourceDetails = actual.TrackedSourceDetails.First();
@@ -717,7 +717,7 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
             results.Should().NotBeNull();
             var actual = results.Single();
             actual.Updated.Should().BeTrue();
-            actual.UpdatedImages.Should().BeEquivalentTo(["index.docker.io/nginx:1.27.1"], "only nginx needed updating");
+            actual.UpdatedImages.Should().BeEquivalentTo(["nginx:1.27.1"], "only nginx needed updating");
             actual.TrackedSourceDetails.Should().HaveCount(1);
 
             var sourceDetails = actual.TrackedSourceDetails.First();

--- a/source/Calamari.Tests/ArgoCD/ContainerImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/ContainerImageReplacerTests.cs
@@ -757,8 +757,8 @@ spec:
       result.UpdatedContents.Should().NotBeNull();
       result.UpdatedContents.Should().Be(expectedYaml);
       result.UpdatedImageReferences.Count.Should().Be(2);
-      result.UpdatedImageReferences.Should().ContainSingle(r => r == "my-custom.io/nginx:1.25");
-      result.UpdatedImageReferences.Should().ContainSingle(r => r == "my-custom.io/busybox:stable");
+      result.UpdatedImageReferences.Should().ContainSingle(r => r == "nginx:1.25");
+      result.UpdatedImageReferences.Should().ContainSingle(r => r == "busybox:stable");
     }
 
     [Test]
@@ -811,7 +811,7 @@ spec:
       result.UpdatedContents.Should().NotBeNull();
       result.UpdatedContents.Should().Be(expectedYaml);
       result.UpdatedImageReferences.Count.Should().Be(1);
-      result.UpdatedImageReferences.Should().ContainSingle(r => r == "my-custom.io/busybox:stable");
+      result.UpdatedImageReferences.Should().ContainSingle(r => r == "busybox:stable");
     }
 
 

--- a/source/Calamari.Tests/ArgoCD/ContainerImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/ContainerImageReplacerTests.cs
@@ -178,6 +178,41 @@ spec:
     }
 
     [Test]
+    public void UpdateImages_WithImageOnNonDefaultRegistry_UpdatesTagAndReportsImage()
+    {
+      // Images on a non-default registry (e.g. GAR/GCR/ECR) must be matched and updated. The
+      // first path segment (us-docker.pkg.dev) is recognised as a registry, and the rest is the
+      // image name; only the tag should change.
+      const string inputYaml = @"apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - name: helloworld
+      image: us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v1";
+      const string expectedYaml = @"apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - name: helloworld
+      image: us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2";
+
+      var imageReplacer = new ContainerImageReplacer(inputYaml, DefaultContainerRegistry);
+
+      var updatedImage = new List<ContainerImageReferenceAndHelmReference>
+      {
+        new(ContainerImageReference.FromReferenceString(
+                "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2",
+                DefaultContainerRegistry))
+      };
+
+      var result = imageReplacer.UpdateImages(updatedImage);
+
+      result.UpdatedContents.Should().Be(expectedYaml);
+      result.UpdatedImageReferences.Should().ContainSingle()
+            .Which.Should().Be("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2");
+    }
+
+    [Test]
     public void DoesNotUpdateComments()
     {
       var commentLine = "#image: nginx:1.19 being used here";
@@ -722,8 +757,8 @@ spec:
       result.UpdatedContents.Should().NotBeNull();
       result.UpdatedContents.Should().Be(expectedYaml);
       result.UpdatedImageReferences.Count.Should().Be(2);
-      result.UpdatedImageReferences.Should().ContainSingle(r => r == "nginx:1.25");
-      result.UpdatedImageReferences.Should().ContainSingle(r => r == "busybox:stable");
+      result.UpdatedImageReferences.Should().ContainSingle(r => r == "my-custom.io/nginx:1.25");
+      result.UpdatedImageReferences.Should().ContainSingle(r => r == "my-custom.io/busybox:stable");
     }
 
     [Test]
@@ -776,7 +811,7 @@ spec:
       result.UpdatedContents.Should().NotBeNull();
       result.UpdatedContents.Should().Be(expectedYaml);
       result.UpdatedImageReferences.Count.Should().Be(1);
-      result.UpdatedImageReferences.Should().ContainSingle(r => r == "busybox:stable");
+      result.UpdatedImageReferences.Should().ContainSingle(r => r == "my-custom.io/busybox:stable");
     }
 
 

--- a/source/Calamari.Tests/ArgoCD/ContainerImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/ContainerImageReplacerTests.cs
@@ -212,6 +212,39 @@ spec:
             .Which.Should().Be("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2");
     }
 
+    [Theory]
+    [TestCase("docker.io/nginx:1.27.1", "docker.io/nginx:1.28.0")]
+    [TestCase("nginx:1.27.1", "nginx:1.28.0")]
+    [TestCase("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v1",
+              "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2")]
+    public void ReturnsSameImageBaseAsInYaml(string originalImage, string expectedImage)
+    {
+      var inputYaml = $@"apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - name: my-container
+      image: {originalImage}";
+      var expectedYaml = $@"apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - name: my-container
+      image: {expectedImage}";
+
+      var imageReplacer = new ContainerImageReplacer(inputYaml, DefaultContainerRegistry);
+
+      var update = new List<ContainerImageReferenceAndHelmReference>
+      {
+        new(ContainerImageReference.FromReferenceString(expectedImage, DefaultContainerRegistry))
+      };
+
+      var result = imageReplacer.UpdateImages(update);
+
+      result.UpdatedContents.Should().Be(expectedYaml);
+      result.UpdatedImageReferences.Should().ContainSingle().Which.Should().Be(expectedImage);
+    }
+
     [Test]
     public void DoesNotUpdateComments()
     {

--- a/source/Calamari.Tests/ArgoCD/DirectoryUpdaterTests.cs
+++ b/source/Calamari.Tests/ArgoCD/DirectoryUpdaterTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Calamari.ArgoCD;
+using Calamari.ArgoCD.Conventions;
+using Calamari.ArgoCD.Conventions.UpdateImageTag;
+using Calamari.ArgoCD.Domain;
+using Calamari.ArgoCD.Models;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Testing.Helpers;
+using Calamari.Tests.Fixtures.Integration.FileSystem;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.ArgoCD
+{
+    /// <summary>
+    /// Integration tests for DirectoryUpdater.Process() workflow.
+    /// Mirrors KustomizeUpdaterTests, focusing on non-default container registries.
+    /// </summary>
+    [TestFixture]
+    public class DirectoryUpdaterTests
+    {
+        ILog log;
+        ICalamariFileSystem fileSystem;
+        string tempDir;
+
+        [SetUp]
+        public void SetUp()
+        {
+            log = new InMemoryLog();
+            fileSystem = TestCalamariPhysicalFileSystem.GetPhysicalFileSystem();
+            tempDir = fileSystem.CreateTemporaryDirectory();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            fileSystem?.DeleteDirectory(tempDir);
+        }
+
+        [Test]
+        public void Process_WithImageOnNonDefaultRegistry_ProducesPatchSoChangesAreCommitted()
+        {
+            // Regression: an image on a non-default registry (e.g. GAR/GCR/ECR) must update the
+            // manifest AND produce a JSON patch, so HasChanges() is true and the commit/push isn't
+            // silently skipped.
+            const string deployment = @"apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helloworld
+spec:
+  template:
+    spec:
+      containers:
+      - name: helloworld
+        image: us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v1
+";
+            fileSystem.OverwriteFile(Path.Combine(tempDir, "deployment.yaml"), deployment);
+
+            var garImages = new List<ContainerImageReferenceAndHelmReference>
+            {
+                new(ContainerImageReference.FromReferenceString(
+                        "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2",
+                        ArgoCDConstants.DefaultContainerRegistry)),
+            };
+
+            var sourceWithMetadata = new ApplicationSourceWithMetadata(
+                new ApplicationSource { Path = "." },
+                SourceType.Directory,
+                0);
+
+            var updater = new DirectoryUpdater(garImages, ArgoCDConstants.DefaultContainerRegistry, log, fileSystem);
+
+            var result = updater.Process(sourceWithMetadata, tempDir);
+
+            result.UpdatedImages.Should().NotBeEmpty();
+            result.HasChanges().Should().BeTrue("a JSON patch must be produced so the commit/push is not skipped");
+            result.PatchedFiles.Should().NotBeEmpty();
+
+            var updatedContent = fileSystem.ReadFile(Path.Combine(tempDir, "deployment.yaml"));
+            updatedContent.Should().Contain("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2");
+            updatedContent.Should().NotContain("helloworld:v1");
+        }
+    }
+}

--- a/source/Calamari.Tests/ArgoCD/Helm/HelmContainerImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Helm/HelmContainerImageReplacerTests.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using Calamari.ArgoCD.Conventions;
+using Calamari.ArgoCD.Helm;
+using Calamari.ArgoCD.Models;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.ArgoCD.Helm;
+
+[TestFixture]
+public class HelmContainerImageReplacerTests
+{
+    const string DefaultRegistry = "docker.io";
+    readonly InMemoryLog log = new();
+
+    [Theory]
+    [TestCase("docker.io/nginx:1.27.1", "docker.io/nginx:1.28.0")]
+    [TestCase("nginx:1.27.1", "nginx:1.28.0")]
+    [TestCase("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v1",
+              "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2")]
+    public void ReturnsSameImageBaseAsInYaml(string originalImage, string expectedImage)
+    {
+        var yaml = $@"image: {originalImage}
+";
+        var annotations = new[] { "{{ .Values.image }}" };
+        var replacer = new HelmContainerImageReplacer(yaml, DefaultRegistry, annotations, log);
+
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString(expectedImage, DefaultRegistry))
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        result.UpdatedImageReferences.Should().ContainSingle().Which.Should().Be(expectedImage);
+        result.UpdatedContents.Should().Contain($"image: {expectedImage}");
+    }
+}

--- a/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
@@ -183,6 +183,30 @@ image:
         result.UpdatedContents.Should().Be(yaml);
     }
 
+    [Theory]
+    [TestCase("docker.io/nginx:1.27.1", "docker.io/nginx:1.28.0")]
+    [TestCase("nginx:1.27.1", "nginx:1.28.0")]
+    [TestCase("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v1",
+              "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2")]
+    public void ReturnsSameImageBaseAsInYaml(string originalImage, string expectedImage)
+    {
+        var yaml = $@"
+image:
+  name: {originalImage}
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString(expectedImage, DefaultRegistry), "image.name")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEquivalentTo(new[] { expectedImage });
+        result.UpdatedContents.Should().Contain($"name: {expectedImage}");
+    }
+
     [Test]
     public void StructuredValue_MismatchedImageName_DoesNotUpdate()
     {

--- a/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Helm/HelmValuesImageReplaceStepVariablesTests.cs
@@ -96,6 +96,30 @@ image:
     }
 
     [Test]
+    public void StructuredValue_ImageOnNonDefaultRegistry_UpdatesFullRefAndTracksWithRegistry()
+    {
+        // Helm/Ref report updates using the registry-qualified FriendlyName, so an image on a
+        // non-default registry (e.g. GAR/GCR/ECR) round-trips with its registry intact.
+        const string yaml = @"
+image:
+  name: us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v1
+";
+        var replacer = new HelmValuesImageReplaceStepVariables(yaml, DefaultRegistry, log);
+        var images = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString(
+                    "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2",
+                    DefaultRegistry), "image.name")
+        };
+
+        var result = replacer.UpdateImages(images);
+
+        using var scope = new AssertionScope();
+        result.UpdatedImageReferences.Should().BeEquivalentTo(["us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2"]);
+        result.UpdatedContents.Should().Contain("name: us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2");
+    }
+
+    [Test]
     public void TwoImagesWithSameTag_OnlyUpdatesConfiguredPath()
     {
         const string yaml = @"

--- a/source/Calamari.Tests/ArgoCD/InlineJson6902ImageReplacerTest.cs
+++ b/source/Calamari.Tests/ArgoCD/InlineJson6902ImageReplacerTest.cs
@@ -41,6 +41,36 @@ patchesJson6902:
         result.UpdatedContents.Should().Contain("nginx:1.25");
     }
 
+    [Theory]
+    [TestCase("docker.io/nginx:1.27.1", "docker.io/nginx:1.28.0")]
+    [TestCase("nginx:1.27.1", "nginx:1.28.0")]
+    [TestCase("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v1",
+              "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2")]
+    public void ReturnsSameImageBaseAsInYaml(string originalImage, string expectedImage)
+    {
+        var content = $@"apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesJson6902:
+- target:
+    kind: Deployment
+    name: my-deployment
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/image
+      value: {originalImage}";
+
+        var imagesToUpdate = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString(expectedImage, ArgoCDConstants.DefaultContainerRegistry))
+        };
+
+        var replacer = new InlineJson6902ImageReplacer(content, ArgoCDConstants.DefaultContainerRegistry, log);
+        var result = replacer.UpdateImages(imagesToUpdate);
+
+        result.UpdatedImageReferences.Should().ContainSingle().Which.Should().Be(expectedImage);
+        result.UpdatedContents.Should().Contain(expectedImage);
+    }
+
     [Test]
     public void ProcessInlineJson6902Patches_WithNoMatches_ReturnsOriginalContent()
     {

--- a/source/Calamari.Tests/ArgoCD/InlineJsonPatchReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/InlineJsonPatchReplacerTests.cs
@@ -388,7 +388,7 @@ patches:
             result.UpdatedContents.Should().Contain("my-registry.com/busybox:stable");
             result.UpdatedImageReferences.Count.Should().Be(2);
             result.UpdatedImageReferences.Should().Contain("nginx:1.25");
-            result.UpdatedImageReferences.Should().Contain("busybox:stable");
+            result.UpdatedImageReferences.Should().Contain("my-registry.com/busybox:stable");
         }
 
         [Test]
@@ -428,7 +428,7 @@ patches:
             result.UpdatedContents.Should().Contain("my-registry.com/busybox:stable");
             result.UpdatedImageReferences.Count.Should().Be(2);
             result.UpdatedImageReferences.Should().Contain("nginx:1.25");
-            result.UpdatedImageReferences.Should().Contain("busybox:stable");
+            result.UpdatedImageReferences.Should().Contain("my-registry.com/busybox:stable");
         }
 
         [Test]

--- a/source/Calamari.Tests/ArgoCD/InlineJsonPatchReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/InlineJsonPatchReplacerTests.cs
@@ -457,6 +457,44 @@ patches:
             result.UpdatedImageReferences.Should().ContainSingle(r => r == "nginx:1.25");
         }
 
+        [Theory]
+        [TestCase("docker.io/nginx:1.27.1", "docker.io/nginx:1.28.0")]
+        [TestCase("nginx:1.27.1", "nginx:1.28.0")]
+        [TestCase("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v1",
+                  "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2")]
+        public void ReturnsSameImageBaseAsInYaml(string originalImage, string expectedImage)
+        {
+            var inputYaml = $@"
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- target:
+    kind: Deployment
+    name: my-deployment
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    spec:
+      template:
+        spec:
+          containers:
+          - name: my-container
+            image: {originalImage}
+";
+
+            var imageReplacer = new InlineJsonPatchReplacer(inputYaml, ArgoCDConstants.DefaultContainerRegistry, log);
+
+            var update = new List<ContainerImageReferenceAndHelmReference>
+            {
+                new(ContainerImageReference.FromReferenceString(expectedImage, ArgoCDConstants.DefaultContainerRegistry))
+            };
+
+            var result = imageReplacer.UpdateImages(update);
+
+            result.UpdatedImageReferences.Should().ContainSingle().Which.Should().Be(expectedImage);
+            result.UpdatedContents.Should().Contain(expectedImage);
+        }
+
         [Test]
         public void UpdateImages_WithJson6902PatchNonImageOperation_DoesNotUpdate()
         {

--- a/source/Calamari.Tests/ArgoCD/InlineJsonPatchReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/InlineJsonPatchReplacerTests.cs
@@ -95,7 +95,7 @@ patches:
             result.UpdatedContents.Should().Contain("my-registry.com/busybox:stable");
             result.UpdatedImageReferences.Count.Should().Be(2);
             result.UpdatedImageReferences.Should().Contain("nginx:1.25");
-            result.UpdatedImageReferences.Should().Contain("busybox:stable");
+            result.UpdatedImageReferences.Should().Contain("my-registry.com/busybox:stable");
         }
 
         [Test]
@@ -146,7 +146,7 @@ patches:
             result.UpdatedContents.Should().NotBeNull();
             result.UpdatedImageReferences.Count.Should().Be(2);
             result.UpdatedImageReferences.Should().Contain("nginx:1.25");
-            result.UpdatedImageReferences.Should().Contain("busybox:stable");
+            result.UpdatedImageReferences.Should().Contain("my-registry.com/busybox:stable");
         }
 
         [Test]

--- a/source/Calamari.Tests/ArgoCD/InlineStrategicMergeTest.cs
+++ b/source/Calamari.Tests/ArgoCD/InlineStrategicMergeTest.cs
@@ -42,6 +42,38 @@ patchesStrategicMerge:
         result.UpdatedContents.Should().Contain("nginx:1.25");
     }
 
+    [Theory]
+    [TestCase("docker.io/nginx:1.27.1", "docker.io/nginx:1.28.0")]
+    [TestCase("nginx:1.27.1", "nginx:1.28.0")]
+    [TestCase("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v1",
+              "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2")]
+    public void ReturnsSameImageBaseAsInYaml(string originalImage, string expectedImage)
+    {
+        var content = $@"apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesStrategicMerge:
+- |
+  apiVersion: apps/v1
+  kind: Deployment
+  spec:
+    template:
+      spec:
+        containers:
+        - name: my-container
+          image: {originalImage}";
+
+        var imagesToUpdate = new List<ContainerImageReferenceAndHelmReference>
+        {
+            new(ContainerImageReference.FromReferenceString(expectedImage, ArgoCDConstants.DefaultContainerRegistry))
+        };
+
+        var replacer = new InlineStrategicMergeImageReplacer(content, ArgoCDConstants.DefaultContainerRegistry, log);
+        var result = replacer.UpdateImages(imagesToUpdate);
+
+        result.UpdatedImageReferences.Should().ContainSingle().Which.Should().Be(expectedImage);
+        result.UpdatedContents.Should().Contain(expectedImage);
+    }
+
     [Test]
     public void ProcessInlineStrategicMergePatches_WithNoMatches_ReturnsOriginalContent()
     {

--- a/source/Calamari.Tests/ArgoCD/JsonPatchImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/JsonPatchImageReplacerTests.cs
@@ -67,7 +67,7 @@ namespace Calamari.Tests.ArgoCD
 
             result.UpdatedContents.Should().NotBeNull();
             result.UpdatedImageReferences.Count.Should().Be(1);
-            result.UpdatedImageReferences.Should().ContainSingle(r => r == "busybox:stable");
+            result.UpdatedImageReferences.Should().ContainSingle(r => r == "my-registry.com/busybox:stable");
             result.UpdatedContents.Should().Contain("my-registry.com/busybox:stable");
         }
 
@@ -100,7 +100,7 @@ namespace Calamari.Tests.ArgoCD
             result.UpdatedContents.Should().NotBeNull();
             result.UpdatedImageReferences.Count.Should().Be(2);
             result.UpdatedImageReferences.Should().Contain("nginx:1.25");
-            result.UpdatedImageReferences.Should().Contain("busybox:stable");
+            result.UpdatedImageReferences.Should().Contain("my-registry.com/busybox:stable");
             result.UpdatedContents.Should().Contain("nginx:1.25");
             result.UpdatedContents.Should().Contain("my-registry.com/busybox:stable");
         }
@@ -166,7 +166,7 @@ namespace Calamari.Tests.ArgoCD
             result.UpdatedContents.Should().NotBeNull();
             result.UpdatedImageReferences.Count.Should().Be(2);
             result.UpdatedImageReferences.Should().Contain("nginx:1.25");
-            result.UpdatedImageReferences.Should().Contain("busybox:stable");
+            result.UpdatedImageReferences.Should().Contain("my-registry.com/busybox:stable");
         }
 
         [Test]
@@ -197,7 +197,7 @@ namespace Calamari.Tests.ArgoCD
             result.UpdatedContents.Should().NotBeNull();
             result.UpdatedImageReferences.Count.Should().Be(2);
             result.UpdatedImageReferences.Should().Contain("nginx:1.25");
-            result.UpdatedImageReferences.Should().Contain("busybox:stable");
+            result.UpdatedImageReferences.Should().Contain("my-registry.com/busybox:stable");
         }
 
         [Test]

--- a/source/Calamari.Tests/ArgoCD/JsonPatchImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/JsonPatchImageReplacerTests.cs
@@ -281,6 +281,34 @@ namespace Calamari.Tests.ArgoCD
             result.UpdatedImageReferences.Should().BeEmpty();
         }
 
+        [Theory]
+        [TestCase("docker.io/nginx:1.27.1", "docker.io/nginx:1.28.0")]
+        [TestCase("nginx:1.27.1", "nginx:1.28.0")]
+        [TestCase("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v1",
+                  "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2")]
+        public void ReturnsSameImageBaseAsInYaml(string originalImage, string expectedImage)
+        {
+            var inputJson = $@"[
+  {{
+    ""op"": ""replace"",
+    ""path"": ""/spec/template/spec/containers/0/image"",
+    ""value"": ""{originalImage}""
+  }}
+]";
+
+            var imageReplacer = new JsonPatchImageReplacer(inputJson, ArgoCDConstants.DefaultContainerRegistry, log);
+
+            var update = new List<ContainerImageReferenceAndHelmReference>
+            {
+                new(ContainerImageReference.FromReferenceString(expectedImage, ArgoCDConstants.DefaultContainerRegistry))
+            };
+
+            var result = imageReplacer.UpdateImages(update);
+
+            result.UpdatedImageReferences.Should().ContainSingle().Which.Should().Be(expectedImage);
+            result.UpdatedContents.Should().Contain(expectedImage);
+        }
+
         [Test]
         public void UpdateImages_WithNonImageStringValues_IgnoresNonImageStrings()
         {

--- a/source/Calamari.Tests/ArgoCD/KustomizeContainerImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/KustomizeContainerImageReplacerTests.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Collections.Generic;
 using Calamari.ArgoCD;
+using Calamari.ArgoCD.Conventions;
 using Calamari.ArgoCD.Conventions.UpdateImageTag;
 using Calamari.ArgoCD.Domain;
+using Calamari.ArgoCD.Models;
 using Calamari.Common.Plumbing.Logging;
+using Calamari.Testing.Helpers;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -12,6 +16,38 @@ namespace Calamari.Tests.ArgoCD
     [TestFixture]
     public class KustomizeContainerImageReplacerTests
     {
+        [Theory]
+        [TestCase("docker.io/nginx", "1.28.0")]
+        [TestCase("nginx", "1.28.0")]
+        [TestCase("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld", "v2")]
+        public void ReturnsSameImageBaseAsInYaml(string originalName, string newTag)
+        {
+            var inputYaml = $@"apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: {originalName}
+";
+            var expectedYaml = $@"apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: {originalName}
+  newTag: ""{newTag}""
+";
+
+            var log = new InMemoryLog();
+            var replacer = new KustomizeContainerImageReplacer(inputYaml, ArgoCDConstants.DefaultContainerRegistry, false, log);
+
+            var update = new List<ContainerImageReferenceAndHelmReference>
+            {
+                new(ContainerImageReference.FromReferenceString($"{originalName}:{newTag}", ArgoCDConstants.DefaultContainerRegistry))
+            };
+
+            var result = replacer.UpdateImages(update);
+
+            result.UpdatedContents.Should().Be(expectedYaml);
+            result.UpdatedImageReferences.Should().ContainSingle().Which.Should().Be($"{originalName}:{newTag}");
+        }
+
         [TestFixture]
         public class DeterminePatchTypeFromFileTests
         {

--- a/source/Calamari.Tests/ArgoCD/KustomizeImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/KustomizeImageReplacerTests.cs
@@ -43,7 +43,7 @@ images:
             result.UpdatedContents.Should().NotBeNull();
             result.UpdatedContents.Should().Be(expectedYaml);
             result.UpdatedImageReferences.Count.Should().Be(1);
-            result.UpdatedImageReferences.Should().ContainSingle(r => r == "nginx:1.25");
+            result.UpdatedImageReferences.Should().ContainSingle(r => r == "docker.io/nginx:1.25");
         }
 
         [Test]
@@ -454,7 +454,7 @@ resources:
             result.UpdatedContents.Should().Be(expectedYaml);
             result.UpdatedImageReferences.Count.Should().Be(2);
             result.UpdatedImageReferences.Should().ContainSingle(r => r == "monopole:100");
-            result.UpdatedImageReferences.Should().ContainSingle(r => r == "nginx:1.25");
+            result.UpdatedImageReferences.Should().ContainSingle(r => r == "docker.io/nginx:1.25");
         }
     }
 }

--- a/source/Calamari.Tests/ArgoCD/KustomizeImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/KustomizeImageReplacerTests.cs
@@ -304,6 +304,35 @@ images:
             result.UpdatedImageReferences.Should().ContainSingle(r => r == "nginx:1.25");
         }
 
+        [Theory]
+        [TestCase("docker.io/nginx", "1.28.0")]
+        [TestCase("nginx", "1.28.0")]
+        [TestCase("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld", "v2")]
+        public void ReturnsSameImageBaseAsInYaml(string originalName, string newTag)
+        {
+            var inputYaml = $@"
+images:
+- name: {originalName}
+";
+            var expectedYaml = $@"
+images:
+- name: {originalName}
+  newTag: ""{newTag}""
+";
+
+            var imageReplacer = new KustomizeImageReplacer(inputYaml, ArgoCDConstants.DefaultContainerRegistry, log);
+
+            var update = new List<ContainerImageReferenceAndHelmReference>
+            {
+                new(ContainerImageReference.FromReferenceString($"{originalName}:{newTag}", ArgoCDConstants.DefaultContainerRegistry))
+            };
+
+            var result = imageReplacer.UpdateImages(update);
+
+            result.UpdatedContents.Should().Be(expectedYaml);
+            result.UpdatedImageReferences.Should().ContainSingle().Which.Should().Be($"{originalName}:{newTag}");
+        }
+
         [Test]
         public void UpdateImages_EmptyYamlContent_LogsAppropriateWarning()
         {

--- a/source/Calamari.Tests/ArgoCD/KustomizeImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/KustomizeImageReplacerTests.cs
@@ -240,7 +240,7 @@ images:
             result.UpdatedContents.Should().NotBeNull();
             result.UpdatedContents.Should().Be(expectedYaml);
             result.UpdatedImageReferences.Count.Should().Be(1);
-            result.UpdatedImageReferences.Should().ContainSingle(r => r == "busybox:stable");
+            result.UpdatedImageReferences.Should().ContainSingle(r => r == "my-registry.com/busybox:stable");
         }
 
         [Test]
@@ -266,7 +266,7 @@ images:
             result.UpdatedContents.Should().NotBeNull();
             result.UpdatedContents.Should().Be(expectedYaml);
             result.UpdatedImageReferences.Count.Should().Be(1);
-            result.UpdatedImageReferences.Should().ContainSingle(r => r == "busybox:stable");
+            result.UpdatedImageReferences.Should().ContainSingle(r => r == "my-registry.com/busybox:stable");
         }
 
         [Test]
@@ -300,7 +300,7 @@ images:
             result.UpdatedContents.Should().NotBeNull();
             result.UpdatedContents.Should().Be(expectedYaml);
             result.UpdatedImageReferences.Count.Should().Be(2);
-            result.UpdatedImageReferences.Should().ContainSingle(r => r == "busybox:stable");
+            result.UpdatedImageReferences.Should().ContainSingle(r => r == "my-registry.com/busybox:stable");
             result.UpdatedImageReferences.Should().ContainSingle(r => r == "nginx:1.25");
         }
 

--- a/source/Calamari.Tests/ArgoCD/KustomizeUpdaterTests.cs
+++ b/source/Calamari.Tests/ArgoCD/KustomizeUpdaterTests.cs
@@ -277,7 +277,7 @@ spec:
             var result = updater.Process(sourceWithMetadata, tempDir);
 
             result.UpdatedImages.Should().Contain("nginx:1.25");
-            result.UpdatedImages.Should().Contain("busybox:stable");
+            result.UpdatedImages.Should().Contain("my-registry.com/busybox:stable");
             result.UpdatedImages.Count.Should().Be(2);
 
             var updatedDeploymentContent = fileSystem.ReadFile(Path.Combine(tempDir,"deployment-patch.yaml"));

--- a/source/Calamari.Tests/ArgoCD/KustomizeUpdaterTests.cs
+++ b/source/Calamari.Tests/ArgoCD/KustomizeUpdaterTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Calamari.ArgoCD;
 using Calamari.ArgoCD.Conventions;
 using Calamari.ArgoCD.Conventions.UpdateImageTag;
@@ -13,7 +12,6 @@ using Calamari.Common.Plumbing.Logging;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.Fixtures.Integration.FileSystem;
 using FluentAssertions;
-using NSubstitute;
 using NUnit.Framework;
 
 namespace Calamari.Tests.ArgoCD
@@ -27,8 +25,8 @@ namespace Calamari.Tests.ArgoCD
     {
         readonly List<ContainerImageReferenceAndHelmReference> imagesToUpdate = new()
         {
-            new(ContainerImageReference.FromReferenceString("nginx:1.25", ArgoCDConstants.DefaultContainerRegistry)),
-            new(ContainerImageReference.FromReferenceString("busybox:stable", "my-registry.com")),
+            new(ContainerImageReference.FromReferenceString("docker.io/nginx:1.25")),
+            new(ContainerImageReference.FromReferenceString("my-registry.com/busybox:stable"))
         };
 
         ILog log;
@@ -289,7 +287,7 @@ spec:
             updatedServiceContent.Should().Contain("busybox:stable");
 
             var updatedKustomizationContent = fileSystem.ReadFile(Path.Combine(tempDir, "kustomization.yaml"));
-            updatedKustomizationContent.Should().Contain("busybox:stable");
+            updatedKustomizationContent.Should().Contain("my-registry.com/busybox:");
         }
 
         [Test]

--- a/source/Calamari.Tests/ArgoCD/KustomizeUpdaterTests.cs
+++ b/source/Calamari.Tests/ArgoCD/KustomizeUpdaterTests.cs
@@ -293,6 +293,44 @@ spec:
         }
 
         [Test]
+        public void Process_WithImageOnNonDefaultRegistry_ProducesPatchSoChangesAreCommitted()
+        {
+            // Regression test: an image whose registry differs from the default (e.g. GAR/GCR/ECR)
+            // must still produce a JSON patch. Previously the recorded image reference had its
+            // registry stripped, so CreateJsonPatch re-parsed it, defaulted the registry to
+            // docker.io, failed to match, and returned no patch — meaning HasChanges() was false
+            // and the working-copy edit was silently discarded (never committed).
+            const string kustomizationContent = @"apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld
+  newTag: ""latest""
+";
+
+            var garImages = new List<ContainerImageReferenceAndHelmReference>
+            {
+                new(ContainerImageReference.FromReferenceString(
+                        "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2",
+                        ArgoCDConstants.DefaultContainerRegistry)),
+            };
+
+            var sourceWithMetadata = new ApplicationSourceWithMetadata(
+                new ApplicationSource { Path = "." },
+                SourceType.Kustomize,
+                0);
+
+            CreateKustomizationFile(kustomizationContent);
+
+            var updater = new KustomizeUpdater(CreateMockDeploymentConfig(garImages), ArgoCDConstants.DefaultContainerRegistry, log, fileSystem);
+
+            var result = updater.Process(sourceWithMetadata, tempDir);
+
+            result.UpdatedImages.Should().Contain("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2");
+            result.HasChanges().Should().BeTrue("a JSON patch must be produced so the commit/push is not skipped");
+            result.PatchedFiles.Should().NotBeEmpty();
+        }
+
+        [Test]
         public void Process_WithNoKustomizationFile_ReturnsEmptyResult()
         {
             var sourceWithMetadata = new ApplicationSourceWithMetadata(

--- a/source/Calamari.Tests/ArgoCD/KustomizeUpdaterTests.cs
+++ b/source/Calamari.Tests/ArgoCD/KustomizeUpdaterTests.cs
@@ -287,7 +287,7 @@ spec:
             updatedServiceContent.Should().Contain("busybox:stable");
 
             var updatedKustomizationContent = fileSystem.ReadFile(Path.Combine(tempDir, "kustomization.yaml"));
-            updatedKustomizationContent.Should().Contain("my-registry.com/busybox:");
+            updatedKustomizationContent.Should().Contain("my-registry.com/busybox:stable");
         }
 
         [Test]

--- a/source/Calamari.Tests/ArgoCD/Models/ContainerImageReferenceTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Models/ContainerImageReferenceTests.cs
@@ -123,7 +123,7 @@ namespace Calamari.Tests.ArgoCD.Models
             var image = ContainerImageReference.FromReferenceString("nginx:latest");
             var result = image.WithTag("1.27");
 
-            result.Should().Be("nginx:1.27");
+            result.FriendlyName().Should().Be("nginx:1.27");
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace Calamari.Tests.ArgoCD.Models
 
             var result = image.WithTag("1.27");
 
-            result.Should().Be("docker.io/nginx:1.27");
+            result.FriendlyName().Should().Be("docker.io/nginx:1.27");
         }
 
         [Test]
@@ -143,7 +143,7 @@ namespace Calamari.Tests.ArgoCD.Models
 
             var result = image.WithTag("1.27");
 
-            result.Should().Be("nginx:1.27");
+            result.FriendlyName().Should().Be("nginx:1.27");
         }
 
         [Theory]

--- a/source/Calamari.Tests/ArgoCD/YamlJson6902PatchImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/YamlJson6902PatchImageReplacerTests.cs
@@ -80,9 +80,9 @@ namespace Calamari.Tests.ArgoCD
             var result = replacer.UpdateImages(imagesToUpdate);
 
             result.UpdatedImageReferences.Should().Contain("nginx:1.25");
-            result.UpdatedImageReferences.Should().Contain("busybox:stable");
+            result.UpdatedImageReferences.Should().Contain("my-registry.com/busybox:stable");
             result.UpdatedContents.Should().Contain("nginx:1.25");
-            result.UpdatedContents.Should().Contain("busybox:stable");
+            result.UpdatedContents.Should().Contain("my-registry.com/busybox:stable");
         }
 
         [Test]
@@ -165,10 +165,10 @@ namespace Calamari.Tests.ArgoCD
             var result = replacer.UpdateImages(imagesToUpdate);
 
             result.UpdatedImageReferences.Should().Contain("nginx:1.25");
-            result.UpdatedImageReferences.Should().Contain("busybox:stable");
+            result.UpdatedImageReferences.Should().Contain("my-registry.com/busybox:stable");
             result.UpdatedImageReferences.Should().HaveCount(2);
             result.UpdatedContents.Should().Contain("nginx:1.25");
-            result.UpdatedContents.Should().Contain("busybox:stable");
+            result.UpdatedContents.Should().Contain("my-registry.com/busybox:stable");
             result.UpdatedContents.Should().Contain("redis:6.0"); // Should remain unchanged
         }
 

--- a/source/Calamari.Tests/ArgoCD/YamlJson6902PatchImageReplacerTests.cs
+++ b/source/Calamari.Tests/ArgoCD/YamlJson6902PatchImageReplacerTests.cs
@@ -237,6 +237,31 @@ namespace Calamari.Tests.ArgoCD
             updatedLines.Should().HaveCount(3);
         }
 
+        [Theory]
+        [TestCase("docker.io/nginx:1.27.1", "docker.io/nginx:1.28.0")]
+        [TestCase("nginx:1.27.1", "nginx:1.28.0")]
+        [TestCase("us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v1",
+                  "us-docker.pkg.dev/shared-gke-dev-gqtrxy/argo-test/helloworld:v2")]
+        public void ReturnsSameImageBaseAsInYaml(string originalImage, string expectedImage)
+        {
+            var yamlContent = $@"
+- op: replace
+  path: /spec/template/spec/containers/0/image
+  value: {originalImage}";
+
+            var replacer = new YamlJson6902PatchImageReplacer(yamlContent, ArgoCDConstants.DefaultContainerRegistry, log);
+
+            var update = new List<ContainerImageReferenceAndHelmReference>
+            {
+                new(ContainerImageReference.FromReferenceString(expectedImage, ArgoCDConstants.DefaultContainerRegistry))
+            };
+
+            var result = replacer.UpdateImages(update);
+
+            result.UpdatedImageReferences.Should().ContainSingle().Which.Should().Be(expectedImage);
+            result.UpdatedContents.Should().Contain(expectedImage);
+        }
+
         [Test]
         public void CombineResults_WithMultipleResults_MergesReplacementsAndUsesLatestContent()
         {

--- a/source/Calamari/ArgoCD/ContainerImageReplacer.cs
+++ b/source/Calamari/ArgoCD/ContainerImageReplacer.cs
@@ -237,19 +237,18 @@ namespace Calamari.ArgoCD
 
                 var matchedUpdate = imagesToUpdate.Select(i => new
                                                   {
-                                                      UpdatedReference = i,
-                                                      ExistinReference = currentReference,
+                                                      Reference = i,
                                                       Comparison = i.CompareWith(currentReference)
 
                                                   })
                                                   .FirstOrDefault(i => i.Comparison.MatchesImage());
+                
                 if (matchedUpdate != null)
                 {
+                    var resultingReference = currentReference.WithTag(matchedUpdate.Reference.Tag);
                     // Only do replacement if the tag is different
                     if (!matchedUpdate.Comparison.TagMatch)
                     {
-                        var newReference = currentReference.WithTag(matchedUpdate.UpdatedReference.Tag);
-
                         // Pattern ensures we only update lines with  `image: <IMAGENAME>` OR  `- image: <IMAGENANME>`.
                         // Ignores comments and white space, while preserving any quotes around the image name
                         var pattern = $@"(?<=^\s*-?\s*image:\s*)([""']?){Regex.Escape(container.Image)}\1(?=\s*(#.*)?$)";
@@ -259,15 +258,15 @@ namespace Calamari.ArgoCD
                                                  {
                                                      var quote = match.Groups[1].Value; // quote char or empty
                                                      // Wrap newReference in the original quotes if any
-                                                     return $"{quote}{newReference}{quote}";
+                                                     return $"{quote}{resultingReference.FriendlyName()}{quote}";
                                                  },
                                                  RegexOptions.Multiline);
 
-                        replacementsMade.Add(matchedUpdate.UpdatedReference.FriendlyName());
+                        replacementsMade.Add(resultingReference.FriendlyName());
                     }
                     else
                     {
-                        alreadyUpToDate.Add(matchedUpdate.ExistinReference.FriendlyName());
+                        alreadyUpToDate.Add(resultingReference.FriendlyName());
                     }
                 }
             }

--- a/source/Calamari/ArgoCD/ContainerImageReplacer.cs
+++ b/source/Calamari/ArgoCD/ContainerImageReplacer.cs
@@ -237,7 +237,8 @@ namespace Calamari.ArgoCD
 
                 var matchedUpdate = imagesToUpdate.Select(i => new
                                                   {
-                                                      Reference = i,
+                                                      UpdatedReference = i,
+                                                      ExistinReference = currentReference,
                                                       Comparison = i.CompareWith(currentReference)
 
                                                   })
@@ -247,7 +248,7 @@ namespace Calamari.ArgoCD
                     // Only do replacement if the tag is different
                     if (!matchedUpdate.Comparison.TagMatch)
                     {
-                        var newReference = currentReference.WithTag(matchedUpdate.Reference.Tag);
+                        var newReference = currentReference.WithTag(matchedUpdate.UpdatedReference.Tag);
 
                         // Pattern ensures we only update lines with  `image: <IMAGENAME>` OR  `- image: <IMAGENANME>`.
                         // Ignores comments and white space, while preserving any quotes around the image name
@@ -262,11 +263,11 @@ namespace Calamari.ArgoCD
                                                  },
                                                  RegexOptions.Multiline);
 
-                        replacementsMade.Add(matchedUpdate.Reference.FriendlyName());
+                        replacementsMade.Add(matchedUpdate.UpdatedReference.FriendlyName());
                     }
                     else
                     {
-                        alreadyUpToDate.Add(matchedUpdate.Reference.FriendlyName());
+                        alreadyUpToDate.Add(matchedUpdate.ExistinReference.FriendlyName());
                     }
                 }
             }

--- a/source/Calamari/ArgoCD/ContainerImageReplacer.cs
+++ b/source/Calamari/ArgoCD/ContainerImageReplacer.cs
@@ -262,11 +262,11 @@ namespace Calamari.ArgoCD
                                                  },
                                                  RegexOptions.Multiline);
 
-                        replacementsMade.Add($"{matchedUpdate.Reference.ImageName}:{matchedUpdate.Reference.Tag}");
+                        replacementsMade.Add(matchedUpdate.Reference.FriendlyName());
                     }
                     else
                     {
-                        alreadyUpToDate.Add($"{matchedUpdate.Reference.ImageName}:{matchedUpdate.Reference.Tag}");
+                        alreadyUpToDate.Add(matchedUpdate.Reference.FriendlyName());
                     }
                 }
             }

--- a/source/Calamari/ArgoCD/Conventions/UpdateImageTag/KustomizeUpdater.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateImageTag/KustomizeUpdater.cs
@@ -97,10 +97,9 @@ public class KustomizeUpdater : BaseUpdater
 
         var allFilesToUpdate = new HashSet<string> { kustomizationFile };
 
+        log.Verbose("kustomization file found, processing images and discovering patch files");
         if (updateKustomizePatches)
         {
-            log.Verbose("kustomization file found, processing images and discovering patch files");
-
             var patchDiscovery = new KustomizePatchDiscovery(fileSystem, log);
             var patchFiles = patchDiscovery.DiscoverPatch(kustomizationFile);
 

--- a/source/Calamari/ArgoCD/Helm/HelmContainerImageReplacer.cs
+++ b/source/Calamari/ArgoCD/Helm/HelmContainerImageReplacer.cs
@@ -62,7 +62,7 @@ namespace Calamari.ArgoCD.Helm
                             // We re-read the node value with the image details so we can ensure we only write out the image ref components expected
                             var imageTagNodeValue = originalYamlParser.GetValueAtPath(existingImageReference.TagPath);
                             var replacementImageRef = ContainerImageReference.FromReferenceString(imageTagNodeValue, defaultClusterRegistry).WithTag(matchedUpdate.Reference.Tag);
-                            fileContent = HelmValuesEditor.UpdateNodeValue(fileContent, existingImageReference.TagPath, replacementImageRef);
+                            fileContent = HelmValuesEditor.UpdateNodeValue(fileContent, existingImageReference.TagPath, replacementImageRef.FriendlyName());
                         }
 
                         updatedImages.Add(matchedUpdate.Reference.FriendlyName());

--- a/source/Calamari/ArgoCD/Helm/HelmContainerImageReplacer.cs
+++ b/source/Calamari/ArgoCD/Helm/HelmContainerImageReplacer.cs
@@ -36,8 +36,8 @@ namespace Calamari.ArgoCD.Helm
             var fileContent = yamlContent;
             foreach (var existingImageReference in existingImageReferences)
             {
-                log.Verbose($"Apply template {existingImageReference.TagPath}, {existingImageReference.ImageReference.ToString()}");
-                var imagesString = imagesToUpdate.Select(i => i.ContainerReference.ToString()).ToList();
+                log.Verbose($"Apply template {existingImageReference.TagPath}, {existingImageReference.ImageReference.FriendlyName()}");
+                var imagesString = imagesToUpdate.Select(i => i.ContainerReference.FriendlyName()).ToList();
                 log.Verbose($"Images to Update = {string.Join(",", imagesString)}");
 
                 var matchedUpdate = imagesToUpdate.Select(i => new

--- a/source/Calamari/ArgoCD/HelmValuesImageReplaceStepVariables.cs
+++ b/source/Calamari/ArgoCD/HelmValuesImageReplaceStepVariables.cs
@@ -59,8 +59,8 @@ public class HelmValuesImageReplaceStepVariables : IContainerImageReplacer
                     if (!comparison.TagMatch)
                     {
                         var newValue = cir.WithTag(newImageTag.ContainerReference.Tag);
-                        updatedYaml = HelmValuesEditor.UpdateNodeValue(updatedYaml, helmReference, newValue);
-                        imagesUpdated.Add(newValue);
+                        updatedYaml = HelmValuesEditor.UpdateNodeValue(updatedYaml, helmReference, newValue.FriendlyName());
+                        imagesUpdated.Add(newValue.FriendlyName());
                     }
                     else
                     {

--- a/source/Calamari/ArgoCD/JsonPatchImageReplacer.cs
+++ b/source/Calamari/ArgoCD/JsonPatchImageReplacer.cs
@@ -192,7 +192,7 @@ namespace Calamari.ArgoCD
             UpdateJsonImageValue(imageValue, newImageRef.FriendlyName());
 
             changes.Add(newImageRef.FriendlyName());
-            log.Verbose($"Updated container image in JSON patch: {newImageRef}");
+            log.Verbose($"Updated container image in JSON patch: {newImageRef.FriendlyName()}");
         }
 
         ImageReferenceMatch? FindMatchingImageUpdate(string currentImageString, IReadOnlyCollection<ContainerImageReferenceAndHelmReference> imagesToUpdate)

--- a/source/Calamari/ArgoCD/JsonPatchImageReplacer.cs
+++ b/source/Calamari/ArgoCD/JsonPatchImageReplacer.cs
@@ -187,7 +187,8 @@ namespace Calamari.ArgoCD
             if (matchedUpdate == null || matchedUpdate.Comparison.TagMatch)
                 return;
 
-            var newImageRef = matchedUpdate.Reference.WithTag(matchedUpdate.Reference.Tag);
+            var currentImageRef = ContainerImageReference.FromReferenceString(currentImageString, defaultRegistry);
+            var newImageRef = currentImageRef.WithTag(matchedUpdate.Reference.Tag);
             UpdateJsonImageValue(imageValue, newImageRef.FriendlyName());
 
             changes.Add(newImageRef.FriendlyName());

--- a/source/Calamari/ArgoCD/JsonPatchImageReplacer.cs
+++ b/source/Calamari/ArgoCD/JsonPatchImageReplacer.cs
@@ -190,7 +190,7 @@ namespace Calamari.ArgoCD
             var newImageRef = matchedUpdate.Reference.WithTag(matchedUpdate.Reference.Tag);
             UpdateJsonImageValue(imageValue, newImageRef);
 
-            changes.Add($"{matchedUpdate.Reference.ImageName}:{matchedUpdate.Reference.Tag}");
+            changes.Add(matchedUpdate.Reference.FriendlyName());
             log.Verbose($"Updated container image in JSON patch: {newImageRef}");
         }
 

--- a/source/Calamari/ArgoCD/JsonPatchImageReplacer.cs
+++ b/source/Calamari/ArgoCD/JsonPatchImageReplacer.cs
@@ -188,7 +188,7 @@ namespace Calamari.ArgoCD
                 return;
 
             var newImageRef = matchedUpdate.Reference.WithTag(matchedUpdate.Reference.Tag);
-            UpdateJsonImageValue(imageValue, newImageRef);
+            UpdateJsonImageValue(imageValue, newImageRef.FriendlyName());
 
             changes.Add(matchedUpdate.Reference.FriendlyName());
             log.Verbose($"Updated container image in JSON patch: {newImageRef}");

--- a/source/Calamari/ArgoCD/JsonPatchImageReplacer.cs
+++ b/source/Calamari/ArgoCD/JsonPatchImageReplacer.cs
@@ -190,7 +190,7 @@ namespace Calamari.ArgoCD
             var newImageRef = matchedUpdate.Reference.WithTag(matchedUpdate.Reference.Tag);
             UpdateJsonImageValue(imageValue, newImageRef.FriendlyName());
 
-            changes.Add(matchedUpdate.Reference.FriendlyName());
+            changes.Add(newImageRef.FriendlyName());
             log.Verbose($"Updated container image in JSON patch: {newImageRef}");
         }
 

--- a/source/Calamari/ArgoCD/KustomizeImageReplacer.cs
+++ b/source/Calamari/ArgoCD/KustomizeImageReplacer.cs
@@ -91,6 +91,8 @@ namespace Calamari.ArgoCD
                 }
 
                 //update or insert the newTag node
+                var resultingRef = matchedUpdate.CurrentReference.WithTag(matchedUpdate.Reference.Tag);
+
                 if (matchedUpdate.ExistingTagNode != null)
                 {
                     if (!matchedUpdate.Comparison.TagMatch)
@@ -100,17 +102,17 @@ namespace Calamari.ArgoCD
                         {
                             matchedUpdate.ExistingTagNode.Style = ScalarStyle.DoubleQuoted;
                         }
-                        replacementsMade.Add(matchedUpdate.Reference.FriendlyName());
+                        replacementsMade.Add(resultingRef.FriendlyName());
                     }
                     else
                     {
-                        alreadyUpToDateImages.Add(matchedUpdate.Reference.FriendlyName());
+                        alreadyUpToDateImages.Add(resultingRef.FriendlyName());
                     }
                 }
                 else
                 {
                     imageNode.Children.Add(new YamlScalarNode(NewTagNodeKey), new YamlScalarNode(matchedUpdate.Reference.Tag) { Style = ScalarStyle.DoubleQuoted });
-                    replacementsMade.Add(matchedUpdate.Reference.FriendlyName());
+                    replacementsMade.Add(resultingRef.FriendlyName());
                 }
 
                 //remove any digest node (as we want the newTag node to dictate the container version)
@@ -152,7 +154,7 @@ namespace Calamari.ArgoCD
 
             var currentReference = ContainerImageReference.FromReferenceString(testReference, defaultRegistry);
 
-            return imagesToUpdate.Select(i => new ImageReferenceMatch(i, i.CompareWith(currentReference), existingTagNode))
+            return imagesToUpdate.Select(i => new ImageReferenceMatch(i, i.CompareWith(currentReference), existingTagNode, currentReference))
                                               .FirstOrDefault(i => i.Comparison.MatchesImage());
         }
 
@@ -186,7 +188,7 @@ namespace Calamari.ArgoCD
                    .Insert(originalImagesSequenceStartIndex, updatedImagesYaml);
         }
         
-        record ImageReferenceMatch(ContainerImageReference Reference, ContainerImageComparison Comparison, YamlScalarNode? ExistingTagNode);
+        record ImageReferenceMatch(ContainerImageReference Reference, ContainerImageComparison Comparison, YamlScalarNode? ExistingTagNode, ContainerImageReference CurrentReference);
     }
 }
 

--- a/source/Calamari/ArgoCD/KustomizeImageReplacer.cs
+++ b/source/Calamari/ArgoCD/KustomizeImageReplacer.cs
@@ -100,17 +100,17 @@ namespace Calamari.ArgoCD
                         {
                             matchedUpdate.ExistingTagNode.Style = ScalarStyle.DoubleQuoted;
                         }
-                        replacementsMade.Add($"{matchedUpdate.Reference.ImageName}:{matchedUpdate.Reference.Tag}");
+                        replacementsMade.Add(matchedUpdate.Reference.FriendlyName());
                     }
                     else
                     {
-                        alreadyUpToDateImages.Add($"{matchedUpdate.Reference.ImageName}:{matchedUpdate.Reference.Tag}");
+                        alreadyUpToDateImages.Add(matchedUpdate.Reference.FriendlyName());
                     }
                 }
                 else
                 {
                     imageNode.Children.Add(new YamlScalarNode(NewTagNodeKey), new YamlScalarNode(matchedUpdate.Reference.Tag) { Style = ScalarStyle.DoubleQuoted });
-                    replacementsMade.Add($"{matchedUpdate.Reference.ImageName}:{matchedUpdate.Reference.Tag}");
+                    replacementsMade.Add(matchedUpdate.Reference.FriendlyName());
                 }
 
                 //remove any digest node (as we want the newTag node to dictate the container version)

--- a/source/Calamari/ArgoCD/Models/ContainerImageReference.cs
+++ b/source/Calamari/ArgoCD/Models/ContainerImageReference.cs
@@ -95,9 +95,9 @@ namespace Calamari.ArgoCD.Models
             return string.IsNullOrEmpty(Registry) ? ImageName : $"{Registry}/{ImageName}";
         }
 
-        public string WithTag(string tag)
+        public ContainerImageReference WithTag(string tag)
         {
-            return $"{ToOriginalFormatName()}:{tag}";
+            return new ContainerImageReference(Registry, ImageName, tag, DefaultRegistry);
         }
 
         static bool RegistriesMatch(ContainerImageReference reference1, ContainerImageReference reference2)

--- a/source/Calamari/ArgoCD/YamlJson6902PatchImageReplacer.cs
+++ b/source/Calamari/ArgoCD/YamlJson6902PatchImageReplacer.cs
@@ -183,7 +183,7 @@ namespace Calamari.ArgoCD
                     imageScalar.Style = ScalarStyle.DoubleQuoted;
                 }
 
-                log.Verbose($"Updated container image in YAML JSON 6902 patch: {newImageRef}");
+                log.Verbose($"Updated container image in YAML JSON 6902 patch: {newImageRef.FriendlyName()}");
 
                 return new ImageReplacementResult(yamlContent, new HashSet<string> { newImageRef.FriendlyName() }, new HashSet<string>());
             }

--- a/source/Calamari/ArgoCD/YamlJson6902PatchImageReplacer.cs
+++ b/source/Calamari/ArgoCD/YamlJson6902PatchImageReplacer.cs
@@ -175,7 +175,7 @@ namespace Calamari.ArgoCD
 
             if (matchedUpdate != null && !matchedUpdate.Comparison.TagMatch)
             {
-                var newImageRef = matchedUpdate.Reference.WithTag(matchedUpdate.Reference.Tag);
+                var newImageRef = currentImageRef.WithTag(matchedUpdate.Reference.Tag);
                 imageScalar.Value = newImageRef.FriendlyName();
 
                 if (imageScalar.Style != ScalarStyle.SingleQuoted && imageScalar.Style != ScalarStyle.DoubleQuoted)
@@ -183,10 +183,9 @@ namespace Calamari.ArgoCD
                     imageScalar.Style = ScalarStyle.DoubleQuoted;
                 }
 
-                var replacement = $"{matchedUpdate.Reference.ImageName}:{matchedUpdate.Reference.Tag}";
                 log.Verbose($"Updated container image in YAML JSON 6902 patch: {newImageRef}");
 
-                return new ImageReplacementResult(yamlContent, new HashSet<string> { replacement }, new HashSet<string>());
+                return new ImageReplacementResult(yamlContent, new HashSet<string> { newImageRef.FriendlyName() }, new HashSet<string>());
             }
 
             return NoChangeResult;

--- a/source/Calamari/ArgoCD/YamlJson6902PatchImageReplacer.cs
+++ b/source/Calamari/ArgoCD/YamlJson6902PatchImageReplacer.cs
@@ -176,7 +176,7 @@ namespace Calamari.ArgoCD
             if (matchedUpdate != null && !matchedUpdate.Comparison.TagMatch)
             {
                 var newImageRef = matchedUpdate.Reference.WithTag(matchedUpdate.Reference.Tag);
-                imageScalar.Value = newImageRef;
+                imageScalar.Value = newImageRef.FriendlyName();
 
                 if (imageScalar.Style != ScalarStyle.SingleQuoted && imageScalar.Style != ScalarStyle.DoubleQuoted)
                 {


### PR DESCRIPTION
**Fix for issue:**

Update Argo CD Application Image Tags for kustomize apps does commit any changes during deployment if **image pushed to non-default registry** ( `docker.io` )

```yaml
images:
  - name: vplakydatestregistry.azurecr.io/xeonalex/guesbook-unprivileged
    newTag: "latest"
```


:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
