### PR TITLE
Fail AI agent step on deterministic Claude Code failures

### DIFF
--- a/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeAgentOutcomeEvaluatorFixture.cs
+++ b/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeAgentOutcomeEvaluatorFixture.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using Calamari.AiAgent.ClaudeCodeBehaviour;
+using Calamari.AiAgent.ClaudeCodeBehaviour.JsonResponseModels;
+using Calamari.Common.Commands;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.AiAgent.Tests.ClaudeCodeBehaviour;
+
+[TestFixture]
+public class ClaudeAgentOutcomeEvaluatorFixture
+{
+    ClaudeAgentOutcomeEvaluator evaluator = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        evaluator = new ClaudeAgentOutcomeEvaluator();
+    }
+
+    [Test]
+    public void ExitZeroWithSuccessResult_DoesNotThrow()
+    {
+        var result = new ResultStreamEvent { Subtype = "success", IsError = false };
+
+        evaluator.Invoking(e => e.EnsureSuccessful(0, result)).Should().NotThrow();
+    }
+
+    [Test]
+    public void NullResult_WithZeroExit_DoesNotThrow()
+    {
+        evaluator.Invoking(e => e.EnsureSuccessful(0, null)).Should().NotThrow();
+    }
+
+    [Test]
+    public void NonZeroExit_Throws_WithExitCodeInMessage()
+    {
+        evaluator.Invoking(e => e.EnsureSuccessful(2, new ResultStreamEvent { Subtype = "success", IsError = false }))
+                 .Should().Throw<CommandException>().WithMessage("*exited with code 2*");
+    }
+
+    [Test]
+    public void NonSuccessSubtype_Throws_WithSubtypeAndStopReason()
+    {
+        var result = new ResultStreamEvent { Subtype = "error_max_turns", IsError = false, StopReason = "max_turns" };
+
+        evaluator.Invoking(e => e.EnsureSuccessful(0, result))
+                 .Should().Throw<CommandException>()
+                 .Which.Message.Should().Contain("error_max_turns").And.Contain("max_turns");
+    }
+
+    [Test]
+    public void IsErrorTrue_WithSuccessSubtype_Throws()
+    {
+        var result = new ResultStreamEvent { Subtype = "success", IsError = true };
+
+        evaluator.Invoking(e => e.EnsureSuccessful(0, result))
+                 .Should().Throw<CommandException>().WithMessage("*did not complete successfully*");
+    }
+
+    [Test]
+    public void ExitZero_SuccessSubtype_WithPermissionDenials_Throws_NamingDeniedTools()
+    {
+        var result = new ResultStreamEvent
+        {
+            Subtype = "success",
+            IsError = false,
+            PermissionDenials = new List<PermissionDenial>
+            {
+                new() { ToolName = "Bash", ToolUseId = "toolu_1" },
+                new() { ToolName = "WebFetch", ToolUseId = "toolu_2" },
+            },
+        };
+
+        evaluator.Invoking(e => e.EnsureSuccessful(0, result))
+                 .Should().Throw<CommandException>()
+                 .Which.Message.Should().Contain("denied permission").And.Contain("Bash").And.Contain("WebFetch");
+    }
+}

--- a/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeAgentOutcomeEvaluatorFixture.cs
+++ b/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeAgentOutcomeEvaluatorFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Calamari.AiAgent.ClaudeCodeBehaviour;
 using Calamari.AiAgent.ClaudeCodeBehaviour.JsonResponseModels;
