### PR TITLE
Let dotnet-script roll forward to a newer .NET runtime

### DIFF
--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
@@ -11,6 +11,8 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
 {
     public class DotnetScriptExecutor : ScriptExecutor
     {
+        const string DotnetRollForwardVariableName = "DOTNET_ROLL_FORWARD";
+
         readonly ICommandLineRunner commandLineRunner;
 
         public DotnetScriptExecutor(ICommandLineRunner commandLineRunner, ILog log): base(log)
@@ -37,13 +39,37 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
             bool.TryParse(variables.Get("Octopus.Action.Script.CSharp.BypassIsolation", "false"), out var bypassDotnetScriptIsolation);
 
             var cli = CreateCommandLineInvocation(executable, arguments, !string.IsNullOrWhiteSpace(localDotnetScriptPath));
-            cli.EnvironmentVars = environmentVars;
+            cli.EnvironmentVars = WithDotnetRollForward(environmentVars);
             cli.WorkingDirectory = workingDirectory;
             cli.Isolate = !bypassDotnetScriptIsolation;
 
             yield return new ScriptExecution(cli, otherTemporaryFiles.Concat(new[] { bootstrapFile, configurationFile }));
         }
         
+        /// <summary>
+        /// dotnet-script is a framework-dependent application - the bundled copy targets
+        /// Microsoft.NETCore.App 8.0.0. By default a framework-dependent app will not roll forward
+        /// across a major version, so on a machine that only has a newer runtime installed it fails
+        /// to launch with "You must install or update .NET to run this application".
+        ///
+        /// Calamari itself is published self-contained and carries no such requirement; this affects
+        /// only the separate dotnet-script process. Setting DOTNET_ROLL_FORWARD=Major lets it run on
+        /// whatever newer runtime is present, so C# script steps don't additionally require the exact
+        /// runtime dotnet-script was built against.
+        /// </summary>
+        static Dictionary<string, string> WithDotnetRollForward(Dictionary<string, string>? environmentVars)
+        {
+            var vars = environmentVars == null
+                ? new Dictionary<string, string>()
+                : new Dictionary<string, string>(environmentVars);
+
+            // Don't override an explicit value - the surrounding environment may have set one deliberately.
+            if (!vars.ContainsKey(DotnetRollForwardVariableName))
+                vars[DotnetRollForwardVariableName] = "Major";
+
+            return vars;
+        }
+
         private string GetExecutable(string? localDotnetScriptPath, string bundledExecutable)
         {
             return string.IsNullOrWhiteSpace(localDotnetScriptPath)


### PR DESCRIPTION
Sets `DOTNET_ROLL_FORWARD=Major` on the dotnet-script child process.

## Why

The bundled dotnet-script is framework-dependent, targets `Microsoft.NETCore.App 8.0.0`. Framework-dependent apps don't cross major version boundary by default, machine with .NET 10 and **no** .NET 8 **already** gets error:

```
You must install or update .NET to run this application.
```

Because `worker-tools:ubuntu.24.04` ships SDK 10 with no .NET 8 runtime, so C# script steps cannot run there today.

## Change

```csharp
if (!vars.ContainsKey("DOTNET_ROLL_FORWARD"))
    vars["DOTNET_ROLL_FORWARD"] = "Major";
```

## Question

> **When my Octopus instance gets the dotnet10 Calamari build. But the workers/targets I run only have dotnet8 SDK, no net10. What happens?**

## Answer
**Nothing changes. They keep working, C# script steps included.**

- Calamari doesn't need .NET 10 on worker. It ships self-contained with a runtime.
- dotnet-script asks for `Microsoft.NETCore.App 8.0.0`, finds your .NET 8, and runs on it.
- `Major` only engages when the requested major is **absent**. Where .NET 8 exists, is as-is.

The configuration that breaks is the opposite one, so this PR fixes:

| Worker has | Before | After |
|---|---|---|
| .NET 8 only | works | works — unchanged |
| .NET 8 and .NET 10 | works | works — unchanged, still resolves 8 |
| .NET 10 only | will not launch | launches |

## Risk

Nothing can go from working to broken. Every configuration this alters is one where dotnet-script fails to launch today; every configuration that works today has .NET 8, where the variable is inert.

- An explicit `DOTNET_ROLL_FORWARD` already in the environment is respected, not overwritten.
- Set on the child process only, not exported globally.
- `Calamari.Common`: **79 warnings, 0 errors — identical to `main`.**
- **10/10** `DotnetScriptFixture` tests pass.
- CI agents still have SDK 8 and SDK 10, 


Server will need to reference this build.
