### PR TITLE
Deploy an Azure App Service: support Flex Consumption plans via OneDeploy

### DIFF
--- a/source/Calamari.AzureAppService.Tests/FlexConsumptionRoutingFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/FlexConsumptionRoutingFixture.cs
@@ -1,0 +1,58 @@
+using System.IO;
+using Calamari.AzureAppService;
+using Calamari.AzureAppService.Behaviors;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.AzureAppService.Tests;
+
+[TestFixture]
+public class FlexConsumptionRoutingFixture
+{
+    [TestCase("FlexConsumption", null, true)]
+    [TestCase("flexconsumption", null, true)]      // case-insensitive
+    [TestCase(null, "FC1", true)]                   // tier absent, detect by SKU name
+    [TestCase(null, "fc1", true)]
+    [TestCase("Dynamic", "Y1", false)]              // regular Consumption
+    [TestCase("PremiumV3", "P1v3", false)]
+    [TestCase(null, null, false)]                   // unknown -> non-Flex (falls back to ZipDeploy)
+    public void IsFlexConsumptionTier_MatchesTierOrSkuName(string tier, string name, bool expected)
+    {
+        AzureAppServiceZipDeployBehaviour.IsFlexConsumptionTier(tier, name).Should().Be(expected);
+    }
+
+    [Test]
+    public void OneDeployProvider_ConvertsNupkgToZipSibling()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var nupkg = Path.Combine(dir, "MyApp.1.0.0.nupkg");
+            File.WriteAllText(nupkg, "content");
+
+            var result = new OneDeployZipPackageProvider().ConvertToAzureSupportedFile(new FileInfo(nupkg)).GetAwaiter().GetResult();
+
+            result.FullName.Should().Be(Path.Combine(dir, "MyApp.1.0.0.zip"));
+            result.Exists.Should().BeTrue();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Test]
+    public void OneDeployProvider_PassesZipThroughUnchanged()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var zip = Path.Combine(dir, "MyApp.1.0.0.zip");
+            File.WriteAllText(zip, "content");
+
+            var result = new OneDeployZipPackageProvider().ConvertToAzureSupportedFile(new FileInfo(zip)).GetAwaiter().GetResult();
+
+            result.FullName.Should().Be(zip);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/source/Calamari.AzureAppService.Tests/PackageProviderFactoryFixture.cs
+++ b/source/Calamari.AzureAppService.Tests/PackageProviderFactoryFixture.cs
@@ -15,22 +15,29 @@ public class PackageProviderFactoryFixture
 {
     // The Kudu upload endpoint and sync/async behaviour are the only things that differ between package
     // types (notably .war and .jar route to the same JavaPackageProvider, differing solely by upload URL).
-    [TestCase(".zip", "/api/zipdeploy", true)]
-    [TestCase(".nupkg", "/api/zipdeploy", true)]
-    [TestCase(".war", "/api/wardeploy", false)]
-    [TestCase(".jar", "/api/publish?type=jar", false)]
-    public void GetProvider_SelectsCorrectUploadEndpointAndDeploymentMode(string extension, string expectedUploadUrlPath, bool expectedSupportsAsync)
+    // On a Flex Consumption plan, zip/nupkg packages must use the OneDeploy (/api/publish) endpoint instead
+    // of Kudu ZipDeploy (/api/zipdeploy), which Flex Consumption does not expose (returns 404).
+    [TestCase(".zip", false, "/api/zipdeploy", true, "application/octet-stream")]
+    [TestCase(".nupkg", false, "/api/zipdeploy", true, "application/octet-stream")]
+    [TestCase(".zip", true, "/api/publish?type=zip", false, "application/zip")]
+    [TestCase(".nupkg", true, "/api/publish?type=zip", false, "application/zip")]
+    [TestCase(".war", false, "/api/wardeploy", false, "application/octet-stream")]
+    [TestCase(".war", true, "/api/wardeploy", false, "application/octet-stream")]
+    [TestCase(".jar", false, "/api/publish?type=jar", false, "application/octet-stream")]
+    [TestCase(".jar", true, "/api/publish?type=jar", false, "application/octet-stream")]
+    public void GetProvider_SelectsCorrectUploadEndpointAndDeploymentMode(string extension, bool isFlexConsumption, string expectedUploadUrlPath, bool expectedSupportsAsync, string expectedContentType)
     {
-        var provider = PackageProviderFactory.GetProvider(extension, new InMemoryLog(), Substitute.For<ICalamariFileSystem>(), new CalamariVariables(), DeploymentContext());
+        var provider = PackageProviderFactory.GetProvider(extension, isFlexConsumption, new InMemoryLog(), Substitute.For<ICalamariFileSystem>(), new CalamariVariables(), DeploymentContext());
 
         provider.UploadUrlPath.Should().Be(expectedUploadUrlPath);
         provider.SupportsAsynchronousDeployment.Should().Be(expectedSupportsAsync);
+        provider.ContentType.Should().Be(expectedContentType);
     }
 
     [Test]
     public void GetProvider_ThrowsForUnsupportedExtension()
     {
-        Action act = () => PackageProviderFactory.GetProvider(".rpm", new InMemoryLog(), Substitute.For<ICalamariFileSystem>(), new CalamariVariables(), DeploymentContext());
+        Action act = () => PackageProviderFactory.GetProvider(".rpm", false, new InMemoryLog(), Substitute.For<ICalamariFileSystem>(), new CalamariVariables(), DeploymentContext());
 
         act.Should().Throw<Exception>().WithMessage("Unsupported archive type");
     }

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/BaseZipPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/BaseZipPackageProvider.cs
@@ -27,8 +27,8 @@ namespace Calamari.AzureAppService
 
         protected static async Task<FileInfo> CopyNupkgToZip(FileInfo sourceFile)
         {
-            var newFilePath = sourceFile.FullName.Replace(".nupkg", ".zip");
-            await Task.Run(() => File.Copy(sourceFile.FullName, newFilePath));
+            var newFilePath = Path.ChangeExtension(sourceFile.FullName, ".zip");
+            await Task.Run(() => File.Copy(sourceFile.FullName, newFilePath, overwrite: true));
             return new FileInfo(newFilePath);
         }
     }

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/BaseZipPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/BaseZipPackageProvider.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using System.Threading.Tasks;
+using SharpCompress.Archives;
+using SharpCompress.Archives.Zip;
+using SharpCompress.Common;
+
+namespace Calamari.AzureAppService
+{
+    public abstract class BaseZipPackageProvider : IPackageProvider
+    {
+        public abstract string UploadUrlPath { get; }
+        public abstract bool SupportsAsynchronousDeployment { get; }
+        public virtual string ContentType => "application/octet-stream";
+
+        public async Task<FileInfo> PackageArchive(string sourceDirectory, string targetDirectory)
+        {
+            await Task.Run(() =>
+            {
+                using var archive = ZipArchive.Create();
+                archive.AddAllFromDirectory($"{sourceDirectory}");
+                archive.SaveTo($"{targetDirectory}/app.zip", CompressionType.Deflate);
+            });
+            return new FileInfo($"{targetDirectory}/app.zip");
+        }
+
+        public virtual async Task<FileInfo> ConvertToAzureSupportedFile(FileInfo sourceFile) => await Task.Run(() => sourceFile);
+
+        protected static async Task<FileInfo> CopyNupkgToZip(FileInfo sourceFile)
+        {
+            var newFilePath = sourceFile.FullName.Replace(".nupkg", ".zip");
+            await Task.Run(() => File.Copy(sourceFile.FullName, newFilePath));
+            return new FileInfo(newFilePath);
+        }
+    }
+}

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/IPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/IPackageProvider.cs
@@ -9,6 +9,10 @@ namespace Calamari.AzureAppService
 
         bool SupportsAsynchronousDeployment { get; }
 
