### PR TITLE
Fix CS9124: avoid double-storing primary-constructor log parameter

### DIFF
--- a/source/Calamari.Aws/Kubernetes/Discovery/AwsKubernetesDiscoverer.cs
+++ b/source/Calamari.Aws/Kubernetes/Discovery/AwsKubernetesDiscoverer.cs
@@ -14,6 +14,8 @@ namespace Calamari.Aws.Kubernetes.Discovery;
 
 public class AwsKubernetesDiscoverer(ILog log) : KubernetesDiscovererBase(log)
 {
+    readonly ILog log = log;
+
     /// <remarks>
     /// This type value here must be the same as in Octopus.Server.Orchestration.ServerTasks.Deploy.TargetDiscovery.AwsAuthenticationContext
     /// This value is hardcoded because:
@@ -58,7 +60,7 @@ public class AwsKubernetesDiscoverer(ILog log) : KubernetesDiscovererBase(log)
             Log.Verbose("  Role: No IAM Role provided.");
         }
 
-        if (!authenticationDetails.TryGetCredentials(Log, out var credentials))
+        if (!authenticationDetails.TryGetCredentials(log, out var credentials))
             yield break;
 
         foreach (var region in authenticationDetails.Regions)

--- a/source/Calamari.Common/Features/Discovery/KubernetesDiscovererBase.cs
+++ b/source/Calamari.Common/Features/Discovery/KubernetesDiscovererBase.cs
@@ -9,10 +9,6 @@ namespace Calamari.Common.Features.Discovery;
 
 public abstract class KubernetesDiscovererBase(ILog log) : IKubernetesDiscoverer
 {
-    protected readonly ILog Log = log;
-
-
-
     protected bool TryGetDiscoveryContext<TAuthenticationDetails>(string json, 
                                                                   [NotNullWhen(returnValue: true)] out TAuthenticationDetails? authenticationDetails,
                                                                   out string? workerPoolId) where TAuthenticationDetails : class, ITargetDiscoveryAuthenticationDetails


### PR DESCRIPTION
## What

Resolves CS9124 in `KubernetesDiscovererBase`.

## Why

`KubernetesDiscovererBase(ILog log)` captured the `log` primary-constructor parameter (it's used in `LogDeserialisationError`) **and** also stored it in an explicit `protected readonly ILog Log` field. That holds the same value twice — the compiler's synthesised capture field plus the explicit field — which is what CS9124 flags.

## Change

- **`KubernetesDiscovererBase`**: removed the redundant `protected readonly ILog Log = log;` field. The base now relies solely on the captured `log` parameter.
- **`AwsKubernetesDiscoverer`**: it previously used the inherited `Log` field, so it now keeps its own `readonly ILog log = log;` and uses it for `TryGetCredentials(log, …)`. The remaining `Log.Verbose(…)` calls bind to the static `Calamari.Common.Plumbing.Logging.Log` logger.

## Impact

- Clears the CS9124 warning.
- No behavioural change to logging output.
- `Calamari.Aws` (and `Calamari.Common`) build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)