### PR TITLE
Add variable to disable the Docker credential helper per action

### DIFF
--- a/source/Calamari.Shared/Deployment/SpecialVariables.cs
+++ b/source/Calamari.Shared/Deployment/SpecialVariables.cs
@@ -72,6 +72,7 @@ namespace Calamari.Deployment
             public static readonly string AdditionalXmlConfigurationTransforms = "Octopus.Action.Package.AdditionalXmlConfigurationTransforms";
             public static readonly string IgnoreVariableReplacementErrors = "Octopus.Action.Package.IgnoreVariableReplacementErrors";
             public static readonly string RunPackageScripts = "Octopus.Action.Package.RunScripts";
+            public static readonly string DisableDockerCredentialHelper = "Octopus.Action.Package.DisableDockerCredentialHelper";
         }
 
         public static class GitResources

--- a/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/DockerImagePackageDownloader.cs
@@ -1,18 +1,17 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
 using Calamari.Common.FeatureToggles;
-using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.Deployment;
 using Newtonsoft.Json.Linq;
 using Octopus.Versioning;
 
@@ -60,7 +59,7 @@ namespace Calamari.Integration.Packages.Download
             this.variables = variables;
             this.log = log;
             this.feedLoginDetailsProviderFactory = feedLoginDetailsProviderFactory;
-            this.useCredentialHelper = OctopusFeatureToggles.UseDockerCredentialHelperFeatureToggle.IsEnabled(variables);
+            this.useCredentialHelper = OctopusFeatureToggles.UseDockerCredentialHelperFeatureToggle.IsEnabled(variables) && !variables.GetFlag(SpecialVariables.Package.DisableDockerCredentialHelper, false);
             this.dockerCredentialHelper = new DockerCredentialHelper(log);
         }
 

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderCredentialHelperFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/DockerImagePackageDownloaderCredentialHelperFixture.cs
@@ -11,6 +11,7 @@ using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.Deployment;
 using Calamari.Integration.Packages.Download;
 using Calamari.Testing;
 using Calamari.Testing.Helpers;
@@ -100,6 +101,32 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             pkg.PackageId.Should().Be("octopusdeploy/octo-prerelease");
             
             // Verify credential helper was NOT used
+            log.Messages.Should().NotContain(m => m.FormattedMessage.Contains("Configured Docker credential helper"));
+            log.Messages.Should().NotContain(m => m.FormattedMessage.Contains("Cleaned up Docker credential files"));
+        }
+
+        [Test]
+        [RequiresDockerInstalled]
+        public void CredentialHelper_DisabledByPackageVariable_UsesFallbackLogin()
+        {
+            // Arrange - feature toggle ON, but the per-action variable opts this acquisition out.
+            var log = new InMemoryLog();
+            var variables = new CalamariVariables();
+            variables.Set(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.UseDockerCredentialHelper);
+            variables.Set(SpecialVariables.Package.DisableDockerCredentialHelper, bool.TrueString);
+            var downloader = GetDownloader(log, variables);
+
+            // Act
+            var pkg = downloader.DownloadPackage("octopusdeploy/octo-prerelease",
+                new SemanticVersion("7.3.7-alpine"), "docker-feed",
+                new Uri(dockerHubFeedUri), dockerTestUsername, dockerTestPassword, true, 1,
+                TimeSpan.FromSeconds(10));
+
+            // Assert
+            pkg.Should().NotBeNull();
+            pkg.PackageId.Should().Be("octopusdeploy/octo-prerelease");
+
+            // The package variable must override the feature toggle: helper NOT used, plain login instead.
             log.Messages.Should().NotContain(m => m.FormattedMessage.Contains("Configured Docker credential helper"));
             log.Messages.Should().NotContain(m => m.FormattedMessage.Contains("Cleaned up Docker credential files"));
         }


### PR DESCRIPTION
## Summary

_Follow-up to #2059 and #2061._

Adds a new escape-hatch variable `Octopus.Action.Package.DisableDockerCredentialHelper`. When set to `true`, forces Docker/OCI acquisition down the plain `docker login` path.

This is a per-action escape hatch for runtimes where the credential helper doesn't work today (notably podman 3.x workers (see [Issues#10128](https://github.com/OctopusDeploy/Issues/issues/10128))) — users can opt a specific action out via a variable.

## Behaviour

The credential helper runs only when:
- the toggle is on, and
- the variable is not set. 

The variable does not disable `docker login` itself — login still happens, via the old code path (that logs the plaintext warning).