### PR TITLE
Fix reported KOS stabilisation issues

### DIFF
--- a/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
@@ -10,12 +10,14 @@ namespace Calamari.Common.FeatureToggles
             public const string ArgoRolloutsSupportFeatureToggle = "argo-rollouts-support";
             public const string UseDockerCredentialHelper = "calamari-use-docker-credential-helper";
             public const string GitDependenciesForScriptsFeatureToggle = "git-dependencies-for-scripts";
+            public const string EnableLegacyKubernetesResourceChecks = "enable-legacy-kubernetes-resource-checks";
         };
 
         public static readonly OctopusFeatureToggle KustomizePatchImageUpdatesFeatureToggle = new(KnownSlugs.KustomizePatchImageUpdatesFeatureToggle);
         public static readonly OctopusFeatureToggle ArgoRolloutsSupportFeatureToggle = new(KnownSlugs.ArgoRolloutsSupportFeatureToggle);
         public static readonly OctopusFeatureToggle UseDockerCredentialHelperFeatureToggle = new(KnownSlugs.UseDockerCredentialHelper);
         public static readonly OctopusFeatureToggle GitDependenciesForScriptsFeatureToggle = new(KnownSlugs.GitDependenciesForScriptsFeatureToggle);
+        public static readonly OctopusFeatureToggle EnableLegacyKubernetesResourceChecksFeatureToggle = new(KnownSlugs.EnableLegacyKubernetesResourceChecks);
 
         public class OctopusFeatureToggle
         {

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceRetrieverTests.cs
@@ -326,6 +326,50 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
         }
 
         [Test]
+        public void ChildResourceListsAreFetchedOncePerKindAndNamespacePerPass()
+        {
+            var deployment1Uid = Guid.NewGuid().ToString();
+            var deployment2Uid = Guid.NewGuid().ToString();
+            var replicaSet1Uid = Guid.NewGuid().ToString();
+            var replicaSet2Uid = Guid.NewGuid().ToString();
+
+            var deployment1 = new ResourceResponseBuilder().WithApiVersion("apps/v1").WithKind("Deployment").WithName("d1").WithUid(deployment1Uid).Build();
+            var deployment2 = new ResourceResponseBuilder().WithApiVersion("apps/v1").WithKind("Deployment").WithName("d2").WithUid(deployment2Uid).Build();
+            var replicaSet1 = new ResourceResponseBuilder().WithApiVersion("apps/v1").WithKind("ReplicaSet").WithName("rs1").WithUid(replicaSet1Uid).WithOwnerUid(deployment1Uid).Build();
+            var replicaSet2 = new ResourceResponseBuilder().WithApiVersion("apps/v1").WithKind("ReplicaSet").WithName("rs2").WithUid(replicaSet2Uid).WithOwnerUid(deployment2Uid).Build();
+            var pod1 = new ResourceResponseBuilder().WithApiVersion("v1").WithKind("Pod").WithName("pod-1").WithOwnerUid(replicaSet1Uid).Build();
+            var pod2 = new ResourceResponseBuilder().WithApiVersion("v1").WithKind("Pod").WithName("pod-2").WithOwnerUid(replicaSet2Uid).Build();
+
+            var kubectlGet = Substitute.For<IKubectlGet>();
+            kubectlGet.Resource(Arg.Is<IResourceIdentity>(r => r.Name == "d1"), Arg.Any<IKubectl>()).Returns(SingleResult(deployment1));
+            kubectlGet.Resource(Arg.Is<IResourceIdentity>(r => r.Name == "d2"), Arg.Any<IKubectl>()).Returns(SingleResult(deployment2));
+            kubectlGet.AllResources(Arg.Is<ResourceGroupVersionKind>(g => g.Kind == "ReplicaSet"), Arg.Any<string>(), Arg.Any<IKubectl>()).Returns(ListResult(replicaSet1, replicaSet2));
+            kubectlGet.AllResources(Arg.Is<ResourceGroupVersionKind>(g => g.Kind == "Pod"), Arg.Any<string>(), Arg.Any<IKubectl>()).Returns(ListResult(pod1, pod2));
+
+            var resourceRetriever = new ResourceRetriever(kubectlGet, Substitute.For<ILog>());
+
+            resourceRetriever.GetAllOwnedResources(
+                new List<ResourceIdentifier>
+                {
+                    new ResourceIdentifier(SupportedResourceGroupVersionKinds.DeploymentV1, "d1", "octopus"),
+                    new ResourceIdentifier(SupportedResourceGroupVersionKinds.DeploymentV1, "d2", "octopus")
+                },
+                null, new Options()).ToList();
+
+            // Two deployments each own a ReplicaSet; without caching the Pod list would be fetched once per ReplicaSet.
+            kubectlGet.Received(1).AllResources(Arg.Is<ResourceGroupVersionKind>(g => g.Kind == "ReplicaSet"), Arg.Any<string>(), Arg.Any<IKubectl>());
+            kubectlGet.Received(1).AllResources(Arg.Is<ResourceGroupVersionKind>(g => g.Kind == "Pod"), Arg.Any<string>(), Arg.Any<IKubectl>());
+        }
+
+        static KubectlGetResult SingleResult(string json) => new KubectlGetResult(json, new List<string> { $"Info: {json}" }, 0);
+
+        static KubectlGetResult ListResult(params string[] items)
+        {
+            var json = $"{{items: [{string.Join(",", items)}]}}";
+            return new KubectlGetResult(json, new List<string> { $"Info: {json}" }, 0);
+        }
+
+        [Test]
         public void HandlesKubectlFailureWithExitCode()
         {
             var kubectlGet = new MockKubectlGet();

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DaemonSetTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DaemonSetTests.cs
@@ -54,6 +54,62 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
             });
         }
