### PR TITLE
Update SharpCompress to 0.49.1 and re-arm its vulnerability alerting (SF-1864)

### DIFF
--- a/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/UploadAwsS3Convention.cs
@@ -334,25 +334,25 @@ public class UploadAwsS3Convention(
         using var targetArchive = fileSystem.CreateTemporaryFile(string.Empty, out var targetArchivePath);
         if (supportedZipExtensions.Any(lowercasedFileName.EndsWith) || supportedJavaExtensions.Any(lowercasedFileName.EndsWith))
         {
-            using var archive = ZipArchive.Create();
+            using var archive = ZipArchive.CreateArchive();
             archive.AddAllFromDirectory(stagingDirectory);
             archive.SaveTo(targetArchive, CompressionType.Deflate);
         }
         else if (supportedTarExtensions.Any(lowercasedFileName.EndsWith))
         {
-            using var archive = TarArchive.Create();
+            using var archive = TarArchive.CreateArchive();
             archive.AddAllFromDirectory(stagingDirectory);
             archive.SaveTo(targetArchive, CompressionType.None);
         }
         else if (supportedTarGZipExtensions.Any(lowercasedFileName.EndsWith))
         {
-            using var archive = TarArchive.Create();
+            using var archive = TarArchive.CreateArchive();
             archive.AddAllFromDirectory(stagingDirectory);
             archive.SaveTo(targetArchive, CompressionType.GZip);
         }
         else if (supportedTarBZip2Extensions.Any(lowercasedFileName.EndsWith))
         {
-            using var archive = TarArchive.Create();
+            using var archive = TarArchive.CreateArchive();
             archive.AddAllFromDirectory(stagingDirectory);
             archive.SaveTo(targetArchive, CompressionType.BZip2);
         }

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/NugetPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/NugetPackageProvider.cs
@@ -15,7 +15,7 @@ namespace Calamari.AzureAppService
         {
             await Task.Run(() =>
             {
-                using var archive = ZipArchive.Create();
+                using var archive = ZipArchive.CreateArchive();
                 archive.AddAllFromDirectory(
                     $"{sourceDirectory}");
                 archive.SaveTo($"{targetDirectory}/app.zip", CompressionType.Deflate);

--- a/source/Calamari.AzureAppService/ArchivePackagProvider/ZipPackageProvider.cs
+++ b/source/Calamari.AzureAppService/ArchivePackagProvider/ZipPackageProvider.cs
@@ -15,7 +15,7 @@ namespace Calamari.AzureAppService
         {
             await Task.Run(() =>
             {
-                using var archive = ZipArchive.Create();
+                using var archive = ZipArchive.CreateArchive();
                 archive.AddAllFromDirectory(
                     $"{sourceDirectory}");
                 archive.SaveTo($"{targetDirectory}/app.zip", CompressionType.Deflate);

--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -17,9 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Polly" Version="8.3.1" />
-    <PackageReference Include="SharpCompress" Version="0.37.2">
-      <NoWarn>NU1902</NoWarn>
-    </PackageReference>
+    <PackageReference Include="SharpCompress" Version="0.49.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.16" />
   </ItemGroup>

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -29,9 +29,7 @@
         <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
         <PackageReference Include="Octostache" Version="3.9.2" />
         <PackageReference Include="Polly" Version="8.3.1" />
-        <PackageReference Include="SharpCompress" Version="0.37.2">
-            <NoWarn>NU1902</NoWarn>
-        </PackageReference>
+        <PackageReference Include="SharpCompress" Version="0.49.1" />
         <PackageReference Include="XPath2" Version="1.1.5" />
         <PackageReference Include="YamlDotNet" Version="16.3.0" />
         <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/source/Calamari.Common/Features/Packages/Decorators/ArchiveLimits/EnforceCompressionRatioDecorator.cs
+++ b/source/Calamari.Common/Features/Packages/Decorators/ArchiveLimits/EnforceCompressionRatioDecorator.cs
@@ -32,10 +32,10 @@ namespace Calamari.Common.Features.Packages.Decorators.ArchiveLimits
                 if (maximumCompressionRatio >= 1)
                 {
                     var archiveInfo = new FileInfo(packageFile);
-                    using (var archive = ArchiveFactory.Open(packageFile))
+                    using (var archive = ArchiveFactory.OpenArchive(packageFile))
                     {
                         var compressedSize = archiveInfo.Length;
-                        var uncompressedSize = archive.TotalUncompressSize;
+                        var uncompressedSize = archive.TotalUncompressedSize;
                         var compressionRatio = compressedSize == 0 ? 0 : (double)uncompressedSize / compressedSize;
 
                         if (compressionRatio > maximumCompressionRatio)

--- a/source/Calamari.Common/Features/Packages/Decorators/ArchiveLimits/EnforceDecompressionLimitDecorator.cs
+++ b/source/Calamari.Common/Features/Packages/Decorators/ArchiveLimits/EnforceDecompressionLimitDecorator.cs
@@ -31,9 +31,9 @@ namespace Calamari.Common.Features.Packages.Decorators.ArchiveLimits
             {
                 if (maximumUncompressedSize > 0)
                 {
-                    using (var archive = ArchiveFactory.Open(packageFile))
+                    using (var archive = ArchiveFactory.OpenArchive(packageFile))
                     {
-                        var totalUncompressedSize = archive.TotalUncompressSize;
+                        var totalUncompressedSize = archive.TotalUncompressedSize;
 
                         if (totalUncompressedSize > maximumUncompressedSize)
                         {

--- a/source/Calamari.Common/Features/Packages/Decorators/Logging/LogArchiveMetricsDecorator.cs
+++ b/source/Calamari.Common/Features/Packages/Decorators/Logging/LogArchiveMetricsDecorator.cs
@@ -34,14 +34,14 @@ namespace Calamari.Common.Features.Packages.Decorators.Logging
             try
             {
                 var archiveInfo = new FileInfo(archivePath);
-                using (var archive = ArchiveFactory.Open(archivePath))
+                using (var archive = ArchiveFactory.OpenArchive(archivePath))
                 {
                     var compressedSize = archiveInfo.Length;
-                    var uncompressedSize = archive.TotalUncompressSize;
+                    var uncompressedSize = archive.TotalUncompressedSize;
                     var compressionRatio = compressedSize == 0 ? 0 : (double)uncompressedSize / compressedSize;
 
                     log.LogMetric("DeploymentPackageCompressedSize", compressedSize, operationId);
-                    log.LogMetric("DeploymentPackageUncompressedSize", archive.TotalUncompressSize, operationId);
+                    log.LogMetric("DeploymentPackageUncompressedSize", archive.TotalUncompressedSize, operationId);
                     log.LogMetric("DeploymentPackageCompressionRatio", compressionRatio, operationId);
                 }
             }

--- a/source/Calamari.Common/Features/Packages/NuGet/LocalNuGetPackage.cs
+++ b/source/Calamari.Common/Features/Packages/NuGet/LocalNuGetPackage.cs
@@ -35,7 +35,7 @@ namespace Calamari.Common.Features.Packages.NuGet
         static ManifestMetadata ReadMetadata(string filePath)
         {
             using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
-            using (var archive = ZipArchive.Open(fileStream))
+            using (var archive = ZipArchive.OpenArchive(fileStream))
             {
                 foreach (var entry in archive.Entries)
                 {

--- a/source/Calamari.Common/Features/Packages/NuGet/NupkgExtractor.cs
+++ b/source/Calamari.Common/Features/Packages/NuGet/NupkgExtractor.cs
@@ -40,7 +40,7 @@ namespace Calamari.Common.Features.Packages.NuGet
             var filesExtracted = 0;
 
             using (var packageStream = new FileStream(packageFile, FileMode.Open, FileAccess.Read))
-            using (var archive = ZipArchive.Open(packageStream))
+            using (var archive = ZipArchive.OpenArchive(packageStream))
             {
                 foreach (var entry in archive.Entries)
                 {
@@ -63,7 +63,7 @@ namespace Calamari.Common.Features.Packages.NuGet
                         continue;
 
                     var targetFile = Path.Combine(targetDirectory, Path.GetFileName(unescapedKey));
-                    entry.WriteToFile(targetFile, new PackageExtractionOptions(log) { ExtractFullPath = false, PreserveFileTime = false });
+                    entry.WriteToFile(targetFile, PackageExtractionOptions.Create(log, extractFullPath: false, preserveFileTime: false));
 
                     SetFileLastModifiedTime(entry, targetFile);
 

--- a/source/Calamari.Common/Features/Packages/PackageExtractionOptions.cs
+++ b/source/Calamari.Common/Features/Packages/PackageExtractionOptions.cs
@@ -4,22 +4,20 @@ using SharpCompress.Common;
 
 namespace Calamari.Common.Features.Packages
 {
-    public class PackageExtractionOptions : ExtractionOptions
+    // SharpCompress 0.48 sealed ExtractionOptions, so we can no longer subclass it.
+    // This factory builds a configured ExtractionOptions with Calamari's defaults instead.
+    public static class PackageExtractionOptions
     {
-        readonly ILog log;
-
-        public PackageExtractionOptions(ILog log)
+        public static ExtractionOptions Create(ILog log, bool extractFullPath = true, bool preserveFileTime = true)
         {
-            this.log = log;
-            ExtractFullPath = true;
-            Overwrite = true;
-            PreserveFileTime = true;
-            WriteSymbolicLink = WarnThatSymbolicLinksAreNotSupported;
-        }
-
-        void WarnThatSymbolicLinksAreNotSupported(string sourcepath, string targetpath)
-        {
-            log.WarnFormat("Cannot create symbolic link: {0}, Calamari does not currently support the extraction of symbolic links", sourcepath);
+            return new ExtractionOptions
+            {
+                ExtractFullPath = extractFullPath,
+                Overwrite = true,
+                PreserveFileTime = preserveFileTime,
+                SymbolicLinkHandler = (sourcepath, targetpath) =>
+                    log.WarnFormat("Cannot create symbolic link: {0}, Calamari does not currently support the extraction of symbolic links", sourcepath),
+            };
         }
     }
 }

--- a/source/Calamari.Common/Features/Packages/TarBzipPackageExtractor.cs
+++ b/source/Calamari.Common/Features/Packages/TarBzipPackageExtractor.cs
@@ -17,7 +17,7 @@ namespace Calamari.Common.Features.Packages
 
         protected override Stream GetCompressionStream(Stream stream)
         {
-            return new BZip2Stream(stream, CompressionMode.Decompress, false);
+            return BZip2Stream.Create(stream, CompressionMode.Decompress, false, false);
         }
     }
 }

--- a/source/Calamari.Common/Features/Packages/TarGzipPackageExtractor.cs
+++ b/source/Calamari.Common/Features/Packages/TarGzipPackageExtractor.cs
@@ -16,7 +16,7 @@ namespace Calamari.Common.Features.Packages
 
         protected override Stream GetCompressionStream(Stream stream)
         {
-            var gzipReader = GZipReader.Open(stream);
+            var gzipReader = GZipReader.OpenReader(stream);
             gzipReader.MoveToNextEntry();
             return gzipReader.OpenEntryStream();
         }

--- a/source/Calamari.Common/Features/Packages/TarPackageExtractor.cs
+++ b/source/Calamari.Common/Features/Packages/TarPackageExtractor.cs
@@ -30,7 +30,7 @@ namespace Calamari.Common.Features.Packages
             var compressionStream = GetCompressionStream(inStream);
             try
             {
-                using var reader = TarReader.Open(compressionStream, new ReaderOptions { ArchiveEncoding = new ArchiveEncoding { Default = Encoding.UTF8 } });
+                using var reader = ReaderFactory.OpenReader(compressionStream, new ReaderOptions { ArchiveEncoding = new ArchiveEncoding { Default = Encoding.UTF8 } });
                 while (reader.MoveToNextEntry())
                 {
                     if (reader.Entry.Key != null)
@@ -48,11 +48,11 @@ namespace Calamari.Common.Features.Packages
             return files;
         }
 
-        void ExtractEntry(string directory, TarReader reader)
+        void ExtractEntry(string directory, IReader reader)
         {
             var strategy = PackageExtractorUtils.CreateIoExceptionRetryStrategy(log);
 
-            strategy.Execute(() => reader.WriteEntryToDirectory(directory, new PackageExtractionOptions(log)));
+            strategy.Execute(() => reader.WriteEntryToDirectory(directory, PackageExtractionOptions.Create(log)));
         }
 
         protected virtual Stream GetCompressionStream(Stream stream)

--- a/source/Calamari.Common/Features/Packages/ZipPackageExtractor.cs
+++ b/source/Calamari.Common/Features/Packages/ZipPackageExtractor.cs
@@ -19,7 +19,7 @@ namespace Calamari.Common.Features.Packages
             
             var filesExtracted = 0;
             using var inStream = new FileStream(packageFile, FileMode.Open, FileAccess.Read);
-            using var archive = ZipArchive.Open(inStream);
+            using var archive = ZipArchive.OpenArchive(inStream);
             
             foreach (var entry in archive.Entries)
             {
@@ -36,7 +36,7 @@ namespace Calamari.Common.Features.Packages
         {
             var strategy = PackageExtractorUtils.CreateIoExceptionRetryStrategy(log);
 
-            strategy.Execute(() => entry.WriteToDirectory(directory, new PackageExtractionOptions(log)));
+            strategy.Execute(() => entry.WriteToDirectory(directory, PackageExtractionOptions.Create(log)));
         }
 
         void ProcessEvent(ref int filesExtracted, IEntry entry)

--- a/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
@@ -15,9 +15,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 
-        <PackageReference Include="SharpCompress" Version="0.37.2">
-            <NoWarn>NU1902</NoWarn>
-        </PackageReference>
+        <PackageReference Include="SharpCompress" Version="0.49.1" />
         <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
     </ItemGroup>
     <ItemGroup>

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -36,9 +36,7 @@
     <PackageReference Include="Octopus.Versioning" Version="5.1.884" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="Octostache" Version="3.9.2" />
-    <PackageReference Include="SharpCompress" Version="0.37.2">
-      <NoWarn>NU1902</NoWarn>
-    </PackageReference>
+    <PackageReference Include="SharpCompress" Version="0.49.1" />
     <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />

--- a/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
+++ b/source/Calamari.Shared/Integration/Packages/Download/GitHubPackageDownloader.cs
@@ -277,10 +277,10 @@ namespace Calamari.Integration.Packages.Download
         {
             var rootPathSeperator = -1;
             using (var readerStram = File.Open(src, FileMode.Open, FileAccess.ReadWrite))
-            using (var reader = ReaderFactory.Open(readerStram))
+            using (var reader = ReaderFactory.OpenReader(readerStram))
             {
                 using (var writerStream = File.Open(dest, FileMode.CreateNew, FileAccess.ReadWrite))
-                using (var writer = WriterFactory.Open(writerStream, ArchiveType.Zip, new ZipWriterOptions(CompressionType.Deflate)))
+                using (var writer = WriterFactory.OpenWriter(writerStream, ArchiveType.Zip, new ZipWriterOptions(CompressionType.Deflate)))
                 {
                     while (reader.MoveToNextEntry())
                     {

--- a/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
+++ b/source/Calamari.Tests/AWS/UploadAwsS3CommandFixture.cs
@@ -271,7 +271,7 @@ namespace Calamari.Tests.AWS
                                var file = await client.GetObjectAsync(bucketName, $"{prefix}Package3.1.0.0.zip");
                                var memoryStream = new MemoryStream();
                                await file.ResponseStream.CopyToAsync(memoryStream);
-                               var text = await new StreamReader(ZipArchive.Open(memoryStream).Entries.First(entry => entry.Key == "file.json").OpenEntryStream()).ReadToEndAsync();
+                               var text = await new StreamReader(ZipArchive.OpenArchive(memoryStream).Entries.First(entry => entry.Key == "file.json").OpenEntryStream()).ReadToEndAsync();
                                JObject.Parse(text)["Property1"]["Property2"]["Value"].ToString().Should().Be("InjectedValue");
                            });
         }
@@ -428,7 +428,7 @@ namespace Calamari.Tests.AWS
                                var file = await client.GetObjectAsync(bucketName, $"{prefix}{fileName}");
                                var memoryStream = new MemoryStream();
                                await file.ResponseStream.CopyToAsync(memoryStream);
-                               var text = await new StreamReader(ZipArchive.Open(memoryStream).Entries.First(entry => entry.Key == "file.json").OpenEntryStream()).ReadToEndAsync();
+                               var text = await new StreamReader(ZipArchive.OpenArchive(memoryStream).Entries.First(entry => entry.Key == "file.json").OpenEntryStream()).ReadToEndAsync();
                                JObject.Parse(text)["Property1"]["Property2"]["Value"].ToString().Should().Be("InjectedValue");
                                memoryStream.Close();
                            });

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/PackageExtractorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/PackageExtractorFixture.cs
@@ -163,7 +163,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             {
                 var fileName = Path.Combine(tempFolder.DirectoryPath, $"package.{extension}");
                 using (Stream stream = File.OpenWrite(fileName))
-                using (var writer = WriterFactory.Open(stream, archiveType, new WriterOptions(compressionType)
+                using (var writer = WriterFactory.OpenWriter(stream, archiveType, new WriterOptions(compressionType)
                 {
                     ArchiveEncoding = new ArchiveEncoding {Default = Encoding.UTF8}
                 }))
@@ -241,7 +241,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
             Directory.CreateDirectory(extractionDir);
 
             using (var stream = File.OpenWrite(packageFile))
-            using (var writer = WriterFactory.Open(stream, archiveType, new WriterOptions(compressionType) { ArchiveEncoding = new ArchiveEncoding { Default = Encoding.UTF8 } }))
+            using (var writer = WriterFactory.OpenWriter(stream, archiveType, new WriterOptions(compressionType) { ArchiveEncoding = new ArchiveEncoding { Default = Encoding.UTF8 } }))
             {
                 var payload = "malicious content"u8.ToArray();
                 writer.Write("safe-file.txt", new MemoryStream(payload));
@@ -252,6 +252,45 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
 
             Assert.Throws<InvalidOperationException>(() => extractor.Extract(packageFile, extractionDir));
             Assert.That(File.Exists(Path.Combine(tempFolder.DirectoryPath, "traversal.txt")), Is.False, "Traversal file should not have been written outside the extraction directory");
+        }
+
+        // Directly targets the SharpCompress advisory GHSA-6c8g-7p36-r338 ("zip slip" via *directory entries*
+        // in WriteToDirectory). A normal archive writer won't emit a traversing directory entry, so we craft the
+        // zip with System.IO.Compression to inject one, then extract it through Calamari's Zip extractor.
+        // All traversal vectors stay one level up (inside the temp folder) so a regression can't write outside it.
+        [Test]
+        public void ExtractBlocksZipSlipViaDirectoryEntry()
+        {
+            using var tempFolder = TemporaryDirectory.Create();
+            var packageFile = Path.Combine(tempFolder.DirectoryPath, "zip-slip.zip");
+            var extractionDir = Path.Combine(tempFolder.DirectoryPath, "extraction");
+            Directory.CreateDirectory(extractionDir);
+
+            using (var fileStream = File.Create(packageFile))
+            using (var zip = new System.IO.Compression.ZipArchive(fileStream, System.IO.Compression.ZipArchiveMode.Create))
+            {
+                WriteZipEntry(zip, "safe/ok.txt", "safe");        // a benign entry
+                zip.CreateEntry("../evil-dir/");                   // traversing *directory* entry (the CVE vector)
+                WriteZipEntry(zip, "../evil-dir/pwned.txt", "pwned"); // file inside the escaping directory
+            }
+
+            var extractor = new ZipPackageExtractor(ConsoleLog.Instance);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => extractor.Extract(packageFile, extractionDir));
+            // Pin the failure to the path-traversal guard (not an unrelated read error), so the test can't pass vacuously.
+            ex.Message.Should().Contain("outside the intended extraction directory");
+
+            var escapedDir = Path.Combine(tempFolder.DirectoryPath, "evil-dir");
+            Assert.That(Directory.Exists(escapedDir), Is.False, "Directory entry escaped the extraction root");
+            Assert.That(File.Exists(Path.Combine(escapedDir, "pwned.txt")), Is.False, "File escaped via directory-entry traversal");
+        }
+
+        static void WriteZipEntry(System.IO.Compression.ZipArchive zip, string key, string content)
+        {
+            var entry = zip.CreateEntry(key);
+            using var stream = entry.Open();
+            var bytes = Encoding.UTF8.GetBytes(content);
+            stream.Write(bytes, 0, bytes.Length);
         }
 
         private string GetFileName(string extension)

--- a/source/Calamari.Tests/Helpers/TarGzBuilder.cs
+++ b/source/Calamari.Tests/Helpers/TarGzBuilder.cs
@@ -24,7 +24,7 @@ namespace Calamari.Tests.Helpers
                 File.Delete(outputTarFilename);
 
             using (Stream stream = File.OpenWrite(outputTarFilename))
-            using (var writer = WriterFactory.Open(stream, ArchiveType.Tar, new WriterOptions(CompressionType.GZip) {LeaveStreamOpen = false}))
+            using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Tar, new WriterOptions(CompressionType.GZip) {LeaveStreamOpen = false}))
             {
                 var isRunningOnWindows = CalamariEnvironment.IsRunningOnWindows;
 

--- a/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/InstallTools.cs
@@ -471,9 +471,9 @@ namespace Calamari.Tests.KubernetesFixtures
             {
                 await Download(zipPath, client, downloadUrl);
                 using (Stream stream = File.OpenRead(zipPath))
-                using (var reader = ReaderFactory.Open(stream))
+                using (var reader = ReaderFactory.OpenReader(stream))
                 {
-                    reader.WriteAllToDirectory(destination, new ExtractionOptions { ExtractFullPath = true, Overwrite = true, WriteSymbolicLink = WarnThatSymbolicLinksAreNotSupported });
+                    reader.WriteAllToDirectory(destination, new ExtractionOptions { ExtractFullPath = true, Overwrite = true, SymbolicLinkHandler = WarnThatSymbolicLinksAreNotSupported });
                 }
             }
         }

--- a/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/KubernetesContextScriptWrapperLiveFixtureEks.cs
@@ -707,7 +707,7 @@ namespace Calamari.Tests.KubernetesFixtures
             params (string directory, string fileName, string content)[] files)
         {
             var pathToPackage = Path.Combine(currentDirectory, packageFileName);
-            using (var archive = ZipArchive.Create())
+            using (var archive = ZipArchive.CreateArchive())
             {
                 var readStreams = new List<IDisposable>();
                 foreach (var (directory, fileName, content) in files)
@@ -715,7 +715,7 @@ namespace Calamari.Tests.KubernetesFixtures
                     var pathInPackage = Path.Combine(directory, fileName);
                     var readStream = new MemoryStream(Encoding.UTF8.GetBytes(content));
                     readStreams.Add(readStream);
-                    archive.AddEntry(pathInPackage, readStream);
+                    archive.AddEntry(pathInPackage, readStream, false);
                 }
 
                 using (var writeStream = File.OpenWrite(pathToPackage))

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -42,9 +42,7 @@
     <PackageReference Include="Octopus.Versioning" Version="5.1.884" />
     <PackageReference Include="Octopus.TinyTypes" Version="2.2.1156" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
-    <PackageReference Include="SharpCompress" Version="0.37.2">
-      <NoWarn>NU1902</NoWarn>
-    </PackageReference>
+    <PackageReference Include="SharpCompress" Version="0.49.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.16" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
Resolves [SF-1864](https://linear.app/octopus/issue/SF-1864/update-sharpcompress-version-in-calamari).

> [!IMPORTANT]
> **Alternative to #2085** — same change, landing on **0.49.1** instead of 0.48.0. Pick one; close the other. Both are drafts.

> [!WARNING]
> **Draft: not ready to merge.** Green CI is necessary but not sufficient here — see "How to review".

## Why 0.49.1 rather than 0.48.0

**0.48.0 was never a considered floor.** When the CVE surfaced on 11 May, 0.48.0 (published 6 May) was simply the newest release *and* the first version outside the advisory's `<= 0.47.4` range. Renovate raised it as the `[SECURITY]` bump, and that number got baked into the ticket title, the branch name and the original WIP commit. Everything above it shipped later:

| Version | Published |
|---|---|
| 0.47.4 | 2026-04-05 |
| **0.48.0** | 2026-05-06 ← latest when the CVE landed |
| 0.48.1 | 2026-05-14 |
| 0.49.0 | 2026-05-28 |
| **0.49.1** | 2026-05-29 ← this PR |
| 0.50.0 | 2026-07-13 |
| 0.50.1 | 2026-07-25 |
| 1.0.0 | unlisted (NuGet reports the 1900 sentinel date) |

0.49.1 is also where Octopus Server independently landed (`Octopus.Core.csproj`).

## Why not 0.50.x

0.50.0 changes Tar so it **no longer attempts to decompress streams**, and alters the detection API. `TarGzipPackageExtractor` and `TarBzipPackageExtractor` are built on layered decompression, so that is a materially riskier step — for **no security benefit**, since nothing security-related shipped after 0.48.0.

## The one behaviour change in range, reviewed per call site

0.49.0 flipped `WriterOptions.LeaveStreamOpen` from `true` to `false`, so a writer now closes the stream it was handed. Every affected site:

| Site | Assessment |
|---|---|
| `GitHubPackageDownloader.DeNestContents` | Writer and stream are nested `using`s → stream disposed twice. `Stream.Dispose` is idempotent, and nothing touches the stream after the writer. Safe. |
| `UploadAwsS3Convention` | Returns `targetArchivePath`; never reads the stream after `SaveTo`. Data is flushed to disk under either default. Safe. |
| `ZipPackageProvider` / `NugetPackageProvider` | Use the **path** overload of `SaveTo` — no stream ownership involved. |
| `TarGzBuilder` (tests) | Already set `LeaveStreamOpen = false` explicitly, so unaffected by the default change. |

## Also in this PR: re-arming the alerting

All five references carried `<NoWarn>NU1902</NoWarn>`, added to unblock builds when the CVE was published. Left in place after an upgrade they would silently hide the *next* SharpCompress advisory, so this PR removes all five. With them gone the projects build clean and NuGet's audit raises no advisory for 0.49.1.

## Were we actually vulnerable? Probably not

- The advisory's vulnerable path is the **archive-level** `IArchive.WriteToDirectory()`. Calamari iterates entries itself and calls the **per-entry** APIs — the latter named in the advisory as already guarded.
- `ThrowIfPathTraversalAttempted` independently resolves and bounds-checks every entry key, directory entries included, before anything is written.
- The TAR symlink escalation is blocked because `PackageExtractionOptions` supplies a `WriteSymbolicLink` handler that **refuses** to create links — not, as previously discussed, because Calamari supplies no handler. That distinction is load-bearing: implementing real symlink support there would reopen the arbitrary-file-write primitive.

## Automated tests

`ExtractBlocksZipSlipViaDirectoryEntry` crafts a zip containing a traversing *directory* entry (`System.IO.Compression` injects it, since normal writers won't emit one) and asserts the extractor throws and nothing lands outside the root. It **passes on 0.37.2 too** — so it evidences that *Calamari's own guard* blocks this vector, and deliberately does not claim to verify the library's fix, which was never confirmed upstream.

Verified locally: all affected projects build with 0 errors; 83 tests pass across `PackageExtractorFixture` and `PackageExtractorUtilsFixture`.

**Not covered by executed tests:** `GitHubPackageDownloader`'s own fixtures need GitHub credentials (403 locally), and the Kubernetes EKS fixture that calls `SaveTo` is a live test. Both were assessed by reading the code, not by running it.

## How to review this PR

**Do not merge on green CI alone.** #1913 passed Calamari's full suite, merged, then broke Server unpacking a consolidated package (`An item with the same key has already been added` in `ExtractCalamariPackage`). This is the one area of the repo where the suite is a known-inadequate gate.

Before this leaves draft:
- [ ] Decide between this and #2085, close the other.
- [ ] Build Calamari and point a local Server at it (`build-local.sh` + `OCTOPUS__Dev__CalamariPackagePath`), then run a health check / deployment that unpacks a consolidated package.
- [ ] Exercise the GitHub package downloader path with credentials, since that is where the `LeaveStreamOpen` change actually lands and local tests skip it.
- [ ] Confirm whether a **Requires Server Change** label is needed. Expected not — `ConsolidateCalamariPackages` no longer references SharpCompress at all, so the old signature coupling that blocked Server 2025.4 does not apply.

## Reducing risk

Out of scope, still open from the original discussion: extraction perf (~6s observed vs ~500ms expected, no benchmark exists), and whether this is backported to LTS branches.
