### PR TITLE
Remove --bare from claude step

### DIFF
--- a/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeEnvironmentTests.cs
+++ b/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeEnvironmentTests.cs
@@ -52,11 +52,13 @@ public class ClaudeCodeEnvironmentTests
             ["ANTHROPIC_API_KEY"] = "leaked-from-worker",
         };
 
-        var env = ClaudeCodeEnvironment.Build(source, [], new Dictionary<string, string>
-        {
-            ["ANTHROPIC_API_KEY"] = "fresh",
-            ["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = "1",
-        });
+        var env = ClaudeCodeEnvironment.Build(source,
+            [],
+            new Dictionary<string, string>
+            {
+                ["ANTHROPIC_API_KEY"] = "fresh",
+                ["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = "1",
+            });
 
         env["ANTHROPIC_API_KEY"].Should().Be("fresh");
         env["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"].Should().Be("1");
@@ -70,28 +72,13 @@ public class ClaudeCodeEnvironmentTests
             ["PATH"] = "/usr/bin",
         };
 
-        var env = ClaudeCodeEnvironment.Build(source, [], new Dictionary<string, string>
-        {
-            ["PATH"] = "/controlled/path",
-        });
+        var env = ClaudeCodeEnvironment.Build(source,
+            [],
+            new Dictionary<string, string>
+            {
+                ["PATH"] = "/controlled/path",
+            });
 
         env["PATH"].Should().Be("/controlled/path");
-    }
-
-    [Test]
-    public void Build_PassesProxyVars_FromSource()
-    {
-        // HTTPS_PROXY must flow through so the child can reach api.anthropic.com behind a corporate proxy.
-        var source = new Dictionary<string, string>
-        {
-            ["HTTPS_PROXY"] = "http://proxy.corp.example:3128",
-            ["SECRET_TOKEN"] = "no",
-        };
-
-        var env = ClaudeCodeEnvironment.Build(source, [], new Dictionary<string, string>());
-
-        env.Should().ContainKey("HTTPS_PROXY");
-        env["HTTPS_PROXY"].Should().Be("http://proxy.corp.example:3128");
-        env.Should().NotContainKey("SECRET_TOKEN");
     }
 }

--- a/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCommandArgsBuilderFixture.cs
+++ b/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCommandArgsBuilderFixture.cs
@@ -21,7 +21,6 @@ public class ClaudeCommandArgsBuilderFixture
         args.Should().Contain("--verbose");
         args.Should().Contain("--permission-mode dontAsk");
         args.Should().Contain("--no-session-persistence");
-        args.Should().Contain("--bare");
         args.Should().Contain("--strict-mcp-config");
     }
 

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeEnvironment.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeEnvironment.cs
@@ -70,6 +70,19 @@ public static class ClaudeCodeEnvironment
         "NODE_EXTRA_CA_CERTS", "SSL_CERT_FILE", "SSL_CERT_DIR",
     ];
 
+    // Proxy configuration and custom CA trust.
+    static readonly string[] ClaudeCode =
+    [
+        "ANTHROPIC_BASE_URL",
+        "CLAUDE_CODE_CERT_STORE",
+        "CLAUDE_CODE_CLIENT_CERT",
+        "CLAUDE_CODE_CLIENT_KEY",
+        "CLAUDE_CODE_CLIENT_KEY_PASSPHRASE",
+        "API_TIMEOUT_MS",
+        "BASH_DEFAULT_TIMEOUT_MS",
+        "BASH_MAX_TIMEOUT_MS",
+    ];
+
     static readonly string[] DefaultAllowList =
     [
         .. ExecutableResolution,
@@ -81,5 +94,6 @@ public static class ClaudeCodeEnvironment
         .. WindowsSystemDirectories,
         .. MachineInfo,
         .. ProxyAndTls,
+        .. ClaudeCode,
     ];
 }

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeEnvironment.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeEnvironment.cs
@@ -55,8 +55,15 @@ public static class ClaudeCodeEnvironment
     // Windows system and application directories that many Windows programs require to start.
     static readonly string[] WindowsSystemDirectories =
     [
-        "SystemRoot", "windir", "SystemDrive", "APPDATA", "LOCALAPPDATA",
-        "ProgramData", "ProgramFiles", "ProgramFiles(x86)", "CommonProgramFiles",
+        "SystemRoot",
+        "windir",
+        "SystemDrive",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "ProgramData",
+        "ProgramFiles",
+        "ProgramFiles(x86)",
+        "CommonProgramFiles",
     ];
 
     // Machine and CPU information some tools read to size their work.
