### PR TITLE
Upgrade test dependencies that alert as transitive CVEs

### DIFF
--- a/source/Calamari.Testing/Calamari.Testing.csproj
+++ b/source/Calamari.Testing/Calamari.Testing.csproj
@@ -14,6 +14,9 @@
         <PackageReference Include="NUnit" Version="3.14.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="Octopus.1Password.Sdk" Version="0.0.127"/>
+        <!-- Pinned to remediate the vulnerable RestSharp 110.2.0 pulled in transitively via
+             Octopus.1Password.Sdk (GHSA-4rr6-2v9v-wcpc). -->
+        <PackageReference Include="RestSharp" Version="112.1.0" />
         <PackageReference Include="Serilog" Version="4.4.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
         <PackageReference Include="System.Text.Json" Version="9.0.16" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -20,10 +20,10 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.7.0"/>
+        <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.10"/>
         <PackageReference Include="System.Text.Json" Version="9.0.16" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41"/>
-        <PackageReference Include="WireMock.Net" Version="1.6.9"/>
+        <PackageReference Include="WireMock.Net" Version="2.13.0"/>
         <PackageReference Include="XPath2" Version="1.1.5"/>
         <ProjectReference Include="..\Calamari.Testing\Calamari.Testing.csproj"/>
         <ProjectReference Include="..\Calamari\Calamari.csproj"/>


### PR DESCRIPTION
## Background

Five transitive advisories one is critical.

## Results

Upgrades clear CVE warnings

| Project | Change | Clears |
|---|---|---|
| `Calamari.Tests` | WireMock.Net 1.6.9 to 2.13.0 | Scriban.Signed 5.5.0 with 13 advisories, System.Linq.Dynamic.Core 1.3.12, RestSharp 110.2.0 |
| `Calamari.Tests` | System.DirectoryServices.AccountManagement 4.7.0 to 10.0.10 | System.DirectoryServices.Protocols 4.7.0 |
| `Calamari.Testing` | RestSharp pinned to 112.1.0 | RestSharp 110.2.0 via `Octopus.1Password.Sdk` |

Before and after baselines taken from a clean `origin/main` worktree using `dotnet list package --vulnerable --include-transitive`.

**Not Doing**
System.Text.RegularExpressions 4.3.0 needs Octostache and Sprache to move forward.

## How to review this PR
Do the tests still pass? **Yes**

Server Change? **No**
