### PR TITLE
Return HEAD commit details when no changes are committed

### DIFF
--- a/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
+++ b/source/Calamari.Tests/ArgoCD/Git/RepositoryWrapperTest.cs
@@ -78,6 +78,19 @@ namespace Calamari.Tests.ArgoCD.Git
         }
 
         [Test]
+        public void GetHeadCommitDetailsReturnsTheCurrentHeadCommit()
+        {
+            File.WriteAllText(Path.Combine(RepositoryRootPath, "newFile.txt"), "Lorem ipsum dolor sit amet");
+            repository.StageAllChanges();
+            repository.CommitChanges("Summary Message", "A file has changed").Should().BeTrue();
+
+            using var localRepository = new Repository(RepositoryRootPath);
+            var headTip = localRepository.Head.Tip;
+
+            repository.GetHeadCommitDetails().Should().Be(new Calamari.ArgoCD.Git.PushResult(headTip.Sha, headTip.ShortSha(), headTip.Author.When));
+        }
+
+        [Test]
         public async Task StagingARealFileSucceedsAndCanBeCommittedAndPushed()
         {
             string filename = "newFile.txt";

--- a/source/Calamari.Tests/CommitToGit/CommitToGitOutputVariablesWriterTests.cs
+++ b/source/Calamari.Tests/CommitToGit/CommitToGitOutputVariablesWriterTests.cs
@@ -32,14 +32,6 @@ namespace Calamari.Tests.CommitToGit
         }
 
         [Test]
-        public void WritePushResultOutput_WhenPushResultIsNull_NoOutputVariablesAreWritten()
-        {
-            writer.WritePushResultOutput(null);
-
-            log.Messages.GetServiceMessagesOfType("setVariable").Should().BeEmpty();
-        }
-
-        [Test]
         public void WritePushResultOutput_WhenPushResultIsNotPullRequest_WritesCommitVariablesOnly()
         {
             writer.WritePushResultOutput(new PushResult(CommitSha, ShortSha, Timestamp));

--- a/source/Calamari.Tests/CommitToGitCommandTest.cs
+++ b/source/Calamari.Tests/CommitToGitCommandTest.cs
@@ -11,6 +11,7 @@ using Calamari.CommitToGit;
 using Calamari.Testing.Helpers;
 using Calamari.Tests.ArgoCD.Git;
 using Calamari.Tests.Fixtures.Integration.FileSystem;
+using Calamari.Tests.Helpers;
 using FluentAssertions;
 using LibGit2Sharp;
 using Newtonsoft.Json;
@@ -528,6 +529,39 @@ public class CommitToGitCommandTest
     }
 
     [Test]
