### PR TITLE
Fix bug where cost always shows zero for Haiku models if prompt injection guard is ON

### DIFF
--- a/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeStreamProcessorFixture.cs
+++ b/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeStreamProcessorFixture.cs
@@ -14,6 +14,7 @@ public class ClaudeCodeStreamProcessorFixture
 {
     InMemoryLog log = null!;
     StringBuilder responseBuilder = null!;
+    ClaudeCodeUsageReporter usageReporter = null!;
     ClaudeCodeStreamProcessor processor = null!;
 
     [SetUp]
@@ -21,7 +22,8 @@ public class ClaudeCodeStreamProcessorFixture
     {
         log = new InMemoryLog();
         responseBuilder = new StringBuilder();
-        processor = new ClaudeCodeStreamProcessor(log, responseBuilder);
+        usageReporter = new ClaudeCodeUsageReporter();
+        processor = new ClaudeCodeStreamProcessor(log, responseBuilder, usageReporter);
     }
 
     [Test]
@@ -108,6 +110,7 @@ public class ClaudeCodeStreamProcessorFixture
             """;
 
         processor.ProcessLine(json);
+        usageReporter.WriteServiceMessage(log);
 
         log.ServiceMessages.Should().Contain(m => m.Name == ClaudeCodeServiceMessages.Usage.Name);
 
@@ -130,6 +133,7 @@ public class ClaudeCodeStreamProcessorFixture
             """;
 
         processor.ProcessLine(json);
+        usageReporter.WriteServiceMessage(log);
 
         log.ServiceMessages.Should().Contain(m => m.Name == ClaudeCodeServiceMessages.Usage.Name);
 

--- a/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeUsageReporterFixture.cs
+++ b/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeUsageReporterFixture.cs
@@ -1,0 +1,115 @@
+using System.Linq;
+using System.Text.Json;
+using Calamari.AiAgent.ClaudeCodeBehaviour;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Calamari.Contracts.ClaudeCode;
+
+namespace Calamari.AiAgent.Tests.ClaudeCodeBehaviour;
+
+[TestFixture]
+public class ClaudeCodeUsageReporterFixture
+{
+    InMemoryLog log = null!;
+    ClaudeCodeUsageReporter reporter = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        log = new InMemoryLog();
+        reporter = new ClaudeCodeUsageReporter();
+    }
+
+    [Test]
+    public void NoUsage_DoesNotEmitMessage()
+    {
+        reporter.WriteServiceMessage(log);
+
+        log.ServiceMessages.Should().NotContain(m => m.Name == ClaudeCodeServiceMessages.Usage.Name);
+    }
+
+    [Test]
+    public void EmitsSingleMessage_EvenAcrossMultipleSources()
+    {
+        reporter.AddModelUsage(new[] { new ClaudeCodeModelUsage { Model = "claude-haiku", InputTokens = 10 } });
+        reporter.AddModelUsage(new[] { new ClaudeCodeModelUsage { Model = "claude-opus", InputTokens = 20 } });
+
+        reporter.WriteServiceMessage(log);
+
+        log.ServiceMessages.Count(m => m.Name == ClaudeCodeServiceMessages.Usage.Name).Should().Be(1);
+    }
+
+    [Test]
+    public void SameModelAcrossSources_IsSummedIntoOneEntry()
+    {
+        // e.g. the injection check and the main agent both use the same model
+        reporter.AddModelUsage(new[]
+        {
+            new ClaudeCodeModelUsage { Model = "claude-haiku", InputTokens = 100, OutputTokens = 50 },
+        });
+        reporter.AddModelUsage(new[]
+        {
+            new ClaudeCodeModelUsage
+            {
+                Model = "claude-haiku",
+                InputTokens = 5,
+                OutputTokens = 3,
+                CacheReadInputTokens = 10,
+                CacheCreationInputTokens = 2,
+                CostUsd = 0.01,
+            },
+        });
+
+        reporter.WriteServiceMessage(log);
+
+        var usages = DeserializeModelUsage();
+        usages.Should().ContainSingle();
+        var haiku = usages.Single();
+        haiku.Model.Should().Be("claude-haiku");
+        haiku.InputTokens.Should().Be(105);
+        haiku.OutputTokens.Should().Be(53);
+        haiku.CacheReadInputTokens.Should().Be(10);
+        haiku.CacheCreationInputTokens.Should().Be(2);
+        haiku.CostUsd.Should().Be(0.01);
+    }
+
+    [Test]
+    public void DifferentModels_AreKeptAsSeparateEntries()
+    {
+        reporter.AddModelUsage(new[] { new ClaudeCodeModelUsage { Model = "claude-haiku", InputTokens = 10 } });
+        reporter.AddModelUsage(new[] { new ClaudeCodeModelUsage { Model = "claude-opus", InputTokens = 20 } });
+
+        reporter.WriteServiceMessage(log);
+
+        var usages = DeserializeModelUsage();
+        usages.Should().HaveCount(2);
+        usages.Should().ContainSingle(u => u.Model == "claude-haiku" && u.InputTokens == 10);
+        usages.Should().ContainSingle(u => u.Model == "claude-opus" && u.InputTokens == 20);
+    }
+
+    [Test]
+    public void RunSummaryAttributes_ArePreservedOnTheMessage()
+    {
+        reporter.SetRunSummary(new System.Collections.Generic.Dictionary<string, string>
+        {
+            [ClaudeCodeServiceMessages.Usage.CostUsdAttribute] = "0.003000",
+            [ClaudeCodeServiceMessages.Usage.NumTurnsAttribute] = "1",
+        });
+        reporter.AddModelUsage(new[] { new ClaudeCodeModelUsage { Model = "claude-haiku", InputTokens = 10 } });
+
+        reporter.WriteServiceMessage(log);
+
+        var msg = log.ServiceMessages.Single(m => m.Name == ClaudeCodeServiceMessages.Usage.Name);
+        msg.GetValue(ClaudeCodeServiceMessages.Usage.CostUsdAttribute).Should().Be("0.003000");
+        msg.GetValue(ClaudeCodeServiceMessages.Usage.NumTurnsAttribute).Should().Be("1");
+        msg.GetValue(ClaudeCodeServiceMessages.Usage.ModelUsageAttribute).Should().NotBeNull();
+    }
+
+    ClaudeCodeModelUsage[] DeserializeModelUsage()
+    {
+        var msg = log.ServiceMessages.Single(m => m.Name == ClaudeCodeServiceMessages.Usage.Name);
+        var json = msg.GetValue(ClaudeCodeServiceMessages.Usage.ModelUsageAttribute);
+        return JsonSerializer.Deserialize<ClaudeCodeModelUsage[]>(json!)!;
+    }
+}

