### PR TITLE
Add set environment url helper functions

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -113,6 +113,37 @@ function set_octopusvariable
   echo $MESSAGE
 }
 
+#	---------------------------------------------------------------------------
+# Function for setting environment state
+#   Accepts 3 arguments:
+#     string: value of the key of the environment state
+#     string: value of the value of the environment state
+#     string: optional '-sensitive' to make the value sensitive
+#	---------------------------------------------------------------------------
+function set_environmentstate
+{
+  MESSAGE="##octopus[set-environmentstate"
+
+  if [ -n "$1" ]
+  then
+    MESSAGE="$MESSAGE key='$(encode_servicemessagevalue "$1")'"
+  fi
+
+  if [ -n "$2" ]
+  then
+    MESSAGE="$MESSAGE value='$(encode_servicemessagevalue "$2")'"
+  fi
+
+  if [ ! -z "${3:-}" ] && [ "$3" = "-sensitive" ]
+  then
+    MESSAGE="$MESSAGE sensitive='$(encode_servicemessagevalue "True")'"
+  fi
+
+  MESSAGE="$MESSAGE type='$(encode_servicemessagevalue "State")']"
+
+  echo $MESSAGE
+}
+
 # -----------------------------------------------------------------------------
 # Function to create a new octopus artifact
 #	Accepts 2 arguments:

--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -165,6 +165,23 @@ function Set-OctopusVariable([string]$name, [string]$value, [switch]$sensitive)
     }
 }
 
+function Set-EnvironmentState([string]$key, [string]$value, [switch]$sensitive)
+{
+    $key = Convert-ServiceMessageValue($key)
+    $value = Convert-ServiceMessageValue($value)
+    $type = Convert-ServiceMessageValue("State")
+    $trueEncoded = Convert-ServiceMessageValue("True")
+
+    If ($sensitive)
+    {
+        Write-Host "##octopus[set-environmentstate key='$( $key )' value='$( $value )' sensitive='$( $trueEncoded )' type='$( $type )']"
+    }
+    Else
+    {
+        Write-Host "##octopus[set-environmentstate key='$( $key )' value='$( $value )' type='$( $type )']"
+    }
+}
+
 function Convert-ToServiceMessageParameter([string]$name, [string]$value)
 {
     $value = Convert-ServiceMessageValue($value)

--- a/source/Calamari.Testing/LogParser/ScriptServiceMessageNames.cs
+++ b/source/Calamari.Testing/LogParser/ScriptServiceMessageNames.cs
@@ -12,6 +12,15 @@ namespace Calamari.Testing.LogParser
             public const string SensitiveAttribute = "sensitive";
         }
 
+        public static class EnvironmentState
+        {
+            public const string Name = "set-environmentstate";
+            public const string KeyAttribute = "key";
+            public const string ValueAttribute = "value";
+            public const string SensitiveAttribute = "sensitive";
+            public const string TypeAttribute = "type";
+        }
+
         public static class StdOutBehaviour
         {
             public const string Ignore = "stdout-ignore";

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -49,6 +49,34 @@ namespace Calamari.Tests.Fixtures.Bash
         [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
         [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
+        public void ShouldSetEnvironmentState(FeatureToggle? featureToggle)
+        {
+            var (output, _) = RunScript("set-environment-state.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
+
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("##octopus[set-environmentstate key='TXlLZXk=' value='TXlWYWx1ZQ==' type='U3RhdGU=']");
+                            });
+        }
+
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
+        [RequiresBashDotExeIfOnWindows]
+        public void ShouldSetSensitiveEnvironmentState(FeatureToggle? featureToggle)
+        {
+            var (output, _) = RunScript("set-sensitive-environment-state.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
+
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("##octopus[set-environmentstate key='U2VjcmV0S2V5' value='U2VjcmV0IFZhbHVl' sensitive='VHJ1ZQ==' type='U3RhdGU=']");
+                            });
+        }
+
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
+        [RequiresBashDotExeIfOnWindows]
         public void ShouldCreateArtifact(FeatureToggle? featureToggle)
         {
             var (output, _) = RunScript("create-artifact.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));

--- a/source/Calamari.Tests/Fixtures/Bash/Scripts/set-environment-state.sh
+++ b/source/Calamari.Tests/Fixtures/Bash/Scripts/set-environment-state.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+set_environmentstate "MyKey" "MyValue"

--- a/source/Calamari.Tests/Fixtures/Bash/Scripts/set-sensitive-environment-state.sh
+++ b/source/Calamari.Tests/Fixtures/Bash/Scripts/set-sensitive-environment-state.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+set_environmentstate "SecretKey" "Secret Value" -sensitive

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
@@ -384,6 +384,24 @@ namespace Calamari.Tests.Fixtures.PowerShell
         }
 
         [Test]
+        public void ShouldWriteServiceMessageForEnvironmentState()
+        {
+            var (output, _) = RunPowerShellScript("CanSetEnvironmentState.ps1");
+            output.AssertSuccess();
+            output.AssertOutput("##octopus[set-environmentstate key='TXlLZXk=' value='TXlWYWx1ZQ==' type='U3RhdGU=']");
+            AssertPowerShellEdition(output);
+        }
+
+        [Test]
+        public void ShouldWriteServiceMessageForSensitiveEnvironmentState()
+        {
+            var (output, _) = RunPowerShellScript("CanSetEnvironmentState.ps1");
+            output.AssertSuccess();
+            output.AssertOutput("##octopus[set-environmentstate key='U2VjcmV0S2V5' value='U2VjcmV0IFZhbHVl' sensitive='VHJ1ZQ==' type='U3RhdGU=']");
+            AssertPowerShellEdition(output);
+        }
+
+        [Test]
         public void ShouldSetActionIndexedOutputVariables()
         {
             var (output, variables) = RunPowerShellScript("CanSetVariable.ps1", new Dictionary<string, string>

--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/CanSetEnvironmentState.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/CanSetEnvironmentState.ps1
@@ -1,0 +1,4 @@
+
+Set-EnvironmentState -Key "MyKey" -Value "MyValue"
+
+Set-EnvironmentState -Key "SecretKey" -Value "Secret Value" -Sensitive


### PR DESCRIPTION
## Context

We are adding support for setting environment state within a deployment/runbook run. State will be persisted across deployments for the project/environment/(tenant) and will primarily be used across provisioning, deployment and deprovisioning of ephemeral environments.

State will be set using a new service message in the format `set-environmentstate -key "{key}" -value "{value}" -sensitive "{sensitive}" -type "{type}".

Different types of state will be supported: 
- `State`: General state to be persisted. https://github.com/OctopusDeploy/Calamari/pull/2104
- `Url`: Url to be associated and shown with the environment. <-- This PR

## Changes

Adds helper functions to PowerShell and Bash for setting environment urls, mirroring the functions for setting output variables.

- PowerShell: `Set-EnvironmentUrl -Name {name} -Url {url}`.
- Bash: `set_environmenturl {name} {url}`.

## Reviewing and testing

Automated tests have been added, we'll need to pair and test this with the work in Octopus Server to handle service messages.