@@ -10,33 +11,30 @@ namespace Calamari.AiAgent.Tests.ClaudeCodeBehaviour;
 [TestFixture]
 public class ClaudeAgentOutcomeEvaluatorFixture
 {
-    ClaudeAgentOutcomeEvaluator evaluator = null!;
-
-    [SetUp]
-    public void SetUp()
-    {
-        evaluator = new ClaudeAgentOutcomeEvaluator();
-    }
-
     [Test]
     public void ExitZeroWithSuccessResult_DoesNotThrow()
     {
         var result = new ResultStreamEvent { Subtype = "success", IsError = false };
 
-        evaluator.Invoking(e => e.EnsureSuccessful(0, result)).Should().NotThrow();
+        Action act = () => ClaudeAgentOutcomeEvaluator.EnsureSuccessful(0, result);
+
+        act.Should().NotThrow();
     }
 
     [Test]
     public void NullResult_WithZeroExit_DoesNotThrow()
     {
-        evaluator.Invoking(e => e.EnsureSuccessful(0, null)).Should().NotThrow();
+        Action act = () => ClaudeAgentOutcomeEvaluator.EnsureSuccessful(0, null);
+
+        act.Should().NotThrow();
     }
 
     [Test]
     public void NonZeroExit_Throws_WithExitCodeInMessage()
     {
-        evaluator.Invoking(e => e.EnsureSuccessful(2, new ResultStreamEvent { Subtype = "success", IsError = false }))
-                 .Should().Throw<CommandException>().WithMessage("*exited with code 2*");
+        Action act = () => ClaudeAgentOutcomeEvaluator.EnsureSuccessful(2, new ResultStreamEvent { Subtype = "success", IsError = false });
+
+        act.Should().Throw<CommandException>().WithMessage("*exited with code 2*");
     }
 
     [Test]
@@ -44,9 +42,10 @@ public class ClaudeAgentOutcomeEvaluatorFixture
     {
         var result = new ResultStreamEvent { Subtype = "error_max_turns", IsError = false, StopReason = "max_turns" };
 
-        evaluator.Invoking(e => e.EnsureSuccessful(0, result))
-                 .Should().Throw<CommandException>()
-                 .Which.Message.Should().Contain("error_max_turns").And.Contain("max_turns");
+        Action act = () => ClaudeAgentOutcomeEvaluator.EnsureSuccessful(0, result);
+
+        act.Should().Throw<CommandException>()
+           .Which.Message.Should().Contain("error_max_turns").And.Contain("max_turns");
     }
 
     [Test]
@@ -54,8 +53,9 @@ public class ClaudeAgentOutcomeEvaluatorFixture
     {
         var result = new ResultStreamEvent { Subtype = "success", IsError = true };
 
-        evaluator.Invoking(e => e.EnsureSuccessful(0, result))
-                 .Should().Throw<CommandException>().WithMessage("*did not complete successfully*");
+        Action act = () => ClaudeAgentOutcomeEvaluator.EnsureSuccessful(0, result);
+
+        act.Should().Throw<CommandException>().WithMessage("*did not complete successfully*");
     }
 
     [Test]
@@ -72,8 +72,9 @@ public class ClaudeAgentOutcomeEvaluatorFixture
             },
         };
 
-        evaluator.Invoking(e => e.EnsureSuccessful(0, result))
-                 .Should().Throw<CommandException>()
-                 .Which.Message.Should().Contain("denied permission").And.Contain("Bash").And.Contain("WebFetch");
+        Action act = () => ClaudeAgentOutcomeEvaluator.EnsureSuccessful(0, result);
+
+        act.Should().Throw<CommandException>()
+           .Which.Message.Should().Contain("denied permission").And.Contain("Bash").And.Contain("WebFetch");
     }
 }

--- a/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeStreamProcessorFixture.cs
+++ b/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeStreamProcessorFixture.cs
@@ -123,6 +123,24 @@ public class ClaudeCodeStreamProcessorFixture
     }
 
     [Test]
