### PR TITLE
Pin the bundled .NET runtime so it is a deliberate choice

### DIFF
--- a/build/Build.PackageCalamariProjects.cs
+++ b/build/Build.PackageCalamariProjects.cs
@@ -114,6 +114,9 @@ public partial class Build
                                                   .SetVersion(NugetVersion.Value)
                                                   .SetInformationalVersion(OctoVersionInfo.Value?.InformationalVersion)
                                                   .EnableSelfContained()
+                                                  // Pin the bundled runtime so it is a deliberate choice rather than a
+                                                  // property of whichever SDK the agent has. See BundledRuntime.
+                                                  .AddProperty("RuntimeFrameworkVersion", BundledRuntime.Version)
                                                   .EnablePublishSingleFile()
                                                   .EnablePublishTrimmed()
                                                   .SetOutput(stagingDirectory));
@@ -157,6 +160,9 @@ public partial class Build
                                               .SetVerbosity(BuildVerbosity)
                                               .EnableNoRestore()
                                               .EnableSelfContained()
+                                              // Pin the bundled runtime so it is a deliberate choice rather than a
+                                              // property of whichever SDK the agent has. See BundledRuntime.
+                                              .AddProperty("RuntimeFrameworkVersion", BundledRuntime.Version)
                                               .SetOutput(outputDirectory)));
 
         File.Copy(KnownPaths.RootDirectory / "global.json", outputDirectory / "global.json");

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -125,6 +125,13 @@ partial class Build : NukeBuild
                                              s = s.SetProjectFile(Solution);
                                              if (!string.IsNullOrWhiteSpace(TargetRuntime))
                                                  s = s.SetRuntime(TargetRuntime);
+                                             // Publish pins RuntimeFrameworkVersion and runs with --no-restore, so the
+                                             // pinned runtime pack has to be downloaded here or publish fails with
+                                             // NETSDK1112 on an agent that hasn't cached it. Setting this at restore
+                                             // only affects which pack is downloaded - it does not force test projects
+                                             // to run on that runtime, since dotnet test doesn't pass the property.
+                                             // See BundledRuntime.
+                                             s = s.AddProperty("RuntimeFrameworkVersion", BundledRuntime.Version);
                                              return s;
                                          });
                        });

--- a/build/BundledRuntime.cs
+++ b/build/BundledRuntime.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Calamari.Build
+{
+    /// <summary>
+    /// The .NET runtime version bundled into the published Calamari artifacts.
+    /// </summary>
+    /// <remarks>
+    /// Calamari publishes self-contained, so every artifact carries its own copy of the .NET runtime and
+    /// customer vulnerability scanners report against <em>that</em> runtime, not against the machine's.
+    /// <para>
+    /// Without this pin the bundled version is whatever runtime pack the build agent's SDK happens to ship -
+    /// so the security posture of a release would depend on when the agent was last updated rather than on a
+    /// decision anyone made. Two builds of the same commit on differently-patched agents would ship different
+    /// runtimes.
+    /// </para>
+    /// <para>
+    /// Setting <c>RuntimeFrameworkVersion</c> makes the choice explicit and reproducible: the runtime pack is
+    /// restored from NuGet at this exact version regardless of the agent's SDK. Verified by publishing on an
+    /// SDK whose default pack is older and confirming the output carries the pinned version instead.
+    /// </para>
+    /// <para>
+    /// <b>Keep this current.</b> .NET ships security patches monthly; a stale value here silently ships a
+    /// vulnerable runtime to every deployment target. Bump it when a new 8.0.x patch is released, and note
+    /// .NET 8 reaches end of support on 10 November 2026, after which no patches exist and this must move to
+    /// a supported major.
+    /// </para>
+    /// </remarks>
+    public static class BundledRuntime
+    {
+        /// <summary>Latest .NET 8 patch as at 2026-08-01 (released 2026-07-14, a security update).</summary>
+        public const string Version = "8.0.29";
+    }
+}


### PR DESCRIPTION
## Background

Calamari publishes self-contained. Every artifact carries its own copy of the .NET runtime. Customer vulnerability scanners report against that bundled runtime.

Nothing in the repo chose the runtime version. The version came from whichever runtime pack the build agent's SDK happened to ship. Two builds of the same commit on differently patched agents would ship different runtimes.

## Results

The bundled runtime version is now a single constant in `build/BundledRuntime.cs`. The constant applies at both self-contained publish sites and at restore.

Restore needs the property too. Publish runs with `--no-restore`. Without the pinned pack downloaded during restore, publish fails with NETSDK1112 on any agent that has not cached the pack. `--no-restore` is kept. A comment there records that it prevents `project.assets.json` contention across parallel per-RID publishes.

## Reducing risk

- Verified on a cold cache in both directions. The NETSDK1112 failure was reproduced before the fix was confirmed.
- Verified the pin overrides the SDK default. SDK 8.0.421 defaults to runtime 8.0.27. Published output carries 8.0.29.
- 82 extraction tests pass on a machine whose newest installed runtime is 8.0.27.

## How to review this PR

The constant needs bumping whenever .NET ships a security patch. A stale value silently ships a vulnerable runtime. Worth a Renovate rule after Renovate is re-enabled.

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