--- a/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeUsageReporterFixture.cs
+++ b/source/Calamari.AiAgent.Tests/ClaudeCodeBehaviour/ClaudeCodeUsageReporterFixture.cs
@@ -91,10 +91,10 @@ public class ClaudeCodeUsageReporterFixture
     [Test]
     public void RunSummaryAttributes_ArePreservedOnTheMessage()
     {
-        reporter.SetRunSummary(new System.Collections.Generic.Dictionary<string, string>
+        reporter.SetRunSummary(new ClaudeCodeRunSummary
         {
-            [ClaudeCodeServiceMessages.Usage.CostUsdAttribute] = "0.003000",
-            [ClaudeCodeServiceMessages.Usage.NumTurnsAttribute] = "1",
+            CostUsd = 0.003,
+            NumTurns = 1,
         });
         reporter.AddModelUsage(new[] { new ClaudeCodeModelUsage { Model = "claude-haiku", InputTokens = 10 } });
 

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeCliRunner.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeCliRunner.cs
@@ -12,7 +12,7 @@ using Octopus.Calamari.Contracts.ClaudeCode;
 
 namespace Calamari.AiAgent.ClaudeCodeBehaviour;
 
-public class ClaudeCodeCliRunner(ILog log)
+public class ClaudeCodeCliRunner(ILog log, ClaudeCodeUsageReporter usageReporter)
 {
 
     public async Task<string> RunAsync(ClaudeCommandArgsBuilder argsBuilder,
@@ -38,7 +38,7 @@ public class ClaudeCodeCliRunner(ILog log)
             customEnvVars);
 
         var responseBuilder = new StringBuilder();
-        var streamProcessor = new ClaudeCodeStreamProcessor(log, responseBuilder);
+        var streamProcessor = new ClaudeCodeStreamProcessor(log, responseBuilder, usageReporter);
 
         var stdoutTask = Task.Run(() => ProcessLine(process, streamProcessor, verboseLogPath, cancellationToken), cancellationToken);
         var stderrTask = Task.Run(() => ProcessError(process), cancellationToken);

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeRunSummary.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeRunSummary.cs
@@ -1,0 +1,14 @@
+namespace Calamari.AiAgent.ClaudeCodeBehaviour;
+
+public record ClaudeCodeRunSummary
+{
+    public double? CostUsd { get; init; }
+    public double? TotalCostUsd { get; init; }
+    public double? DurationMs { get; init; }
+    public double? DurationApiMs { get; init; }
+    public int? NumTurns { get; init; }
+    public int? InputTokens { get; init; }
+    public int? OutputTokens { get; init; }
+    public int? CacheReadInputTokens { get; init; }
+    public int? CacheCreationInputTokens { get; init; }
+}

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeStreamProcessor.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeStreamProcessor.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Text.Json;
 using Calamari.AiAgent.ClaudeCodeBehaviour.JsonResponseModels;
 using Calamari.Common.Plumbing.Logging;
-using Calamari.Common.Plumbing.ServiceMessages;
 using Octopus.Calamari.Contracts.ClaudeCode;
 
 namespace Calamari.AiAgent.ClaudeCodeBehaviour
@@ -19,11 +18,13 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
 
         readonly ILog log;
         readonly StringBuilder responseBuilder;
+        readonly ClaudeCodeUsageReporter usageReporter;
 
-        public ClaudeCodeStreamProcessor(ILog log, StringBuilder responseBuilder)
+        public ClaudeCodeStreamProcessor(ILog log, StringBuilder responseBuilder, ClaudeCodeUsageReporter usageReporter)
         {
             this.log = log;
             this.responseBuilder = responseBuilder;
+            this.usageReporter = usageReporter;
         }
 
         public ResultStreamEvent? Result { get; private set; }
@@ -282,10 +283,10 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
 
                 }
 
-                properties[ClaudeCodeServiceMessages.Usage.ModelUsageAttribute] = JsonSerializer.Serialize(usageList, JsonOptions);
+                usageReporter.AddModelUsage(usageList);
             }
 
-            log.WriteServiceMessage(new ServiceMessage(ClaudeCodeServiceMessages.Usage.Name, properties));
+            usageReporter.SetRunSummary(properties);
         }
     }
 }

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeStreamProcessor.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeStreamProcessor.cs
@@ -238,32 +238,8 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
 
             log.Info($"Claude Code usage — Cost: ${evt.CostUsd} USD (total: ${evt.TotalCostUsd}), Duration: {evt.DurationMs}ms, Turns: {evt.NumTurns}");
 
