### PR TITLE
Claude step: Fix bug with SRT where the claude settings flag was passed to SRT

### DIFF
--- a/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeProcessStartInfoFixture.cs
+++ b/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeProcessStartInfoFixture.cs
@@ -50,12 +50,15 @@ public class ClaudeCodeProcessStartInfoFixture
     [Test]
     public void ResolveInvocation_SandboxRuntimeMode_WrapsClaudeWithSrt()
     {
-        var builder = MinimalBuilder().WithSandboxMode(SandboxMode.SandboxRuntime).WithSandboxRuntimeSettingsPath(TestSandboxRuntimeSettingsPath);
+        var builder = MinimalBuilder().WithSandboxMode(SandboxMode.SandboxRuntime).WithSandboxRuntimeSettingsPath(TestSandboxRuntimeSettingsPath).WithPrompt("look! a \"quote\"");
 
         var (fileName, arguments) = ClaudeCodeProcessStartInfo.ResolveInvocation(builder);
 
         fileName.Should().Be("srt");
-        arguments.Should().StartWith($"--settings {TestSandboxRuntimeSettingsPath} claude --model");
+        // The claude invocation is passed as a single escaped argument to srt's -c flag.
+        arguments.Should().StartWith($"--settings {TestSandboxRuntimeSettingsPath} -c \"claude --model");
+        arguments.Should().Contain("-p \\\"look! a \\\\\\\"quote\\\\\\\"\\\"");
+        arguments.Should().EndWith("\"");
     }
 
     [Test]

--- a/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeProcessStartInfoFixture.cs
+++ b/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeProcessStartInfoFixture.cs
@@ -57,7 +57,9 @@ public class ClaudeCodeProcessStartInfoFixture
         fileName.Should().Be("srt");
         // The claude invocation is passed as a single escaped argument to srt's -c flag.
         arguments.Should().StartWith($"--settings {TestSandboxRuntimeSettingsPath} -c \"claude --model");
-        arguments.Should().Contain("-p \\\"look! a \\\\\\\"quote\\\\\\\"\\\"");
+        arguments.Should().Contain("""
+                                   -p \"look! a \\\"quote\\\"\"
+                                   """);
         arguments.Should().EndWith("\"");
     }
 

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeProcessStartInfo.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeProcessStartInfo.cs
@@ -24,7 +24,7 @@ public class ClaudeCodeProcessStartInfo
             SandboxMode.SandboxRuntime when string.IsNullOrWhiteSpace(argsBuilder.SandboxRuntimeSettingsPath)
                 => throw new InvalidOperationException("Sandbox runtime mode requires a settings file path."),
             SandboxMode.SandboxRuntime
-                => (SrtPath, $"--settings {argsBuilder.SandboxRuntimeSettingsPath} {ClaudeCodePath}{claudeArgs}"),
+                => (SrtPath, $"--settings {argsBuilder.SandboxRuntimeSettingsPath} -c {ClaudeCommandArgsBuilder.EscapeArg(ClaudeCodePath + claudeArgs)}"),
             _ => (ClaudeCodePath, claudeArgs),
         };
     }

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCommandArgsBuilder.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCommandArgsBuilder.cs
@@ -153,7 +153,7 @@ public class ClaudeCommandArgsBuilder
         return args.ToString();
     }
 
-    static string EscapeArg(string arg)
+    public static string EscapeArg(string arg)
     {
         if (arg.IndexOfAny(new[] { ' ', '"', '\\' }) < 0)
             return arg;


### PR DESCRIPTION
When running Claude inside SRT, the deployment fails because SRT is trying to read Claude's settings file. This PR calls Claude using the `-c` flag

<img width="2078" height="518" alt="CleanShot 2026-07-07 at 11 22 15@2x" src="https://github.com/user-attachments/assets/be311a08-7a81-4611-a3f8-3dc9e4169e98" />

Related to [MD-2265: SRT sandbox errors without helpful message](https://linear.app/octopus/issue/MD-2265/srt-sandbox-errors-without-helpful-message)