+
+        [Test]
+        public void ShouldBeSuccessfulWhenUpdatedAndAvailableMatchDesired()
+        {
+            var daemonSet = ResourceFactory.FromJson(DaemonSet(desired: 2, updated: 2, available: 2, ready: 2), new Options());
+
+            daemonSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
+        }
+
+        [Test]
+        public void ShouldBeInProgressWhenGenerationIsGreaterThanObservedGeneration()
+        {
+            var daemonSet = ResourceFactory.FromJson(DaemonSet(desired: 2, updated: 2, available: 2, ready: 2, generation: 2, observedGeneration: 1), new Options());
+
+            daemonSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+
+        [Test]
+        public void ShouldNotRequireReadyToMatchDesired()
+        {
+            // gitops-engine considers the rollout finished once updated and available pods match desired; it does not wait on numberReady.
+            var daemonSet = ResourceFactory.FromJson(DaemonSet(desired: 2, updated: 2, available: 2, ready: 0), new Options());
+
+            daemonSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
+        }
+
+        [Test]
+        public void WhenUsingLegacyChecks_RequiresReadyToMatchDesired()
+        {
+            var daemonSet = ResourceFactory.FromJson(DaemonSet(desired: 2, updated: 2, available: 2, ready: 0),
+                new Options { EnableLegacyResourceStatusChecks = true });
+
+            daemonSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+
+        static string DaemonSet(int desired, int updated, int available, int ready, int generation = 1, int observedGeneration = 1)
+        {
+            return $@"{{
+    ""apiVersion"": ""apps/v1"",
+    ""kind"": ""DaemonSet"",
+    ""metadata"": {{
+        ""name"": ""my-ds"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62"",
+        ""generation"": {generation}
+    }},
+    ""status"": {{
+        ""desiredNumberScheduled"": {desired},
+        ""currentNumberScheduled"": {updated},
+        ""numberAvailable"": {available},
+        ""numberReady"": {ready},
+        ""updatedNumberScheduled"": {updated},
+        ""observedGeneration"": {observedGeneration}
+    }}
+}}";
+        }
     }
 }
 

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/DeploymentTests.cs
@@ -37,7 +37,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         }
 
         [Test]
-        public void ShouldNotBeSuccessfulIfSomeChildrenPodsAreStillRunning()
+        public void WhenUsingLegacyChecks_ShouldNotBeSuccessfulIfSomeChildrenPodsAreStillRunning()
         {
             var input = new DeploymentResponseBuilder()
                         .WithDesiredReplicas(3)
@@ -46,7 +46,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                         .WithReadyReplicas(3)
                         .WithUpdatedReplicas(3)
                         .Build();
-            var deployment = ResourceFactory.FromJson(input, new Options());
+            var deployment = ResourceFactory.FromJson(input, new Options { EnableLegacyResourceStatusChecks = true });
 
             var pod = new PodResponseBuilder().Build();
             // More pods remaining than desired
@@ -62,7 +62,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         }
 
         [Test]
-        public void ShouldBeSuccessfulIfOnlyDesiredPodsAreRunning()
+        public void WhenUsingLegacyChecks_ShouldBeSuccessfulIfOnlyDesiredPodsAreRunning()
         {
             var input = new DeploymentResponseBuilder()
                         .WithDesiredReplicas(3)
@@ -71,7 +71,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                         .WithReadyReplicas(3)
                         .WithUpdatedReplicas(3)
                         .Build();
-            var deployment = ResourceFactory.FromJson(input, new Options());
+            var deployment = ResourceFactory.FromJson(input, new Options { EnableLegacyResourceStatusChecks = true });
 
             var pod = new PodResponseBuilder().Build();
             var children = Enumerable.Range(0, 3)
@@ -170,6 +170,47 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
 
             deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
         }
+
+        [Test]
+        public void ShouldIgnoreChildPodCountWhenNotUsingLegacyChecks()
+        {
+            var input = new DeploymentResponseBuilder()
+                        .WithDesiredReplicas(3)
+                        .WithTotalReplicas(3)
+                        .WithAvailableReplicas(3)
+                        .WithReadyReplicas(3)
+                        .WithUpdatedReplicas(3)
+                        .Build();
+            var deployment = ResourceFactory.FromJson(input, new Options());
+
+            var pod = new PodResponseBuilder().Build();
+            // More pods present than desired, as can happen while an HPA is stabilising.
+            var children = Enumerable.Range(0, 5)
+                                     .Select(_ => ResourceFactory.FromJson(pod, new Options()));
+
+            var replicaSet = new Resource();
+            replicaSet.UpdateChildren(children);
+
+            deployment.UpdateChildren(new[] { replicaSet });
+
+            deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
+        }
+
+        [Test]
+        public void ShouldBeSuccessfulWhenPaused()
+        {
+            var input = new DeploymentResponseBuilder()
+                        .WithDesiredReplicas(3)
+                        .WithTotalReplicas(1)
+                        .WithAvailableReplicas(1)
+                        .WithReadyReplicas(1)
+                        .WithUpdatedReplicas(1)
+                        .WithPaused()
+                        .Build();
+            var deployment = ResourceFactory.FromJson(input, new Options());
+
+            deployment.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
+        }
     }
 
     class DeploymentResponseBuilder
@@ -184,7 +225,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 ""generation"": {5}
             }},
             ""spec"": {{
-                ""replicas"": {0}
+                ""replicas"": {0}{8}
             }},
             ""status"": {{
                 ""replicas"": {1},
@@ -203,6 +244,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         int Generation { get; set; } = 1;
         int ObservedGeneration { get; set; } = 1;
         string Conditions { get; set; } = "";
+        bool Paused { get; set; }
 
         public DeploymentResponseBuilder WithDesiredReplicas(int replicas)
         {
@@ -246,6 +288,12 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
             return this;
         }
 
+        public DeploymentResponseBuilder WithPaused()
+        {
+            Paused = true;
+            return this;
+        }
+
         public DeploymentResponseBuilder WithProgressDeadlineExceeded()
         {
             Conditions = @",
@@ -271,7 +319,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                                  UpdatedReplicas,
                                  Generation,
                                  ObservedGeneration,
-                                 Conditions);
+                                 Conditions,
+                                 Paused ? @",
+                ""paused"": true" : "");
         }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/JobTests.cs
@@ -51,7 +51,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         [TestCase(0,1)]
         [TestCase(1,1)]
         [TestCase(1,2)]
-        public void WhenWaitForJobsIsEnabled_ShouldHaveStatusOfFailedIfBackOffLimitHasBeenReached(int backoffLimit, int failures)
+        public void WhenUsingLegacyChecks_ShouldHaveStatusOfFailedIfBackOffLimitHasBeenReached(int backoffLimit, int failures)
         {
             var jobResponse = new JobResponseBuilder()
                 .WithCompletions(1)
@@ -59,13 +59,13 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 .WithFailed(failures)
                 .Build();
 
-            var job = ResourceFactory.FromJson(jobResponse, new Options() { WaitForJobs = true });
+            var job = ResourceFactory.FromJson(jobResponse, new Options { WaitForJobs = true, EnableLegacyResourceStatusChecks = true });
 
             job.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Failed);
         }
 
         [Test]