-            var properties = new Dictionary<string, string>();
-
-            if (evt.CostUsd.HasValue)
-                properties[ClaudeCodeServiceMessages.Usage.CostUsdAttribute] = evt.CostUsd.Value.ToString("F6");
-            if (evt.TotalCostUsd.HasValue)
-                properties[ClaudeCodeServiceMessages.Usage.TotalCostUsdAttribute] = evt.TotalCostUsd.Value.ToString("F6");
-            if (evt.DurationMs.HasValue)
-                properties[ClaudeCodeServiceMessages.Usage.DurationMsAttribute] = evt.DurationMs.Value.ToString("F0");
-            if (evt.DurationApiMs.HasValue)
-                properties[ClaudeCodeServiceMessages.Usage.DurationApiMsAttribute] = evt.DurationApiMs.Value.ToString("F0");
-            if (evt.NumTurns.HasValue)
-                properties[ClaudeCodeServiceMessages.Usage.NumTurnsAttribute] = evt.NumTurns.Value.ToString();
-
             if (evt.Usage is { } usage)
-            {
-                if (usage.InputTokens.HasValue)
-                    properties[ClaudeCodeServiceMessages.Usage.InputTokensAttribute] = usage.InputTokens.Value.ToString();
-                if (usage.OutputTokens.HasValue)
-                    properties[ClaudeCodeServiceMessages.Usage.OutputTokensAttribute] = usage.OutputTokens.Value.ToString();
-                if (usage.CacheReadInputTokens.HasValue)
-                    properties[ClaudeCodeServiceMessages.Usage.CacheReadInputTokensAttribute] = usage.CacheReadInputTokens.Value.ToString();
-                if (usage.CacheCreationInputTokens.HasValue)
-                    properties[ClaudeCodeServiceMessages.Usage.CacheCreationInputTokensAttribute] = usage.CacheCreationInputTokens.Value.ToString();
-
                 log.Info($"Claude Code tokens — Input: {usage.InputTokens}, Output: {usage.OutputTokens}, Cache read: {usage.CacheReadInputTokens}, Cache creation: {usage.CacheCreationInputTokens}");
-            }
 
             if (evt.ModelUsage is { Count: > 0 } modelUsages)
             {
@@ -286,7 +262,18 @@ namespace Calamari.AiAgent.ClaudeCodeBehaviour
                 usageReporter.AddModelUsage(usageList);
             }
 
