### PR TITLE
Docker credential helper: route all helper output to stdout

### DIFF
--- a/source/Calamari.DockerCredentialHelper/DockerCredentialProtocol.cs
+++ b/source/Calamari.DockerCredentialHelper/DockerCredentialProtocol.cs
@@ -13,20 +13,21 @@ namespace Calamari.DockerCredentialHelper
             this.store = store;
         }
 
-        public int Run(string operation, TextReader input, TextWriter output, TextWriter error, string encryptionPassword, string dockerConfigPath)
+        //important: all helper->docker comms need to be over stdout, not stderr 
+        public int Run(string operation, TextReader input, TextWriter output, string encryptionPassword, string dockerConfigPath)
         {
             switch (operation.ToLowerInvariant())
             {
                 case "store":
-                    return Store(input, error, encryptionPassword, dockerConfigPath);
+                    return Store(input, output, encryptionPassword, dockerConfigPath);
                 case "get":
-                    return Get(input, output, error, encryptionPassword, dockerConfigPath);
+                    return Get(input, output, encryptionPassword, dockerConfigPath);
                 case "erase":
                     return Erase(input, dockerConfigPath);
                 case "list":
                     return List(output);
                 default:
-                    error.WriteLine($"Invalid operation: {operation}. Valid operations are: store, get, erase, list");
+                    output.WriteLine($"Invalid operation: {operation}. Valid operations are: store, get, erase, list");
                     return 1;
             }
         }
@@ -40,7 +41,7 @@ namespace Calamari.DockerCredentialHelper
         }
 
         // Docker sends a JSON object on stdin for 'store'.
-        int Store(TextReader input, TextWriter error, string encryptionPassword, string dockerConfigPath)
+        int Store(TextReader input, TextWriter output, string encryptionPassword, string dockerConfigPath)
         {
             StoreRequest? request;
             try
@@ -49,13 +50,13 @@ namespace Calamari.DockerCredentialHelper
             }
             catch (Exception)
             {
-                error.WriteLine("Invalid store request");
+                output.WriteLine("Invalid store request");
                 return 1;
             }
 
             if (request == null || string.IsNullOrEmpty(request.ServerURL))
             {
-                error.WriteLine("Invalid store request");
+                output.WriteLine("Invalid store request");
                 return 1;
             }
 
@@ -64,12 +65,12 @@ namespace Calamari.DockerCredentialHelper
         }
 
         // Docker sends a bare server URL line on stdin for 'get' and 'erase'.
-        int Get(TextReader input, TextWriter output, TextWriter error, string encryptionPassword, string dockerConfigPath)
+        int Get(TextReader input, TextWriter output, string encryptionPassword, string dockerConfigPath)
         {
             var serverUrl = input.ReadLine()?.Trim();
             if (string.IsNullOrEmpty(serverUrl))
             {
-                error.WriteLine("No server URL provided");
+                output.WriteLine("No server URL provided");
                 return 1;
             }
 

--- a/source/Calamari.DockerCredentialHelper/Program.cs
+++ b/source/Calamari.DockerCredentialHelper/Program.cs
@@ -10,7 +10,7 @@ namespace Calamari.DockerCredentialHelper
         {
             if (args.Length == 0)
             {
-                Console.Error.WriteLine("A credential operation is required (store, get, erase)");
+                Console.Out.WriteLine("A credential operation is required (store, get, erase)");
                 return 1;
             }
 
@@ -24,13 +24,13 @@ namespace Calamari.DockerCredentialHelper
 
             if (string.IsNullOrEmpty(encryptionPassword))
             {
-                Console.Error.WriteLine("OCTOPUS_CREDENTIAL_PASSWORD environment variable not set");
+                Console.Out.WriteLine("OCTOPUS_CREDENTIAL_PASSWORD environment variable not set");
                 return 1;
             }
 
             if (string.IsNullOrEmpty(dockerConfigPath))
             {
-                Console.Error.WriteLine("DOCKER_CONFIG environment variable not set");
+                Console.Out.WriteLine("DOCKER_CONFIG environment variable not set");
                 return 1;
             }
 
@@ -44,11 +44,11 @@ namespace Calamari.DockerCredentialHelper
                 using var output = new StreamWriter(Console.OpenStandardOutput(), utf8) { AutoFlush = true };
 
                 var protocol = new DockerCredentialProtocol(new DockerCredentialStore());
-                return protocol.Run(operation, input, output, Console.Error, encryptionPassword, dockerConfigPath);
+                return protocol.Run(operation, input, output, encryptionPassword, dockerConfigPath);
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"Docker credential operation failed: {ex.Message}");
+                Console.Out.WriteLine($"Docker credential operation failed: {ex.Message}");
                 return 1;
             }
         }