-        public void WhenWaitForJobsIsEnabled_ShouldHaveStatusOfSuccessfulIfDesiredCompletionsHaveBeenAchieved()
+        public void WhenUsingLegacyChecks_ShouldHaveStatusOfSuccessfulIfDesiredCompletionsHaveBeenAchieved()
         {
             var jobResponse = new JobResponseBuilder()
                 .WithCompletions(3)
@@ -74,13 +74,13 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 .WithFailed(1)
                 .Build();
 
-            var job = ResourceFactory.FromJson(jobResponse, new Options() { WaitForJobs = true });
+            var job = ResourceFactory.FromJson(jobResponse, new Options { WaitForJobs = true, EnableLegacyResourceStatusChecks = true });
 
             job.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
         }
 
         [Test]
-        public void WhenWaitForJobsIsEnabled_ShouldHaveStatusOfInProgressIsDesiredCompletionsHaveNotBeenReached()
+        public void WhenUsingLegacyChecks_ShouldHaveStatusOfInProgressIfDesiredCompletionsHaveNotBeenReached()
         {
             var jobResponse = new JobResponseBuilder()
                 .WithCompletions(3)
@@ -89,7 +89,45 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 .WithFailed(1)
                 .Build();
 
-            var job = ResourceFactory.FromJson(jobResponse, new Options() { WaitForJobs = true });
+            var job = ResourceFactory.FromJson(jobResponse, new Options { WaitForJobs = true, EnableLegacyResourceStatusChecks = true });
+
+            job.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+
+        [Test]
+        public void WhenWaitForJobsIsEnabled_JobWithCompleteConditionShouldBeSuccessful()
+        {
+            var jobResponse = new JobResponseBuilder()
+                .WithCompletions(1)
+                .WithCondition("Complete", "True")
+                .Build();
+
+            var job = ResourceFactory.FromJson(jobResponse, new Options { WaitForJobs = true });
+
+            job.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
+        }
+
+        [Test]
+        public void WhenWaitForJobsIsEnabled_JobWithFailedConditionShouldBeFailed()
+        {
+            var jobResponse = new JobResponseBuilder()
+                .WithCompletions(1)
+                .WithCondition("Failed", "True")
+                .Build();
+
+            var job = ResourceFactory.FromJson(jobResponse, new Options { WaitForJobs = true });
+
+            job.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Failed);
+        }
+
+        [Test]
+        public void WhenWaitForJobsIsEnabled_JobWithoutConditionsShouldBeInProgress()
+        {
+            var jobResponse = new JobResponseBuilder()
+                .WithCompletions(1)
+                .Build();
+
+            var job = ResourceFactory.FromJson(jobResponse, new Options { WaitForJobs = true });
 
             job.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
         }
@@ -113,7 +151,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         ""succeeded"": {2},
         ""failed"": {3},
         ""startTime"": ""{4}"",
-        ""completionTime"": ""{5}""
+        ""completionTime"": ""{5}""{6}
     }}
 }}";
 
@@ -123,6 +161,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         private int Failed { get; set; }
         private string StartTime { get; set; }
         private string CompletionTime { get; set; }
+        private string Conditions { get; set; } = "";
 
         public JobResponseBuilder WithCompletions(int completions)
         {
@@ -160,10 +199,17 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
             return this;
         }
 
+        public JobResponseBuilder WithCondition(string type, string status)
+        {
+            Conditions = $@",
+        ""conditions"": [ {{ ""type"": ""{type}"", ""status"": ""{status}"" }} ]";
+            return this;
+        }
+
         public string Build()
         {
-            return string.Format(Template, Completions, BackoffLimit, Succeeded, Failed, StartTime, CompletionTime);
-        }        
+            return string.Format(Template, Completions, BackoffLimit, Succeeded, Failed, StartTime, CompletionTime, Conditions);
+        }
         
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/PodTests.cs
@@ -41,7 +41,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 Namespace = "test",
                 Ready = "1/2",
                 Restarts = 3,
-                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
+                ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.Failed
             });
         }
         
@@ -141,9 +141,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
             var pod = (Pod)ResourceFactory.FromJson(podResponse, new Options());
 
             pod.Status.Should().Be("ImagePullBackOff");
-            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.InProgress);
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Failed);
         }
-        
+
         [Test]
         public void WhenContainerFailsExecutionAndRestarting_TheStatusShouldShowCrashLoopBackOff()
         {
@@ -159,7 +159,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
             var pod = (Pod)ResourceFactory.FromJson(podResponse, new Options());
 
             pod.Status.Should().Be("CrashLoopBackOff");
-            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.InProgress);
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Failed);
         }
         
         [Test]
