### PR TITLE
Bump AWSSDK.Core, AWSSDK.CloudFormation and AWSSDK.ECR together

### DIFF
--- a/source/Calamari.Aws/Calamari.Aws.csproj
+++ b/source/Calamari.Aws/Calamari.Aws.csproj
@@ -24,8 +24,8 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.ECS" Version="4.0.19" />
     <PackageReference Include="AWSSDK.EKS" Version="4.0.15.1" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.8.19" />
-    <PackageReference Include="AWSSDK.Core" Version="4.0.3.29" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.102" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.100.9" />
     <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.18" />
     <PackageReference Include="AWSSDK.S3" Version="4.0.21.1" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.20" />

--- a/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
+++ b/source/Calamari.CloudAccounts/Calamari.CloudAccounts.csproj
@@ -18,9 +18,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.Core" Version="4.0.3.29" />
+      <PackageReference Include="AWSSDK.Core" Version="4.0.100.9" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.20" />
-      <PackageReference Include="AWSSDK.ECR" Version="4.0.13.1" />
+      <PackageReference Include="AWSSDK.ECR" Version="4.0.100.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
       <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
     </ItemGroup>


### PR DESCRIPTION
## Background
Dependabot opened two separate PRs that both bump `AWSSDK.Core`, but to different consuming projects (#2098 for `Calamari.Aws`, #2100 for `Calamari.CloudAccounts`). Building either branch on its own against the full solution produced NuGet version-downgrade warnings, since `AWSSDK.Core` ended up pinned to different versions across projects. Combining them into one branch resolves that.

## Results
- `AWSSDK.Core` → `4.0.100.9` (both projects)
- `AWSSDK.CloudFormation` → `4.0.102` (`Calamari.Aws`)
- `AWSSDK.ECR` → `4.0.100.7` (`Calamari.CloudAccounts`)

Supersedes #2098 and #2100 — those can be closed once this merges.

## Testing
Ran a clean `dotnet restore` + `dotnet build Calamari.sln`: 0 errors, no `AWSSDK.Core` version-downgrade warnings.

## How to review
Two commits, each a straight cherry-pick of one of the superseded Dependabot PRs — no manual edits, just combined onto one branch.

:warning: Does this change require a corresponding Server Change?
No.