### PR TITLE
Have buildx output directly to OCI tar file

### DIFF
--- a/build/Build.Docker.cs
+++ b/build/Build.Docker.cs
@@ -77,7 +77,7 @@ public partial class Build
                                                                                                          .SetTag(tag)
                                                                                                          .SetFile(dockerFile)
                                                                                                          .SetPath(KnownPaths.RootDirectory)
-                                                                                                         .SetOutput($"type=tar,dest={outputFile}");
+                                                                                                         .SetOutput($"type=docker,tar=true,dest={outputFile}");
                                                                                                          // This is required so we can save below.
                                                                                                          // Otherwise, the image just remains in the build cache
                                                                                                          //.EnableLoad();

--- a/build/Build.Docker.cs
+++ b/build/Build.Docker.cs
@@ -60,6 +60,13 @@ public partial class Build
                                                             }
 
                                                             var tag = $"octopusdeploy/{flavour}:{NugetVersion.Value}".ToLowerInvariant();
+                                                            
+                                                            var sanitizedTag = tag.Replace("/", "-").Replace(":", ".");
+                                                            var outputFile = KnownPaths.PublishDirectory / $"{sanitizedTag}.tar";
+
+                                                            //create the publish directory
+                                                            Directory.CreateDirectory(KnownPaths.PublishDirectory);
+                                                            
 
                                                             //build the docker image for this flavour
                                                             DockerTasks.DockerBuildxBuild(settings =>
@@ -70,23 +77,20 @@ public partial class Build
                                                                                                          .SetTag(tag)
                                                                                                          .SetFile(dockerFile)
                                                                                                          .SetPath(KnownPaths.RootDirectory)
+                                                                                                         .SetOutput($"type=tar,dest={outputFile}");
                                                                                                          // This is required so we can save below.
                                                                                                          // Otherwise, the image just remains in the build cache
-                                                                                                         .EnableLoad();
+                                                                                                         //.EnableLoad();
 
                                                                                               return settings;
                                                                                           });
 
-                                                            var sanitizedTag = tag.Replace("/", "-").Replace(":", ".");
-                                                            var outputFile = KnownPaths.PublishDirectory / $"{sanitizedTag}.tar";
 
-                                                            //create the publish directory
-                                                            Directory.CreateDirectory(KnownPaths.PublishDirectory);
 
                                                             //save the docker image to a tar file
-                                                            DockerTasks.DockerImageSave(_ => _
-                                                                                             .SetImages(tag)
-                                                                                             .SetOutput(outputFile));
+                                                            // DockerTasks.DockerImageSave(_ => _
+                                                            //                                  .SetImages(tag)
+                                                            //                                  .SetOutput(outputFile));
 
                                                             //compress with gzip
                                                             PowerShellTasks.PowerShell(_ => _

--- a/build/Build.Docker.cs
+++ b/build/Build.Docker.cs
@@ -77,7 +77,7 @@ public partial class Build
                                                                                                          .SetTag(tag)
                                                                                                          .SetFile(dockerFile)
                                                                                                          .SetPath(KnownPaths.RootDirectory)
-                                                                                                         .SetOutput($"type=docker,tar=true,dest={outputFile}");
+                                                                                                         .SetOutput($"type=oci,tar=true,dest={outputFile}");
                                                                                                          // This is required so we can save below.
                                                                                                          // Otherwise, the image just remains in the build cache
                                                                                                          //.EnableLoad();

--- a/build/Build.Docker.cs
+++ b/build/Build.Docker.cs
@@ -78,19 +78,9 @@ public partial class Build
                                                                                                          .SetFile(dockerFile)
                                                                                                          .SetPath(KnownPaths.RootDirectory)
                                                                                                          .SetOutput($"type=oci,tar=true,dest={outputFile}");
-                                                                                                         // This is required so we can save below.
-                                                                                                         // Otherwise, the image just remains in the build cache
-                                                                                                         //.EnableLoad();
 
                                                                                               return settings;
                                                                                           });
-
-
-
-                                                            //save the docker image to a tar file
-                                                            // DockerTasks.DockerImageSave(_ => _
-                                                            //                                  .SetImages(tag)
-                                                            //                                  .SetOutput(outputFile));
 
                                                             //compress with gzip
                                                             PowerShellTasks.PowerShell(_ => _


### PR DESCRIPTION
There is an issue where the docker images don't have all the platforms we are building. I'm not 100% sure why this is, but after testing, changing to an OCI image layout seems to work correctly.

This requires a small change to the deployment process in https://github.com/OctopusDeploy/Modern-Deployments/pull/3