@@ -246,10 +246,46 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
             var pod = (Pod)ResourceFactory.FromJson(podResponse, new Options());
 
             pod.Status.Should().Be("ImagePullBackOff");
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.Failed);
+        }
+
+        [Test]
+        public void WhenAHookPodHasContainerErrors_ItShouldNotBeFailed()
+        {
+            // gitops-engine only fast-fails image-pull/crash-loop for RestartPolicy=Always pods so that
+            // finite hook pods (OnFailure/Never) are not prematurely failed.
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Pending")
+                .WithRestartPolicy("Never")
+                .WithContainerStates(new ContainerState[]
+                {
+                    new ContainerState { Waiting = new ContainerStateWaiting { Reason = "ImagePullBackOff" } }
+                })
+                .Build();
+
+            var pod = (Pod)ResourceFactory.FromJson(podResponse, new Options());
+
+            pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.InProgress);
+        }
+
+        [Test]
+        public void WhenUsingLegacyChecks_ContainerErrorsAreInProgressNotFailed()
+        {
+            var podResponse = new PodResponseBuilder()
+                .WithPhase("Running")
+                .WithContainerStates(new ContainerState[]
+                {
+                    new ContainerState { Waiting = new ContainerStateWaiting { Reason = "CrashLoopBackOff" } }
+                })
+                .WithReady(false)
+                .Build();
+
+            var pod = (Pod)ResourceFactory.FromJson(podResponse, new Options { EnableLegacyResourceStatusChecks = true });
+
             pod.ResourceStatus.Should().Be(KubernetesResources.ResourceStatus.InProgress);
         }
     }
-    
+
     public class PodResponseBuilder
     {
         private const string Template = @"
@@ -261,11 +297,14 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         ""namespace"": ""test"",
         ""uid"": ""123""
     }},
+    ""spec"": {{
+        ""restartPolicy"": ""{4}""
+    }},
     ""status"": {{
         ""phase"": ""{0}"",
         ""initContainerStatuses"": {1},
         ""containerStatuses"": {2},
-        ""conditions"": 
+        ""conditions"":
             [
                 {{
                     ""status"": ""{3}"",
@@ -274,15 +313,22 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
             ]
     }}
 }}";
-    
+
         private string Phase { get; set; } = "Running";
         private string InitContainerStatuses { get; set; } = "[]";
         private string ContainerStatuses { get; set; } = "[]";
         private string Ready { get; set; } = "False";
-        
+        private string RestartPolicy { get; set; } = "Always";
+
         public string Build()
         {
-            return string.Format(Template, Phase, InitContainerStatuses, ContainerStatuses, Ready);
+            return string.Format(Template, Phase, InitContainerStatuses, ContainerStatuses, Ready, RestartPolicy);
+        }
+
+        public PodResponseBuilder WithRestartPolicy(string restartPolicy)
+        {
+            RestartPolicy = restartPolicy;
+            return this;
         }
         
         public PodResponseBuilder WithPhase(string phase)

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ReplicaSetTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/ReplicaSetTests.cs
@@ -19,6 +19,9 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
         ""namespace"": ""default"",
         ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62""
     },
+    ""spec"": {
+        ""replicas"": 3
+    },
     ""status"": {
         ""availableReplicas"": 2,
         ""readyReplicas"": 2,
@@ -26,7 +29,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
     }
 }";
             var replicaSet = ResourceFactory.FromJson(input, new Options());
-            
+
             replicaSet.Should().BeEquivalentTo(new
             {
                 GroupVersionKind = SupportedResourceGroupVersionKinds.ReplicaSetV1,
@@ -38,6 +41,70 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 Current = 2,
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
             });
+        }
+
+        [Test]
+        public void ShouldBeSuccessfulWhenAvailableReplicasMatchesSpec()
+        {
+            var replicaSet = ResourceFactory.FromJson(ReplicaSet(specReplicas: 3, availableReplicas: 3), new Options());
+
+            replicaSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
+        }
+
+        [Test]
+        public void ShouldBeInProgressWhenGenerationIsGreaterThanObservedGeneration()
+        {
+            var replicaSet = ResourceFactory.FromJson(ReplicaSet(specReplicas: 3, availableReplicas: 3, generation: 2, observedGeneration: 1), new Options());
+
+            replicaSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+
+        [Test]
+        public void ShouldBeFailedWhenReplicaFailureConditionIsTrue()
+        {
+            const string conditions = @",""conditions"": [ { ""type"": ""ReplicaFailure"", ""status"": ""True"" } ]";
+            var replicaSet = ResourceFactory.FromJson(ReplicaSet(specReplicas: 3, availableReplicas: 0, conditions: conditions), new Options());
+
+            replicaSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Failed);
+        }
+
+        [Test]
+        public void WhenUsingLegacyChecks_StatusIsBasedOnStatusReplicas()
+        {
+            // No spec.replicas: the legacy check compares status.replicas, readyReplicas and availableReplicas.
+            var replicaSet = ResourceFactory.FromJson(ReplicaSet(availableReplicas: 3, readyReplicas: 3, statusReplicas: 3),
+                new Options { EnableLegacyResourceStatusChecks = true });
+
+            replicaSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
+        }
+
+        static string ReplicaSet(
+            int? specReplicas = null,
+            int availableReplicas = 0,
+            int readyReplicas = 0,
+            int statusReplicas = 0,
+            int generation = 0,
+            int observedGeneration = 0,
+            string conditions = "")
+        {
+            var spec = specReplicas.HasValue ? $@"""spec"": {{ ""replicas"": {specReplicas.Value} }}," : "";
+            return $@"{{
+    ""apiVersion"": ""apps/v1"",
+    ""kind"": ""ReplicaSet"",
+    ""metadata"": {{
+        ""name"": ""nginx"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62"",
+        ""generation"": {generation}
+    }},
+    {spec}
+    ""status"": {{
+        ""availableReplicas"": {availableReplicas},
+        ""readyReplicas"": {readyReplicas},
+        ""replicas"": {statusReplicas},
+        ""observedGeneration"": {observedGeneration}{conditions}
+    }}
+}}";
         }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/StatefulSetTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/Resources/StatefulSetTests.cs
@@ -25,7 +25,7 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
     }
 }";
             var statefulSet = ResourceFactory.FromJson(input, new Options());
-            
+
             statefulSet.Should().BeEquivalentTo(new
             {
                 GroupVersionKind = SupportedResourceGroupVersionKinds.StatefulSetV1,
@@ -36,6 +36,77 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus.Resources
                 ResourceStatus = Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress
             });
         }
+
+        [Test]
+        public void ShouldBeSuccessfulWhenObservedAndAllReplicasReadyAtCurrentRevision()
+        {
+            var statefulSet = ResourceFactory.FromJson(StatefulSet(specReplicas: 3, readyReplicas: 3), new Options());
+
+            statefulSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
+        }
+
+        [Test]
+        public void ShouldBeInProgressWhenReadyReplicasLessThanSpec()
+        {
+            var statefulSet = ResourceFactory.FromJson(StatefulSet(specReplicas: 3, readyReplicas: 2), new Options());
+
+            statefulSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+
+        [Test]
+        public void ShouldBeInProgressWhenGenerationIsGreaterThanObservedGeneration()
+        {
+            var statefulSet = ResourceFactory.FromJson(StatefulSet(specReplicas: 3, readyReplicas: 3, generation: 2, observedGeneration: 1), new Options());
+
+            statefulSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+
+        [Test]
+        public void ShouldBeInProgressWhenUpdateRevisionDiffersFromCurrentRevision()
+        {
+            var statefulSet = ResourceFactory.FromJson(StatefulSet(specReplicas: 3, readyReplicas: 3, updateRevision: "rev2", currentRevision: "rev1"), new Options());
+
+            statefulSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.InProgress);
+        }
+
+        [Test]
+        public void WhenUsingLegacyChecks_StatusComparesReadyToStatusReplicas()
+        {
+            var statefulSet = ResourceFactory.FromJson(StatefulSet(readyReplicas: 3, statusReplicas: 3, observedGeneration: 0),
+                new Options { EnableLegacyResourceStatusChecks = true });
+
+            statefulSet.ResourceStatus.Should().Be(Kubernetes.ResourceStatus.Resources.ResourceStatus.Successful);
+        }
+
+        static string StatefulSet(
+            int? specReplicas = null,
+            int readyReplicas = 0,
+            int? statusReplicas = null,
+            int generation = 1,
+            int observedGeneration = 1,
+            string updateRevision = "rev1",
+            string currentRevision = "rev1")
+        {
+            var spec = specReplicas.HasValue ? $@"""spec"": {{ ""replicas"": {specReplicas.Value} }}," : "";
+            return $@"{{
+    ""apiVersion"": ""apps/v1"",
+    ""kind"": ""StatefulSet"",
+    ""metadata"": {{
+        ""name"": ""my-sts"",
+        ""namespace"": ""default"",
+        ""uid"": ""01695a39-5865-4eea-b4bf-1a4783cbce62"",
+        ""generation"": {generation}
+    }},
+    {spec}
+    ""status"": {{
+        ""readyReplicas"": {readyReplicas},
+        ""replicas"": {statusReplicas ?? readyReplicas},
+        ""updatedReplicas"": {readyReplicas},
+        ""observedGeneration"": {observedGeneration},
+        ""updateRevision"": ""{updateRevision}"",
+        ""currentRevision"": ""{currentRevision}""
+    }}
+}}";
+        }
     }
 }
