### PR TITLE
Add rider auto-attach for Calamari

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Option 1 is recommended if you can use the default worker.
 
 ### Bonus Project Variables!
 - Set `Octopus.Calamari.WaitForDebugger` to `True` in Octopus, to get a debug version of Calamari to wait for a Debugger to be attached before continuing. The log message from Calamari will show it’s waiting for the debugger and it will give the PID to use when you’re looking to attach.
+  - Set it to `Rider` instead of `True` to have Calamari automatically signal a locally-running JetBrains Rider to attach to the process (via `rider attach-to-process`), then wait as usual. This only works when Calamari runs on the same machine as your Rider (i.e. the local-debug loop using the `Octopus.Calamari.Executable` override above).
 - Set `OctopusPrintEvaluatedVariables` to `True` to get all variables that are sent to Calamari, printed to the verbose long when executing a step.
 
 > Note: These can be scoped to an individual step if required.
@@ -99,7 +100,7 @@ Option 1 is recommended if you can use the default worker.
 > Tip: Creating a variable set with your configuration makes it easy to toggle this behaviour per project
 
 ### Bonus Environment Varable
-- Set the environment variable `_CALAMARI_WAIT_FOR_DEBUGGER` to `true` in Server to enable the WaitForDebugger behaviour above outside the scope of a Project. E.g. HealthChecks etc. 
+- Set the environment variable `_CALAMARI_WAIT_FOR_DEBUGGER` to `true` in Server to enable the WaitForDebugger behaviour above outside the scope of a Project. E.g. HealthChecks etc. Set it to `Rider` to enable the auto-attach behaviour described above.
 
 ## Testing:
 

--- a/source/Calamari.Common/CalamariFlavourProgram.cs
+++ b/source/Calamari.Common/CalamariFlavourProgram.cs
@@ -60,10 +60,14 @@ public abstract class CalamariFlavourProgram(ILog log)
             using var container = builder.Build();
             container.Resolve<VariableLogger>().LogVariables();
 #if DEBUG
