### PR TITLE
Remove unused Microsoft.AspNetCore.WebUtilities from Calamari.AzureAppService and Markdown dependency 

### DIFF
--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -14,7 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.ResourceManager.AppService" Version="1.0.2" />
     <PackageReference Include="Azure.ResourceManager.ResourceGraph" Version="1.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Polly" Version="8.3.1" />
     <PackageReference Include="SharpCompress" Version="0.37.2">

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -47,7 +47,6 @@
     <PackageReference Include="Polly" Version="8.3.1" />
     <PackageReference Include="NuGet.Commands" Version="7.0.3" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
-    <PackageReference Include="Markdown" Version="2.1.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -38,7 +38,6 @@
         <ProjectReference Include="..\Calamari.Aws\Calamari.Aws.csproj"/>
         <ProjectReference Include="..\Calamari.Azure\Calamari.Azure.csproj"/>
         <ProjectReference Include="..\Calamari.DockerCredentialHelper\Calamari.DockerCredentialHelper.csproj"/>
-        <PackageReference Include="Markdown" Version="2.1.0"/>
         <PackageReference Include="NGitLab" Version="10.4.1"/>
         <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.3.0"/>
     </ItemGroup>


### PR DESCRIPTION
Unreferenced: no use of WebUtilities or any of its types, no ImplicitUsings, 

This drops an ASP.NET Core 2.2 dependency.

Verified: net8.0 builds of Calamari.AzureAppService and Calamari.AzureAppService.Tests both report 0 errors, and a forced
--no-cache restore confirms the package is absent from the dependency graph.


Markdown library was never really used.

<img width="2864" height="1032" alt="CleanShot 2026-07-31 at 15 33 16@2x" src="https://github.com/user-attachments/assets/2079f40b-0786-4583-91ff-8ae690200acc" />
