### PR TITLE
Helm 4 support

### DIFF
--- a/source/Calamari.Shared/Util/HelmVersion.cs
+++ b/source/Calamari.Shared/Util/HelmVersion.cs
@@ -1,8 +1,0 @@
-namespace Calamari.Util
-{
-    public enum HelmVersion
-    {
-        V2,
-        V3
-    }
-}

--- a/source/Calamari.Shared/Util/HelmVersionParser.cs
+++ b/source/Calamari.Shared/Util/HelmVersionParser.cs
@@ -2,12 +2,13 @@ namespace Calamari.Util
 {
     public static class HelmVersionParser
     {
-        //versionString from "helm version --client --short"
-        public static HelmVersion? ParseVersion(string versionString)
+        //versionString from "helm version --short"
+        public static int? ParseMajorVersion(string versionString)
         {
             //eg of output for helm 2: Client: v2.16.1+gbbdfe5e
             //eg of output for helm 3: v3.0.1+g7c22ef9
-            
+            //eg of output for helm 4: v4.2.0+g0646808
+
             var indexOfVersionIdentifier = versionString.IndexOf('v');
             if (indexOfVersionIdentifier == -1)
                 return null;
@@ -16,16 +17,18 @@ namespace Calamari.Util
             if (indexOfVersionNumber >= versionString.Length)
                 return null;
 
-            var version = versionString[indexOfVersionNumber];
-            switch (version)
+            var digitCount = 0;
+            while (indexOfVersionNumber + digitCount < versionString.Length
+                   && char.IsDigit(versionString[indexOfVersionNumber + digitCount]))
             {
-                case '3':
-                    return HelmVersion.V3;
-                case '2':
-                    return HelmVersion.V2;
-                default:
-                    return null;
+                digitCount++;
             }
+
+            if (digitCount == 0)
+                return null;
+
+            var majorVersionText = versionString.Substring(indexOfVersionNumber, digitCount);
+            return int.TryParse(majorVersionText, out var majorVersion) ? majorVersion : (int?)null;
         }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/Conventions/Helm/HelmUpgradeExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Conventions/Helm/HelmUpgradeExecutorTests.cs
@@ -278,6 +278,7 @@ namespace Calamari.Tests.KubernetesFixtures.Conventions.Helm
             //helm 4 removed the --client flag from `helm version`, so the mocked invocation
             //(and its output) reflects a Helm 4 client to prove the executor still works with it.
             commandLineRunner.Execute(Arg.Is<CommandLineInvocation>(i => i.Arguments.StartsWith("version") && i.Arguments.Contains("--short")))
+                             .Returns(info =>
                              {
                                  var invocation = (CommandLineInvocation)info[0];
                                  invocation.AdditionalInvocationOutputSink?.WriteInfo("v4.2.0");

--- a/source/Calamari.Tests/KubernetesFixtures/Conventions/Helm/HelmUpgradeExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Conventions/Helm/HelmUpgradeExecutorTests.cs
@@ -275,11 +275,13 @@ namespace Calamari.Tests.KubernetesFixtures.Conventions.Helm
 
         void SetupHelmVersionMock()
         {
-            commandLineRunner.Execute(Arg.Is<CommandLineInvocation>(i => i.Arguments.Contains("version") && i.Arguments.Contains("--client")))
+            //helm 4 removed the --client flag from `helm version`, so the mocked invocation
+            //(and its output) reflects a Helm 4 client to prove the executor still works with it.
+            commandLineRunner.Execute(Arg.Is<CommandLineInvocation>(i => i.Arguments.Contains("version")))
                              .Returns(info =>
                              {
                                  var invocation = (CommandLineInvocation)info[0];
-                                 invocation.AdditionalInvocationOutputSink?.WriteInfo("v3.14.0");
+                                 invocation.AdditionalInvocationOutputSink?.WriteInfo("v4.2.0");
                                  return new CommandResult("helm version", 0);
                              });
         }

--- a/source/Calamari.Tests/KubernetesFixtures/Conventions/Helm/HelmUpgradeExecutorTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Conventions/Helm/HelmUpgradeExecutorTests.cs
@@ -277,8 +277,7 @@ namespace Calamari.Tests.KubernetesFixtures.Conventions.Helm
         {
             //helm 4 removed the --client flag from `helm version`, so the mocked invocation
             //(and its output) reflects a Helm 4 client to prove the executor still works with it.
-            commandLineRunner.Execute(Arg.Is<CommandLineInvocation>(i => i.Arguments.Contains("version")))
-                             .Returns(info =>
+            commandLineRunner.Execute(Arg.Is<CommandLineInvocation>(i => i.Arguments.StartsWith("version") && i.Arguments.Contains("--short")))
                              {
                                  var invocation = (CommandLineInvocation)info[0];
                                  invocation.AdditionalInvocationOutputSink?.WriteInfo("v4.2.0");

--- a/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmUpgradeFixture.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Calamari.Common.Features.Deployment;
@@ -20,7 +19,6 @@ using Calamari.Testing;
 using Calamari.Testing.Helpers;
 using Calamari.Testing.Requirements;
 using Calamari.Tests.Helpers;
-using Calamari.Util;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -454,44 +452,5 @@ namespace Calamari.Tests.KubernetesFixtures
             }
         }
 
-        static HelmVersion GetVersion()
-        {
-            StringBuilder stdout = new StringBuilder();
-            var result = SilentProcessRunner.ExecuteCommand("helm",
-                "version --client --short",
-                Environment.CurrentDirectory,
-                output => stdout.AppendLine(output),
-                error => { });
-
-            result.ExitCode.Should().Be(0, $"Failed to retrieve version from Helm (Exit code {result.ExitCode}). Error output: \r\n{result.ErrorOutput}");
-
-            return ParseVersion(stdout.ToString());
-        }
-
-        //versionString from "helm version --client --short"
-        static HelmVersion ParseVersion(string versionString)
-        {
-            //eg of output for helm 2: Client: v2.16.1+gbbdfe5e
-            //eg of output for helm 3: v3.0.1+g7c22ef9
-
-            var indexOfVersionIdentifier = versionString.IndexOf('v');
-            if (indexOfVersionIdentifier == -1)
-                throw new FormatException($"Failed to find version identifier from '{versionString}'.");
-
-            var indexOfVersionNumber = indexOfVersionIdentifier + 1;
-            if (indexOfVersionNumber >= versionString.Length)
-                throw new FormatException($"Failed to find version number from '{versionString}'.");
-
-            var version = versionString[indexOfVersionNumber];
-            switch (version)
-            {
-                case '3':
-                    return HelmVersion.V3;
-                case '2':
-                    return HelmVersion.V2;
-                default:
-                    throw new InvalidOperationException($"Unsupported helm version '{version}'");
-            }
-        }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/HelmVersionParserFixture.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/HelmVersionParserFixture.cs
@@ -8,41 +8,47 @@ namespace Calamari.Tests.KubernetesFixtures
     public class HelmVersionParserFixture
     {
         [Test]
-        public void ParseVersion_V2Version_V2()
+        public void ParseMajorVersion_V2Version_2()
         {
-            HelmVersionParser.ParseVersion("Client: v2.16.1+gbbdfe5e").Should().Be(HelmVersion.V2);
-        }
-        
-        [Test]
-        public void ParseVersion_V3Version_V3()
-        {
-            HelmVersionParser.ParseVersion("v3.0.2+g19e47ee").Should().Be(HelmVersion.V3);
-        }
-        
-        [Test]
-        public void ParseVersion_OtherVersion_Null()
-        {
-            HelmVersionParser.ParseVersion("v4.0.2+g19e47ee").Should().BeNull();
+            HelmVersionParser.ParseMajorVersion("Client: v2.16.1+gbbdfe5e").Should().Be(2);
         }
 
         [Test]
-        public void ParseVersion_V3UppercaseVersion_Null()
+        public void ParseMajorVersion_V3Version_3()
         {
-            HelmVersionParser.ParseVersion("V3.0.2+g19e47ee").Should().BeNull();
+            HelmVersionParser.ParseMajorVersion("v3.0.2+g19e47ee").Should().Be(3);
         }
 
         [Test]
-        public void ParseVersion_V3WithoutPrefix_Null()
+        public void ParseMajorVersion_V4Version_4()
         {
-            HelmVersionParser.ParseVersion("3.0.2+g19e47ee").Should().BeNull();
+            HelmVersionParser.ParseMajorVersion("v4.0.2+g19e47ee").Should().Be(4);
         }
-        
+
+        [Test]
+        public void ParseMajorVersion_V5Version_5()
+        {
+            HelmVersionParser.ParseMajorVersion("v5.0.0+g19e47ee").Should().Be(5);
+        }
+
+        [Test]
+        public void ParseMajorVersion_V3UppercaseVersion_Null()
+        {
+            HelmVersionParser.ParseMajorVersion("V3.0.2+g19e47ee").Should().BeNull();
+        }
+
+        [Test]
+        public void ParseMajorVersion_V3WithoutPrefix_Null()
+        {
+            HelmVersionParser.ParseMajorVersion("3.0.2+g19e47ee").Should().BeNull();
+        }
+
         [TestCase("vzsd3242347ee", Description = "Has a v")]
         [TestCase("zsd3242347ee", Description = "No v")]
         [TestCase("v", Description = "Just v")]
-        public void ParseVersion_Rubbish_Null(string version)
+        public void ParseMajorVersion_Rubbish_Null(string version)
         {
-            HelmVersionParser.ParseVersion(version).Should().BeNull();
+            HelmVersionParser.ParseMajorVersion(version).Should().BeNull();
         }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/Integration/HelmCliTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/Integration/HelmCliTests.cs
@@ -37,7 +37,7 @@ namespace Calamari.Tests.KubernetesFixtures.Integration
             using (var _ = new AssertionScope())
             {
                 actual.Executable.Should().BeEquivalentTo("helm");
-                actual.Arguments.Should().BeEquivalentTo($"version --client --short");
+                actual.Arguments.Should().BeEquivalentTo($"version --short");
             }
         }
 

--- a/source/Calamari/Kubernetes/Conventions/Helm/HelmUpgradeExecutor.cs
+++ b/source/Calamari/Kubernetes/Conventions/Helm/HelmUpgradeExecutor.cs
@@ -131,7 +131,7 @@ namespace Calamari.Kubernetes.Conventions.Helm
         {
             var args = new List<string>();
 
-            AssertHelmV3();
+            AssertSupportedHelmVersion();
 
             SetResetValuesParameter(deployment, args);
             SetTimeoutParameter(deployment, args);
@@ -383,7 +383,7 @@ namespace Calamari.Kubernetes.Conventions.Helm
             return files;
         }
 
-        void AssertHelmV3()
+        void AssertSupportedHelmVersion()
         {
             var (exitCode, infoOutput) = helmCli.GetExecutableVersion();
             if (exitCode != 0)
@@ -392,14 +392,14 @@ namespace Calamari.Kubernetes.Conventions.Helm
                 return;
             }
 
-            var toolVersion = HelmVersionParser.ParseVersion(infoOutput);
-            if (!toolVersion.HasValue)
+            var majorVersion = HelmVersionParser.ParseMajorVersion(infoOutput);
+            if (!majorVersion.HasValue)
             {
                 log.Warn("Unable to parse the Helm tool version text: " + infoOutput);
             }
-            else if (toolVersion.Value != HelmVersion.V3)
+            else if (majorVersion.Value < 3)
             {
-                throw new CommandException("Helm V2 is no longer supported. Please migrate to Helm V3.");
+                throw new CommandException("Helm V2 is no longer supported. Please migrate to Helm V3 or later.");
             }
         }
     }

--- a/source/Calamari/Kubernetes/Integration/HelmCli.cs
+++ b/source/Calamari/Kubernetes/Integration/HelmCli.cs
@@ -65,7 +65,9 @@ namespace Calamari.Kubernetes.Integration
         
         public (int ExitCode, string InfoOutput) GetExecutableVersion()
         {
-            var result = ExecuteCommandAndReturnOutput("version", "--client", "--short");
+            //note: the `--client` flag was a no-op in Helm 3, but was removed entirely in Helm 4
+            //(passing it causes the command to fail). `version --short` alone works on both.
+            var result = ExecuteCommandAndReturnOutput("version", "--short");
             return (result.Result.ExitCode, result.Output.MergeInfoLogs());
         }
 
@@ -78,8 +80,8 @@ namespace Calamari.Kubernetes.Integration
                 log.Warn("Unable to retrieve the Helm tool version");
                 return null;
             }
-            
-            //helm v3 output looks like: v3.14.2+gc309b6f
+
+            //helm v3/v4 output looks like: v3.14.2+gc309b6f or v4.2.0+g0646808
             var vStripped = infoOutput.TrimStart('v');
 
             return SemVerFactory.CreateVersion(vStripped);


### PR DESCRIPTION
Updating the Helm version resolver to support v4 and future major version of Helm, and removing the `--client` argument from `helm version` as it was a no-op in Helm v3 and removed in Helm v4.

**This PR does not upgrade the bundled helm version in Octopus, just adds support for customers who have installed helm v4 to use that version.**

## Before
<img width="1849" height="500" alt="image" src="https://github.com/user-attachments/assets/c78e6f99-b0a2-4db4-91cc-81cfd80e5c86" />

## After
<img width="966" height="435" alt="image" src="https://github.com/user-attachments/assets/86a6e0f0-8c2a-448b-8c44-d28728866c0b" />
