### PR TITLE
Commit To Git Step: Skip committing when transformation script fails

### DIFF
--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -570,6 +570,24 @@ public class CommitToGitCommandTest
             .Should().NotBe(0, "the command must reject runs whose --customPropertiesFile path does not exist");
     }
 
+    [Test]
+    public void CommitToGit_SkipsCommitting_WhenTransformationScript_ReturnsNonZeroExitCode()
+    {
+        const string packageReferenceName = "my-configs";
+        const string destinationPath = "output-dir";
+
+        var zipPath = CreateZipWithEntry(packageReferenceName, "configs/settings.json", "{\"setting\": \"value\"}");
+        AddInputPackageVariables(packageReferenceName, zipPath, destinationPath);
+        variables.AddRange([
+            new CalamariExecutionVariable(ScriptVariables.ScriptBody, "exit 1", false),
+            new CalamariExecutionVariable(ScriptVariables.Syntax, ScriptSyntax.Bash.ToString(), false),
+        ]);
+
+        RunCommitToGit().Should().NotBe(0);
+        GetCommittedFileContent($"{destinationPath}/configs/settings.json")
+            .Should().BeNull("the package files should not have been committed into the repository under the destination path, when the transformation script returns non-zero exit code");
+    }
+
     // --- Helpers ---
 
     int RunCommitToGit(params string[] extraArgs)

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -275,7 +275,6 @@ public class CommitToGitCommand : Command
                                                   log.SetOutputVariable(SpecialVariables.Action.Script.ExitCode, "0", d.Variables);
                                                   return;
                                               }
-
                                               new ExecuteScriptConvention(scriptEngine, commandLineRunner, log).Install(d);
                                           })
         ];

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -275,6 +275,7 @@ public class CommitToGitCommand : Command
                                                   log.SetOutputVariable(SpecialVariables.Action.Script.ExitCode, "0", d.Variables);
                                                   return;
                                               }
+
                                               new ExecuteScriptConvention(scriptEngine, commandLineRunner, log).Install(d);
                                           })
         ];
@@ -286,6 +287,13 @@ public class CommitToGitCommand : Command
         {
             new DelegateInstallConvention(d =>
                                           {
+                                              var exitCode = d.Variables.GetInt32(SpecialVariables.Action.Script.ExitCode) ?? 0;
+                                              if (exitCode != 0)
+                                              {
+                                                  log.Error($"Transformation script exited with code {exitCode}. Skipping commit to Git.");
+                                                  return;
+                                              }
+
                                               var commitParams = repositoryConfig!.CommitParameters;
                                               var updater = new RepositoryUpdater(commitParams, log, new UserDefinedCommitMessageGenerator(commitParams.Description));
                                               

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -289,8 +289,7 @@ public class CommitToGitCommand : Command
                                               var exitCode = d.Variables.GetInt32(SpecialVariables.Action.Script.ExitCode) ?? 0;
                                               if (exitCode != 0)
                                               {
-                                                  log.Error($"Transformation script exited with code {exitCode}. Skipping commit to Git.");
-                                                  return;
+                                                  throw new CommandException($"Transformation script exited with code {exitCode}. Changes will not be committed.");
                                               }
 
                                               var commitParams = repositoryConfig!.CommitParameters;


### PR DESCRIPTION
The commit to git step currently will commit any changes made regardless of the success of the transformation script, so a script could partially succeed and make some file changes, those changes will be committed even though the deployment has failed. 

This change makes it so that the convention to commit files is skipped if the script exit code != 0, so a deployment failing due to the transformation script won't leave behind artifacts(commits, pull requests etc)

Tested locally against latest version of main
<img width="2162" height="884" alt="Screenshot 2026-06-30 at 2 08 05 pm" src="https://github.com/user-attachments/assets/fed24658-7fc2-4977-baf7-eefdf8d2036a" />
