### PR TITLE
Use the Claude CLI's default model when none is selected

### DIFF
--- a/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCommandArgsBuilderFixture.cs
+++ b/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCommandArgsBuilderFixture.cs
@@ -9,8 +9,7 @@ public class ClaudeCommandArgsBuilderFixture
 {
     ClaudeCommandArgsBuilder MinimalBuilder() =>
         new ClaudeCommandArgsBuilder()
-            .WithPrompt("test prompt")
-            .WithModel("claude-sonnet-4-20250514");
+            .WithPrompt("test prompt");
 
     [Test]
     public void Build_IncludesRequiredFlags()
@@ -18,13 +17,29 @@ public class ClaudeCommandArgsBuilderFixture
         var args = MinimalBuilder().Build();
 
         args.Should().Contain("-p");
-        args.Should().Contain("--model claude-sonnet-4-20250514");
         args.Should().Contain("--output-format stream-json");
         args.Should().Contain("--verbose");
         args.Should().Contain("--permission-mode dontAsk");
         args.Should().Contain("--no-session-persistence");
         args.Should().Contain("--bare");
         args.Should().Contain("--strict-mcp-config");
+    }
+
+    [Test]
+    public void Build_IncludesModel_WhenSet()
+    {
+        var args = MinimalBuilder().WithModel("claude-sonnet-4-6").Build();
+
+        args.Should().Contain("--model claude-sonnet-4-6");
+    }
+
+    [Test]
+    public void Build_OmitsModel_WhenNotSet()
+    {
+        // No default: a blank model lets the Claude CLI choose its own current default.
+        var args = MinimalBuilder().Build();
+
+        args.Should().NotContain("--model");
     }
 
     [Test]

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCommandArgsBuilder.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCommandArgsBuilder.cs
@@ -78,8 +78,12 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
 
             var args = new StringBuilder();
 
-            args.Append(" --model ");
-            args.Append(EscapeArg(model ?? "claude-sonnet-4-20250514"));
+            if (!string.IsNullOrWhiteSpace(model))
+            {
+                args.Append(" --model ");
+                args.Append(EscapeArg(model));
+            }
+
             args.Append(" --bare");
             args.Append(" --strict-mcp-config");
             args.Append(" --output-format stream-json");


### PR DESCRIPTION
Only pass --model when the user sets one, instead of falling back to a hardcoded id that can later become inaccessible.