### PR TITLE
Upgrade static Kubernetes clusters to 1.34

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/StaticClusters/AKS/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/StaticClusters/AKS/aks.tf
@@ -8,7 +8,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   resource_group_name = azurerm_resource_group.default.name
   location            = "Australia East"
   dns_prefix          = "${var.static_resource_prefix}-k8s"
-  kubernetes_version  = "1.32"
+  kubernetes_version  = "1.34"
 
   tags = {
     octopus-project                = "aks-static"

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/StaticClusters/AKS/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/StaticClusters/AKS/aks.tf
@@ -38,7 +38,7 @@ resource "azurerm_kubernetes_cluster" "local_access_disabled" {
   resource_group_name = azurerm_resource_group.default.name
   location            = "Australia East"
   dns_prefix          = "${var.static_resource_prefix}-k8s-no-local"
-  kubernetes_version  = "1.32"
+  kubernetes_version  = "1.34"
 
   tags = {
     octopus-project                = "aks-static-no-local"

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/StaticClusters/EKS/eks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/StaticClusters/EKS/eks.tf
@@ -74,7 +74,7 @@ resource "aws_eks_node_group" "default" {
 resource "aws_eks_cluster" "default" {
   name     = "${var.static_resource_prefix}-eks"
   role_arn = aws_iam_role.cluster.arn
-  version  = "1.32"
+  version  = "1.34"
 
   tags = {
     octopus-environment = "Staging"

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/StaticClusters/GKE/gke.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/StaticClusters/GKE/gke.tf
@@ -5,7 +5,7 @@ data "google_container_engine_versions" "main" {
 
   # Since this is just a string match, it's recommended that you append a . after minor versions 
   # to ensure that prefixes such as 1.1 don't match versions like 1.12.5-gke.10 accidentally.
-  version_prefix = "1.32."
+  version_prefix = "1.34."
 }
 
 # VPC


### PR DESCRIPTION
These were running _very_ old versions that are no longer in support