### PR TITLE
Move Calamari to .NET 10

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -65,14 +65,14 @@ else {
     # This means we would need to manually update our global.json file every time there is a new
     # .NET SDK available, and then all developers would need to immediately install this on their machines.
     #
-    # In our builds, we want the same "automatic roll-forward" behaviour that we get when we use the dotnet/sdk:8.0 docker
+    # In our builds, we want the same "automatic roll-forward" behaviour that we get when we use the dotnet/sdk:10.0 docker
     # images -- where we always get the latest patch version of the SDK without manual intervention.
     #
     # We achieve this with a small tweak to the Nuke bootstrapper to tell it to install the latest version from
-    # the 8.0 channel, regardless of what's in the global.json.
+    # the 10.0 channel, regardless of what's in the global.json.
 
     Remove-Variable DotNetVersion
-    $DotNetChannel = "8.0"
+    $DotNetChannel = "10.0"
     # ----- End Octopus Deploy Modification -----
 
     # Install by channel or version

--- a/build.sh
+++ b/build.sh
@@ -91,14 +91,14 @@ else
     # This means we would need to manually update our global.json file every time there is a new
     # .NET SDK available, and then all developers would need to immediately install this on their machines.
     #
-    # In our builds, we want the same "automatic roll-forward" behaviour that we get when we use the dotnet/sdk:8.0 docker
+    # In our builds, we want the same "automatic roll-forward" behaviour that we get when we use the dotnet/sdk:10.0 docker
     # images -- where we always get the latest patch version of the SDK without manual intervention.
     #
     # We achieve this with a small tweak to the Nuke bootstrapper to tell it to install the latest version from
-    # the 8.0 channel, regardless of what's in the global.json.
+    # the 10.0 channel, regardless of what's in the global.json.
 
     unset DOTNET_VERSION
-    DOTNET_CHANNEL="8.0"
+    DOTNET_CHANNEL="10.0"
     # ----- End Octopus Deploy Modification -----
 
     # Install by channel or version

--- a/build/Build.PackageCalamariProjects.cs
+++ b/build/Build.PackageCalamariProjects.cs
@@ -37,7 +37,7 @@ public partial class Build
                                                           .Select(rid =>
                                                                   {
                                                                       //we are making the bold assumption all projects only have a single target framework
-                                                                      var framework = project.GetTargetFrameworks()?.Single() ?? Frameworks.Net80;
+                                                                      var framework = project.GetTargetFrameworks()?.Single() ?? Frameworks.Net100;
                                                                       return new CalamariPackageMetadata(project, framework, rid);
                                                                   }))
                                           .ToList();