-            usageReporter.SetRunSummary(properties);
+            usageReporter.SetRunSummary(new ClaudeCodeRunSummary
+            {
+                CostUsd = evt.CostUsd,
+                TotalCostUsd = evt.TotalCostUsd,
+                DurationMs = evt.DurationMs,
+                DurationApiMs = evt.DurationApiMs,
+                NumTurns = evt.NumTurns,
+                InputTokens = evt.Usage?.InputTokens,
+                OutputTokens = evt.Usage?.OutputTokens,
+                CacheReadInputTokens = evt.Usage?.CacheReadInputTokens,
+                CacheCreationInputTokens = evt.Usage?.CacheCreationInputTokens,
+            });
         }
     }
 }

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeUsageReporter.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeUsageReporter.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.ServiceMessages;
+using Octopus.Calamari.Contracts.ClaudeCode;
+
+namespace Calamari.AiAgent.ClaudeCodeBehaviour;
+
+/// <summary>
+/// Accumulates Claude Code model usage from every source in a single run
+/// (the prompt-injection check and the main agent invocation) and emits a
+/// single <c>claude-code-usage</c> service message. Usage for the same model
+/// is summed into one entry so the receiver sees exactly one
+/// <see cref="ClaudeCodeModelUsage"/> per model.
+/// </summary>
+public class ClaudeCodeUsageReporter
+{
+    readonly Dictionary<string, ClaudeCodeModelUsage> modelUsage = new();
+    readonly Dictionary<string, string> summaryProperties = new();
+
+    /// <summary>
+    /// Adds per-model usage, summing token/cost values into any existing entry for the same model.
+    /// </summary>
+    public void AddModelUsage(IEnumerable<ClaudeCodeModelUsage> usages)
+    {
+        foreach (var usage in usages)
+        {
+            modelUsage[usage.Model] = modelUsage.TryGetValue(usage.Model, out var existing)
+                ? Merge(existing, usage)
+                : usage;
+        }
+    }
+
+    /// <summary>
+    /// Records the run-level summary attributes (cost, duration, turns, aggregate tokens)
+    /// captured from the main agent's result event. The last write wins.
+    /// </summary>
+    public void SetRunSummary(IReadOnlyDictionary<string, string> properties)
+    {
+        foreach (var kvp in properties)
+            summaryProperties[kvp.Key] = kvp.Value;
+    }
+
+    /// <summary>
+    /// Emits the aggregated <c>claude-code-usage</c> service message. Does nothing when no usage
+    /// has been recorded, so failure paths that never produced usage don't emit an empty message.
+    /// </summary>
+    public void WriteServiceMessage(ILog log)
+    {
+        if (modelUsage.Count == 0 && summaryProperties.Count == 0)
+            return;
+
+        var properties = new Dictionary<string, string>(summaryProperties);
+
+        if (modelUsage.Count > 0)
+        {
+            var usageList = new List<ClaudeCodeModelUsage>(modelUsage.Values);
+            properties[ClaudeCodeServiceMessages.Usage.ModelUsageAttribute] = JsonSerializer.Serialize(usageList);
+        }
+
+        log.WriteServiceMessage(new ServiceMessage(ClaudeCodeServiceMessages.Usage.Name, properties));
+    }
+
+    static ClaudeCodeModelUsage Merge(ClaudeCodeModelUsage a, ClaudeCodeModelUsage b) => new()
+    {
+        Model = a.Model,
+        InputTokens = Sum(a.InputTokens, b.InputTokens),
+        OutputTokens = Sum(a.OutputTokens, b.OutputTokens),
+        CacheReadInputTokens = Sum(a.CacheReadInputTokens, b.CacheReadInputTokens),
+        CacheCreationInputTokens = Sum(a.CacheCreationInputTokens, b.CacheCreationInputTokens),
+        CostUsd = Sum(a.CostUsd, b.CostUsd),
+    };
+
+    static int? Sum(int? x, int? y) => x.HasValue || y.HasValue ? (x ?? 0) + (y ?? 0) : null;
+
+    static double? Sum(double? x, double? y) => x.HasValue || y.HasValue ? (x ?? 0) + (y ?? 0) : null;
+}

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeUsageReporter.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeUsageReporter.cs
@@ -32,13 +32,27 @@ public class ClaudeCodeUsageReporter
     }
 
     /// <summary>