-            if (CalamariEnvironment.ShouldWaitForDebugger(container.Resolve<IVariables>()))
+            var debuggerWaitMode = CalamariEnvironment.GetDebuggerWaitMode(container.Resolve<IVariables>());
+            if (debuggerWaitMode != DebuggerWaitMode.None)
             {
                 using var proc = Process.GetCurrentProcess();
                 log.Info($"Waiting for debugger to attach... (PID: {proc.Id})");
+
+                if (debuggerWaitMode == DebuggerWaitMode.AttachRider)
+                    RiderDebuggerAttacher.TryAttach(proc.Id, log);
 
                 while (!Debugger.IsAttached)
                 {

--- a/source/Calamari.Common/CalamariFlavourProgramAsync.cs
+++ b/source/Calamari.Common/CalamariFlavourProgramAsync.cs
@@ -118,10 +118,14 @@ public abstract class CalamariFlavourProgramAsync(ILog log)
             using var container = builder.Build();
             container.Resolve<VariableLogger>().LogVariables();
 #if DEBUG
-            if (CalamariEnvironment.ShouldWaitForDebugger(container.Resolve<IVariables>()))
+            var debuggerWaitMode = CalamariEnvironment.GetDebuggerWaitMode(container.Resolve<IVariables>());
+            if (debuggerWaitMode != DebuggerWaitMode.None)
             {
                 using var proc = Process.GetCurrentProcess();
                 Log.Info($"Waiting for debugger to attach... (PID: {proc.Id})");
+
+                if (debuggerWaitMode == DebuggerWaitMode.AttachRider)
+                    RiderDebuggerAttacher.TryAttach(proc.Id, ConsoleLog.Instance);
 
                 while (!Debugger.IsAttached)
                 {

--- a/source/Calamari.Common/Plumbing/CalamariEnvironment.cs
+++ b/source/Calamari.Common/Plumbing/CalamariEnvironment.cs
@@ -5,6 +5,13 @@ using Calamari.Common.Plumbing.Variables;
 
 namespace Calamari.Common.Plumbing
 {
+    public enum DebuggerWaitMode
+    {
+        None,
+        Wait,
+        AttachRider
+    }
+
     public static class CalamariEnvironment
     {
         public static bool IsRunningOnKubernetes =>
@@ -22,16 +29,19 @@ namespace Calamari.Common.Plumbing
             Environment.OSVersion.Platform == PlatformID.Win32Windows ||
             Environment.OSVersion.Platform == PlatformID.WinCE;
 
-        public static bool ShouldWaitForDebugger(IVariables variables)
+        public static DebuggerWaitMode GetDebuggerWaitMode(IVariables variables)
         {
 #if DEBUG
+            var fromVariable = variables.Get(KnownVariables.Calamari.WaitForDebugger);
+            var fromEnvironment = Environment.GetEnvironmentVariable("_CALAMARI_WAIT_FOR_DEBUGGER");
 
-            var waitForDebugger = variables.Get(KnownVariables.Calamari.WaitForDebugger);
-            var waitForDebuggerInEnv = Environment.GetEnvironmentVariable("_CALAMARI_WAIT_FOR_DEBUGGER");
-            
-            return string.Equals(waitForDebugger, "true", StringComparison.OrdinalIgnoreCase) || string.Equals(waitForDebuggerInEnv, "true", StringComparison.OrdinalIgnoreCase);
+            if (string.Equals(fromVariable, "rider", StringComparison.OrdinalIgnoreCase) || string.Equals(fromEnvironment, "rider", StringComparison.OrdinalIgnoreCase))
+                return DebuggerWaitMode.AttachRider;
+
+            if (string.Equals(fromVariable, "true", StringComparison.OrdinalIgnoreCase) || string.Equals(fromEnvironment, "true", StringComparison.OrdinalIgnoreCase))
+                return DebuggerWaitMode.Wait;
 #endif
-            return false;
+            return DebuggerWaitMode.None;
         }
 
         public static bool IsRunningOnMac

--- a/source/Calamari.Common/Plumbing/RiderDebuggerAttacher.cs
+++ b/source/Calamari.Common/Plumbing/RiderDebuggerAttacher.cs
@@ -1,0 +1,59 @@
+#if DEBUG
+using System;
+using System.IO;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.Logging;
+
+namespace Calamari.Common.Plumbing
+{
+    public static class RiderDebuggerAttacher
+    {
+        public static bool TryAttach(int pid, ILog log)
+        {
+            try
+            {
+                var launcher = Environment.GetEnvironmentVariable("_CALAMARI_RIDER_PATH");
+                if (string.IsNullOrWhiteSpace(launcher))
+                    launcher = "rider";
+
+                var solution = FindCalamariSolution();
+                var arguments = solution == null
+                    ? $"attach-to-process {pid}"
+                    : $"attach-to-process {pid} \"{solution}\"";
+
+                log.Info($"Asking Rider to attach to the debugger: {launcher} {arguments}");
+
+                var result = SilentProcessRunner.ExecuteCommand(launcher, arguments, Environment.CurrentDirectory, log.Verbose, log.Verbose);
+                if (result.ExitCode != 0)
+                {
+                    log.Warn($"Rider exited with code {result.ExitCode} when asked to attach. Attach to PID {pid} manually.");
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                log.Warn($"Failed to ask Rider to attach the debugger: {ex.Message}. Attach to PID {pid} manually, or set _CALAMARI_RIDER_PATH to the Rider launcher.");
+                return false;
+            }
+        }
+
+        static string? FindCalamariSolution()
+        {
+            var overrideSolution = Environment.GetEnvironmentVariable("_CALAMARI_RIDER_SOLUTION");
+            if (!string.IsNullOrWhiteSpace(overrideSolution))
+                return overrideSolution;
+
+            for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory != null; directory = directory.Parent)
+            {
+                var solution = Path.Combine(directory.FullName, "Calamari.sln");
+                if (File.Exists(solution))
+                    return solution;
+            }
+
+            return null;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
This PR adds a small quality of life update to automatically attach Rider to a calamari PID when launched by Octopus. 