@@ -109,7 +109,7 @@ public partial class Build
                                DotNetPublish(s => s
                                                   .SetConfiguration(Configuration)
                                                   .SetProject(helperProject)
-                                                  .SetFramework(Frameworks.Net80)
+                                                  .SetFramework(Frameworks.Net100)
                                                   .SetRuntime(rid)
                                                   .SetVersion(NugetVersion.Value)
                                                   .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion)

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -60,7 +60,7 @@ partial class Build : NukeBuild
         // Mimic the behaviour of this attribute, but lazily so we don't pay the OctoVersion cost when it isn't needed
         OctoVersionInfo = new Lazy<OctoVersionInfo?>(() =>
                                                      {
-                                                         var attribute = new OctoVersionAttribute { BranchMember = nameof(BranchName), Framework = "net8.0"};
+                                                         var attribute = new OctoVersionAttribute { BranchMember = nameof(BranchName), Framework = Frameworks.Net100};
 
                                                          // the Attribute does all the work such as calling TeamCity.Instance?.SetBuildNumber for us
                                                          var version = attribute.GetValue(null!, this);

--- a/build/Frameworks.cs
+++ b/build/Frameworks.cs
@@ -6,5 +6,7 @@ namespace Calamari.Build
     {
         public const string Net80 = "net8.0";
         public const string Net80Windows = "net8.0-windows";
+        public const string Net100 = "net10.0";
+        public const string Net100Windows = "net10.0-windows";
     }
 }

--- a/build/Frameworks.cs
+++ b/build/Frameworks.cs
@@ -4,8 +4,6 @@ namespace Calamari.Build
 {
     public static class Frameworks
     {
-        public const string Net80 = "net8.0";
-        public const string Net80Windows = "net8.0-windows";
         public const string Net100 = "net10.0";
         public const string Net100Windows = "net10.0-windows";
     }

--- a/build/Signing.cs
+++ b/build/Signing.cs
@@ -90,7 +90,12 @@ namespace Calamari.Build
         {
             try
             {
+                // SYSLIB0057 points at X509CertificateLoader, but that only loads certificate *files*.
+                // There is no replacement for reading the Authenticode signature embedded in a signed
+                // PE file, so this API is still the only way to do this check.
+#pragma warning disable SYSLIB0057
                 X509Certificate.CreateFromSignedFile(filePath);
+#pragma warning restore SYSLIB0057
                 return true;
             }
             catch

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <RuntimeIdentifiers>win-x64;linux-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <RootNamespace>Calamari.Build</RootNamespace>
         <NoWarn>CS0649;CS0169</NoWarn>
@@ -25,6 +25,11 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+        <!-- Pinned to remediate vulnerable versions pulled in transitively via Octopus.Nuke.Common.
+             The .NET 10 SDK audits transitive packages during restore, so these surface as NU1902/NU1903. -->
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+        <PackageReference Include="RestSharp" Version="112.1.0" />
         <PackageReference Include="NuGet.CommandLine" Version="7.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.419",
+    "version": "10.0.302",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/source/Calamari.Aws/Calamari.Aws.csproj
+++ b/source/Calamari.Aws/Calamari.Aws.csproj
@@ -18,7 +18,7 @@
     <ApplicationManifest>Calamari.Aws.exe.manifest</ApplicationManifest>
     <ApplicationIcon />
     <StartupObject />
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/source/Calamari.Azure/Calamari.Azure.csproj
+++ b/source/Calamari.Azure/Calamari.Azure.csproj
@@ -5,7 +5,7 @@
         <OutputType>Library</OutputType>
         <Authors>Octopus Deploy</Authors>
         <Copyright>Octopus Deploy Pty Ltd</Copyright>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>

--- a/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
+++ b/source/Calamari.AzureAppService.Tests/Calamari.AzureAppService.Tests.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Calamari.AzureAppService.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
@@ -18,7 +18,6 @@
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="Polly" Version="8.3.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.16" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41" />
   </ItemGroup>
 

--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
     <NoWarn>NU5104</NoWarn>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
+++ b/source/Calamari.AzureAppService/Calamari.AzureAppService.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Polly" Version="8.3.1" />
     <PackageReference Include="SharpCompress" Version="0.49.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.16" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari.AzureScripting\Calamari.AzureScripting.csproj" />

--- a/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
+++ b/source/Calamari.AzureResourceGroup.Tests/Calamari.AzureResourceGroup.Tests.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Calamari.AzureResourceGroup.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
+++ b/source/Calamari.AzureResourceGroup/Calamari.AzureResourceGroup.csproj
@@ -7,7 +7,7 @@
         <IsPackable>false</IsPackable>
         <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/Calamari.AzureScripting.Tests/Calamari.AzureScripting.Tests.csproj
+++ b/source/Calamari.AzureScripting.Tests/Calamari.AzureScripting.Tests.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <IsPackable>false</IsPackable>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>

--- a/source/Calamari.AzureScripting/Calamari.AzureScripting.csproj
+++ b/source/Calamari.AzureScripting/Calamari.AzureScripting.csproj
@@ -8,7 +8,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <IsPackable>true</IsPackable>
         <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/source/Calamari.AzureScripting/CalamariCertificateStore.cs
+++ b/source/Calamari.AzureScripting/CalamariCertificateStore.cs
@@ -146,7 +146,7 @@ namespace Calamari.AzureScripting
         {
             try
             {
-                var cert = new X509Certificate2(file, (string)null!, flags);
+                var cert = X509CertificateLoader.LoadPkcs12FromFile(file, null, flags);
 
                 // ReSharper disable once InvertIf
                 if (!HasPrivateKey(cert) && requirePrivateKey)

--- a/source/Calamari.AzureServiceFabric.Tests/Calamari.AzureServiceFabric.Tests.csproj
+++ b/source/Calamari.AzureServiceFabric.Tests/Calamari.AzureServiceFabric.Tests.csproj
@@ -4,7 +4,7 @@
         <RootNamespace>Calamari.AzureServiceFabric.Tests</RootNamespace>
         <AssemblyName>Calamari.AzureServiceFabric.Tests</AssemblyName>
         <IsPackable>false</IsPackable>
-        <TargetFramework>net8.0-windows</TargetFramework>
+        <TargetFramework>net10.0-windows</TargetFramework>
         <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>

--- a/source/Calamari.AzureServiceFabric/Calamari.AzureServiceFabric.csproj
+++ b/source/Calamari.AzureServiceFabric/Calamari.AzureServiceFabric.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/source/Calamari.AzureServiceFabric/CalamariCertificateStore.cs
+++ b/source/Calamari.AzureServiceFabric/CalamariCertificateStore.cs
@@ -160,7 +160,7 @@ namespace Calamari.AzureServiceFabric
         {
             try
             {
-                var cert = new X509Certificate2(file, password, flags);
+                var cert = X509CertificateLoader.LoadPkcs12FromFile(file, password, flags);
 
                 // ReSharper disable once InvertIf
                 if (!HasPrivateKey(cert) && requirePrivateKey)

--- a/source/Calamari.AzureWebApp.Tests/Calamari.AzureWebApp.Tests.csproj
+++ b/source/Calamari.AzureWebApp.Tests/Calamari.AzureWebApp.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Calamari.AzureWebApp.Tests</RootNamespace>
     <AssemblyName>Calamari.AzureWebApp.Tests</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Calamari.AzureWebApp/AzureWebAppBehaviour.cs
+++ b/source/Calamari.AzureWebApp/AzureWebAppBehaviour.cs
@@ -62,6 +62,14 @@ namespace Calamari.AzureWebApp
             RemoteCertificateValidationCallback originalServerCertificateValidationCallback = null;
             try
             {
+                // TODO: this callback appears to be dead code and should be removed or reinstated properly.
+                // NetCoreWebDeploymentExecutor runs Web Deploy in a separate net462 child process (the
+                // NetCoreShim), so a ServicePointManager callback registered here cannot affect the TLS
+                // validation the child performs. That has been true since Web Deploy moved into the shim,
+                // not something .NET 10 changed - but .NET 10's obsoletion message says these settings no
+                // longer affect SslStream or HttpClient, which makes it worth resolving deliberately rather
+                // than deleting as a drive-by in a framework migration.
+#pragma warning disable SYSLIB0014
                 originalServerCertificateValidationCallback = ServicePointManager.ServerCertificateValidationCallback;
                 ServicePointManager.ServerCertificateValidationCallback = WrapperForServerCertificateValidationCallback;
 
@@ -70,6 +78,7 @@ namespace Calamari.AzureWebApp
             finally
             {
                 ServicePointManager.ServerCertificateValidationCallback = originalServerCertificateValidationCallback;
+#pragma warning restore SYSLIB0014
             }
         }
 

--- a/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
+++ b/source/Calamari.AzureWebApp/Calamari.AzureWebApp.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <LangVersion>8.0</LangVersion>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
+++ b/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace>Calamari.CloudAccounts</RootNamespace>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <PackageId>Octopus.Calamari.CloudAccounts</PackageId>
         <Title>Calamari.CloudAccounts</Title>
         <Authors>Octopus Deploy</Authors>

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PlatformTarget>anycpu</PlatformTarget>
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
         <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
-        <PackageReference Include="Autofac" Version="4.8.0" />
+        <PackageReference Include="Autofac" Version="9.3.1" />
         <PackageReference Include="Octopus.Globfish" Version="1.0.8" />
         <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
         <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
@@ -11,6 +11,8 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
 {
     public class DotnetScriptExecutor : ScriptExecutor
     {
+        const string DotnetRollForwardVariableName = "DOTNET_ROLL_FORWARD";
+
         readonly ICommandLineRunner commandLineRunner;
 
         public DotnetScriptExecutor(ICommandLineRunner commandLineRunner, ILog log): base(log)
@@ -37,13 +39,37 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
             bool.TryParse(variables.Get("Octopus.Action.Script.CSharp.BypassIsolation", "false"), out var bypassDotnetScriptIsolation);
 
             var cli = CreateCommandLineInvocation(executable, arguments, !string.IsNullOrWhiteSpace(localDotnetScriptPath));
-            cli.EnvironmentVars = environmentVars;
+            cli.EnvironmentVars = WithDotnetRollForward(environmentVars);
             cli.WorkingDirectory = workingDirectory;
             cli.Isolate = !bypassDotnetScriptIsolation;
 
             yield return new ScriptExecution(cli, otherTemporaryFiles.Concat(new[] { bootstrapFile, configurationFile }));
         }
         
+        /// <summary>
+        /// dotnet-script is a framework-dependent application - the bundled copy targets
+        /// Microsoft.NETCore.App 8.0.0. By default a framework-dependent app will not roll forward
+        /// across a major version, so on a machine that only has a newer runtime installed it fails
+        /// to launch with "You must install or update .NET to run this application".
+        ///
+        /// Calamari itself is published self-contained and carries no such requirement; this affects
+        /// only the separate dotnet-script process. Setting DOTNET_ROLL_FORWARD=Major lets it run on
+        /// whatever newer runtime is present, so C# script steps don't additionally require the exact
+        /// runtime dotnet-script was built against.
+        /// </summary>
+        static Dictionary<string, string> WithDotnetRollForward(Dictionary<string, string>? environmentVars)
+        {
+            var vars = environmentVars == null
+                ? new Dictionary<string, string>()
+                : new Dictionary<string, string>(environmentVars);
+
+            // Don't override an explicit value - the surrounding environment may have set one deliberately.
+            if (!vars.ContainsKey(DotnetRollForwardVariableName))
+                vars[DotnetRollForwardVariableName] = "Major";
+
+            return vars;
+        }
+
         private string GetExecutable(string? localDotnetScriptPath, string bundledExecutable)
         {
             return string.IsNullOrWhiteSpace(localDotnetScriptPath)

--- a/source/Calamari.ConsolidateCalamariPackages.Api/Calamari.ConsolidateCalamariPackages.Api.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages.Api/Calamari.ConsolidateCalamariPackages.Api.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <RootNamespace>Octopus.Calamari.ConsolidatedPackage.Api</RootNamespace>
         <AssemblyName>Octopus.Calamari.ConsolidatedPackage.Api</AssemblyName>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Authors>Octopus Deploy</Authors>

--- a/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>

--- a/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages/Calamari.ConsolidateCalamariPackages.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <RootNamespace>Octopus.Calamari.ConsolidatedPackage</RootNamespace>
         <AssemblyName>Octopus.Calamari.ConsolidatedPackage</AssemblyName>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Octopus Deploy</Authors>

--- a/source/Calamari.Contracts/Calamari.Contracts.csproj
+++ b/source/Calamari.Contracts/Calamari.Contracts.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <RootNamespace>Octopus.Calamari.Contracts</RootNamespace>
         <AssemblyName>Octopus.Calamari.Contracts</AssemblyName>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Authors>Octopus Deploy</Authors>

--- a/source/Calamari.DockerCredentialHelper/Calamari.DockerCredentialHelper.csproj
+++ b/source/Calamari.DockerCredentialHelper/Calamari.DockerCredentialHelper.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <AssemblyName>docker-credential-octopus</AssemblyName>
         <RootNamespace>Calamari.DockerCredentialHelper</RootNamespace>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,11 +13,5 @@
              NOT here. Setting them as project properties leaks into how Calamari.Tests consumes this
              project reference and produces a non-runnable apphost in the test output. -->
     </PropertyGroup>
-
-    <ItemGroup>
-        <!-- Match the System.Text.Json version the rest of the solution uses, so the assemblies in a
-             shared output directory (e.g. Calamari.Tests) agree with this project's deps.json. -->
-        <PackageReference Include="System.Text.Json" Version="9.0.16" />
-    </ItemGroup>
 
 </Project>

--- a/source/Calamari.GoogleCloudAccounts/Calamari.GoogleCloudAccounts.csproj
+++ b/source/Calamari.GoogleCloudAccounts/Calamari.GoogleCloudAccounts.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace>Calamari.GoogleCloudAccounts</RootNamespace>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <!-- CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. -->
         <NoWarn>CS8632</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Calamari.GoogleCloudScripting.Tests/Calamari.GoogleCloudScripting.Tests.csproj
+++ b/source/Calamari.GoogleCloudScripting.Tests/Calamari.GoogleCloudScripting.Tests.csproj
@@ -5,7 +5,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>

--- a/source/Calamari.GoogleCloudScripting/Calamari.GoogleCloudScripting.csproj
+++ b/source/Calamari.GoogleCloudScripting/Calamari.GoogleCloudScripting.csproj
@@ -6,7 +6,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <IsPackable>false</IsPackable>
         <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <!-- CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. -->
         <NoWarn>CS8632</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Calamari.Scripting.Tests/Calamari.Scripting.Tests.csproj
+++ b/source/Calamari.Scripting.Tests/Calamari.Scripting.Tests.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <AssemblyName>Calamari.Scripting.Tests</AssemblyName>
         <RootNamespace>Calamari.Scripting.Tests</RootNamespace>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <IsPackable>true</IsPackable>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -22,7 +22,7 @@
     <StartupObject />
     <RootNamespace>Calamari</RootNamespace>
     <Nullable>enable</Nullable>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Calamari.Terraform.Tests/Calamari.Terraform.Tests.csproj
+++ b/source/Calamari.Terraform.Tests/Calamari.Terraform.Tests.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>Calamari.Terraform.Tests</AssemblyName>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
         <IsPackable>false</IsPackable>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <!-- CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. -->
         <NoWarn>CS8632</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Calamari.Terraform/Calamari.Terraform.csproj
+++ b/source/Calamari.Terraform/Calamari.Terraform.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/source/Calamari.Testing/Calamari.Testing.csproj
+++ b/source/Calamari.Testing/Calamari.Testing.csproj
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <PackageId>Octopus.Calamari.Testing</PackageId>
     </PropertyGroup>
@@ -16,10 +16,11 @@
         <PackageReference Include="Octopus.1Password.Sdk" Version="0.0.127"/>
         <!-- Pinned to remediate the vulnerable RestSharp 110.2.0 pulled in transitively via
              Octopus.1Password.Sdk (GHSA-4rr6-2v9v-wcpc). -->
+        <!-- Pinned to remediate the vulnerable RestSharp pulled in transitively via
+             Octopus.1Password.Sdk. Surfaced by .NET 10's transitive package auditing. -->
         <PackageReference Include="RestSharp" Version="112.1.0" />
         <PackageReference Include="Serilog" Version="4.4.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
-        <PackageReference Include="System.Text.Json" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -10,7 +10,7 @@
         <ApplicationIcon/>
         <StartupObject/>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
     </PropertyGroup>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -21,7 +21,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.10"/>
-        <PackageReference Include="System.Text.Json" Version="9.0.16" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41"/>
         <PackageReference Include="WireMock.Net" Version="2.13.0"/>
         <PackageReference Include="XPath2" Version="1.1.5"/>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.JsonFileOutput/Acme.JsonFileOutput.csproj
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.JsonFileOutput/Acme.JsonFileOutput.csproj
@@ -5,7 +5,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>1.0.0.0</VersionPrefix>
     <Authors>ACME Corporation</Authors>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Acme.JsonFileOutput</AssemblyName>
     <PackageId>Acme.JsonFileOutput</PackageId>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Package/Acme.Package.csproj
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Package/Acme.Package.csproj
@@ -5,7 +5,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>1.0.0.0</VersionPrefix>
     <Authors>ACME Corporation</Authors>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Acme.Package</AssemblyName>
     <PackageId>Acme.Package</PackageId>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.PackageBilingual/Acme.PackageBilingual.csproj
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.PackageBilingual/Acme.PackageBilingual.csproj
@@ -5,7 +5,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>1.0.0.0</VersionPrefix>
     <Authors>ACME Corporation</Authors>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Acme.PackageBilingual</AssemblyName>
     <PackageId>Acme.PackageBilingual</PackageId>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Service/Acme.Service.csproj
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Service/Acme.Service.csproj
@@ -4,7 +4,7 @@
     <Description>A sample project containing a Windows service.</Description>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>ACME Corporation</Authors>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Acme.Service</AssemblyName>
     <PackageId>Acme.Service</PackageId>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/Acme.StructuredConfigFiles.csproj
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.StructuredConfigFiles/Acme.StructuredConfigFiles.csproj
@@ -5,7 +5,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>1.0.0.0</VersionPrefix>
     <Authors>ACME Corporation</Authors>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Acme.StructuredConfigFiles</AssemblyName>
     <PackageId>Acme.StructuredConfigFiles</PackageId>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web.Tests/Acme.Web.Tests.csproj
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web.Tests/Acme.Web.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>Test project for Calamari.</Description>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Octopus Deploy</Authors>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Acme.Web.Tests</AssemblyName>
     <PackageId>Acme.Web.Tests</PackageId>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Acme.Web.Nix.csproj
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Acme.Web.Nix.csproj
@@ -4,7 +4,7 @@
     <Description>Test project for Calamari.</Description>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Octopus Deploy</Authors>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Acme.Web</AssemblyName>
     <PackageId>Acme.Web</PackageId>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Acme.Web.csproj
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Acme.Web/Acme.Web.csproj
@@ -4,7 +4,7 @@
     <Description>Test project for Calamari.</Description>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Octopus Deploy</Authors>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Acme.Web</AssemblyName>
     <PackageId>Acme.Web</PackageId>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>

--- a/source/Calamari.Tests/Fixtures/Deployment/Packages/Octopus.Sample.AzureCloudService/Octopus.Sample.AzureCloudService.csproj
+++ b/source/Calamari.Tests/Fixtures/Deployment/Packages/Octopus.Sample.AzureCloudService/Octopus.Sample.AzureCloudService.csproj
@@ -5,7 +5,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>1.0.0.0</VersionPrefix>
     <Authors>Octopus Deploy</Authors>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Octopus.Sample.AzureCloudService</AssemblyName>
     <PackageId>Octopus.Sample.AzureCloudService</PackageId>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Calamari/</PackageProjectUrl>

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxyEnvironmentVariablesGeneratorFixture.cs
@@ -179,17 +179,17 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
 
         void ResetProxyEnvironmentVariables()
         {
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyUsername, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, string.Empty);
-            Environment.SetEnvironmentVariable("HTTP_PROXY", string.Empty);
-            Environment.SetEnvironmentVariable("http_proxy", string.Empty);
-            Environment.SetEnvironmentVariable("HTTPS_PROXY", string.Empty);
-            Environment.SetEnvironmentVariable("https_proxy", string.Empty);
-            Environment.SetEnvironmentVariable("NO_PROXY", string.Empty);
-            Environment.SetEnvironmentVariable("no_proxy", string.Empty);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyUsername, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, null);
+            Environment.SetEnvironmentVariable("HTTP_PROXY", null);
+            Environment.SetEnvironmentVariable("http_proxy", null);
+            Environment.SetEnvironmentVariable("HTTPS_PROXY", null);
+            Environment.SetEnvironmentVariable("https_proxy", null);
+            Environment.SetEnvironmentVariable("NO_PROXY", null);
+            Environment.SetEnvironmentVariable("no_proxy", null);
         }
 
         void AssertAuthenticatedProxyUsed(IEnumerable<EnvironmentVariable> result)

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxySettingsInitializerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/ProxySettingsInitializerFixture.cs
@@ -79,11 +79,11 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
 
         void ResetProxyEnvironmentVariables()
         {
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyUsername, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, string.Empty);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyUsername, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, null);
         }
 
         void AssertCustomProxy(IProxySettings proxySettings, bool hasCredentials)
@@ -101,8 +101,8 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
             }
             else
             {
-                proxy.Username.Should().BeNull();
-                proxy.Password.Should().BeNull();
+                proxy.Username.Should().BeNullOrEmpty();
+                proxy.Password.Should().BeNullOrEmpty();
             }
         }
 
@@ -118,8 +118,8 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
             }
             else
             {
-                proxy.Username.Should().BeNull();
-                proxy.Password.Should().BeNull();
+                proxy.Username.Should().BeNullOrEmpty();
+                proxy.Password.Should().BeNullOrEmpty();
             }
         }
 

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/ScriptProxyFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/ScriptProxyFixtureBase.cs
@@ -93,14 +93,14 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
 
         void ResetProxyEnvironmentVariables()
         {
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyUsername, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, string.Empty);
-            EnvironmentHelper.SetEnvironmentVariable("HTTP_PROXY", string.Empty);
-            EnvironmentHelper.SetEnvironmentVariable("HTTPS_PROXY", string.Empty);
-            EnvironmentHelper.SetEnvironmentVariable("NO_PROXY", string.Empty);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyUsername, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, null);
+            EnvironmentHelper.SetEnvironmentVariable("HTTP_PROXY", null);
+            EnvironmentHelper.SetEnvironmentVariable("HTTPS_PROXY", null);
+            EnvironmentHelper.SetEnvironmentVariable("NO_PROXY", null);
         }
 
         protected virtual void AssertAuthenticatedProxyUsed(CalamariResult output)

