### PR TITLE
Move to NSubstitute 6.0.0

### DIFF
--- a/source/Calamari.AiAgent.Tests/Calamari.AiAgent.Tests.csproj
+++ b/source/Calamari.AiAgent.Tests/Calamari.AiAgent.Tests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="7.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-        <PackageReference Include="NSubstitute" Version="4.2.2" />
+        <PackageReference Include="NSubstitute" Version="6.0.0" />
         <PackageReference Include="nunit" Version="3.14.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />

--- a/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
+++ b/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Azure.ResourceManager.Resources" Version="1.0.0-preview.2" />
     <PackageReference Include="Azure.ResourceManager.Storage" Version="1.1.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />

--- a/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
+++ b/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Calamari.AzureScripting.Tests/Calamari.AzureScripting.Tests.csproj
+++ b/source/Calamari.AzureScripting.Tests/Calamari.AzureScripting.Tests.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />
-        <PackageReference Include="NSubstitute" Version="4.2.1" />
+        <PackageReference Include="NSubstitute" Version="6.0.0" />
         <PackageReference Include="Octopus.Dependencies.AzureCLI" Version="2.0.50" GeneratePathProperty="true" />
         <PackageReference Include="Octopus.Dependencies.AzureCmdlets" Version="6.13.1" GeneratePathProperty="true" />
         <PackageReference Include="Octopus.Server.Extensibility" Version="14.3.2" />

--- a/source/Calamari.AzureServiceFabric.Tests/Calamari.AzureServiceFabric.Tests.csproj
+++ b/source/Calamari.AzureServiceFabric.Tests/Calamari.AzureServiceFabric.Tests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />
-        <PackageReference Include="NSubstitute" Version="4.2.2" />
+        <PackageReference Include="NSubstitute" Version="6.0.0" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Calamari.AzureServiceFabric\Calamari.AzureServiceFabric.csproj" />

--- a/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Assent" Version="1.5.0" />
         <PackageReference Include="FluentAssertions" Version="7.2.0" />
-        <PackageReference Include="NSubstitute" Version="4.2.1" />
+        <PackageReference Include="NSubstitute" Version="6.0.0" />
         <PackageReference Include="NuGet.Packaging" Version="7.4.0-octopus-release.17001" />
         <PackageReference Include="nunit" Version="3.14.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />

--- a/source/Calamari.Scripting.Tests/Calamari.Scripting.Tests.csproj
+++ b/source/Calamari.Scripting.Tests/Calamari.Scripting.Tests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="7.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-        <PackageReference Include="NSubstitute" Version="4.2.2" />
+        <PackageReference Include="NSubstitute" Version="6.0.0" />
         <PackageReference Include="nunit" Version="3.14.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />

--- a/source/Calamari.Terraform.Tests/Calamari.Terraform.Tests.csproj
+++ b/source/Calamari.Terraform.Tests/Calamari.Terraform.Tests.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />
-        <PackageReference Include="NSubstitute" Version="4.2.2" />
+        <PackageReference Include="NSubstitute" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -28,7 +28,7 @@
         <ProjectReference Include="..\Calamari.Testing\Calamari.Testing.csproj"/>
         <ProjectReference Include="..\Calamari\Calamari.csproj"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0"/>
-        <PackageReference Include="NSubstitute" Version="2.0.3"/>
+        <PackageReference Include="NSubstitute" Version="6.0.0"/>
         <PackageReference Include="FluentAssertions" Version="7.2.0"/>
         <PackageReference Include="NUnit" Version="3.14.0"/>
         <PackageReference Include="NUnit3TestAdapter" Version="5.2.0"/>


### PR DESCRIPTION
Moving to NSubstitute 6.0.0 (latest) across all nine test projects.