### PR TITLE
Change to throw CommandException when throwing on substitution failure

### DIFF
--- a/source/Calamari.Common/Features/Substitutions/FileSubstituter.cs
+++ b/source/Calamari.Common/Features/Substitutions/FileSubstituter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -22,7 +23,7 @@ namespace Calamari.Common.Features.Substitutions
         public void PerformSubstitution(string sourceFile)
             => PerformSubstitution(sourceFile, sourceFile);
 
-        public void PerformSubstitution(string sourceFile, string targetFile) 
+        public void PerformSubstitution(string sourceFile, string targetFile)
             => PerformSubstitutionAndUpdateFile(sourceFile, targetFile, variables.GetFlag(KnownVariables.ShouldFailDeploymentOnSubstitutionFails));
 
         protected virtual void PerformSubstitutionAndUpdateFile(string sourceFile, string targetFile, bool throwOnError, bool throwPlainOctostacheError = false)
@@ -36,15 +37,14 @@ namespace Calamari.Common.Features.Substitutions
 
             if (!string.IsNullOrEmpty(error))
             {
+                var errorMessage = $"Parsing file '{sourceFile}' with Octostache returned the following error: `{error}`";
                 if (throwOnError)
                 {
-                    var message = !throwPlainOctostacheError
-                        ? $"Parsing file '{sourceFile}' with Octostache returned the following error: `{error}`"
-                        : error;
-                    throw new InvalidOperationException(message);
+                    var message = throwPlainOctostacheError ? error : errorMessage;
+                    throw new CommandException(message);
                 }
 
-                log.VerboseFormat("Parsing file '{0}' with Octostache returned the following error: `{1}`", sourceFile, error);
+                log.Verbose(errorMessage);
             }
 
             fileSystem.OverwriteFile(targetFile, result, encoding);

--- a/source/Calamari.Common/Features/Substitutions/NonSensitiveFileSubstituter.cs
+++ b/source/Calamari.Common/Features/Substitutions/NonSensitiveFileSubstituter.cs
@@ -20,7 +20,7 @@ namespace Calamari.Common.Features.Substitutions
                 //We always want to throw when substitution fails
                 base.PerformSubstitutionAndUpdateFile(sourceFile, targetFile, true, true);
             }
-            catch (InvalidOperationException e)
+            catch (CommandException e)
             {
                 throw new CommandException($"{e.Message}. This may be due to missing or sensitive variables.");
             }


### PR DESCRIPTION
When the `ShouldFailDeploymentOnSubstitutionFails` variable is enabled, we should not throw an exception that prints the entire stacktrace