-    /// Records the run-level summary attributes (cost, duration, turns, aggregate tokens)
-    /// captured from the main agent's result event. The last write wins.
+    /// Records the run-level summary (cost, duration, turns, aggregate tokens) captured from the
+    /// main agent's result event, formatting each populated field into its service message attribute.
+    /// The last write wins.
     /// </summary>
-    public void SetRunSummary(IReadOnlyDictionary<string, string> properties)
+    public void SetRunSummary(ClaudeCodeRunSummary summary)
     {
-        foreach (var kvp in properties)
-            summaryProperties[kvp.Key] = kvp.Value;
+        SetProperty(ClaudeCodeServiceMessages.Usage.CostUsdAttribute, summary.CostUsd?.ToString("F6"));
+        SetProperty(ClaudeCodeServiceMessages.Usage.TotalCostUsdAttribute, summary.TotalCostUsd?.ToString("F6"));
+        SetProperty(ClaudeCodeServiceMessages.Usage.DurationMsAttribute, summary.DurationMs?.ToString("F0"));
+        SetProperty(ClaudeCodeServiceMessages.Usage.DurationApiMsAttribute, summary.DurationApiMs?.ToString("F0"));
+        SetProperty(ClaudeCodeServiceMessages.Usage.NumTurnsAttribute, summary.NumTurns?.ToString());
+        SetProperty(ClaudeCodeServiceMessages.Usage.InputTokensAttribute, summary.InputTokens?.ToString());
+        SetProperty(ClaudeCodeServiceMessages.Usage.OutputTokensAttribute, summary.OutputTokens?.ToString());
+        SetProperty(ClaudeCodeServiceMessages.Usage.CacheReadInputTokensAttribute, summary.CacheReadInputTokens?.ToString());
+        SetProperty(ClaudeCodeServiceMessages.Usage.CacheCreationInputTokensAttribute, summary.CacheCreationInputTokens?.ToString());
+    }
+
+    void SetProperty(string key, string? value)
+    {
+        if (value != null)
+            summaryProperties[key] = value;
     }
 
     /// <summary>

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeUsageReporter.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/ClaudeCodeUsageReporter.cs
@@ -6,21 +6,11 @@ using Octopus.Calamari.Contracts.ClaudeCode;
 
 namespace Calamari.AiAgent.ClaudeCodeBehaviour;
 
