### PR TITLE
Fix: signal Helm --dry-run to the server and gate ArgoRollouts manifest reporting on dry-run

### DIFF
--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmUpgradeExecutor.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmUpgradeExecutor.cs
@@ -65,13 +65,19 @@ namespace Calamari.Kubernetes.Conventions.Helm
                 throw new CommandException("Helm Upgrade returned zero exit code but had error output. Deployment terminated.");
             }
 
-            if (OctopusFeatureToggles.ArgoRolloutsSupportFeatureToggle.IsEnabled(deployment.Variables))
+            //A --dry-run never persists a release or applies resources, so there is nothing to report.
+            //HelmManifestAndStatusReporter already skips reporting under --dry-run; mirror that here so
+            //the ArgoRollouts (inline) path doesn't report phantom manifests either.
+            if (OctopusFeatureToggles.ArgoRolloutsSupportFeatureToggle.IsEnabled(deployment.Variables) && !IsHelmDryRun(deployment))
             {
                 ReportManifestAndSetAppliedResources(deployment, releaseName, newRevisionNumber);
             }
 
             installCompletedCts.Cancel();
         }
+
+        public static bool IsHelmDryRun(RunningDeployment deployment)
+            => deployment.Variables.Get(SpecialVariables.Helm.AdditionalArguments)?.Contains("--dry-run") ?? false;
 
         void ReportManifestAndSetAppliedResources(RunningDeployment deployment, string releaseName, int revisionNumber)
         {

--- a/source/Calamari/Kubernetes/Conventions/HelmUpgradeWithKOSConvention.cs
+++ b/source/Calamari/Kubernetes/Conventions/HelmUpgradeWithKOSConvention.cs
@@ -7,6 +7,7 @@ using Calamari.Common.Features.Processes;
 using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.ServiceMessages;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Deployment.Conventions;
 using Calamari.Kubernetes.Conventions.Helm;
@@ -51,6 +52,13 @@ namespace Calamari.Kubernetes.Conventions
             var isArgoRolloutsSupportToggleEnabled = OctopusFeatureToggles.ArgoRolloutsSupportFeatureToggle.IsEnabled(deployment.Variables);
             
             var releaseName = GetReleaseName(deployment.Variables);
+
+            //Signal to the server that this is a dry-run BEFORE running helm, so that even if the task
+            //subsequently fails or is cancelled the server knows not to mark Live Status Unavailable
+            //(a dry-run never changes the cluster). A service message is persisted immediately by the
+            //server (unlike an output variable, which is only flushed at task completion). See FD-565.
+            if (HelmUpgradeExecutor.IsHelmDryRun(deployment))
+                log.WriteServiceMessage(new ServiceMessage(SpecialVariables.ServiceMessages.DryRun.Name));
 
             var helmCli = new HelmCli(log, commandLineRunner, deployment, fileSystem);
 

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -176,6 +176,11 @@ namespace Calamari.Kubernetes
                 public const string ManifestAttribute = "manifest";
                 public const string NamespaceAttribute = "ns";
             }
+
+            public static class DryRun
+            {
+                public const string Name = "k8s-dry-run";
+            }
         }
     }
 }


### PR DESCRIPTION
# Background

A Helm deployment step run with `--dry-run` that fails or is cancelled causes Kubernetes Live Status to be marked Unavailable on the server, even though a dry-run never changes the cluster (FD-565). The server had no way to know a deployment was a dry-run. Separately, the ArgoRollouts inline manifest reporter (`HelmUpgradeExecutor`) did not skip reporting under `--dry-run`, unlike the default `HelmManifestAndStatusReporter`.

# Results

The Helm KOS convention now emits a `k8s-dry-run` service message before running helm when `--dry-run` is detected, giving the server a durable, immediate signal (consumed by the paired server change). The ArgoRollouts inline path now also skips manifest reporting under `--dry-run`, matching the default path.

Fixes FD-565

## Before

- No signal to the server that a deployment is a dry-run, so a failed/cancelled dry-run flips Live Status to Unavailable.
- With `argo-rollouts-support` enabled, `HelmUpgradeExecutor` reported manifests even for a `--dry-run`.

## After

- `k8s-dry-run` is emitted (via a shared `IsHelmDryRun` check) before helm runs, so the signal is recorded even if the task later fails or is cancelled.
- `HelmUpgradeExecutor.ReportManifestAndSetAppliedResources` is skipped under `--dry-run`.

## Pairs with

The OctopusDeploy server PR that consumes `k8s-dry-run` and skips the Unavailable flip.

# Reducing risk

## Automated Tests
- [x] Run full chain build

# Pre-requisites

- [ ] I have considered appropriate testing for my change.
- [ ] I have considered the appropriate target version for this PR.
- [ ] I have considered safety nets to reduce any time-to-recovery for my change.