### PR TITLE
Fall back to USEast1 aws region when region is not set

### DIFF
--- a/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
+++ b/source/Calamari.CloudAccounts/AwsEnvironmentGeneration.cs
@@ -136,11 +136,11 @@ namespace Calamari.CloudAccounts
         {
             get
             {
-                // "aws-global" routes to the global STS endpoint (sts.amazonaws.com), preserving SDK v3 behaviour.
-                // See: https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html
+                // Fall back to us-east-1: unsigned AssumeRoleWithWebIdentity fails against "aws-global".
+                // AWS recommends regional over global: https://docs.aws.amazon.com/general/latest/gr/sts.html
                 if (!EnvironmentVars.TryGetValue("AWS_REGION", out var awsRegion) || string.IsNullOrWhiteSpace(awsRegion))
                 {
-                    return RegionEndpoint.GetBySystemName("aws-global");
+                    return RegionEndpoint.USEast1;
                 }
 
                 return RegionEndpoint.GetBySystemName(awsRegion);

--- a/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
+++ b/source/Calamari.Tests/AWS/AwsEnvironmentGenerationFixture.cs
@@ -92,7 +92,7 @@ namespace Calamari.Tests.AWS
             awsEnvironmentGenerator.EnvironmentVars.Should().Contain(new KeyValuePair<string, string>("AWS_SESSION_TOKEN", sessionToken));
         }
         [Test]
-        public void FallsBackToAwsGlobalWhenRegionIsMissing()
+        public void FallsBackToUsEast1WhenRegionIsMissing()
         {
             IVariables variables = new CalamariVariables();
             variables.Add("Octopus.Account.AccountType", "AmazonWebServicesAccount");
@@ -101,7 +101,7 @@ namespace Calamari.Tests.AWS
             variables.Add("AWSAccount.SecretKey", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
 
             var envGeneration = new AwsEnvironmentGeneration(Substitute.For<ILog>(), variables);
-            envGeneration.AwsRegion.SystemName.Should().Be("aws-global");
+            envGeneration.AwsRegion.SystemName.Should().Be("us-east-1");
         }
 
         // Repros the Terraform-step-on-EKS scenario from Issues #8337


### PR DESCRIPTION
:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!

# Background

AWS OIDC accounts stopped working for Kubernetes API targets on EKS after the AWS SDK v4 upgrade in 2026.2, with health checks and deployments both failing with `Cannot find supported authentication schema`. A Kubernetes API target has nowhere to set an AWS region, so Calamari falls back to the `aws-global` region which fails for unsigned STS requests.

# Results

- Fixes health checks and deployments for Kubernetes API targets using AWS OIDC accounts, and ECS targets with a blank region.
- Falls back to `us-east-1` instead of `aws-global`. A configured region still takes precedence.
- No variables are contributed, so per-step regions are untouched.
- Verified on an EKS cluster in `ap-southeast-2` with no region set: health check, raw YAML deployment, access-key account and assume-role.


Fixes HPY-1542

## Before

<img width="2454" height="1136" alt="Screenshot 2026-08-05 at 10 35 13 AM" src="https://github.com/user-attachments/assets/bcf8fcf1-8145-411a-a23f-ace3a1d9f8de" />



## After

<img width="2454" height="1136" alt="Screenshot 2026-08-05 at 10 57 58 AM" src="https://github.com/user-attachments/assets/14bba718-5b68-4faa-970a-c015bb9daf5d" />

