### PR TITLE
Send transcript as service msg

### DIFF
--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeCliRunner.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeCliRunner.cs
@@ -60,14 +60,9 @@ public class ClaudeCodeCliRunner(ILog log)
 
         if (File.Exists(verboseLogPath))
         {
-            var fileInfo = new FileInfo(verboseLogPath);
-            var movedFilePath = Path.Combine(calamariDir, "log", fileInfo.Name);
-            fileInfo.MoveTo(movedFilePath);
-            log.NewOctopusArtifact(movedFilePath, "claude-agent-verbose.log", fileInfo.Length);
-            
             log.WriteServiceMessage(new ServiceMessage(ClaudeCodeServiceMessages.Transcript.Name, new Dictionary<string, string>()
             {
-                {ClaudeCodeServiceMessages.Transcript.TranscriptAttribute, await File.ReadAllTextAsync(movedFilePath, cancellationToken)},
+                {ClaudeCodeServiceMessages.Transcript.TranscriptAttribute, await File.ReadAllTextAsync(verboseLogPath, cancellationToken)},
             }));
         }
 

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeCliRunner.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeCliRunner.cs
@@ -7,6 +7,8 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.ServiceMessages;
+using Octopus.Calamari.Contracts.ClaudeCode;
 
 namespace Calamari.AiAgent.ClaudeCodeBehaviour;
 
@@ -62,6 +64,11 @@ public class ClaudeCodeCliRunner(ILog log)
             var movedFilePath = Path.Combine(calamariDir, "log", fileInfo.Name);
             fileInfo.MoveTo(movedFilePath);
             log.NewOctopusArtifact(movedFilePath, "claude-agent-verbose.log", fileInfo.Length);
+            
+            log.WriteServiceMessage(new ServiceMessage(ClaudeCodeServiceMessages.Transcript.Name, new Dictionary<string, string>()
+            {
+                {ClaudeCodeServiceMessages.Transcript.TranscriptAttribute, await File.ReadAllTextAsync(movedFilePath, cancellationToken)},
+            }));
         }
 
         ClaudeAgentOutcomeEvaluator.EnsureSuccessful(process.ExitCode, streamProcessor.Result);

--- a/source/Calamari.Contracts/ClaudeCode/ServiceMessages.cs
+++ b/source/Calamari.Contracts/ClaudeCode/ServiceMessages.cs
@@ -19,4 +19,14 @@ public static class ClaudeCodeServiceMessages
         public const string CacheCreationInputTokensAttribute = "cacheCreationInputTokens";
         public const string ModelAttribute = "model"; //TODO: @team-modern-deployments ensure we capture the model used
     }
+    
+    public static class Transcript
+    {
+        public const string Name = "claude-code-transcript";
+
+        /// <summary>
+        /// The attribute carrying the full session transcript content (raw JSONL/text).
+        /// </summary>
+        public const string TranscriptAttribute = "transcript";
+    }
 }


### PR DESCRIPTION
This PR sends the Claude transcript (stdout essentially) as a service message so Server can save it. We also stop sending it back as an artifact in case there's sensitive information

Related to: [MD-2089: Audit records are created with enough information to understand the step](https://linear.app/octopus/issue/MD-2089/audit-records-are-created-with-enough-information-to-understand-the)