--- a/source/Calamari.Tests/Fixtures/Integration/Proxies/WebProxyInitializerFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Proxies/WebProxyInitializerFixture.cs
@@ -164,11 +164,11 @@ namespace Calamari.Tests.Fixtures.Integration.Proxies
 
         void ResetProxyEnvironmentVariables()
         {
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyUsername, string.Empty);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, string.Empty);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleUseDefaultProxy, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyUsername, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, null);
         }
 
         void AssertAuthenticatedProxyUsed()

--- a/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Nginx/NginxFixture.cs
@@ -306,8 +306,7 @@ namespace Calamari.Tests.Fixtures.Nginx
             {
                 var chainCertFilePath = TestEnvironment.GetTestPath("Helpers", "Certificates", "SampleCertificateFiles",
                     "3-cert-chain.pfx");
-                var certificateCollection = new X509Certificate2Collection();
-                certificateCollection.Import(chainCertFilePath, "hello world", X509KeyStorageFlags.PersistKeySet);
+                var certificateCollection = X509CertificateLoader.LoadPkcs12CollectionFromFile(chainCertFilePath, "hello world", X509KeyStorageFlags.PersistKeySet);
 
                 var certificate = certificateCollection.First();
                 var certificatePem = new string(PemEncoding.Write("CERTIFICATE", certificate.RawData));

--- a/source/Calamari.Tests/Helpers/Certificates/SampleCertificate.cs
+++ b/source/Calamari.Tests/Helpers/Certificates/SampleCertificate.cs
@@ -139,7 +139,7 @@ namespace Calamari.Tests.Helpers.Certificates
 
         X509Certificate2 LoadAsX509Certificate2()
         {
-            return new X509Certificate2(FilePath, Password,
+            return X509CertificateLoader.LoadPkcs12FromFile(FilePath, Password,
                 X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
         }
 

--- a/source/Calamari.Tests/Helpers/CodeGenerator.cs
+++ b/source/Calamari.Tests/Helpers/CodeGenerator.cs
@@ -26,11 +26,11 @@ namespace Calamari.Tests.Helpers
             File.WriteAllText(Path.Combine(projectPath.FullName, "global.json"),
                 @"{
     ""sdk"": {
-            ""version"": ""8.0.10"",
+            ""version"": ""10.0.302"",
             ""rollForward"": ""latestFeature""
         }
     }");
-            var result = clr.Execute(CreateCommandLineInvocation("dotnet", "new console -f net8.0"));
+            var result = clr.Execute(CreateCommandLineInvocation("dotnet", "new console -f net10.0"));
             result.VerifySuccess();
             var programCS = Path.Combine(projectPath.FullName, "Program.cs");
             var newProgram = $@"using System;

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -18,7 +18,7 @@
     <Product>Calamari</Product>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
     <ApplicationManifest>Calamari.exe.manifest</ApplicationManifest>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <!-- CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. -->
     <NoWarn>CS8632</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="SharpCompress" Version="0.49.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.16" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
-    <PackageReference Include="Autofac" Version="4.8.0" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="KubernetesClient" Version="17.0.14" />
     <PackageReference Include="Octopus.LibGit2Sharp" Version="0.31.1-octopus.3" />
   </ItemGroup>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -39,7 +39,6 @@
     <PackageReference Include="Octopus.TinyTypes" Version="2.2.1156" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
     <PackageReference Include="SharpCompress" Version="0.49.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.16" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="KubernetesClient" Version="17.0.14" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -31,10 +31,6 @@
     <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
     <ProjectReference Include="..\Calamari.Contracts\Calamari.Contracts.csproj" />
     <ProjectReference Include="..\Calamari.Shared\Calamari.Shared.csproj" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Octokit" Version="14.0.0" />

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <IsWindowsNetCoreBuild Condition="'$([MSBuild]::IsOSPlatform(`Windows`))' == 'true' AND '$(TargetFramework)' == 'net8.0'">true</IsWindowsNetCoreBuild>
+    <IsWindowsNetCoreBuild Condition="'$([MSBuild]::IsOSPlatform(`Windows`))' == 'true' AND '$(TargetFramework)' == 'net10.0'">true</IsWindowsNetCoreBuild>
     <IsWindowsNetCoreBuild Condition="'$(IsWindowsNetCoreBuild)' == ''">false</IsWindowsNetCoreBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
.NET 8 is end of support on 10 November 2026.

## What

- All product and test projects move to `net10.0` / `net10.0-windows`; `global.json` 8.0.419 → 10.0.302
- Autofac 4.8.0 → 9.3.1; dead net462 reference assemblies dropped
- Framework-provided package references removed. net10 prunes them, `TreatWarningsAsErrors` makes NU1510 fatal
- `DOTNET_ROLL_FORWARD=Major` for the bundled dotnet-script
- SDK 10 installed *alongside* 8.0 in the Nuke bootstrappers

#2094 and #2116 have landed on `main`; their commits have dropped out of this branch. The remaining net8-safe subset is #2095.

## Test failures

113 → 0. Every one was a hardcoded SDK version in test or build scaffolding, not product code. Four places wrote `8.0` down: `CodeGenerator.cs`, the TeamCity Windows MSI step, the three TestContainers Dockerfile templates, and `test.sh`.

One runtime behaviour change: on net10 `Environment.SetEnvironmentVariable(name, "")` stores an empty value instead of deleting the variable. 30 occurrences, all test code — the proxy fixtures used it to mean "unset", which then leaked `HTTP_PROXY=""` into later fixtures. Inherited empty variables are unchanged, so production is unaffected.

## Build

`source/Calamari.sln` on SDK 10.0.302: **174 warnings, 0 errors**. `main` on SDK 8.0.421 is 164. The ten new ones are all net10 surfacing things that were already there:

| Code | Where |
|---|---|
| `NU1510` ×3 | `System.Text.Encoding.CodePages` (Common, Shared), `System.Threading.AccessControl` (Common). Heuristic — both are genuinely used; removing `AccessControl` breaks the build because these target plain `net10.0`, not `-windows` |
| `SYSLIB0014` ×4 | `WebRequest`/`WebClient` |
| `SYSLIB0057` | `CalamariCertificateStore.cs:175`, `X509Certificate2(string, string, flags)` |
| `SYSLIB0060` | `AesEncryption.cs:137`, `Rfc2898DeriveBytes` ctor |
| `CS8714` | `Resolver.cs:17` — from Autofac 9's `notnull` constraint on `Resolve<T>`, not from net10 |

`build/Signing.cs` suppresses `SYSLIB0057` at one call site. The replacement API only loads certificate files; nothing replaces reading an Authenticode signature out of a signed PE.

## Not green

`Test: Amazon Linux 2` — glibc 2.26, below net10's 2.27 floor. Not fixable in code; blocked on the OS-floor decision.

## How to review this PR

General quality.

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