-/// <summary>
-/// Accumulates Claude Code model usage from every source in a single run
-/// (the prompt-injection check and the main agent invocation) and emits a
-/// single <c>claude-code-usage</c> service message. Usage for the same model
-/// is summed into one entry so the receiver sees exactly one
-/// <see cref="ClaudeCodeModelUsage"/> per model.
-/// </summary>
 public class ClaudeCodeUsageReporter
 {
     readonly Dictionary<string, ClaudeCodeModelUsage> modelUsage = new();
     readonly Dictionary<string, string> summaryProperties = new();
 
-    /// <summary>
-    /// Adds per-model usage, summing token/cost values into any existing entry for the same model.
-    /// </summary>
     public void AddModelUsage(IEnumerable<ClaudeCodeModelUsage> usages)
     {
         foreach (var usage in usages)
@@ -31,11 +21,6 @@ public class ClaudeCodeUsageReporter
         }
     }
 
-    /// <summary>
-    /// Records the run-level summary (cost, duration, turns, aggregate tokens) captured from the
-    /// main agent's result event, formatting each populated field into its service message attribute.
-    /// The last write wins.
-    /// </summary>
     public void SetRunSummary(ClaudeCodeRunSummary summary)
     {
         SetProperty(ClaudeCodeServiceMessages.Usage.CostUsdAttribute, summary.CostUsd?.ToString("F6"));
@@ -55,10 +40,6 @@ public class ClaudeCodeUsageReporter
             summaryProperties[key] = value;
     }
 
-    /// <summary>
-    /// Emits the aggregated <c>claude-code-usage</c> service message. Does nothing when no usage
-    /// has been recorded, so failure paths that never produced usage don't emit an empty message.
-    /// </summary>
     public void WriteServiceMessage(ILog log)
     {
         if (modelUsage.Count == 0 && summaryProperties.Count == 0)

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/InjectionCheck/PromptInjectionGuard.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/InjectionCheck/PromptInjectionGuard.cs
@@ -1,15 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Logging;
-using Calamari.Common.Plumbing.ServiceMessages;
 using Octopus.Calamari.Contracts.ClaudeCode;
 
 namespace Calamari.AiAgent.ClaudeCodeBehaviour.InjectionCheck;
@@ -20,11 +16,13 @@ public class PromptInjectionGuard
 
     readonly ILog log;
     readonly InjectionCheckOptions options;
+    readonly ClaudeCodeUsageReporter usageReporter;
 
-    public PromptInjectionGuard(ILog log, InjectionCheckOptions options)
+    public PromptInjectionGuard(ILog log, InjectionCheckOptions options, ClaudeCodeUsageReporter usageReporter)
     {
         this.log = log;
         this.options = options;
+        this.usageReporter = usageReporter;
     }
 
     public async Task CheckAsync(string workingDir, string prompt, string apiToken, CancellationToken cancellationToken)
@@ -76,7 +74,7 @@ public class PromptInjectionGuard
 
     void ReportUsage(InjectionCheckResult result)
     {
-        var usage = new[]
+        usageReporter.AddModelUsage(new[]
         {
             new ClaudeCodeModelUsage
             {
@@ -84,14 +82,7 @@ public class PromptInjectionGuard
                 InputTokens = result.InputTokens,
                 OutputTokens = result.OutputTokens,
             },
-        };
-
-        var properties = new Dictionary<string, string>
-        {
-            [ClaudeCodeServiceMessages.Usage.ModelUsageAttribute] = JsonSerializer.Serialize(usage),
-        };
-
-        log.WriteServiceMessage(new ServiceMessage(ClaudeCodeServiceMessages.Usage.Name, properties));
+        });
     }
 
     static string FormatFindings(InjectionVerdict verdict)

--- a/source/Calamari.AiAgent/ClaudeCodeBehaviour/InvokeClaudeCodeBehaviour.cs
+++ b/source/Calamari.AiAgent/ClaudeCodeBehaviour/InvokeClaudeCodeBehaviour.cs
@@ -117,36 +117,46 @@ public class InvokeClaudeCodeBehaviour : IDeployBehaviour
         argsBuilder.WithSystemPromptFile(new SystemPromptWriter().WriteSystemPromptFile(workingDir));
         argsBuilder.WithMcpConfigPath(mcpConfig);
 
