### PR TITLE
Add OS architecture and process architecture info

### DIFF
--- a/source/Calamari.Common/Plumbing/Extensions/EnvironmentHelper.cs
+++ b/source/Calamari.Common/Plumbing/Extensions/EnvironmentHelper.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Principal;
+using System.Runtime.InteropServices;
 
 // Needed for dotnetcore
 
@@ -41,7 +42,9 @@ namespace Calamari.Common.Plumbing.Extensions
         {
             yield return SafelyGet(() => $"OperatingSystem: {Environment.OSVersion}");
             yield return SafelyGet(() => $"OsBitVersion: {(Environment.Is64BitOperatingSystem ? "x64" : "x86")}");
+            yield return SafelyGet(() => $"OsArchitecture: {RuntimeInformation.OSArchitecture}");
             yield return SafelyGet(() => $"Is64BitProcess: {Environment.Is64BitProcess}");
+            yield return SafelyGet(() => $"ProcessArchitecture: {RuntimeInformation.ProcessArchitecture}");
             yield return SafelyGet(() => $"CurrentUser: {(OperatingSystem.IsWindows() ? WindowsIdentity.GetCurrent().Name : Environment.UserName)}");
             yield return SafelyGet(() => $"MachineName: {Environment.MachineName}");
             yield return SafelyGet(() => $"ProcessorCount: {Environment.ProcessorCount}");


### PR DESCRIPTION
Includes `RuntimeInformation.OSArchitecture` and `ProcessArchitecture` to the environment output helper. It's helpful when trying to diagnose exactly what the arch is being used.

<img width="780" height="322" alt="image" src="https://github.com/user-attachments/assets/e49b0c4f-89f2-40ea-b4cf-c282d5796bc7" />

🍏 Mac:
<img width="898" height="340" alt="CleanShot 2026-07-17 at 11 01 20@2x" src="https://github.com/user-attachments/assets/b5bd5e32-73b8-4c2d-bc2b-d64466941b6b" />