+    public void WhenThereAreNoChangesToCommit_OutputVariablesAreSetFromTheHeadOfTheTargetBranch()
+    {
+        var log = new InMemoryLog();
+
+        RunCommitToGit(log).Should().Be(0);
+
+        var branchTip = bareOrigin.Branches[targetBranchFriendlyName].Tip;
+        var serviceMessages = log.Messages.GetServiceMessagesOfType("setVariable");
+        serviceMessages.GetPropertyValue(CommitToGitOutputVariablesWriter.CommitSha).Should().Be(branchTip.Sha);
+        serviceMessages.GetPropertyValue(CommitToGitOutputVariablesWriter.ShortSha).Should().Be(branchTip.ShortSha());
+        serviceMessages.GetPropertyValue(CommitToGitOutputVariablesWriter.CommitTimestamp).Should().Be(branchTip.Author.When.ToString("O"));
+    }
+
+    [Test]
+    public void WhenChangesAreCommitted_OutputVariablesAreSetFromTheNewCommit()
+    {
+        var previousTipSha = bareOrigin.Branches[targetBranchFriendlyName].Tip.Sha;
+        variables.AddRange([
+            new CalamariExecutionVariable(ScriptVariables.ScriptBody, "touch \"$(get_octopusvariable 'Octopus.Calamari.Git.RepositoryPath')/proof.txt\"", false),
+            new CalamariExecutionVariable(ScriptVariables.Syntax, ScriptSyntax.Bash.ToString(), false),
+        ]);
+        var log = new InMemoryLog();
+
+        RunCommitToGit(log).Should().Be(0);
+
+        var branchTip = bareOrigin.Branches[targetBranchFriendlyName].Tip;
+        branchTip.Sha.Should().NotBe(previousTipSha, "the transform script should have created a new commit");
+        var serviceMessages = log.Messages.GetServiceMessagesOfType("setVariable");
+        serviceMessages.GetPropertyValue(CommitToGitOutputVariablesWriter.CommitSha).Should().Be(branchTip.Sha);
+        serviceMessages.GetPropertyValue(CommitToGitOutputVariablesWriter.ShortSha).Should().Be(branchTip.ShortSha());
+    }
+
+    [Test]
     public void WhenBothScriptParametersArgAndVariableAreSetVariableTakesPrecedence()
     {
         var proofFile = Path.Combine(executionDirectory, "arg_check.txt");
@@ -591,9 +625,15 @@ public class CommitToGitCommandTest
     // --- Helpers ---
 
     int RunCommitToGit(params string[] extraArgs)
-        => RunCommitToGit(includeCustomProperties: true, extraArgs);
+        => RunCommitToGit(new InMemoryLog(), includeCustomProperties: true, extraArgs);
+
+    int RunCommitToGit(InMemoryLog log, params string[] extraArgs)
+        => RunCommitToGit(log, includeCustomProperties: true, extraArgs);
 
     int RunCommitToGit(bool includeCustomProperties, params string[] extraArgs)
+        => RunCommitToGit(new InMemoryLog(), includeCustomProperties, extraArgs);
+
+    int RunCommitToGit(InMemoryLog log, bool includeCustomProperties, params string[] extraArgs)
     {
         var absPathToVariables = Path.Combine(executionDirectory, variableFileName);
         File.WriteAllBytes(absPathToVariables, AesEncryption.ForServerVariables(variablePassword).Encrypt(variables.ToJsonString()));
@@ -613,7 +653,7 @@ public class CommitToGitCommandTest
 
         args.AddRange(extraArgs);
 
-        return Program.Main(args.ToArray());
+        return new TestProgram(log).RunWithArgs(args.ToArray());
     }
 
     string WriteCustomPropertiesFile(string credentialName, string repositoryUrl, string username, string password)

--- a/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
+++ b/source/Calamari/ArgoCD/Git/RepositoryWrapper.cs
@@ -62,6 +62,12 @@ namespace Calamari.ArgoCD.Git
             }
         }
 
+        public PushResult GetHeadCommitDetails()
+        {
+            var commit = repository.Head.Tip;
+            return new PushResult(commit.Sha, commit.ShortSha(), commit.Author.When);
+        }
+
         public void StageAllChanges()
         {
             try

--- a/source/Calamari/Commands/CommitToGitCommand.cs
+++ b/source/Calamari/Commands/CommitToGitCommand.cs
@@ -296,6 +296,12 @@ public class CommitToGitCommand : Command
                                               var updater = new RepositoryUpdater(commitParams, log, new UserDefinedCommitMessageGenerator(commitParams.Description));
                                               
                                               var pushResult = updater.PushToRemote(clonedRepository, repositoryConfig.GitConnection.GitReference, FileUpdateResult.EmptyFileUpdateResult);
+                                              if (pushResult is null)
+                                              {
+                                                  log.Info("No changes were committed");
+                                                  pushResult = clonedRepository.GetHeadCommitDetails();
+                                              }
+
                                               new CommitToGitOutputVariablesWriter(log).WritePushResultOutput(pushResult);
                                           })
         };

--- a/source/Calamari/CommitToGit/CommitToGitOutputVariablesWriter.cs
+++ b/source/Calamari/CommitToGit/CommitToGitOutputVariablesWriter.cs
@@ -21,11 +21,8 @@ namespace Calamari.CommitToGit
             this.log = log;
         }
 
-        public void WritePushResultOutput(PushResult? pushResult)
+        public void WritePushResultOutput(PushResult pushResult)
         {
-            if (pushResult is null)
-                return;
-
             log.SetOutputVariableButDoNotAddToVariables(CommitSha, pushResult.CommitSha);
             log.SetOutputVariableButDoNotAddToVariables(ShortSha, pushResult.ShortSha);
             log.SetOutputVariableButDoNotAddToVariables(CommitTimestamp, pushResult.CommitTimestamp.ToString("O"));


### PR DESCRIPTION
When the commit to git step returned an empty result, the commit details returned were empty. This may not be desirable when the result is being used later on in other steps, which would cause dereference issues. Instead, we now return the details of the HEAD of the branch we're currently on.