@@ -65,22 +72,16 @@ public static class ClaudeCodeEnvironment
     // Proxy configuration and custom CA trust.
     static readonly string[] ProxyAndTls =
     [
-        "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
-        "http_proxy", "https_proxy", "no_proxy",
-        "NODE_EXTRA_CA_CERTS", "SSL_CERT_FILE", "SSL_CERT_DIR",
-    ];
-
-    // Proxy configuration and custom CA trust.
-    static readonly string[] ClaudeCode =
-    [
         "ANTHROPIC_BASE_URL",
-        "CLAUDE_CODE_CERT_STORE",
-        "CLAUDE_CODE_CLIENT_CERT",
-        "CLAUDE_CODE_CLIENT_KEY",
-        "CLAUDE_CODE_CLIENT_KEY_PASSPHRASE",
-        "API_TIMEOUT_MS",
-        "BASH_DEFAULT_TIMEOUT_MS",
-        "BASH_MAX_TIMEOUT_MS",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "NODE_EXTRA_CA_CERTS",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
     ];
 
     static readonly string[] DefaultAllowList =
@@ -94,6 +95,5 @@ public static class ClaudeCodeEnvironment
         .. WindowsSystemDirectories,
         .. MachineInfo,
         .. ProxyAndTls,
-        .. ClaudeCode,
     ];
 }

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCommandArgsBuilder.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCommandArgsBuilder.cs
@@ -102,7 +102,6 @@ public class ClaudeCommandArgsBuilder
             args.Append(EscapeArg(model));
         }
 
-        args.Append(" --bare");
         args.Append(" --strict-mcp-config");
         args.Append(" --output-format stream-json");
         args.Append(" --verbose");

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/InvokeClaudeCodeBehaviour.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/InvokeClaudeCodeBehaviour.cs
@@ -106,6 +106,8 @@ public class InvokeClaudeCodeBehaviour : IDeployBehaviour
         argsBuilder.WithSystemPromptFile(new SystemPromptWriter().WriteSystemPromptFile(workingDir));
         argsBuilder.WithMcpConfigPath(mcpConfig);
 
+        var claudeConfigDir = Path.Combine(workingDir, ".claude");
+
         var environment = ClaudeCodeEnvironment.Build(
             ClaudeCodeEnvironment.GetCurrentEnvironmentVariables(),
             PassThroughEnvironmentVariables(variables),
@@ -113,6 +115,10 @@ public class InvokeClaudeCodeBehaviour : IDeployBehaviour
             {
                 ["ANTHROPIC_API_KEY"] = apiToken,
                 ["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = "1", // Strips Anthropic/cloud credentials from Bash, hook, and MCP subprocess environments
+                ["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1", // Disables the auto-updater, telemetry, error reporting, and feedback surveys
+                ["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] = "1",
+                ["CLAUDE_CODE_DISABLE_CRON"] = "1",
+                ["CLAUDE_CONFIG_DIR"] = claudeConfigDir,
             });
 
         var response = await new ClaudeCodeCliRunner(log).RunAsync(


### PR DESCRIPTION
As per [ADR-005](https://github.com/OctopusDeploy/adr/blob/main/team-modern-deployments/calamari-ai-agent/adr-005-do-not-use-bare-mode-yet.md) we do not want to use bare mode yet because it interacts with other options and we can't get the desired behaviour.

This might be revisited in the future if Claude code alters how --bare behaves.

Closes MD-2118