### PR TITLE
Make the git push retry count configurable

### DIFF
--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -367,6 +367,8 @@ namespace Calamari.Deployment
                 public const string CommitMessageSummary = "Octopus.Action.Git.CommitMessageSummary";
                 public const string CommitMessageDescription = "Octopus.Action.Git.CommitMessageDescription";
 
+                public const string PushRetryAttempts = "Octopus.Action.Git.PushRetryAttempts";
+
                 public static class PullRequest
                 {
                     public const string Create = "Octopus.Action.Git.PullRequest.Create";

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/DeploymentConfigFactoryTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/DeploymentConfigFactoryTests.cs
@@ -88,5 +88,33 @@ namespace Calamari.Tests.ArgoCD.Commands.Conventions
 
             action.Should().Throw<CommandException>();
         }
+
+        [TestCase(null, GitCommitParameters.DefaultPushRetryAttempts, TestName = "Unset uses the default")]
+        [TestCase("5", 5, TestName = "Explicit value is honoured")]
+        [TestCase("0", 0, TestName = "Minimum is honoured")]
+        [TestCase("10", 10, TestName = "Maximum is honoured")]
+        [TestCase("25", 10, TestName = "Above maximum is clamped down")]
+        [TestCase("-5", 0, TestName = "Below minimum is clamped up")]
+        public void Create_PushRetryAttempts_DefaultedAndClamped(string variableValue, int expected)
+        {
+            var nonSensitiveCalamariVariables = new NonSensitiveCalamariVariables()
+            {
+                [SpecialVariables.Git.InputPath] = "",
+                [SpecialVariables.Git.CommitMethod] = "DirectCommit",
+                [SpecialVariables.Git.CommitMessageSummary] = "Summary",
+            };
+            var allVariables = new CalamariVariables();
+            allVariables.Merge(nonSensitiveCalamariVariables);
+            if (variableValue != null)
+                allVariables[SpecialVariables.Git.PushRetryAttempts] = variableValue;
+
+            var runningDeployment = new RunningDeployment("./arbitraryFile.txt", allVariables);
+
+            var factory = new DeploymentConfigFactory(nonSensitiveCalamariVariables);
+
+            var config = factory.CreateCommitToGitConfig(runningDeployment);
+
+            config.CommitParameters.PushRetryAttempts.Should().Be(expected);
+        }
     }
 }

--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Calamari.ArgoCD.Conventions;
 using Calamari.ArgoCD.Git;
 using Calamari.ArgoCD.Git.PullRequests;
 using Calamari.Common.Commands;
@@ -88,6 +89,7 @@ namespace Calamari.Tests.ArgoCD.Git
                                          "Summary Message",
                                          "A file has changed",
                                          branchName,
+                                         GitCommitParameters.DefaultPushRetryAttempts,
                                          CancellationToken.None);
 
             //ensure the remote contains the file
@@ -106,11 +108,13 @@ namespace Calamari.Tests.ArgoCD.Git
                                          "Summary Message",
                                          "There is no data to comm it",
                                          GitBranchName.CreateFromFriendlyName("arbitraryBranch1"),
+                                         GitCommitParameters.DefaultPushRetryAttempts,
                                          CancellationToken.None);
             await repository.PushChanges(false,
                                          "Summary Message",
                                          "There is no data to comm it",
                                          GitBranchName.CreateFromFriendlyName("arbitraryBranch2"),
+                                         GitCommitParameters.DefaultPushRetryAttempts,
                                          CancellationToken.None);
         }
 
@@ -128,6 +132,7 @@ namespace Calamari.Tests.ArgoCD.Git
                                          commitSummary,
                                          commitDescription,
                                          prBranch,
