### PR TITLE
Update versioning version to support image digests

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Octopus.Globfish" Version="1.0.8" />
         <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
         <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
-        <PackageReference Include="Octopus.Versioning" Version="5.1.883" />
+        <PackageReference Include="Octopus.Versioning" Version="5.1.884-grace-support-image-digests" />
         <PackageReference Include="Octopus.TinyTypes" Version="2.2.1156" />
         <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
         <PackageReference Include="Octostache" Version="3.9.2" />

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Octopus.Globfish" Version="1.0.8" />
         <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
         <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
-        <PackageReference Include="Octopus.Versioning" Version="5.1.885-grace-support-image-digests" />
+        <PackageReference Include="Octopus.Versioning" Version="5.1.884" />
         <PackageReference Include="Octopus.TinyTypes" Version="2.2.1156" />
         <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
         <PackageReference Include="Octostache" Version="3.9.2" />

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Octopus.Globfish" Version="1.0.8" />
         <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
         <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
-        <PackageReference Include="Octopus.Versioning" Version="5.1.884-grace-support-image-digests" />
+        <PackageReference Include="Octopus.Versioning" Version="5.1.885-grace-support-image-digests" />
         <PackageReference Include="Octopus.TinyTypes" Version="2.2.1156" />
         <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
         <PackageReference Include="Octostache" Version="3.9.2" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.10.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="Octopus.Octodiff" Version="2.0.547" />
-    <PackageReference Include="Octopus.Versioning" Version="5.1.884-grace-support-image-digests" />
+    <PackageReference Include="Octopus.Versioning" Version="5.1.885-grace-support-image-digests" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="Octostache" Version="3.9.2" />
     <PackageReference Include="SharpCompress" Version="0.37.2">

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.10.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="Octopus.Octodiff" Version="2.0.547" />
-    <PackageReference Include="Octopus.Versioning" Version="5.1.883" />
+    <PackageReference Include="Octopus.Versioning" Version="5.1.884-grace-support-image-digests" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="Octostache" Version="3.9.2" />
     <PackageReference Include="SharpCompress" Version="0.37.2">

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.10.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="Octopus.Octodiff" Version="2.0.547" />
-    <PackageReference Include="Octopus.Versioning" Version="5.1.885-grace-support-image-digests" />
+    <PackageReference Include="Octopus.Versioning" Version="5.1.884" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="Octostache" Version="3.9.2" />
     <PackageReference Include="SharpCompress" Version="0.37.2">

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="NGitLab" Version="10.4.1" />
-    <PackageReference Include="Octopus.Versioning" Version="5.1.883" />
+    <PackageReference Include="Octopus.Versioning" Version="5.1.884-grace-support-image-digests" />
     <PackageReference Include="Octopus.TinyTypes" Version="2.2.1156" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="SharpCompress" Version="0.37.2">

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="NGitLab" Version="10.4.1" />
-    <PackageReference Include="Octopus.Versioning" Version="5.1.885-grace-support-image-digests" />
+    <PackageReference Include="Octopus.Versioning" Version="5.1.884" />
     <PackageReference Include="Octopus.TinyTypes" Version="2.2.1156" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="SharpCompress" Version="0.37.2">

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="NGitLab" Version="10.4.1" />
-    <PackageReference Include="Octopus.Versioning" Version="5.1.884-grace-support-image-digests" />
+    <PackageReference Include="Octopus.Versioning" Version="5.1.885-grace-support-image-digests" />
     <PackageReference Include="Octopus.TinyTypes" Version="2.2.1156" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="SharpCompress" Version="0.37.2">


### PR DESCRIPTION
# Background

Calamari depends on `Octopus.Versioning` for version parsing. 
The package reference needs bumping to pick up the new DockerTag Digest support.

# Results

Bumps  `Octopus.Versioning` to version with changes from https://github.com/OctopusDeploy/Versioning/pull/94 - `5.1.884`

Fixes HPY-1502