-

--- a/source/Calamari/Kubernetes/ResourceStatus/Options.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Options.cs
@@ -12,7 +12,13 @@ namespace Calamari.Kubernetes.ResourceStatus
         public bool WaitForJobs { get; set; }
 
         public bool PrintVerboseKubectlOutputOnError { get; set; }
-        
+
         public bool PrintVerboseOutput { get; set; }
+
+        /// <summary>
+        /// Break-glass toggle that reverts resource status checks to the legacy logic that predates
+        /// alignment with the gitops-engine health checks. Disabled by default.
+        /// </summary>
+        public bool EnableLegacyResourceStatusChecks { get; set; }
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
@@ -50,6 +50,8 @@ namespace Calamari.Kubernetes.ResourceStatus
         /// <inheritdoc />
         public IEnumerable<ResourceRetrieverResult> GetAllOwnedResources(IEnumerable<ResourceIdentifier> resourceIdentifiers, IKubectl kubectl, Options options)
         {
+            var childResourceCache = new Dictionary<(ResourceGroupVersionKind, string), KubectlGetResult>();
+
             var results = resourceIdentifiers
                           .Select(identifier => GetResource(identifier, kubectl, options))
                           .ToList();
@@ -57,7 +59,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             foreach (var result in results.Where(r => r.IsSuccess))
             {
                 var resource = result.Value;
-                resource.UpdateChildren(GetChildrenResources(resource, kubectl, options));
+                resource.UpdateChildren(GetChildrenResources(resource, kubectl, options, childResourceCache));
             }
 
             return results;
@@ -75,13 +77,13 @@ namespace Calamari.Kubernetes.ResourceStatus
             return !parseResult.IsSuccess ? ResourceRetrieverResult.Failure(parseResult.ErrorMessage) : ResourceRetrieverResult.Success(parseResult.Value);
         }
 
