### PR TITLE
Fix CA1416: mark IsRunningOnWindows as a platform guard

### DIFF
--- a/source/Calamari.Common/Plumbing/CalamariEnvironment.cs
+++ b/source/Calamari.Common/Plumbing/CalamariEnvironment.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Common.Plumbing
@@ -15,6 +16,7 @@ namespace Calamari.Common.Plumbing
         /// </summary>
         public static bool IsRunningOnNix => Environment.OSVersion.Platform == PlatformID.Unix && !IsRunningOnMac;
 
+        [SupportedOSPlatformGuard("windows")]
         public static bool IsRunningOnWindows => Environment.OSVersion.Platform == PlatformID.Win32NT ||
             Environment.OSVersion.Platform == PlatformID.Win32S ||
             Environment.OSVersion.Platform == PlatformID.Win32Windows ||


### PR DESCRIPTION
## What

Adds `[SupportedOSPlatformGuard("windows")]` to `CalamariEnvironment.IsRunningOnWindows`.

## Why

CA1416 (platform compatibility) fires at `DockerCredentialHelper.EnsureCredentialHelperIsExecutable`, where `File.GetUnixFileMode`/`File.SetUnixFileMode` (both `[UnsupportedOSPlatform("windows")]`) are called. That method already guards with:

```csharp
if (CalamariEnvironment.IsRunningOnWindows)
    return;
```

…but the analyzer's flow analysis only recognises the BCL guards (`OperatingSystem.IsWindows()`, `RuntimeInformation.IsOSPlatform`, or the platform attributes), so it couldn't tell the Unix-only calls are unreachable on Windows.

`SupportedOSPlatformGuardAttribute` is the purpose-built way to teach the analyzer that a custom boolean member is an OS guard. It's read from metadata, so it works **cross-assembly** (the property lives in `Calamari.Common`, the call site in `Calamari.Shared`) and clears CA1416 anywhere the property is used as a guard — not just this one site.

## Impact

- Clears the CA1416 category (4 warnings counting both TFMs).
- **No behaviour change** — purely an analyzer annotation; the property's logic is untouched.
- Keeps the codebase-standard `CalamariEnvironment.IsRunningOnWindows` rather than swapping in `OperatingSystem.IsWindows()` at each call site.
- `Calamari.Shared` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)