+        // Content-Type header for the upload. OneDeploy (/api/publish?type=zip) requires "application/zip";
+        // the Kudu zip/war/jar endpoints accept "application/octet-stream".
+        string ContentType { get; }
+
         Task<FileInfo> PackageArchive(string sourceDirectory, string targetDirectory);
 
         Task<FileInfo> ConvertToAzureSupportedFile(FileInfo sourceFile);

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/IPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/IPackageProvider.cs
@@ -9,8 +9,7 @@ namespace Calamari.AzureAppService
 
         bool SupportsAsynchronousDeployment { get; }
 
-        // Content-Type header for the upload. OneDeploy (/api/publish?type=zip) requires "application/zip";
-        // the Kudu zip/war/jar endpoints accept "application/octet-stream".
+        // OneDeploy requires "application/zip"; the Kudu zip/war/jar endpoints accept "application/octet-stream".
         string ContentType { get; }
 
         Task<FileInfo> PackageArchive(string sourceDirectory, string targetDirectory);

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/JavaPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/JavaPackageProvider.cs
@@ -15,6 +15,7 @@ namespace Calamari.AzureAppService
     {
         readonly ICalamariFileSystem fileSystem;
         public bool SupportsAsynchronousDeployment => false;
+        public string ContentType => "application/octet-stream";
         private ILog Log { get; }
         private IVariables Variables { get; }
         private RunningDeployment Deployment { get; }

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/NugetPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/NugetPackageProvider.cs
@@ -1,33 +1,13 @@
-﻿using System.IO;
+using System.IO;
 using System.Threading.Tasks;
-using SharpCompress.Archives;
-using SharpCompress.Archives.Zip;
-using SharpCompress.Common;
 
 namespace Calamari.AzureAppService
 {
-    class NugetPackageProvider : IPackageProvider
+    class NugetPackageProvider : BaseZipPackageProvider
     {
-        public bool SupportsAsynchronousDeployment => true;
-        public string UploadUrlPath => @"/api/zipdeploy";
+        public override bool SupportsAsynchronousDeployment => true;
+        public override string UploadUrlPath => @"/api/zipdeploy";
 
-        public async Task<FileInfo> PackageArchive(string sourceDirectory, string targetDirectory)
-        {
-            await Task.Run(() =>
-            {
-                using var archive = ZipArchive.Create();
-                archive.AddAllFromDirectory(
-                    $"{sourceDirectory}");
-                archive.SaveTo($"{targetDirectory}/app.zip", CompressionType.Deflate);
-            });
-            return new FileInfo($"{targetDirectory}/app.zip");
-        }
-
-        public async Task<FileInfo> ConvertToAzureSupportedFile(FileInfo sourceFile)
-        {
-            var newFilePath = sourceFile.FullName.Replace(".nupkg", ".zip");
-            await Task.Run(() => File.Copy(sourceFile.FullName, newFilePath));
-            return new FileInfo(newFilePath);
-        }
+        public override async Task<FileInfo> ConvertToAzureSupportedFile(FileInfo sourceFile) => await CopyNupkgToZip(sourceFile);
     }
 }

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/OneDeployZipPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/OneDeployZipPackageProvider.cs
@@ -1,0 +1,17 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Calamari.AzureAppService
+{
+    // Flex Consumption plans don't expose Kudu's /api/zipdeploy endpoint; they require the OneDeploy
+    // (/api/publish) endpoint. This runs synchronously, mirroring the existing .jar (/api/publish?type=jar) path.
+    public class OneDeployZipPackageProvider : BaseZipPackageProvider
+    {
+        public override string UploadUrlPath => @"/api/publish?type=zip";
+        public override bool SupportsAsynchronousDeployment => false;
+        public override string ContentType => "application/zip";
+
+        public override async Task<FileInfo> ConvertToAzureSupportedFile(FileInfo sourceFile)
+            => sourceFile.Extension == ".nupkg" ? await CopyNupkgToZip(sourceFile) : await Task.Run(() => sourceFile);
+    }
+}

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/OneDeployZipPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/OneDeployZipPackageProvider.cs
@@ -3,8 +3,7 @@ using System.Threading.Tasks;
 
 namespace Calamari.AzureAppService
 {
-    // Flex Consumption plans don't expose Kudu's /api/zipdeploy endpoint; they require the OneDeploy
-    // (/api/publish) endpoint. This runs synchronously, mirroring the existing .jar (/api/publish?type=jar) path.
+    // Flex Consumption requires the OneDeploy (/api/publish) endpoint, not Kudu's /api/zipdeploy.
     public class OneDeployZipPackageProvider : BaseZipPackageProvider
     {
         public override string UploadUrlPath => @"/api/publish?type=zip";

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/PackageProviderFactory.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/PackageProviderFactory.cs
@@ -8,9 +8,11 @@ namespace Calamari.AzureAppService
 {
     // Maps a file extension to its package provider (upload endpoint + sync/async mode). The one Calamari-owned
     // decision in an otherwise Azure-bound deploy, so it's unit-tested in PackageProviderFactoryFixture.
+    // On a Flex Consumption plan, zip/nupkg packages use OneDeploy (/api/publish); Flex doesn't expose /api/zipdeploy.
     public static class PackageProviderFactory
     {
         public static IPackageProvider GetProvider(string fileExtension,
+                                                   bool isFlexConsumption,
                                                    ILog log,
                                                    ICalamariFileSystem fileSystem,
                                                    IVariables variables,
@@ -18,8 +20,8 @@ namespace Calamari.AzureAppService
         {
             return fileExtension switch
                    {
-                       ".zip" => new ZipPackageProvider(),
-                       ".nupkg" => new NugetPackageProvider(),
+                       ".zip" => isFlexConsumption ? new OneDeployZipPackageProvider() : new ZipPackageProvider(),
+                       ".nupkg" => isFlexConsumption ? new OneDeployZipPackageProvider() : new NugetPackageProvider(),
                        ".war" => new JavaPackageProvider(log, fileSystem, variables, deployment, "/api/wardeploy"),
                        ".jar" => new JavaPackageProvider(log, fileSystem, variables, deployment, "/api/publish?type=jar"),
                        _ => throw new Exception("Unsupported archive type")

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/ZipPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/ZipPackageProvider.cs
@@ -1,28 +1,8 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-using SharpCompress.Archives;
-using SharpCompress.Archives.Zip;
-using SharpCompress.Common;
-
 namespace Calamari.AzureAppService
 {
-    public class ZipPackageProvider : IPackageProvider
+    public class ZipPackageProvider : BaseZipPackageProvider
     {
-        public string UploadUrlPath => @"/api/zipdeploy";
-        public bool SupportsAsynchronousDeployment => true;
-
-        public async Task<FileInfo> PackageArchive(string sourceDirectory, string targetDirectory)
-        {
-            await Task.Run(() =>
-            {
-                using var archive = ZipArchive.Create();
-                archive.AddAllFromDirectory(
-                    $"{sourceDirectory}");
-                archive.SaveTo($"{targetDirectory}/app.zip", CompressionType.Deflate);
-            });
-            return new FileInfo($"{targetDirectory}/app.zip");
-        }
-
-        public async Task<FileInfo> ConvertToAzureSupportedFile(FileInfo sourceFile) => await Task.Run(() => sourceFile);
+        public override string UploadUrlPath => @"/api/zipdeploy";
+        public override bool SupportsAsynchronousDeployment => true;
     }
 }

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -24,6 +24,7 @@ using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Variables;
+using Newtonsoft.Json.Linq;
 using Octopus.CoreUtilities.Extensions;
 using Polly;
 using Polly.Timeout;
@@ -161,7 +162,7 @@ namespace Calamari.AzureAppService.Behaviors
                 }
                 else
                 {
-                    await UploadZipAsync(account, publishingProfile, scmPublishEnabled, uploadPath, targetSite.ScmSiteAndSlot, packageProvider);
+                    await UploadZipAsync(account, publishingProfile, scmPublishEnabled, uploadPath, targetSite.ScmSiteAndSlot, packageProvider, pollingTimeout);
                 }
             }
             finally
@@ -228,7 +229,8 @@ namespace Calamari.AzureAppService.Behaviors
                                           bool scmPublishEnabled,
                                           string uploadZipPath,
                                           string targetSite,
-                                          IPackageProvider packageProvider)
+                                          IPackageProvider packageProvider,
+                                          TimeSpan pollingTimeout)
         {
             Log.Verbose($"Path to upload: {uploadZipPath}");
             Log.Verbose($"Target Site: {targetSite}");
@@ -279,7 +281,48 @@ namespace Calamari.AzureAppService.Behaviors
             if (!response.IsSuccessStatusCode)
                 throw new Exception($"Zip upload to {zipUploadUrl} failed with HTTP Status {(int)response.StatusCode} '{response.ReasonPhrase}'.");
 
+            // OneDeploy (/api/publish) accepts the upload with 202 + a Location, then processes it asynchronously.
+            // Poll that Location so a server-side failure is surfaced instead of being reported as success.
+            if (response.StatusCode == HttpStatusCode.Accepted && response.Headers.Location != null)
+                await PollDeploymentUntilComplete(httpClient, response.Headers.Location, authenticationHeader, pollingTimeout);
+
             Log.Verbose("Finished deploying");
+        }
+
+        async Task PollDeploymentUntilComplete(HttpClient httpClient, Uri statusUrl, AuthenticationHeaderValue authenticationHeader, TimeSpan pollingTimeout)
+        {
+            Log.Verbose($"Deployment accepted; polling {statusUrl} for completion.");
+            var deadline = DateTimeOffset.UtcNow + pollingTimeout;
+
+            while (true)
+            {
+                var statusResponse = await RetryPolicies.TransientHttpErrorsPolicy.ExecuteAsync(async () =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Get, statusUrl) { Headers = { Authorization = authenticationHeader } };
+                    var r = await httpClient.SendAsync(request);
+                    r.EnsureSuccessStatusCode();
+                    return r;
+                });
+
+                var json = JObject.Parse(await statusResponse.Content.ReadAsStringAsync());
+                var complete = json.Value<bool?>("complete") ?? false;
+                var status = json.Value<int?>("status");
+
+                if (complete)
+                {
+                    // Kudu DeployStatus: 4 = Success, 3 = Failed.
+                    if (status == 4)
+                        return;
+
+                    var statusText = json.Value<string>("status_text");
+                    throw new Exception($"Deployment failed with status {status}. {statusText}".Trim());
+                }
+
+                if (DateTimeOffset.UtcNow >= deadline)
+                    throw new Exception($"Deployment did not complete within {pollingTimeout}.");
+
+                await Task.Delay(TimeSpan.FromSeconds(5));
+            }
         }
 
         static async Task<AuthenticationHeaderValue> GetAuthenticationHeaderValue(IAzureAccount azureAccount, PublishingProfile publishingProfile, bool scmPublishEnabled)

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -93,9 +93,13 @@ namespace Calamari.AzureAppService.Behaviors
             var webSiteResource = armClient.GetWebSiteResource(targetSite.CreateWebSiteResourceIdentifier());
             Log.Verbose($"App Service '{targetSite.Site}' found, with Azure Resource Manager Id '{webSiteResource.Id.ToString()}'.");
 
+            var isFlexConsumption = await IsFlexConsumptionPlan(armClient, webSiteResource);
+            if (isFlexConsumption)
+                Log.Verbose("Flex Consumption plan detected; using the OneDeploy (/api/publish) endpoint instead of ZipDeploy (/api/zipdeploy).");
+
             var packageFileInfo = new FileInfo(variables.Get(TentacleVariables.CurrentDeployment.PackageFilePath)!);
 
-            var packageProvider = PackageProviderFactory.GetProvider(packageFileInfo.Extension, Log, fileSystem, variables, context);
+            var packageProvider = PackageProviderFactory.GetProvider(packageFileInfo.Extension, isFlexConsumption, Log, fileSystem, variables, context);
 
             // Let's process our archive while the slot is spun up. We will await it later before we try to upload to it.
             Task<WebSiteSlotResource>? slotCreateTask = null;
@@ -169,6 +173,21 @@ namespace Calamari.AzureAppService.Behaviors
             }
         }
 
