### PR TITLE
Fix: resolve $ref value files for Helm-typed Argo CD ref sources

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
@@ -1359,6 +1359,95 @@ service:
         }
 
         [Test]
+        public void RefSourceTypedAsHelm_StillResolvesRefAndUpdatesReferencedFile()
+        {
+            // FD-530: when a ref source's `path` contains a Chart.yaml, ArgoCD reports its
+            // SourceType as Helm rather than Directory. The $ref-referenced values file must
+            // still be updated - it must not be skipped just because the ref source is Helm-typed.
+            var updater = CreateConvention();
+            var variables = new CalamariVariables
+            {
+                [PackageVariables.IndexedImage("nginx")] = "index.docker.io/nginx:1.27.1",
+                [PackageVariables.IndexedPackagePurpose("nginx")] = "DockerImageReference",
+                [ProjectVariables.Slug] = ProjectSlug,
+                [DeploymentEnvironment.Slug] = EnvironmentSlug,
+            };
+            var runningDeployment = new RunningDeployment(null, variables);
+            runningDeployment.CurrentDirectoryProvider = DeploymentWorkingDirectory.StagingDirectory;
+            runningDeployment.StagingDirectory = tempDirectory;
+
+            var existingYamlFile = Path.Combine("otherRepoPath", "values.yaml");
+            var filesInRepo = new (string, string)[]
+            {
+                (
+                    existingYamlFile,
+                    @"
+image:
+  repository: index.docker.io/nginx
+  tag: ""1.0""
+containerPort: 8080
+service:
+  type: LoadBalancer
+"
+                )
+            };
+            originRepo.AddFilesToBranch(argoCDBranchName, filesInRepo);
+
+            var argoCDAppWithHelmSource = new ArgoCDApplicationBuilder()
+                                          .WithName("App1").WithNamespace("argocd")
+                                          .WithAnnotations(new Dictionary<string, string>()
+                                          {
+                                              [ArgoCDConstants.Annotations.OctopusProjectAnnotationKey(new ApplicationSourceName("ref-source"))] = ProjectSlug,
+                                              [ArgoCDConstants.Annotations.OctopusEnvironmentAnnotationKey(new ApplicationSourceName("ref-source"))] = EnvironmentSlug,
+                                              [ArgoCDConstants.Annotations.OctopusImageReplacementPathsKey(new ApplicationSourceName("helm-source"))] = "{{ .Values.image.repository }}:{{ .Values.image.tag }}",
+                                          })
+                                          .WithSource(new ApplicationSource
+                                              {
+                                                  OriginalRepoUrl = "https://github.com/org/repo",
+                                                  Path = "",
+                                                  TargetRevision = ArgoCDBranchFriendlyName,
+                                                  Helm = new HelmConfig
+                                                  {
+                                                      ValueFiles = new List<string>()
+                                                      {
+                                                          "$values/otherRepoPath/values.yaml"
+                                                      }
+                                                  },
+                                                  Name = "helm-source",
+                                              },
+                                              SourceTypeConstants.Helm)
+                                          .WithSource(new ApplicationSource
+                                              {
+                                                  Name = "ref-source",
+                                                  Ref = "values",
+                                                  Path = "chart",
+                                                  TargetRevision = ArgoCDBranchFriendlyName,
+                                                  OriginalRepoUrl = OriginUrl,
+                                              },
+                                              SourceTypeConstants.Helm)
+                                          .Build();
+
+            argoCdApplicationManifestParser.ParseManifest(Arg.Any<string>())
+                                           .Returns(argoCDAppWithHelmSource);
+
+            // Act
+            updater.Install(runningDeployment);
+
+            // Assert - the $values-referenced file is updated even though the ref source is Helm-typed
+            const string updatedYamlContent =
+                @"
+image:
+  repository: index.docker.io/nginx
+  tag: ""1.27.1""
+containerPort: 8080
+service:
+  type: LoadBalancer
+";
+            var clonedRepoPath = RepositoryHelpers.CloneOrigin(tempDirectory, OriginPath, argoCDBranchName);
+            AssertFileContents(clonedRepoPath, existingYamlFile, updatedYamlContent);
+        }
+
+        [Test]
         public void DirectorySource_ImageMatches_ReportsDeploymentWithNonEmptyCommitSha()
         {
             var valuesFilename = Path.Combine("files", "values.yml");

--- a/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
+++ b/source/Calamari.Tests/ArgoCD/Commands/Conventions/UpdateArgoCDAppImagesInstallConventionHelmTests.cs
@@ -1430,6 +1430,9 @@ service:
             argoCdApplicationManifestParser.ParseManifest(Arg.Any<string>())
                                            .Returns(argoCDAppWithHelmSource);
 
+            IReadOnlyList<ProcessApplicationResult> capturedResults = null;
+            deploymentReporter.ReportFilesUpdated(Arg.Any<GitCommitParameters>(), Arg.Do<IReadOnlyList<ProcessApplicationResult>>(x => capturedResults = x));
+
             // Act
             updater.Install(runningDeployment);
 
@@ -1444,7 +1447,82 @@ service:
   type: LoadBalancer
 ";
             var clonedRepoPath = RepositoryHelpers.CloneOrigin(tempDirectory, OriginPath, argoCDBranchName);
+
+            AssertOutputVariables(matchingApplicationTotalSourceCounts: "2");
+
+            using (new AssertionScope())
+            {
+                capturedResults.Should().NotBeNull();
+                var sourceDetails = capturedResults.Single().TrackedSourceDetails.First();
+                var expectedPatch = new JsonPatchDocument([
+                    JsonPatchOperation.Replace(new JsonPointer("/0/image/tag"), "1.27.1"),
+                ]);
+                sourceDetails.PatchedFiles.Should()
+                             .BeEquivalentTo([
+                                 new FileJsonPatch("./otherRepoPath/values.yaml", JsonSerializer.Serialize(expectedPatch)),
+                             ]);
+            }
+
             AssertFileContents(clonedRepoPath, existingYamlFile, updatedYamlContent);
+        }
+
+        [Test]
+        public void RefSourceReferencedByNoValueFile_WarnsNothingWasReferenced()
+        {
+            // FD-530 follow-up: if an in-scope ref source is processed but no value file in the
+            // application references it, warn instead of silently reporting "Nothing to update".
+            var updater = CreateConvention();
+            var variables = new CalamariVariables
+            {
+                [PackageVariables.IndexedImage("nginx")] = "index.docker.io/nginx:1.27.1",
+                [PackageVariables.IndexedPackagePurpose("nginx")] = "DockerImageReference",
+                [ProjectVariables.Slug] = ProjectSlug,
+                [DeploymentEnvironment.Slug] = EnvironmentSlug,
+            };
+            var runningDeployment = new RunningDeployment(null, variables);
+            runningDeployment.CurrentDirectoryProvider = DeploymentWorkingDirectory.StagingDirectory;
+            runningDeployment.StagingDirectory = tempDirectory;
+
+            originRepo.AddFilesToBranch(argoCDBranchName, ("otherRepoPath/values.yaml", @"
+image:
+  repository: index.docker.io/nginx
+  tag: ""1.0""
+"));
+
+            var argoCDApp = new ArgoCDApplicationBuilder()
+                            .WithName("App1").WithNamespace("argocd")
+                            .WithAnnotations(new Dictionary<string, string>()
+                            {
+                                [ArgoCDConstants.Annotations.OctopusProjectAnnotationKey(new ApplicationSourceName("ref-source"))] = ProjectSlug,
+                                [ArgoCDConstants.Annotations.OctopusEnvironmentAnnotationKey(new ApplicationSourceName("ref-source"))] = EnvironmentSlug,
+                                [ArgoCDConstants.Annotations.OctopusImageReplacementPathsKey(new ApplicationSourceName("helm-source"))] = "{{ .Values.image.repository }}:{{ .Values.image.tag }}",
+                            })
+                            .WithSource(new ApplicationSource
+                                {
+                                    OriginalRepoUrl = "https://github.com/org/repo",
+                                    Path = "",
+                                    TargetRevision = ArgoCDBranchFriendlyName,
+                                    Helm = new HelmConfig { ValueFiles = new List<string>() },
+                                    Name = "helm-source",
+                                },
+                                SourceTypeConstants.Helm)
+                            .WithSource(new ApplicationSource
+                                {
+                                    Name = "ref-source",
+                                    Ref = "values",
+                                    TargetRevision = ArgoCDBranchFriendlyName,
+                                    OriginalRepoUrl = OriginUrl,
+                                },
+                                SourceTypeConstants.Directory)
+                            .Build();
+
+            argoCdApplicationManifestParser.ParseManifest(Arg.Any<string>()).Returns(argoCDApp);
+
+            // Act
+            updater.Install(runningDeployment);
+
+            // Assert
+            log.MessagesWarnFormatted.Should().Contain(w => w.Contains("ref-source") && w.Contains("no value files") && w.Contains("referenced it"));
         }
 
         [Test]

--- a/source/Calamari/ArgoCD/Conventions/UpdateImageTag/ApplicationSourceUpdater.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateImageTag/ApplicationSourceUpdater.cs
@@ -69,23 +69,21 @@ public class ApplicationSourceUpdater
     ISourceUpdater CreateSpecificUpdater(ApplicationSourceWithMetadata sourceWithMetadata)
     {
         ISourceUpdater sourceUpdater;
-        if (sourceWithMetadata.SourceType == SourceType.Directory)
+        // A ref source resolves $ref-prefixed value files regardless of the SourceType ArgoCD reports (it reports Helm when the ref's path contains a Chart.yaml).
+        if (sourceWithMetadata.Source.Ref != null)
         {
-            if (sourceWithMetadata.Source.Ref == null)
-            {
-                sourceUpdater = new DirectoryUpdater(deploymentConfig.ImageReferences,
-                                                     defaultRegistry,
-                                                     log,
-                                                     fileSystem);
-            }
-            else
-            {
-                sourceUpdater = new RefUpdater(applicationFromYaml,
-                                               deploymentConfig,
-                                               defaultRegistry,
-                                               log,
-                                               fileSystem);
-            }
+            sourceUpdater = new RefUpdater(applicationFromYaml,
+                                           deploymentConfig,
+                                           defaultRegistry,
+                                           log,
+                                           fileSystem);
+        }
+        else if (sourceWithMetadata.SourceType == SourceType.Directory)
+        {
+            sourceUpdater = new DirectoryUpdater(deploymentConfig.ImageReferences,
+                                                 defaultRegistry,
+                                                 log,
+                                                 fileSystem);
         }
         else if (sourceWithMetadata.SourceType == SourceType.Helm)
         {

--- a/source/Calamari/ArgoCD/Conventions/UpdateImageTag/RefUpdater.cs
+++ b/source/Calamari/ArgoCD/Conventions/UpdateImageTag/RefUpdater.cs
@@ -52,6 +52,7 @@ public class RefUpdater : AbstractHelmUpdater
             .GetHelmTargetsForRefSource(sourceWithMetadata);
 
         HelmHelpers.LogHelmSourceConfigurationProblems(log, helmTargetsForRefSource.Problems);
+        WarnIfNothingReferencedRefSource(sourceWithMetadata, helmTargetsForRefSource.Targets.Count, helmTargetsForRefSource.Problems.Count);
 
         return ProcessHelmUpdateTargets(workingDirectory,
                                         helmTargetsForRefSource.Targets);
@@ -62,10 +63,18 @@ public class RefUpdater : AbstractHelmUpdater
     {
         var extractor = new HelmValuesFileExtractor(applicationFromYaml);
         var valuesFiles = extractor.GetValueFilesReferencedInRefSource(sourceWithMetadata)
-                                   .Select(file => Path.Combine(workingDirectory, file));
+                                   .Select(file => Path.Combine(workingDirectory, file))
+                                   .ToHashSet();
+        WarnIfNothingReferencedRefSource(sourceWithMetadata, valuesFiles.Count, 0);
 
-        return ProcessHelmValuesFiles(valuesFiles.ToHashSet(),
+        return ProcessHelmValuesFiles(valuesFiles,
                                       workingDirectory,
                                       sourceWithMetadata);
+    }
+
+    void WarnIfNothingReferencedRefSource(ApplicationSourceWithMetadata sourceWithMetadata, int targetCount, int problemCount)
+    {
+        if (targetCount == 0 && problemCount == 0)
+            log.WarnFormat("Ref source '{0}' was processed but no value files in the application referenced it (via ${1}/...), so nothing was updated.", sourceWithMetadata.SourceIdentity, sourceWithMetadata.Source.Ref);
     }
 }


### PR DESCRIPTION
# Background

The Update Argo CD Image Tags step updates image tags in a multi-source Argo CD Application's Helm value files. When a Helm source references a value file in another source using Argo CD's `$ref` syntax (for example `$app/chart/values-b2b-dev.yaml`), the referenced file lives in the ref source's repository. The step only resolved that reference when the ref source was typed Directory. Argo CD types a ref source as Helm whenever the ref's path contains a `Chart.yaml`, and in that case the referenced value file was skipped: the image tag never changed and the deployment reported "Nothing to update".

# Results

The step now resolves `$ref`-prefixed value files for a ref source regardless of the source type Argo CD reports.

Fixes FD-530

## Before

For a multi-source app with a chart source referencing `$app/chart/values-b2b-dev.yaml` and an `app` ref source whose path contained a `Chart.yaml` (so Argo CD typed it Helm), the step cloned the ref source's repository and did nothing. The referenced file kept its old image tag and the application reported "Nothing to update".

## After

The same app updates the image tag in the referenced file and commits it. A source carrying a ref is routed to `RefUpdater` whether Argo CD typed it Helm or Directory, so the `$ref` reference is resolved either way.

## Implementation

`ApplicationSourceUpdater.CreateSpecificUpdater` now checks `Source.Ref != null` before `SourceType`, so any ref source uses `RefUpdater` (which resolves `$ref` value files). Sources without a ref are unchanged, and Directory + ref already used `RefUpdater`, so the only behaviour change is that a Helm-typed ref source now resolves its referenced files. This matches `RefUpdater`'s existing contract, which updates only referenced files for a ref source and directs users to a separate source for files under the path.

Added test `RefSourceTypedAsHelm_StillResolvesRefAndUpdatesReferencedFile`.

Note on local test runs: nine existing file-content tests in `UpdateArgoCDAppImagesInstallConventionHelmTests` fail on Windows on a trailing-whitespace assertion in `AssertFileContents`. This is a pre-existing line-ending artifact unrelated to this change, confirmed by running the class on `main` with these changes stashed (the same nine fail). They pass on CI.

# Reducing risk

## Automated Tests
- [x] Run full chain build (PRs targeting `main` `release/*` branches only)

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered the [appropriate target version for this PR](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1145896982/Which+versions+should+I+patch#Process).
- [ ] I have considered appropriate testing for my change.
  - Automated testing / Exploratory testing / Nothing required?
- [ ] I have considered manually testing my changes on a [branch instance](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1262256152/Use+a+Core+Feature+Branch+Instance) to check correctness, stability and performance on Octopus Cloud.
- [ ] I have considered safety nets to reduce any time-to-recovery for my change.