-        IEnumerable<Resource> GetChildrenResources(Resource parentResource, IKubectl kubectl, Options options)
+        IEnumerable<Resource> GetChildrenResources(Resource parentResource, IKubectl kubectl, Options options,
+            Dictionary<(ResourceGroupVersionKind, string), KubectlGetResult> childResourceCache)
         {
             var childGvk = parentResource.ChildGroupVersionKind;
             if (childGvk is null) return Enumerable.Empty<Resource>();
 
-            var result = kubectlGet.AllResources(childGvk, parentResource.Namespace, kubectl);
-            LogKubectlErrorIfFailed(result, options, log);
+            var result = GetAllResourcesCached(childGvk, parentResource.Namespace, kubectl, options, childResourceCache);
 
             if (result.RawOutput.IsNullOrEmpty())
             {
@@ -103,10 +105,25 @@ namespace Calamari.Kubernetes.ResourceStatus
             return resources.Where(resource => resource.OwnerUids.Contains(parentResource.Uid))
                             .Select(child =>
                                     {
-                                        child.UpdateChildren(GetChildrenResources(child, kubectl, options));
+                                        child.UpdateChildren(GetChildrenResources(child, kubectl, options, childResourceCache));
                                         return child;
                                     })
                             .ToList();
+        }
+
+        KubectlGetResult GetAllResourcesCached(ResourceGroupVersionKind groupVersionKind, string @namespace, IKubectl kubectl, Options options,
+            Dictionary<(ResourceGroupVersionKind, string), KubectlGetResult> childResourceCache)
+        {
+            var cacheKey = (groupVersionKind, @namespace);
+            if (childResourceCache.TryGetValue(cacheKey, out var cachedResult))
+            {
+                return cachedResult;
+            }
+
+            var result = kubectlGet.AllResources(groupVersionKind, @namespace, kubectl);
+            LogKubectlErrorIfFailed(result, options, log);
+            childResourceCache[cacheKey] = result;
+            return result;
         }
 
         static ParseResult<T> TryParse<T>(Func<string, Options, T> function, KubectlGetResult getResult, Options options) where T : class

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceStatusReportExecutor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes.ResourceStatus.Resources;
 
@@ -35,8 +36,9 @@ namespace Calamari.Kubernetes.ResourceStatus
 
             return runningResourceStatusCheckFactory(timeout, new Options
             {
-                WaitForJobs = waitForJobs, 
-                PrintVerboseKubectlOutputOnError = variables.GetFlag(SpecialVariables.PrintVerboseKubectlOutputOnError)
+                WaitForJobs = waitForJobs,
+                PrintVerboseKubectlOutputOnError = variables.GetFlag(SpecialVariables.PrintVerboseKubectlOutputOnError),
+                EnableLegacyResourceStatusChecks = OctopusFeatureToggles.EnableLegacyKubernetesResourceChecksFeatureToggle.IsEnabled(variables)
             }, initialResources);
         }
     }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ContainerStatus.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ContainerStatus.cs
@@ -7,7 +7,10 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     {
         [JsonProperty("state")]
         public ContainerState State { get; set; }
-        
+
+        [JsonProperty("lastState")]
+        public ContainerState LastState { get; set; }
+
         [JsonProperty("ready")]
         public bool Ready { get; set; }
         

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
@@ -26,9 +26,42 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                 ?.ToObject<Dictionary<string, string>>() ?? new Dictionary<string, string>();
             NodeSelector = FormatNodeSelectors(selectors);
 
-            ResourceStatus = Available == Desired && UpToDate == Desired && Ready == Desired
+            ResourceStatus = options.EnableLegacyResourceStatusChecks
+                ? GetLegacyResourceStatus()
+                : GetResourceStatus();
+        }
+
+        ResourceStatus GetLegacyResourceStatus()
+            => Available == Desired && UpToDate == Desired && Ready == Desired
                 ? ResourceStatus.Successful
                 : ResourceStatus.InProgress;
+
+        // Aligns with gitops-engine getDaemonSetHealth.
+        ResourceStatus GetResourceStatus()
+        {
+            var generation = FieldOrDefault("$.metadata.generation", 0);
+            var observedGeneration = FieldOrDefault("$.status.observedGeneration", 0);
+            if (generation > observedGeneration)
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            if (Field("$.spec.updateStrategy.type") == "OnDelete")
+            {
+                return ResourceStatus.Successful;
+            }
+
+            if (UpToDate < Desired)
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            if (Available < Desired)
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            return ResourceStatus.Successful;
         }
 
         public override bool HasUpdate(Resource lastStatus)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
