### PR TITLE
Fix SYSLIB0013: use Uri.EscapeDataString for URL path segments

### DIFF
--- a/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
@@ -127,7 +127,7 @@ namespace Calamari.Integration.Packages.Download
             JArray? req = null;
             while (req == null || req.Count != 0 && req.Count < 1000)
             {
-                var uri = feedUri.AbsoluteUri + $"repos/{Uri.EscapeUriString(owner)}/{Uri.EscapeUriString(repository)}/tags?page={++page}&per_page=1000";
+                var uri = feedUri.AbsoluteUri + $"repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repository)}/tags?page={++page}&per_page=1000";
                 req = PerformRequest(authorizationToken, uri) as JArray;
                 if (req == null)
                     break;


### PR DESCRIPTION
## What

Replaces the two obsolete `Uri.EscapeUriString` calls in `GitHubPackageDownloader` with `Uri.EscapeDataString` when building the GitHub tags API URL.

## Why

`Uri.EscapeUriString` is obsolete (**SYSLIB0013**) precisely because it **under-escapes** — it leaves reserved characters (`/`, `?`, `#`, `&`, etc.) unescaped. The `owner` and `repository` values are interpolated as individual URL **path segments**:

```csharp
$"repos/{owner}/{repository}/tags?..."
```

`Uri.EscapeDataString` is the documented correct replacement for URI components. This also fixes a latent bug: an owner/repo name containing a reserved character would previously corrupt the constructed URL.

## Impact

- Clears the SYSLIB0013 warning category (4 warnings counting both TFMs).
- Behaviour-positive: correct escaping of path-segment values; no change for names that contain only unreserved characters.
- `Calamari.Shared` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)