### PR TITLE
Update static AKS instance to 1.35

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/StaticClusters/AKS/aks.tf
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/StaticClusters/AKS/aks.tf
@@ -8,7 +8,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   resource_group_name = azurerm_resource_group.default.name
   location            = "Australia East"
   dns_prefix          = "${var.static_resource_prefix}-k8s"
-  kubernetes_version  = "1.34"
+  kubernetes_version  = "1.35"
 
   tags = {
     octopus-project                = "aks-static"


### PR DESCRIPTION
I accidentally set auto-upgrades on this in the Azure Portal, so it auto-upgraded to 1.35 🤦 