-        await new PromptInjectionGuard(log, InjectionCheckOptions.Resolve(variables))
-            .CheckAsync(workingDir, prompt, apiKey, cancellationToken.Token);
+        // Both the prompt-injection check and the main agent run contribute usage. Collect it all
+        // and emit a single claude-code-usage service message (one entry per model) at the end.
+        var usageReporter = new ClaudeCodeUsageReporter();
+        try
+        {
+            await new PromptInjectionGuard(log, InjectionCheckOptions.Resolve(variables), usageReporter)
+                .CheckAsync(workingDir, prompt, apiKey, cancellationToken.Token);
 
-        var claudeConfigDir = Path.Combine(workingDir, ".claude");
+            var claudeConfigDir = Path.Combine(workingDir, ".claude");
 
-        var environment = ClaudeCodeEnvironment.Build(
-            ClaudeCodeEnvironment.GetCurrentEnvironmentVariables(),
-            PassThroughEnvironmentVariables(variables),
-            new Dictionary<string, string>
-            {
-                ["ANTHROPIC_API_KEY"] = apiKey,
-                ["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = "0", // If set, this stops us using auto mode
-                ["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1", // Disables the auto-updater, telemetry, error reporting, and feedback surveys
-                ["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] = "1",
-                ["CLAUDE_CODE_DISABLE_CRON"] = "1",
-                ["CLAUDE_CONFIG_DIR"] = claudeConfigDir,
-            });
+            var environment = ClaudeCodeEnvironment.Build(
+                ClaudeCodeEnvironment.GetCurrentEnvironmentVariables(),
+                PassThroughEnvironmentVariables(variables),
+                new Dictionary<string, string>
+                {
+                    ["ANTHROPIC_API_KEY"] = apiKey,
+                    ["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = "0", // If set, this stops us using auto mode
+                    ["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1", // Disables the auto-updater, telemetry, error reporting, and feedback surveys
+                    ["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] = "1",
+                    ["CLAUDE_CODE_DISABLE_CRON"] = "1",
+                    ["CLAUDE_CONFIG_DIR"] = claudeConfigDir,
+                });
 
-        var response = await new ClaudeCodeCliRunner(log).RunAsync(
-            argsBuilder,
-            environment,
-            workingDir,
-            context.CurrentDirectory,
-            cancellationToken.Token);
+            var response = await new ClaudeCodeCliRunner(log, usageReporter).RunAsync(
+                argsBuilder,
+                environment,
+                workingDir,
+                context.CurrentDirectory,
+                cancellationToken.Token);
 
-        foreach (var artifact in new ArtifactManifestCollector(variables).Collect(workingDir, context.CurrentDirectory))
-            log.NewOctopusArtifact(artifact.Path, artifact.Name, artifact.Length);
+            foreach (var artifact in new ArtifactManifestCollector(variables).Collect(workingDir, context.CurrentDirectory))
+                log.NewOctopusArtifact(artifact.Path, artifact.Name, artifact.Length);
 
-        Log.SetOutputVariable(SpecialVariables.Action.Claude.Response, response, variables);
-        log.Info("Claude Code invocation complete.");
+            Log.SetOutputVariable(SpecialVariables.Action.Claude.Response, response, variables);
+            log.Info("Claude Code invocation complete.");
+        }
+        finally
+        {
+            usageReporter.WriteServiceMessage(log);
+        }
     }
 
     internal static ClaudePermissionMode ResolvePermissionMode(IVariables variables)


### PR DESCRIPTION
Server expects one service message per model type (unique DB key).

Prompt injection was sending its own service message, so the main CLI invocation's usage stats would be dropped if its model was the same.

This PR accumulates the usages and only writes it at the end.

Relates to [MD-2256: Cost always shows zero for Haiku models](https://linear.app/octopus/issue/MD-2256/cost-always-shows-zero-for-haiku-models)