+                                         GitCommitParameters.DefaultPushRetryAttempts,
                                          CancellationToken.None);
             await gitVendorPullRequestClient.Received(1)
                                                  .CreatePullRequest(
@@ -188,7 +193,7 @@ namespace Calamari.Tests.ArgoCD.Git
             bareOrigin.AddFilesToBranch(branchName, ("concurrentFile.txt", "concurrent content"));
 
             // Act: first push attempt will fail, retry should fetch+merge and succeed
-            await repository.PushChanges(false, "Our commit", "", branchName, CancellationToken.None);
+            await repository.PushChanges(false, "Our commit", "", branchName, GitCommitParameters.DefaultPushRetryAttempts, CancellationToken.None);
 
             // Assert: origin has our file
             bareOrigin.ReadFileFromBranch(branchName, filename).Should().Be(fileContents);
@@ -212,10 +217,31 @@ namespace Calamari.Tests.ArgoCD.Git
             bareOrigin.AddFilesToBranch(branchName, (conflictFile, "their content"));
 
             // Act & Assert: push fails, FetchAndMerge detects conflict and throws
-            Func<Task> act = () => repository.PushChanges(false, "Our commit", "", branchName, CancellationToken.None);
+            Func<Task> act = () => repository.PushChanges(false, "Our commit", "", branchName, GitCommitParameters.DefaultPushRetryAttempts, CancellationToken.None);
             await act.Should()
                      .ThrowAsync<CommandException>()
                      .WithMessage("*Rebase conflict*");
+        }
+
+        [Test]
+        public async Task WhenRetriesDisabled_PushFailsImmediatelyWithoutFetchAndRebase()
+        {
+            // Arrange: commit a file in our clone
+            const string filename = "ourFile.txt";
+            await File.WriteAllTextAsync(Path.Combine(RepositoryRootPath, filename), "our content");
+            repository.StageAllChanges();
+            repository.CommitChanges("Our commit", "").Should().BeTrue();
+
+            // Simulate a concurrent push to origin (causes non-fast-forward failure)
+            bareOrigin.AddFilesToBranch(branchName, ("concurrentFile.txt", "concurrent content"));
+
+            // Act & Assert: with retries disabled the first failure is final - no fetch/rebase is attempted
+            Func<Task> act = () => repository.PushChanges(false, "Our commit", "", branchName, maxRetryAttempts: 0, CancellationToken.None);
+            await act.Should().ThrowAsync<CommandException>();
+
+            log.MessagesVerboseFormatted
+               .Should()
+               .NotContain(m => m.Contains("fetching and rebasing before retrying"));
         }
 
         [Test]
@@ -234,6 +260,7 @@ namespace Calamari.Tests.ArgoCD.Git
                                          "Summary Message",
                                          "A file has changed",
                                          branchName,
+                                         GitCommitParameters.DefaultPushRetryAttempts,
                                          CancellationToken.None);
 
             //ensure the remote contains the file

--- a/source/Calamari.Tests/CommitToGit/CommitToGitConfigFactoryTests.cs
+++ b/source/Calamari.Tests/CommitToGit/CommitToGitConfigFactoryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Calamari.ArgoCD.Conventions;
 using Calamari.ArgoCD.Git;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Variables;
@@ -67,5 +68,24 @@ public class CommitToGitConfigFactoryTests
         var config = factory.CreateRepositoryConfig(deployment, loader);
 
         config.DestinationPath.Should().Be(string.Empty);
+    }
+
+    [TestCase(null, GitCommitParameters.DefaultPushRetryAttempts, TestName = "Unset uses the default")]
+    [TestCase(5, 5, TestName = "Explicit value is honoured")]
+    [TestCase(0, 0, TestName = "Minimum is honoured")]
+    [TestCase(10, 10, TestName = "Maximum is honoured")]
+    [TestCase(25, 10, TestName = "Above maximum is clamped down")]
+    [TestCase(-5, 0, TestName = "Below minimum is clamped up")]
+    public void CreateRepositoryConfig_PushRetryAttempts_DefaultedAndClamped(int? variableValue, int expected)
+    {
+        loader.Load<CommitToGitCustomPropertiesDto>()
+              .Returns(new CommitToGitCustomPropertiesDto(new UsernamePasswordGitCredentialDto("MyCred", "https://example.invalid/repo.git", "user", "pwd")));
+        variables.GetInt32(SpecialVariables.Action.Git.PushRetryAttempts).Returns(variableValue);
+
+        var deployment = new RunningDeployment(null, variables);
+
+        var config = factory.CreateRepositoryConfig(deployment, loader);
+
+        config.CommitParameters.PushRetryAttempts.Should().Be(expected);
     }
 }