+    public void ResultEvent_CapturesResultWithPermissionDenials()
+    {
+        var json = """
+            {"type":"result","subtype":"success","is_error":false,"result":"done","cost_usd":0.001,"permission_denials":[{"tool_name":"Bash","tool_use_id":"toolu_1","tool_input":{"command":"rm -rf /"}}]}
+            """;
+
+        processor.ProcessLine(json);
+
+        log.ServiceMessages.Should().Contain(m => m.Name == ClaudeCodeServiceMessages.Usage.Name);
+
+        processor.Result.Should().NotBeNull();
+        processor.Result!.Subtype.Should().Be("success");
+        processor.Result.IsError.Should().BeFalse();
+        processor.Result.PermissionDenials.Should().ContainSingle()
+                 .Which.ToolName.Should().Be("Bash");
+    }
+
+    [Test]
     public void ResultEvent_FallsBackToResultText_WhenNoAssistantText()
     {
         var json = """

--- a/source/Calamari.AiAgent.Tests/DeterministicFailureFixture.cs
+++ b/source/Calamari.AiAgent.Tests/DeterministicFailureFixture.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading.Tasks;
+using Calamari.Testing;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.AiAgent.Tests;
+
+[TestFixture]
+[Explicit("Exercises the real claude CLI end-to-end; most cases need ANTHROPIC_TOKEN.")]
+[Category("Integration")]
+public class DeterministicFailureFixture
+{
+    const string Model = "claude-sonnet-4-5-20250929";
+
+    static string Token => Environment.GetEnvironmentVariable("ANTHROPIC_TOKEN");
+
+    static void RequireToken()
+    {
+        if (string.IsNullOrWhiteSpace(Token))
+            Assert.Ignore("ANTHROPIC_TOKEN is not set.");
+    }
+
+    // Needs no token: a bad key fails auth and exits non-zero.
+    [Test]
+    public async Task InvalidApiKey_FailsStep()
+    {
+        var result = await CommandTestBuilder.CreateAsync<RunAgentCommand, Program>()
+            .WithArrange(context =>
+            {
+                context.Variables.Add(SpecialVariables.Action.Claude.ApiToken, "sk-ant-invalid-test-000");
+                context.Variables.Add(SpecialVariables.Action.Claude.MaxTurns, "1");
+                context.Variables.Add(SpecialVariables.Action.Claude.Prompt, "Reply with exactly: DONE");
+            })
+            .Execute(assertWasSuccess: false);
+
+        result.WasSuccessful.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task SimplePrompt_SucceedsStep()
+    {
+        RequireToken();
+
+        var result = await CommandTestBuilder.CreateAsync<RunAgentCommand, Program>()
+            .WithArrange(context =>
+            {
+                context.Variables.Add(SpecialVariables.Action.Claude.ApiToken, Token);
+                context.Variables.Add(SpecialVariables.Action.Claude.Model, Model);
+                context.Variables.Add(SpecialVariables.Action.Claude.MaxTurns, "3");
+                context.Variables.Add(SpecialVariables.Action.Claude.Prompt,
+                    "What is the capital of France? Reply with just the city name.");
+            })
+            .Execute(assertWasSuccess: false);
+
+        result.WasSuccessful.Should().BeTrue();
+        result.FullLog.Should().Contain("Paris");
+    }
+}

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeAgentOutcomeEvaluator.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeAgentOutcomeEvaluator.cs
@@ -5,9 +5,9 @@ using Calamari.Common.Commands;
 
 namespace Calamari.AiAgent.ClaudeCodeBehaviour
 {
-    public class ClaudeAgentOutcomeEvaluator
+    public static class ClaudeAgentOutcomeEvaluator
     {
-        public void EnsureSuccessful(int exitCode, ResultStreamEvent? result)
+        public static void EnsureSuccessful(int exitCode, ResultStreamEvent? result)
         {
             if (exitCode != 0)
             {

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeAgentOutcomeEvaluator.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeAgentOutcomeEvaluator.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using Calamari.AiAgent.ClaudeCodeBehaviour.JsonResponseModels;
+using Calamari.Common.Commands;
+
+namespace Calamari.AiAgent.ClaudeCodeBehaviour
+{
+    public class ClaudeAgentOutcomeEvaluator
+    {
+        public void EnsureSuccessful(int exitCode, ResultStreamEvent? result)
+        {
+            if (exitCode != 0)
+            {
+                throw new CommandException($"Claude Code exited with code {exitCode}.");
+            }
+
+            // Exit code 0 but no terminal result event: the CLI reported success at the process level, but we
+            // couldn't observe a result to inspect (output-format drift or an unparseable result line). We have
+            // no failure signal beyond the exit code, so we defer to it rather than fail on a parsing gap.
+            if (result == null)
+            {
+                return;
+            }
+
+            if (result.IsError == true || !"success".Equals(result.Subtype, StringComparison.OrdinalIgnoreCase))
+            {
+                var subtype = string.IsNullOrEmpty(result.Subtype) ? "<none>" : result.Subtype;
+                var stopReason = string.IsNullOrEmpty(result.StopReason) ? "<none>" : result.StopReason;
+                throw new CommandException(
+                    $"Claude Code did not complete successfully (subtype: {subtype}, stop_reason: {stopReason}).");
+            }
+
+            if (result.PermissionDenials is { Count: > 0 } denials)
+            {
+                var toolNames = string.Join(", ", denials.Select(d => string.IsNullOrEmpty(d.ToolName) ? "<unknown>" : d.ToolName));
+                throw new CommandException(
+                    $"Claude Code was denied permission to use the following tool(s): {toolNames}.");
+            }
+        }
+    }
+}

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeCliRunner.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeCliRunner.cs
@@ -8,7 +8,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Logging;
 
 namespace Calamari.AiAgent.ClaudeCodeBehaviour
@@ -40,16 +39,14 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
                 customEnvVars,
                 cancellationToken);
 
-            var stdoutTask = Task.Run(() => ProcessLine(process, verboseLogPath, cancellationToken), cancellationToken);
+            var responseBuilder = new StringBuilder();
+            var streamProcessor = new ClaudeCodeStreamProcessor(log, responseBuilder);
+
+            var stdoutTask = Task.Run(() => ProcessLine(process, streamProcessor, verboseLogPath, cancellationToken), cancellationToken);
             var stderrTask = Task.Run(() => ProcessError(process), cancellationToken);
 
             await Task.WhenAll(stdoutTask, stderrTask);
             await process.WaitForExitAsync(cancellationToken);
-
-            if (process.ExitCode != 0)
-            {
-                throw new CommandException($"Claude Code exited with code {process.ExitCode}");
-            }
 
             Directory.CreateDirectory(Path.Combine(calamariDir, "log"));
             if (File.Exists(debugLogPath))
@@ -68,7 +65,9 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
                 log.NewOctopusArtifact(movedFilePath, "claude-agent-verbose.log", fileInfo.Length);
             }
 
-            return stdoutTask.Result.ToString();
+            new ClaudeAgentOutcomeEvaluator().EnsureSuccessful(process.ExitCode, streamProcessor.Result);
+
+            return responseBuilder.ToString();
         }
 
         async Task ProcessError(Process process)
@@ -82,10 +81,8 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
             }
         }
 
-        async Task<StringBuilder> ProcessLine(Process process, string verboseLogPath, CancellationToken cancellationToken)
+        async Task ProcessLine(Process process, ClaudeCodeStreamProcessor streamProcessor, string verboseLogPath, CancellationToken cancellationToken)
         {
-            var responseBuilder = new StringBuilder();
-            var streamProcessor = new ClaudeCodeStreamProcessor(log, responseBuilder);
             var line = string.Empty;
             int ch;
             while ((ch = process.StandardOutput.Read()) >= 0)
@@ -114,7 +111,6 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
                 await File.AppendAllTextAsync(verboseLogPath, line + "\n", cancellationToken);
                 streamProcessor.ProcessLine(line);
             }
-            return responseBuilder;
         }
     }
 

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeCliRunner.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeCliRunner.cs
@@ -65,7 +65,7 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
                 log.NewOctopusArtifact(movedFilePath, "claude-agent-verbose.log", fileInfo.Length);
             }
 
-            new ClaudeAgentOutcomeEvaluator().EnsureSuccessful(process.ExitCode, streamProcessor.Result);
+            ClaudeAgentOutcomeEvaluator.EnsureSuccessful(process.ExitCode, streamProcessor.Result);
 
             return responseBuilder.ToString();
         }

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeStreamProcessor.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeStreamProcessor.cs
@@ -25,6 +25,8 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
             this.responseBuilder = responseBuilder;
         }
 
+        public ResultStreamEvent? Result { get; private set; }
+
         public void ProcessLine(string json)
         {
             JsonDocument doc;
@@ -224,6 +226,8 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
 
         void HandleResultEvent(ResultStreamEvent evt)
         {
+            Result = evt;
+
             if (evt.Result != null && responseBuilder.Length == 0)
             {
                 responseBuilder.Append(evt.Result);


### PR DESCRIPTION
Per ADR-004, fail the step on any of: a non-zero CLI exit, a non-success terminal status (is_error or subtype != success), or a populated permission_denials list.

The processor now captures the final result event and a pure ClaudeAgentOutcomeEvaluator decides the outcome in the runner.

As part of testing this I discovered that in built tools appear to be allowed even if not called out in the allowed tools list but tackling that separately.

Resolves MD-2077