@@ -9,6 +9,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     {
         public override ResourceGroupVersionKind ChildGroupVersionKind => SupportedResourceGroupVersionKinds.ReplicaSetV1;
 
+        readonly bool enableLegacyResourceStatusChecks;
+
         public int UpToDate { get; }
         public string Ready { get; }
         public int Available { get; }
@@ -22,52 +24,71 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public Deployment(JObject json, Options options) : base(json, options)
         {
+            enableLegacyResourceStatusChecks = options.EnableLegacyResourceStatusChecks;
+
             ReadyReplicas = FieldOrDefault("$.status.readyReplicas", 0);
             Desired = FieldOrDefault("$.spec.replicas", 0);
             TotalReplicas = FieldOrDefault("$.status.replicas", 0);
             Ready = $"{ReadyReplicas}/{Desired}";
             Available = FieldOrDefault("$.status.availableReplicas", 0);
             UpToDate = FieldOrDefault("$.status.updatedReplicas", 0);
-            
+
+            ResourceStatus = GetResourceStatus(json);
+        }
+
+        // Deployment status logic aligns with ArgoCD's gitops-engine, which is also used in the Kubernetes Monitor.
+        ResourceStatus GetResourceStatus(JObject json)
+        {
+            // gitops-engine treats a paused deployment as suspended rather than blocking on it.
+            if (!enableLegacyResourceStatusChecks && FieldOrDefault("$.spec.paused", false))
+            {
+                return ResourceStatus.Successful;
+            }
+
             var generation = FieldOrDefault("$.metadata.generation", 0);
             var observedGeneration = FieldOrDefault("$.status.observedGeneration", 0);
-            
-            // Note that deployment status logic aligns with ArgoCD's gitops-engine, which is also used in the Kubernetes Monitor
-            if (generation <= observedGeneration)
+
+            if (generation > observedGeneration)
             {
-                var conditions = json.SelectToken("$.status.conditions") as JArray;
-                var progressingCondition = conditions?.FirstOrDefault(c => c["type"]?.ToString() == "Progressing");
-                
-                if (progressingCondition != null && progressingCondition["reason"]?.ToString() == "ProgressDeadlineExceeded")
-                {
-                    ResourceStatus = ResourceStatus.Failed;
-                }
-                else if (Desired > 0 && UpToDate < Desired)
-                {
-                    ResourceStatus = ResourceStatus.InProgress;
-                }
-                else if (TotalReplicas > UpToDate)
-                {
-                    ResourceStatus = ResourceStatus.InProgress;
-                }
-                else if (Available < UpToDate)
-                {
-                    ResourceStatus = ResourceStatus.InProgress;
-                }
-                else
-                {
-                    ResourceStatus = ResourceStatus.Successful;
-                }
+                return ResourceStatus.InProgress;
             }
-            else
+
+            var conditions = json.SelectToken("$.status.conditions") as JArray;
+            var progressingCondition = conditions?.FirstOrDefault(c => c["type"]?.ToString() == "Progressing");
+            if (progressingCondition != null && progressingCondition["reason"]?.ToString() == "ProgressDeadlineExceeded")
             {
-                ResourceStatus = ResourceStatus.InProgress;
+                return ResourceStatus.Failed;
             }
+
+            if (Desired > 0 && UpToDate < Desired)
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            if (TotalReplicas > UpToDate)
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            if (Available < UpToDate)
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            return ResourceStatus.Successful;
         }
 
         public override void UpdateChildren(IEnumerable<Resource> children)
         {
             base.UpdateChildren(children);
+
+            // This legacy check races against autoscalers (e.g. HPA) that adjust spec.replicas during a deployment
+            // Remove once we're happy to push out fully
+            if (!enableLegacyResourceStatusChecks)
+            {
+                return;
+            }
+
             var foundReplicas = Children
                 ?.SelectMany(child => child?.Children ?? Enumerable.Empty<Resource>())
                 .Count() ?? 0;
@@ -78,8 +99,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         {
             var last = CastOrThrow<Deployment>(lastStatus);
             return last.ResourceStatus != ResourceStatus
-                || last.UpToDate != UpToDate 
-                || last.Ready != Ready 
+                || last.UpToDate != UpToDate
+                || last.Ready != Ready
                 || last.Available != Available;
         }
     }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
@@ -20,29 +20,60 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
             Duration = $"{completionTime - startTime:c}";
 
-            var backoffLimit = FieldOrDefault("$.spec.backoffLimit", 0);
-
-            // Using a default value of -1 rather than 0 as a job can be created with a backoffLimit of 0 and we don't want to immediately mark the job as failed
-            var failed = FieldOrDefault("$.status.failed", -1);
-
             if (!options.WaitForJobs)
             {
                 ResourceStatus = ResourceStatus.Successful;
                 return;
             }
 
+            ResourceStatus = options.EnableLegacyResourceStatusChecks
+                ? GetLegacyResourceStatus(succeeded, desired)
+                : GetResourceStatus(json);
+        }
+
+        ResourceStatus GetLegacyResourceStatus(int succeeded, int desired)
+        {
+            var backoffLimit = FieldOrDefault("$.spec.backoffLimit", 0);
+
+            // Using a default value of -1 rather than 0 as a job can be created with a backoffLimit of 0 and we don't want to immediately mark the job as failed
+            var failed = FieldOrDefault("$.status.failed", -1);
+
             if (failed >= backoffLimit)
             {
-                ResourceStatus = ResourceStatus.Failed;
-            } 
-            else if (succeeded == desired)
-            {
-                ResourceStatus = ResourceStatus.Successful;
+                return ResourceStatus.Failed;
             }
-            else
+
+            return succeeded == desired ? ResourceStatus.Successful : ResourceStatus.InProgress;
+        }
+
+        // Aligns with gitops-engine getJobHealth.
+        static ResourceStatus GetResourceStatus(JObject json)
+        {
+            var conditions = json.SelectToken("$.status.conditions") as JArray ?? new JArray();
+            var complete = false;
+            var failed = false;
+            foreach (var condition in conditions)
             {
-                ResourceStatus = ResourceStatus.InProgress;
+                switch (condition["type"]?.ToString())
+                {
+                    case "Failed":
+                        complete = true;
+                        failed = true;
+                        break;
+                    // gitops-engine also treats a Suspended job as complete; both it and a completed job are non-blocking here.
+                    case "Complete":
+                    case "Suspended":
+                        complete = true;
+                        break;
+                }
             }
+
+            if (!complete)
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            return failed ? ResourceStatus.Failed : ResourceStatus.Successful;
         }
 
         public override bool HasUpdate(Resource lastStatus)
@@ -52,4 +83,3 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         }
     }
 }
-

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
@@ -24,29 +24,78 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             
             Status = GetStatus(phase, initContainerStatuses, containerStatuses);
 
-            switch (phase)
-            {
-                case "Failed":
-                case "Unknown":
-                    ResourceStatus = ResourceStatus.Failed;
-                    break;
-                case "Succeeded":
-                    ResourceStatus = ResourceStatus.Successful;
-                    break;
-                case "Pending":
-                    ResourceStatus = ResourceStatus.InProgress;
-                    break;
-                default:
-                    ResourceStatus = ready == "True" ? ResourceStatus.Successful : ResourceStatus.InProgress;
-                    break;
-            }
+            var restartPolicy = FieldOrDefault("$.spec.restartPolicy", "Always");
+            ResourceStatus = options.EnableLegacyResourceStatusChecks
+                ? GetLegacyResourceStatus(phase, ready)
+                : GetResourceStatus(phase, containerStatuses, ready, restartPolicy);
 
             var containers = containerStatuses.Length;
             var readyContainers = containerStatuses.Count(status => status.Ready);
             Ready = $"{readyContainers}/{containers}";
             Restarts = containerStatuses.Select(status => status.RestartCount).Sum();
         }