--- a/source/Calamari/ArgoCD/Conventions/DeploymentConfigFactory.cs
+++ b/source/Calamari/ArgoCD/Conventions/DeploymentConfigFactory.cs
@@ -52,7 +52,8 @@ namespace Calamari.ArgoCD.Conventions
             // the variable is sensitive
             var summary = EvaluateNonsensitiveExpression(nonSensitiveVariables.GetMandatoryVariableRaw(SpecialVariables.Git.CommitMessageSummary));
             var description = EvaluateNonsensitiveExpression(nonSensitiveVariables.GetRaw(SpecialVariables.Git.CommitMessageDescription) ?? string.Empty);
-            return new GitCommitParameters(summary, description, requiresPullRequest);
+            var pushRetryAttempts = GitCommitParameters.ClampPushRetryAttempts(deployment.Variables.GetInt32(SpecialVariables.Git.PushRetryAttempts));
+            return new GitCommitParameters(summary, description, requiresPullRequest, pushRetryAttempts);
         }
         string EvaluateNonsensitiveExpression(string expression)
         {

--- a/source/Calamari/ArgoCD/Conventions/GitCommitParameters.cs
+++ b/source/Calamari/ArgoCD/Conventions/GitCommitParameters.cs
@@ -4,15 +4,27 @@ namespace Calamari.ArgoCD.Conventions
 {
     public class GitCommitParameters
     {
+        public const int DefaultPushRetryAttempts = 2;
+        public const int MinPushRetryAttempts = 0;
+        public const int MaxPushRetryAttempts = 10;
+
         public string Summary { get; }
         public string Description { get; }
         public bool RequiresPr { get; }
+        public int PushRetryAttempts { get; }
 
-        public GitCommitParameters(string summary, string description, bool requiresPr)
+        public GitCommitParameters(string summary, string description, bool requiresPr, int pushRetryAttempts = DefaultPushRetryAttempts)
         {
             Summary = summary;
             Description = description;
             RequiresPr = requiresPr;
+            PushRetryAttempts = pushRetryAttempts;
+        }
+
+        // Clamps a user-supplied (and possibly missing) retry count to the supported range, falling back to the default when unset.
+        public static int ClampPushRetryAttempts(int? value)
+        {
+            return Math.Clamp(value ?? DefaultPushRetryAttempts, MinPushRetryAttempts, MaxPushRetryAttempts);
         }
     }
 }

--- a/source/Calamari/ArgoCD/Git/RepositoryUpdater.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryUpdater.cs
@@ -37,6 +37,7 @@ public class RepositoryUpdater
                                       commitParameters.Summary,
                                       changeDescription,
                                       branchName,
+                                      commitParameters.PushRetryAttempts,
                                       CancellationToken.None)
                          .GetAwaiter()
                          .GetResult();

--- a/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
@@ -86,8 +86,8 @@ namespace Calamari.ArgoCD.Git
 
             log.Info($"Pushing changes to branch '{pushToBranchName.ToFriendlyName()}'");
 