--- a/source/Calamari.Tests/Fixtures/Docker/DockerCredentialProtocolFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Docker/DockerCredentialProtocolFixture.cs
@@ -30,11 +30,11 @@ namespace Calamari.Tests.Fixtures.Docker
         public void Store_ThenGet_WritesCredentialJsonToStdout()
         {
             var storeInput = new StringReader("{\"ServerURL\":\"https://example.com\",\"Username\":\"alice\",\"Secret\":\"s3cret\"}");
-            var storeExit = protocol.Run("store", storeInput, new StringWriter(), new StringWriter(), Password, configPath);
+            var storeExit = protocol.Run("store", storeInput, new StringWriter(), Password, configPath);
             Assert.That(storeExit, Is.EqualTo(0));
 
             var getOutput = new StringWriter();
-            var getExit = protocol.Run("get", new StringReader("https://example.com"), getOutput, new StringWriter(), Password, configPath);
+            var getExit = protocol.Run("get", new StringReader("https://example.com"), getOutput, Password, configPath);
 
             Assert.That(getExit, Is.EqualTo(0));
             Assert.That(getOutput.ToString(), Does.Contain("alice"));
@@ -45,8 +45,7 @@ namespace Calamari.Tests.Fixtures.Docker
         public void Get_WhenMissing_WritesNotFoundSentinelToStdout()
         {
             var output = new StringWriter();
-            var error = new StringWriter();
-            var exit = protocol.Run("get", new StringReader("https://example.com"), output, error, Password, configPath);
+            var exit = protocol.Run("get", new StringReader("https://example.com"), output, Password, configPath);
 
             Assert.That(exit, Is.EqualTo(1));
             // We need to emit this exact sentence stdout - clients such as podman check for it explicitly
@@ -58,39 +57,39 @@ namespace Calamari.Tests.Fixtures.Docker
         {
             protocol.Run("store",
                          new StringReader("{\"ServerURL\":\"https://example.com\",\"Username\":\"alice\",\"Secret\":\"s3cret\"}"),
-                         new StringWriter(), new StringWriter(), Password, configPath);
+                         new StringWriter(), Password, configPath);
 
-            var eraseExit = protocol.Run("erase", new StringReader("https://example.com"), new StringWriter(), new StringWriter(), Password, configPath);
+            var eraseExit = protocol.Run("erase", new StringReader("https://example.com"), new StringWriter(), Password, configPath);
             Assert.That(eraseExit, Is.EqualTo(0));
 
-            var getExit = protocol.Run("get", new StringReader("https://example.com"), new StringWriter(), new StringWriter(), Password, configPath);
+            var getExit = protocol.Run("get", new StringReader("https://example.com"), new StringWriter(), Password, configPath);
             Assert.That(getExit, Is.EqualTo(1));
         }
 
         [Test]
         public void Run_WithUnknownOperation_ReturnsExitOne()
         {
-            var error = new StringWriter();
-            var exit = protocol.Run("bogus", new StringReader(""), new StringWriter(), error, Password, configPath);
+            var output = new StringWriter();
+            var exit = protocol.Run("bogus", new StringReader(""), output, Password, configPath);
 
             Assert.That(exit, Is.EqualTo(1));
-            Assert.That(error.ToString(), Does.Contain("Invalid operation"));
+            Assert.That(output.ToString(), Does.Contain("Invalid operation"));
         }
 
         [Test]
         public void Store_WithMalformedJson_ReturnsExitOneAndError()
         {
-            var error = new StringWriter();
-            var exit = protocol.Run("store", new StringReader("not json"), new StringWriter(), error, Password, configPath);
+            var output = new StringWriter();
+            var exit = protocol.Run("store", new StringReader("not json"), output, Password, configPath);
 
             Assert.That(exit, Is.EqualTo(1));
-            Assert.That(error.ToString(), Does.Contain("Invalid store request"));
+            Assert.That(output.ToString(), Does.Contain("Invalid store request"));
         }
 
         [Test]
         public void Store_WithEmptyInput_ReturnsExitOne()
         {
-            var exit = protocol.Run("store", new StringReader(""), new StringWriter(), new StringWriter(), Password, configPath);
+            var exit = protocol.Run("store", new StringReader(""), new StringWriter(), Password, configPath);
             Assert.That(exit, Is.EqualTo(1));
         }
 
@@ -98,7 +97,7 @@ namespace Calamari.Tests.Fixtures.Docker
         public void List_ReturnsEmptyJsonObjectAndExitZero()
         {
             var output = new StringWriter();
-            var exit = protocol.Run("list", new StringReader(""), output, new StringWriter(), Password, configPath);
+            var exit = protocol.Run("list", new StringReader(""), output, Password, configPath);
 
             Assert.That(exit, Is.EqualTo(0));
             Assert.That(output.ToString().Trim(), Is.EqualTo("{}"));


### PR DESCRIPTION
## Summary

_Follow-up to #2059 (which moved the "credentials not found" error to stdout)_

The docker credential-helper ~protocol~ example code (`docker-credential-helpers` `Serve`) only emits to stdout, not stderr.

Our `docker-credential-octopus` wrote some messages to stderr, where docker's `cmd.Output()` discards them and the client surfaces it as:
 
`error getting credentials - err: exit status 1, out: \`\``. 

Relates to https://github.com/OctopusDeploy/Issues/issues/10128.

## Results

This PR changes the rest to stdout.