-    
+
+        static ResourceStatus GetLegacyResourceStatus(string phase, string ready)
+        {
+            switch (phase)
+            {
+                case "Failed":
+                case "Unknown":
+                    return ResourceStatus.Failed;
+                case "Succeeded":
+                    return ResourceStatus.Successful;
+                case "Pending":
+                    return ResourceStatus.InProgress;
+                default:
+                    return ready == "True" ? ResourceStatus.Successful : ResourceStatus.InProgress;
+            }
+        }
+
+        // Aligns with gitops-engine getPodHealth.
+        static ResourceStatus GetResourceStatus(string phase, ContainerStatus[] containerStatuses, string ready, string restartPolicy)
+        {
+            // gitops-engine flags image-pull/crash-loop errors as failed, but only for pods that are meant to
+            // run continuously (RestartPolicy=Always) so that finite hook pods are not prematurely failed.
+            if (restartPolicy == "Always" && containerStatuses.Any(HasImageOrCrashError))
+            {
+                return ResourceStatus.Failed;
+            }
+
+            switch (phase)
+            {
+                case "Pending":
+                    return ResourceStatus.InProgress;
+                case "Succeeded":
+                    return ResourceStatus.Successful;
+                case "Failed":
+                    return ResourceStatus.Failed;
+                case "Running":
+                    if (restartPolicy == "OnFailure" || restartPolicy == "Never")
+                    {
+                        return ResourceStatus.InProgress;
+                    }
+                    if (ready == "True")
+                    {
+                        return ResourceStatus.Successful;
+                    }
+                    return containerStatuses.Any(status => status.LastState?.Terminated != null)
+                        ? ResourceStatus.Failed
+                        : ResourceStatus.InProgress;
+                default:
+                    return ResourceStatus.InProgress;
+            }
+        }
+
+        static bool HasImageOrCrashError(ContainerStatus status)
+        {
+            var reason = status.State?.Waiting?.Reason;
+            if (string.IsNullOrEmpty(reason))
+            {
+                return false;
+            }
+            return reason.StartsWith("Err") || reason.EndsWith("Error") || reason.EndsWith("BackOff");
+        }
+
         public override bool HasUpdate(Resource lastStatus)
         {
             var last = CastOrThrow<Pod>(lastStatus);

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ReplicaSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ReplicaSet.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Newtonsoft.Json.Linq;
 
 namespace Calamari.Kubernetes.ResourceStatus.Resources
@@ -15,16 +16,41 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             Desired = FieldOrDefault("$.status.replicas", 0);
             Current = FieldOrDefault($".status.availableReplicas", 0);
             Ready = FieldOrDefault("$.status.readyReplicas", 0);
-            
-            if (Ready == Desired && Desired == Current)
-            {
-                ResourceStatus = ResourceStatus.Successful;
-            }
-            else
-            {
-                ResourceStatus = ResourceStatus.InProgress;
-            }
+
+            ResourceStatus = options.EnableLegacyResourceStatusChecks
+                ? GetLegacyResourceStatus()
+                : GetResourceStatus(json);
         }
+
+        ResourceStatus GetLegacyResourceStatus()
+            => Ready == Desired && Desired == Current ? ResourceStatus.Successful : ResourceStatus.InProgress;
+
+        // Aligns with gitops-engine getReplicaSetHealth.
+        ResourceStatus GetResourceStatus(JObject json)
+        {
+            var generation = FieldOrDefault("$.metadata.generation", 0);
+            var observedGeneration = FieldOrDefault("$.status.observedGeneration", 0);
+            if (generation > observedGeneration)
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            var conditions = json.SelectToken("$.status.conditions") as JArray;
+            var replicaFailure = conditions?.FirstOrDefault(c => c["type"]?.ToString() == "ReplicaFailure");
+            if (replicaFailure != null && replicaFailure["status"]?.ToString() == "True")
+            {
+                return ResourceStatus.Failed;
+            }
+
+            var specReplicas = FieldOrDefault<int?>("$.spec.replicas", null);
+            if (specReplicas.HasValue && Current < specReplicas.Value)
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            return ResourceStatus.Successful;
+        }
+
         public override bool HasUpdate(Resource lastStatus)
         {
             var last = CastOrThrow<ReplicaSet>(lastStatus);

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/StatefulSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/StatefulSet.cs
@@ -14,7 +14,53 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             var replicas = FieldOrDefault("$.status.replicas", 0);
             Ready = $"{readyReplicas}/{replicas}";
 
-            ResourceStatus = readyReplicas == replicas ? ResourceStatus.Successful : ResourceStatus.InProgress;
+            ResourceStatus = options.EnableLegacyResourceStatusChecks
+                ? GetLegacyResourceStatus(readyReplicas, replicas)
+                : GetResourceStatus(readyReplicas);
+        }
+
+        static ResourceStatus GetLegacyResourceStatus(int readyReplicas, int replicas)
+            => readyReplicas == replicas ? ResourceStatus.Successful : ResourceStatus.InProgress;
+
+        // Aligns with gitops-engine getStatefulSetHealth.
+        ResourceStatus GetResourceStatus(int readyReplicas)
+        {
+            var generation = FieldOrDefault("$.metadata.generation", 0);
+            var observedGeneration = FieldOrDefault("$.status.observedGeneration", 0);
+            if (observedGeneration == 0 || generation > observedGeneration)
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            var specReplicas = FieldOrDefault<int?>("$.spec.replicas", null);
+            if (specReplicas.HasValue && readyReplicas < specReplicas.Value)
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            var updateStrategy = Field("$.spec.updateStrategy.type");
+            if (updateStrategy == "RollingUpdate" && data.SelectToken("$.spec.updateStrategy.rollingUpdate") != null)
+            {
+                var partition = FieldOrDefault<int?>("$.spec.updateStrategy.rollingUpdate.partition", null);
+                var updatedReplicas = FieldOrDefault("$.status.updatedReplicas", 0);
+                if (specReplicas.HasValue && partition.HasValue && updatedReplicas < specReplicas.Value - partition.Value)
+                {
+                    return ResourceStatus.InProgress;
+                }
+                return ResourceStatus.Successful;
+            }
+
+            if (updateStrategy == "OnDelete")
+            {
+                return ResourceStatus.Successful;
+            }
+
+            if (Field("$.status.updateRevision") != Field("$.status.currentRevision"))
+            {
+                return ResourceStatus.InProgress;
+            }
+
+            return ResourceStatus.Successful;
         }
 
         public override bool HasUpdate(Resource lastStatus)
@@ -24,4 +70,3 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         }
     }
 }
-


### PR DESCRIPTION
When KOS was running against a deployment with a HPA, there were 2 reported issues:

1. We never stabilised, due to HPAs constantly adjusting replica counts
2. The check took a long time (3min+) to run on clusters with many resources

This change aligns most workload-level resources with the logic that GitOps engine uses, as they have worked out more edge cases than we have. This leads to the checks being more reliable, and we also match KOS with KLOS, which implements the GitOps engine entirely.

We also add a cache for child objects to each check (invalidated for each check run) so that we don't list _all_ resources in the cluster multiple times for any given check, which caused slow check speeds.