### PR TITLE
Docker credential helper: emit not-found error on stdout

### DIFF
--- a/source/Calamari.DockerCredentialHelper/DockerCredentialProtocol.cs
+++ b/source/Calamari.DockerCredentialHelper/DockerCredentialProtocol.cs
@@ -76,7 +76,7 @@ namespace Calamari.DockerCredentialHelper
             var credential = store.Get(serverUrl, encryptionPassword, dockerConfigPath);
             if (credential == null)
             {
-                error.WriteLine("credentials not found in native keychain");
+                output.WriteLine("credentials not found in native keychain");
                 return 1;
             }
 

--- a/source/Calamari.Tests/Fixtures/Docker/DockerCredentialProtocolFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Docker/DockerCredentialProtocolFixture.cs
@@ -42,13 +42,15 @@ namespace Calamari.Tests.Fixtures.Docker
         }
 
         [Test]
-        public void Get_WhenMissing_ReturnsExitOneAndNotFoundMessage()
+        public void Get_WhenMissing_WritesNotFoundSentinelToStdout()
         {
+            var output = new StringWriter();
             var error = new StringWriter();
-            var exit = protocol.Run("get", new StringReader("https://example.com"), new StringWriter(), error, Password, configPath);
+            var exit = protocol.Run("get", new StringReader("https://example.com"), output, error, Password, configPath);
 
             Assert.That(exit, Is.EqualTo(1));
-            Assert.That(error.ToString(), Does.Contain("credentials not found"));
+            // We need to emit this exact sentence stdout - clients such as podman check for it explicitly
+            Assert.That(output.ToString(), Does.Contain("credentials not found in native keychain"));
         }
 
         [Test]


### PR DESCRIPTION
## Summary

The `docker-credential-octopus` (the credential helper added in #1981) wrote its
"credentials not found in native keychain" error message to **stderr**.

The docker credential-helper protocol actually requires it on stdout - clients such as 
podman match that exact string to recognise the "no stored credential yet" case.

When using podman  (via the `podman-docker` shim), podman probes the helper
with `get` at `login` time. With the error message on stderr & stdout empty,
podman treated the exit-1 as a fatal error.

Relates to https://github.com/OctopusDeploy/Issues/issues/10128.

## Results

This PR moves the error message to stdout, matching the reference `docker-credential-helpers`
`Serve` behaviour.

Testing: this has been verified to work on podman 4.9.3, but AFAICT, requires podman 4.x (based on the v4.0.0 tag [referenced here](https://github.com/podman-container-tools/podman/issues/11636)). This does _not_ work on podman 3.4.4 (the version referenced in the issue above).

## Server change

No — helper output stream only, no server-side change required.