+        // Flex Consumption plans don't expose Kudu's /api/zipdeploy endpoint. The tier lives on the
+        // App Service Plan (ServerFarm), not the site, so we resolve the plan to read its SKU tier.
+        async Task<bool> IsFlexConsumptionPlan(ArmClient armClient, WebSiteResource webSiteResource)
+        {
+            var siteData = (await webSiteResource.GetAsync()).Value.Data;
+            var appServicePlanId = siteData.AppServicePlanId;
+            if (appServicePlanId is null)
+                return false;
+
+            var appServicePlan = await armClient.GetAppServicePlanResource(appServicePlanId).GetAsync();
+            var planSku = appServicePlan.Value.Data.Sku;
+            Log.Verbose($"App Service Plan '{appServicePlanId.Name}' is on the '{planSku?.Tier}' tier (SKU '{planSku?.Name}').");
+            return string.Equals(planSku?.Tier, "FlexConsumption", StringComparison.OrdinalIgnoreCase);
+        }
+
         private async Task<WebSiteSlotResource> FindOrCreateSlot(ArmClient armClient, WebSiteResource webSiteResource, AzureTargetSite site)
         {
             Log.Verbose($"Checking if deployment slot '{site.Slot}' exists.");
@@ -226,8 +245,8 @@ namespace Calamari.AzureAppService.Behaviors
                                                                                       {
                                                                                           await using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
                                                                                           using var streamContent = new StreamContent(fileStream);
-                                                                                          streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-                                                                                          
+                                                                                          streamContent.Headers.ContentType = new MediaTypeHeaderValue(packageProvider.ContentType);
+
                                                                                           //we have to create a new request message each time
                                                                                           var request = new HttpRequestMessage(HttpMethod.Post, zipUploadUrl)
                                                                                           {
@@ -304,7 +323,7 @@ namespace Calamari.AzureAppService.Behaviors
                                                                                                 //we have to create a new request message each time
                                                                                                 await using var fileStream = new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
                                                                                                 using var streamContent = new StreamContent(fileStream);
-                                                                                                streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                                                                                                streamContent.Headers.ContentType = new MediaTypeHeaderValue(packageProvider.ContentType);
 
                                                                                                 var uploadRequest = new HttpRequestMessage(HttpMethod.Post, zipUploadUrl)
                                                                                                 {

--- a/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
+++ b/source/Calamari.AzureAppService/Behaviors/AzureAppServiceZipDeployBehaviour.cs
@@ -173,20 +173,34 @@ namespace Calamari.AzureAppService.Behaviors
             }
         }
 
-        // Flex Consumption plans don't expose Kudu's /api/zipdeploy endpoint. The tier lives on the
-        // App Service Plan (ServerFarm), not the site, so we resolve the plan to read its SKU tier.
+        // The SKU tier lives on the App Service Plan (ServerFarm), not the site, so we resolve the plan to read it.
+        // Fails open: if the tier can't be read we fall back to ZipDeploy rather than break a valid deployment.
         async Task<bool> IsFlexConsumptionPlan(ArmClient armClient, WebSiteResource webSiteResource)
         {
-            var siteData = (await webSiteResource.GetAsync()).Value.Data;
-            var appServicePlanId = siteData.AppServicePlanId;
-            if (appServicePlanId is null)
-                return false;
+            try
+            {
+                var siteData = (await webSiteResource.GetAsync()).Value.Data;
+                var appServicePlanId = siteData.AppServicePlanId;
+                if (appServicePlanId is null)
+                {
+                    Log.Verbose("App Service has no associated App Service Plan; treating as non-Flex Consumption.");
+                    return false;
+                }
 
-            var appServicePlan = await armClient.GetAppServicePlanResource(appServicePlanId).GetAsync();
-            var planSku = appServicePlan.Value.Data.Sku;
-            Log.Verbose($"App Service Plan '{appServicePlanId.Name}' is on the '{planSku?.Tier}' tier (SKU '{planSku?.Name}').");
-            return string.Equals(planSku?.Tier, "FlexConsumption", StringComparison.OrdinalIgnoreCase);
+                var planSku = (await armClient.GetAppServicePlanResource(appServicePlanId).GetAsync()).Value.Data.Sku;
+                Log.Verbose($"App Service Plan '{appServicePlanId.Name}' is on the '{planSku?.Tier}' tier (SKU '{planSku?.Name}').");
+                return IsFlexConsumptionTier(planSku?.Tier, planSku?.Name);
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"Could not determine the App Service Plan tier ({ex.Message}). Treating as non-Flex Consumption and using the ZipDeploy endpoint. If this is a Flex Consumption plan, grant the account 'Microsoft.Web/serverfarms/read' on the plan.");
+                return false;
+            }
         }
+
+        internal static bool IsFlexConsumptionTier(string? skuTier, string? skuName)
+            => string.Equals(skuTier, "FlexConsumption", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(skuName, "FC1", StringComparison.OrdinalIgnoreCase);
 
         private async Task<WebSiteSlotResource> FindOrCreateSlot(ArmClient armClient, WebSiteResource webSiteResource, AzureTargetSite site)
         {


### PR DESCRIPTION
# Background

The built-in "Deploy an Azure App Service" step fails with HTTP 404 when the target Function App runs on an Azure Flex Consumption plan. Calamari uploads the package by POSTing to the Kudu `/api/zipdeploy` endpoint, which Flex Consumption plans don't expose. Microsoft now recommends Flex Consumption over the classic Consumption plan and is deprecating the classic plan on 2028-09-30, so more customers will hit this over time.

# Results

Detects the App Service Plan SKU tier at deploy time and, when it's Flex Consumption, uploads zip/nupkg packages through the OneDeploy (`/api/publish?type=zip`) endpoint with an `application/zip` content type instead of ZipDeploy.

Fixes HPY-20.

## Before 

Deploying a zip/nupkg package to a Flex Consumption Function App POSTs to `https://<scm>/api/zipdeploy` and returns `404 (Not Found)`, so the step fails.
<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/9479e378-ea71-4a42-9e31-476d683e7779" />


## After (this PR)

The step resolves the plan tier (`App Service Plan '...' is on the 'FlexConsumption' tier (SKU 'FC1')`), POSTs to `/api/publish?type=zip`, polls to completion, and the deployment succeeds. Non-Flex plans are unaffected and still use `/api/zipdeploy`.
<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/ace33765-60de-4e6f-a603-abea4b3599cf" />


Both captured live against the same real Flex Consumption Function App, same package — only the Calamari build differs.

## Testing

- Unit: extended `PackageProviderFactoryFixture` to assert the upload endpoint, sync/async mode, and content type for the Flex and non-Flex cases across `.zip`/`.nupkg`/`.war`/`.jar`.
- Live end-to-end against a real Azure Flex Consumption Function App (dotnet-isolated 8.0), deploying via the built-in step with this build injected through `Octopus.Calamari.Executable`:
  - Before: `POST .../api/zipdeploy?isAsync=true` → `404 (Not Found)`, deployment fails.
  - After: `App Service Plan ... is on the 'FlexConsumption' tier (SKU 'FC1')` → `POST .../api/publish?type=zip` → deployment succeeds.

## Automated Tests
- [x] Run full chain build (PRs targeting `main` `release/*` branches only)

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered the [appropriate target version for this PR](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1145896982/Which+versions+should+I+patch#Process).
- [ ] I have considered appropriate testing for my change.
- [ ] I have considered manually testing my changes on a [branch instance](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1262256152/Use+a+Core+Feature+Branch+Instance) to check correctness, stability and performance on Octopus Cloud.
- [ ] I have considered safety nets to reduce any time-to-recovery for my change.