-            // maxRetryAttempts is clamped to 0..10 by the caller. Polly rejects a retry strategy with MaxRetryAttempts < 1.
-            var retryPipeline = maxRetryAttempts == 0
+            // Polly rejects a retry strategy with MaxRetryAttempts < 1
+            var retryPipeline = maxRetryAttempts <= 0
                 ? ResiliencePipeline.Empty
                 : new ResiliencePipelineBuilder()
                   .AddRetry(new RetryStrategyOptions

--- a/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
@@ -78,6 +78,7 @@ namespace Calamari.ArgoCD.Git
                                                   string summary,
                                                   string description,
                                                   GitReference branchName,
+                                                  int maxRetryAttempts,
                                                   CancellationToken cancellationToken)
         {
             var currentBranchName = repository.GetBranchName(branchName);
@@ -85,21 +86,24 @@ namespace Calamari.ArgoCD.Git
 
             log.Info($"Pushing changes to branch '{pushToBranchName.ToFriendlyName()}'");
 
-            var retryPipeline = new ResiliencePipelineBuilder()
-                                .AddRetry(new RetryStrategyOptions
-                                {
-                                    ShouldHandle = new PredicateBuilder().Handle<CommandException>().Handle<NonFastForwardException>(),
-                                    MaxRetryAttempts = 2,
-                                    UseJitter =  true,
-                                    Delay = TimeSpan.FromSeconds(2),
-                                    OnRetry = args =>
-                                    {
-                                        log.Verbose($"Push to '{pushToBranchName.ToFriendlyName()}' failed (attempt {args.AttemptNumber + 1}), fetching and rebasing before retrying");
-                                        FetchAndRebase(currentBranchName);
-                                        return default;
-                                    }
-                                })
-                                .Build();
+            // maxRetryAttempts is clamped to 0..10 by the caller. Polly rejects a retry strategy with MaxRetryAttempts < 1.
+            var retryPipeline = maxRetryAttempts == 0
+                ? ResiliencePipeline.Empty
+                : new ResiliencePipelineBuilder()
+                  .AddRetry(new RetryStrategyOptions
+                  {
+                      ShouldHandle = new PredicateBuilder().Handle<CommandException>().Handle<NonFastForwardException>(),
+                      MaxRetryAttempts = maxRetryAttempts,
+                      UseJitter =  true,
+                      Delay = TimeSpan.FromSeconds(2),
+                      OnRetry = args =>
+                      {
+                          log.Verbose($"Push to '{pushToBranchName.ToFriendlyName()}' failed (attempt {args.AttemptNumber + 1}), fetching and rebasing before retrying");
+                          FetchAndRebase(currentBranchName);
+                          return default;
+                      }
+                  })
+                  .Build();
 
             try
             {

--- a/source/Calamari/CommitToGit/CommitToGitConfigFactory.cs
+++ b/source/Calamari/CommitToGit/CommitToGitConfigFactory.cs
@@ -33,7 +33,8 @@ namespace Calamari.CommitToGit
             var requiresPullRequest = variables.GetFlag(SpecialVariables.Action.Git.PullRequest.Create);
             var summary = EvaluateNonsensitiveExpression(nonSensitiveVariables.GetMandatoryVariableRaw(SpecialVariables.Action.Git.CommitMessageSummary));
             var description = EvaluateNonsensitiveExpression(nonSensitiveVariables.GetRaw(SpecialVariables.Action.Git.CommitMessageDescription) ?? string.Empty);
-            var commitParameters = new GitCommitParameters(summary, description, requiresPullRequest);
+            var pushRetryAttempts = GitCommitParameters.ClampPushRetryAttempts(variables.GetInt32(SpecialVariables.Action.Git.PushRetryAttempts));
+            var commitParameters = new GitCommitParameters(summary, description, requiresPullRequest, pushRetryAttempts);
 
             var properties = customPropertiesLoader.Load<CommitToGitCustomPropertiesDto>();
 

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -80,6 +80,8 @@ namespace Calamari.Kubernetes
 
             public static readonly string PurgeOutput = "Octopus.Action.ArgoCD.PurgeOutputFolder";
 
+            public static readonly string PushRetryAttempts = "Octopus.Action.ArgoCD.PushRetryAttempts";
+
             public static class PullRequest
             {
                 public static readonly string Create = "Octopus.Action.ArgoCD.PullRequest.Create";


### PR DESCRIPTION
The git push retry count (previously hard-coded to 2) is now read from a deployment variable, clamped to 0–10 and still defaulting to 2:

- `Octopus.Action.Git.PushRetryAttempts` — Commit to Git step
- `Octopus.Action.ArgoCD.PushRetryAttempts` — Update Argo CD Application Image Tags / Manifests steps

All three flow through the single `RepositoryWrapper.PushChanges` retry pipeline. This lets projects sharing a mono-repo raise the retry budget when concurrent deployments contend on the same branch. A value of `0` performs a single push with no retry.

Pairs with the server PR that adds the variable definitions, validation and the step UI field: OctopusDeploy/OctopusDeploy#44571
