### PR TITLE
Go to NSubstitute 4.2.2, why not later, let me check...

### DIFF
--- a/source/Calamari.AzureScripting.Tests/Calamari.AzureScripting.Tests.csproj
+++ b/source/Calamari.AzureScripting.Tests/Calamari.AzureScripting.Tests.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />
-        <PackageReference Include="NSubstitute" Version="4.2.1" />
+        <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="Octopus.Dependencies.AzureCLI" Version="2.0.50" GeneratePathProperty="true" />
         <PackageReference Include="Octopus.Dependencies.AzureCmdlets" Version="6.13.1" GeneratePathProperty="true" />
         <PackageReference Include="Octopus.Server.Extensibility" Version="14.3.2" />

--- a/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Assent" Version="1.5.0" />
         <PackageReference Include="FluentAssertions" Version="7.2.0" />
-        <PackageReference Include="NSubstitute" Version="4.2.1" />
+        <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="NuGet.Packaging" Version="7.4.0-octopus-release.17001" />
         <PackageReference Include="nunit" Version="3.14.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -28,7 +28,7 @@
         <ProjectReference Include="..\Calamari.Testing\Calamari.Testing.csproj"/>
         <ProjectReference Include="..\Calamari\Calamari.csproj"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0"/>
-        <PackageReference Include="NSubstitute" Version="2.0.3"/>
+        <PackageReference Include="NSubstitute" Version="4.2.2"/>
         <PackageReference Include="FluentAssertions" Version="7.2.0"/>
         <PackageReference Include="NUnit" Version="3.14.0"/>
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0"/>


### PR DESCRIPTION
All nine test projects now reference NSubstitute 4.2.2. It was 2.0.3