### PR TITLE
Add set environment url helper functions

### DIFF
--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -164,7 +164,7 @@ function set_environmenturl
     MESSAGE="$MESSAGE value='$(encode_servicemessagevalue "$2")'"
   fi
 
-  MESSAGE="$MESSAGE type='$(encode_servicemessagevalue "url")']"
+  MESSAGE="$MESSAGE type='$(encode_servicemessagevalue "Url")']"
 
   echo $MESSAGE
 }

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -144,6 +144,31 @@ function set_environmentstate
   echo $MESSAGE
 }
 
+#	---------------------------------------------------------------------------
+# Function for setting an environment url
+#   Accepts 2 arguments:
+#     string: value of the name of the environment url
+#     string: value of the url of the environment
+#	---------------------------------------------------------------------------
+function set_environmenturl
+{
+  MESSAGE="##octopus[set-environmentstate"
+
+  if [ -n "$1" ]
+  then
+    MESSAGE="$MESSAGE key='$(encode_servicemessagevalue "$1")'"
+  fi
+
+  if [ -n "$2" ]
+  then
+    MESSAGE="$MESSAGE value='$(encode_servicemessagevalue "$2")'"
+  fi
+
+  MESSAGE="$MESSAGE type='$(encode_servicemessagevalue "url")']"
+
+  echo $MESSAGE
+}
+
 # -----------------------------------------------------------------------------
 # Function to create a new octopus artifact
 #	Accepts 2 arguments:

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -147,7 +147,7 @@ function set_environmentstate
 #	---------------------------------------------------------------------------
 # Function for setting an environment url
 #   Accepts 2 arguments:
-#     string: value of the name of the environment url
+#     string: value of the key of the environment url
 #     string: value of the url of the environment
 #	---------------------------------------------------------------------------
 function set_environmenturl

--- a/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
+++ b/source/Calamari.Common/Features/Scripting/Bash/Bootstrap.sh
@@ -115,10 +115,11 @@ function set_octopusvariable
 
 #	---------------------------------------------------------------------------
 # Function for setting environment state
-#   Accepts 3 arguments:
+#   Accepts 4 arguments:
 #     string: value of the key of the environment state
 #     string: value of the value of the environment state
 #     string: optional '-sensitive' to make the value sensitive
+#     string: optional value of the type of the environment state, defaults to 'State'
 #	---------------------------------------------------------------------------
 function set_environmentstate
 {
@@ -139,7 +140,7 @@ function set_environmentstate
     MESSAGE="$MESSAGE sensitive='$(encode_servicemessagevalue "True")'"
   fi
 
-  MESSAGE="$MESSAGE type='$(encode_servicemessagevalue "State")']"
+  MESSAGE="$MESSAGE type='$(encode_servicemessagevalue "${4:-State}")']"
 
   echo $MESSAGE
 }
@@ -152,21 +153,7 @@ function set_environmentstate
 #	---------------------------------------------------------------------------
 function set_environmenturl
 {
-  MESSAGE="##octopus[set-environmentstate"
-
-  if [ -n "$1" ]
-  then
-    MESSAGE="$MESSAGE key='$(encode_servicemessagevalue "$1")'"
-  fi
-
-  if [ -n "$2" ]
-  then
-    MESSAGE="$MESSAGE value='$(encode_servicemessagevalue "$2")'"
-  fi
-
-  MESSAGE="$MESSAGE type='$(encode_servicemessagevalue "Url")']"
-
-  echo $MESSAGE
+  set_environmentstate "$1" "$2" "" "Url"
 }
 
 # -----------------------------------------------------------------------------

--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -165,11 +165,11 @@ function Set-OctopusVariable([string]$name, [string]$value, [switch]$sensitive)
     }
 }
 
-function Set-EnvironmentState([string]$key, [string]$value, [switch]$sensitive)
+function Set-EnvironmentState([string]$key, [string]$value, [switch]$sensitive, [string]$type = "State")
 {
     $key = Convert-ServiceMessageValue($key)
     $value = Convert-ServiceMessageValue($value)
-    $type = Convert-ServiceMessageValue("State")
+    $type = Convert-ServiceMessageValue($type)
     $trueEncoded = Convert-ServiceMessageValue("True")
 
     If ($sensitive)
@@ -184,11 +184,7 @@ function Set-EnvironmentState([string]$key, [string]$value, [switch]$sensitive)
 
 function Set-EnvironmentUrl([string]$key, [string]$url)
 {
-    $key = Convert-ServiceMessageValue($key)
-    $url = Convert-ServiceMessageValue($url)
-    $type = Convert-ServiceMessageValue("Url")
-
-    Write-Host "##octopus[set-environmentstate key='$( $key )' value='$( $url )' type='$( $type )']"
+    Set-EnvironmentState -Key $key -Value $url -Type "Url"
 }
 
 function Convert-ToServiceMessageParameter([string]$name, [string]$value)

--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -186,7 +186,7 @@ function Set-EnvironmentUrl([string]$name, [string]$url)
 {
     $name = Convert-ServiceMessageValue($name)
     $url = Convert-ServiceMessageValue($url)
-    $type = Convert-ServiceMessageValue("url")
+    $type = Convert-ServiceMessageValue("Url")
 
     Write-Host "##octopus[set-environmentstate key='$( $name )' value='$( $url )' type='$( $type )']"
 }

--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -182,13 +182,13 @@ function Set-EnvironmentState([string]$key, [string]$value, [switch]$sensitive)
     }
 }
 
-function Set-EnvironmentUrl([string]$name, [string]$url)
+function Set-EnvironmentUrl([string]$key, [string]$url)
 {
-    $name = Convert-ServiceMessageValue($name)
+    $key = Convert-ServiceMessageValue($key)
     $url = Convert-ServiceMessageValue($url)
     $type = Convert-ServiceMessageValue("Url")
 
-    Write-Host "##octopus[set-environmentstate key='$( $name )' value='$( $url )' type='$( $type )']"
+    Write-Host "##octopus[set-environmentstate key='$( $key )' value='$( $url )' type='$( $type )']"
 }
 
 function Convert-ToServiceMessageParameter([string]$name, [string]$value)

--- a/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
+++ b/source/Calamari.Common/Features/Scripting/WindowsPowerShell/Bootstrap.ps1
@@ -182,6 +182,15 @@ function Set-EnvironmentState([string]$key, [string]$value, [switch]$sensitive)
     }
 }
 
+function Set-EnvironmentUrl([string]$name, [string]$url)
+{
+    $name = Convert-ServiceMessageValue($name)
+    $url = Convert-ServiceMessageValue($url)
+    $type = Convert-ServiceMessageValue("url")
+
+    Write-Host "##octopus[set-environmentstate key='$( $name )' value='$( $url )' type='$( $type )']"
+}
+
 function Convert-ToServiceMessageParameter([string]$name, [string]$value)
 {
     $value = Convert-ServiceMessageValue($value)

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -23,7 +23,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [RequiresBashDotExeIfOnWindows]
         public void ShouldPrintEncodedVariable(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("print-encoded-variable.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+            var (output, _) = RunScript("print-encoded-variable.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
 
             Assert.Multiple(() =>
                             {
@@ -37,7 +37,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [RequiresBashDotExeIfOnWindows]
         public void ShouldPrintSensitiveVariable(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("print-sensitive-variable.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+            var (output, _) = RunScript("print-sensitive-variable.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
 
             Assert.Multiple(() =>
                             {
@@ -51,7 +51,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [RequiresBashDotExeIfOnWindows]
         public void ShouldSetEnvironmentState(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("set-environment-state.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+            var (output, _) = RunScript("set-environment-state.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
 
             Assert.Multiple(() =>
                             {
@@ -65,7 +65,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [RequiresBashDotExeIfOnWindows]
         public void ShouldSetSensitiveEnvironmentState(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("set-sensitive-environment-state.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+            var (output, _) = RunScript("set-sensitive-environment-state.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
 
             Assert.Multiple(() =>
                             {
@@ -73,6 +73,7 @@ namespace Calamari.Tests.Fixtures.Bash
                                 output.AssertOutput("##octopus[set-environmentstate key='U2VjcmV0S2V5' value='U2VjcmV0IFZhbHVl' sensitive='VHJ1ZQ==' type='U3RhdGU=']");
                             });
         }
+
 
         [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
         [TestCase(null)]
@@ -93,22 +94,22 @@ namespace Calamari.Tests.Fixtures.Bash
         [RequiresBashDotExeIfOnWindows]
         public void ShouldCreateArtifact(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("create-artifact.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+            var (output, _) = RunScript("create-artifact.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
 
             const string regexPattern = @"##octopus\[createArtifact path='([\S]+)' name='bXlmaWxl' length='MA==']";
-
+    
             Assert.Multiple(() =>
                             {
                                 output.AssertSuccess();
                                 output.AssertOutputMatches(regexPattern);
 
-
+                                
                                 var match = Regex.Match(output.CapturedOutput.ToString(), regexPattern);
                                 match.Success.Should().BeTrue();
-
+                                
                                 //the second match is the first match group
                                 var matchedPath = match.Groups[1];
-
+                                
                                 //decoded path
                                 var decodedPath = Encoding.UTF8.GetString(Convert.FromBase64String(matchedPath.Value));
 
@@ -122,7 +123,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [RequiresBashDotExeIfOnWindows]
         public void ShouldUpdateProgress(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("update-progress.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+            var (output, _) = RunScript("update-progress.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
 
             Assert.Multiple(() =>
                             {
@@ -130,13 +131,13 @@ namespace Calamari.Tests.Fixtures.Bash
                                 output.AssertOutput("##octopus[progress percentage='NTA=' message='SGFsZiBXYXk=']");
                             });
         }
-
+        
         [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
         [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
         public void ShouldReportKubernetesManifest(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("report-kubernetes-manifest.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+            var (output, _) = RunScript("report-kubernetes-manifest.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
 
             Assert.Multiple(() =>
                             {
@@ -147,7 +148,7 @@ namespace Calamari.Tests.Fixtures.Bash
                                 output.AssertOutput("##octopus[k8s-manifest-applied manifest='ImFwaVZlcnNpb24iOiAidjEiCiJraW5kIjogIk5hbWVzcGFjZSIKIm1ldGFkYXRhIjoKICAibmFtZSI6ICJkaWZmcyIKImxhYmVscyI6CiAgICAibmFtZSI6ICJkaWZmcyIK' ns='bXk=']");
                             });
         }
-
+        
         [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
         [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
@@ -167,7 +168,7 @@ namespace Calamari.Tests.Fixtures.Bash
   ""name"": ""diffs""
 ""labels"":
     ""name"": ""diffs""".ReplaceLineEndings("\n");
-
+            
             var filePath = Path.Combine(tempPath, "ShouldWriteServiceMessageForKubernetesManifestFile.manifest.yaml");
             File.WriteAllText(filePath, manifest);
 
@@ -175,12 +176,12 @@ namespace Calamari.Tests.Fixtures.Bash
             var updatedFilePath = filePath;
             if (CalamariEnvironment.IsRunningOnWindows)
             {
-                var qualifiedPath = filePath.Replace(@"\", @"\\");
+                var qualifiedPath = filePath.Replace(@"\",@"\\");
 
                 var path = string.Empty;
                 var result = SilentProcessRunner.ExecuteCommand("wsl", $"wslpath -a -u {qualifiedPath}", tempPath, output => path = output,
                                                                 _ => { });
-
+                
                 if (result.ExitCode != 0)
                 {
                     Assert.Fail("Failed to convert windows path to WSL path");
@@ -222,7 +223,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("parameters.sh",
                                         new Dictionary<string, string>
-                                        { [SpecialVariables.Action.Script.ScriptParameters] = "\"Para meter0\" 'Para meter1'" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+                                            { [SpecialVariables.Action.Script.ScriptParameters] = "\"Para meter0\" 'Para meter1'" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -275,7 +276,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("hello.sh",
                                         new Dictionary<string, string>()
-                                        { ["Name"] = "NameToEncrypt" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }), sensitiveVariablesPassword:
+                                            { ["Name"] = "NameToEncrypt" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }), sensitiveVariablesPassword:
             "5XETGOgqYR2bRhlfhDruEg==");
 
             Assert.Multiple(() =>
@@ -292,7 +293,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("hello.sh",
                                         new Dictionary<string, string>()
-                                        { ["Name"] = null }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+                                            { ["Name"] = null }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -308,7 +309,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("hello.sh",
                                         new Dictionary<string, string>()
-                                        { ["Name"] = null }, sensitiveVariablesPassword:
+                                            { ["Name"] = null }, sensitiveVariablesPassword:
             "5XETGOgqYR2bRhlfhDruEg==");
 
             Assert.Multiple(() =>
@@ -340,7 +341,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("stderr.sh",
                                         new Dictionary<string, string>()
-                                        { [SpecialVariables.Action.FailScriptOnErrorOutput] = "True" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+                                            { [SpecialVariables.Action.FailScriptOnErrorOutput] = "True" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -356,7 +357,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("hello.sh",
                                         new Dictionary<string, string>()
-                                        { [SpecialVariables.Action.FailScriptOnErrorOutput] = "True" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+                                            { [SpecialVariables.Action.FailScriptOnErrorOutput] = "True" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             output.AssertSuccess();
         }

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -84,7 +84,7 @@ namespace Calamari.Tests.Fixtures.Bash
             Assert.Multiple(() =>
                             {
                                 output.AssertSuccess();
-                                output.AssertOutput("##octopus[set-environmentstate key='TXlFbnZpcm9ubWVudA==' value='aHR0cHM6Ly9teS1lbnZpcm9ubWVudC5leGFtcGxlLmNvbQ==' type='dXJs']");
+                                output.AssertOutput("##octopus[set-environmentstate key='TXlFbnZpcm9ubWVudA==' value='aHR0cHM6Ly9teS1lbnZpcm9ubWVudC5leGFtcGxlLmNvbQ==' type='VXJs']");
                             });
         }
 

--- a/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Bash/BashFixture.cs
@@ -23,7 +23,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [RequiresBashDotExeIfOnWindows]
         public void ShouldPrintEncodedVariable(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("print-encoded-variable.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
+            var (output, _) = RunScript("print-encoded-variable.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -37,7 +37,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [RequiresBashDotExeIfOnWindows]
         public void ShouldPrintSensitiveVariable(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("print-sensitive-variable.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
+            var (output, _) = RunScript("print-sensitive-variable.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -51,7 +51,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [RequiresBashDotExeIfOnWindows]
         public void ShouldSetEnvironmentState(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("set-environment-state.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
+            var (output, _) = RunScript("set-environment-state.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -65,7 +65,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [RequiresBashDotExeIfOnWindows]
         public void ShouldSetSensitiveEnvironmentState(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("set-sensitive-environment-state.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
+            var (output, _) = RunScript("set-sensitive-environment-state.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -77,24 +77,38 @@ namespace Calamari.Tests.Fixtures.Bash
         [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
         [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
+        public void ShouldSetEnvironmentUrl(FeatureToggle? featureToggle)
+        {
+            var (output, _) = RunScript("set-environment-url.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+
+            Assert.Multiple(() =>
+                            {
+                                output.AssertSuccess();
+                                output.AssertOutput("##octopus[set-environmentstate key='TXlFbnZpcm9ubWVudA==' value='aHR0cHM6Ly9teS1lbnZpcm9ubWVudC5leGFtcGxlLmNvbQ==' type='dXJs']");
+                            });
+        }
+
+        [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
+        [TestCase(null)]
+        [RequiresBashDotExeIfOnWindows]
         public void ShouldCreateArtifact(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("create-artifact.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
+            var (output, _) = RunScript("create-artifact.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             const string regexPattern = @"##octopus\[createArtifact path='([\S]+)' name='bXlmaWxl' length='MA==']";
-    
+
             Assert.Multiple(() =>
                             {
                                 output.AssertSuccess();
                                 output.AssertOutputMatches(regexPattern);
 
-                                
+
                                 var match = Regex.Match(output.CapturedOutput.ToString(), regexPattern);
                                 match.Success.Should().BeTrue();
-                                
+
                                 //the second match is the first match group
                                 var matchedPath = match.Groups[1];
-                                
+
                                 //decoded path
                                 var decodedPath = Encoding.UTF8.GetString(Convert.FromBase64String(matchedPath.Value));
 
@@ -108,7 +122,7 @@ namespace Calamari.Tests.Fixtures.Bash
         [RequiresBashDotExeIfOnWindows]
         public void ShouldUpdateProgress(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("update-progress.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
+            var (output, _) = RunScript("update-progress.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -116,13 +130,13 @@ namespace Calamari.Tests.Fixtures.Bash
                                 output.AssertOutput("##octopus[progress percentage='NTA=' message='SGFsZiBXYXk=']");
                             });
         }
-        
+
         [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
         [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
         public void ShouldReportKubernetesManifest(FeatureToggle? featureToggle)
         {
-            var (output, _) = RunScript("report-kubernetes-manifest.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?>{featureToggle}));
+            var (output, _) = RunScript("report-kubernetes-manifest.sh", new Dictionary<string, string>().AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -133,7 +147,7 @@ namespace Calamari.Tests.Fixtures.Bash
                                 output.AssertOutput("##octopus[k8s-manifest-applied manifest='ImFwaVZlcnNpb24iOiAidjEiCiJraW5kIjogIk5hbWVzcGFjZSIKIm1ldGFkYXRhIjoKICAibmFtZSI6ICJkaWZmcyIKImxhYmVscyI6CiAgICAibmFtZSI6ICJkaWZmcyIK' ns='bXk=']");
                             });
         }
-        
+
         [TestCase(FeatureToggle.BashParametersArrayFeatureToggle)]
         [TestCase(null)]
         [RequiresBashDotExeIfOnWindows]
@@ -153,7 +167,7 @@ namespace Calamari.Tests.Fixtures.Bash
   ""name"": ""diffs""
 ""labels"":
     ""name"": ""diffs""".ReplaceLineEndings("\n");
-            
+
             var filePath = Path.Combine(tempPath, "ShouldWriteServiceMessageForKubernetesManifestFile.manifest.yaml");
             File.WriteAllText(filePath, manifest);
 
@@ -161,12 +175,12 @@ namespace Calamari.Tests.Fixtures.Bash
             var updatedFilePath = filePath;
             if (CalamariEnvironment.IsRunningOnWindows)
             {
-                var qualifiedPath = filePath.Replace(@"\",@"\\");
+                var qualifiedPath = filePath.Replace(@"\", @"\\");
 
                 var path = string.Empty;
                 var result = SilentProcessRunner.ExecuteCommand("wsl", $"wslpath -a -u {qualifiedPath}", tempPath, output => path = output,
                                                                 _ => { });
-                
+
                 if (result.ExitCode != 0)
                 {
                     Assert.Fail("Failed to convert windows path to WSL path");
@@ -208,7 +222,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("parameters.sh",
                                         new Dictionary<string, string>
-                                            { [SpecialVariables.Action.Script.ScriptParameters] = "\"Para meter0\" 'Para meter1'" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+                                        { [SpecialVariables.Action.Script.ScriptParameters] = "\"Para meter0\" 'Para meter1'" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -261,7 +275,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("hello.sh",
                                         new Dictionary<string, string>()
-                                            { ["Name"] = "NameToEncrypt" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }), sensitiveVariablesPassword:
+                                        { ["Name"] = "NameToEncrypt" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }), sensitiveVariablesPassword:
             "5XETGOgqYR2bRhlfhDruEg==");
 
             Assert.Multiple(() =>
@@ -278,7 +292,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("hello.sh",
                                         new Dictionary<string, string>()
-                                            { ["Name"] = null }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+                                        { ["Name"] = null }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -294,7 +308,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("hello.sh",
                                         new Dictionary<string, string>()
-                                            { ["Name"] = null }, sensitiveVariablesPassword:
+                                        { ["Name"] = null }, sensitiveVariablesPassword:
             "5XETGOgqYR2bRhlfhDruEg==");
 
             Assert.Multiple(() =>
@@ -326,7 +340,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("stderr.sh",
                                         new Dictionary<string, string>()
-                                            { [SpecialVariables.Action.FailScriptOnErrorOutput] = "True" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+                                        { [SpecialVariables.Action.FailScriptOnErrorOutput] = "True" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             Assert.Multiple(() =>
                             {
@@ -342,7 +356,7 @@ namespace Calamari.Tests.Fixtures.Bash
         {
             var (output, _) = RunScript("hello.sh",
                                         new Dictionary<string, string>()
-                                            { [SpecialVariables.Action.FailScriptOnErrorOutput] = "True" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
+                                        { [SpecialVariables.Action.FailScriptOnErrorOutput] = "True" }.AddFeatureToggleToDictionary(new List<FeatureToggle?> { featureToggle }));
 
             output.AssertSuccess();
         }

--- a/source/Calamari.Tests/Fixtures/Bash/Scripts/set-environment-url.sh
+++ b/source/Calamari.Tests/Fixtures/Bash/Scripts/set-environment-url.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+set_environmenturl "MyEnvironment" "https://my-environment.example.com"

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
@@ -58,7 +58,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
             var output = InvokeCalamariForPowerShell(calamari => calamari
                 .Action("run-script")
-                .Argument("script", GetFixtureResource("Scripts", ProfileScript)),
+                .Argument("script", GetFixtureResource("Scripts", ProfileScript)), 
                 variables);
 
             output.AssertSuccess();
@@ -146,7 +146,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                 new CalamariExecutionVariable("Octopus.Action[PreviousStep].Output.FirstName", "Steve", false),
                 new CalamariExecutionVariable("Octopus.Action[PreviousStep].Output.LastName", "Not Jobs", true)
             };
-
+            
             var serialized = variables.ToJsonString();
             var bytes = ProtectedData.Protect(Encoding.UTF8.GetBytes(serialized), Convert.FromBase64String("5XETGOgqYR2bRhlfhDruEg=="), DataProtectionScope.CurrentUser);
             var encoded = Convert.ToBase64String(bytes);
@@ -205,7 +205,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
         public void ShouldWriteServiceMessageForArtifacts()
         {
             var artifactPath = IsRunningOnUnixLikeEnvironment ? @"\tmp\calamari\File.txt" : @"C:\Path\File.txt";
-            var (output, _) = RunPowerShellScript("CanCreateArtifact.ps1", new Dictionary<string, string> { { "ArtifactPath", artifactPath } });
+            var (output, _) = RunPowerShellScript("CanCreateArtifact.ps1", new Dictionary<string, string> {{"ArtifactPath", artifactPath}});
             output.AssertSuccess();
             var expectedArtifactServiceMessage = IsRunningOnUnixLikeEnvironment
                 ? "##octopus[createArtifact path='L3RtcC9jYWxhbWFyaS9GaWxlLnR4dA==' name='XHRtcFxjYWxhbWFyaVxGaWxlLnR4dA==' length='MA==']"
@@ -245,7 +245,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
             try
             {
-                var (output, _) = RunPowerShellScript("CanCreateArtifactPiped.ps1", new Dictionary<string, string> { { "TempDirectory", tempPath } });
+                var (output, _) = RunPowerShellScript("CanCreateArtifactPiped.ps1", new Dictionary<string, string> {{"TempDirectory", tempPath}});
                 output.AssertSuccess();
                 foreach (var artifact in artifacts)
                 {
@@ -276,7 +276,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
             output.AssertOutput("##octopus[k8s-manifest-applied manifest='ImFwaVZlcnNpb24iOiAidjEiDQoia2luZCI6ICJOYW1lc3BhY2UiDQoibWV0YWRhdGEiOg0KICAibmFtZSI6ICJkaWZmcyINCiJsYWJlbHMiOg0KICAgICJuYW1lIjogImRpZmZzIg0K' ns='bXk=']");
             AssertPowerShellEdition(output);
         }
-
+        
         [Test]
         public void ShouldWriteServiceMessageForKubernetesManifestFile()
         {
@@ -300,7 +300,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
             try
             {
-                var (output, _) = RunPowerShellScript("ReportKubernetesManifestFile.ps1", new Dictionary<string, string> { { "ManifestFilePath", filePath } });
+                var (output, _) = RunPowerShellScript("ReportKubernetesManifestFile.ps1", new Dictionary<string, string> {{"ManifestFilePath", filePath}});
                 output.AssertSuccess();
                 output.AssertOutput("##octopus[k8s-manifest-applied manifest='ImFwaVZlcnNpb24iOiAidjEiDQoia2luZCI6ICJOYW1lc3BhY2UiDQoibWV0YWRhdGEiOg0KICAibmFtZSI6ICJleGFtcGxlIg0KImxhYmVscyI6DQogICAgIm5hbWUiOiAiZXhhbXBsZSINCg==']");
                 output.AssertOutput("##octopus[k8s-manifest-applied manifest='ImFwaVZlcnNpb24iOiAidjEiDQoia2luZCI6ICJOYW1lc3BhY2UiDQoibWV0YWRhdGEiOg0KICAibmFtZSI6ICJkaWZmcyINCiJsYWJlbHMiOg0KICAgICJuYW1lIjogImRpZmZzIg==']");
@@ -341,7 +341,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
             var nonExistantArtifactPath = IsRunningOnUnixLikeEnvironment
                 ? @"\tmp\NonExistantPath\NonExistantFile.txt"
                 : @"C:\NonExistantPath\NonExistantFile.txt";
-            var (output, _) = RunPowerShellScript("WarningForMissingArtifact.ps1", new Dictionary<string, string> { { "ArtifactPath", nonExistantArtifactPath } });
+            var (output, _) = RunPowerShellScript("WarningForMissingArtifact.ps1", new Dictionary<string, string> {{"ArtifactPath", nonExistantArtifactPath}});
             output.AssertSuccess();
             output.AssertOutput($@"There is no file at '{nonExistantArtifactPath}' right now. Writing the service message just in case the file is available when the artifacts are collected at a later point in time.");
             var expectedArtifactServiceMessage = IsRunningOnUnixLikeEnvironment
@@ -676,12 +676,12 @@ namespace Calamari.Tests.Fixtures.PowerShell
             var variableDictionary = variables ?? new CalamariVariables();
             variableDictionary.Add(PowerShellVariables.Edition, GetPowerShellEditionVariable());
 
-            using (var variablesFile = CreateVariablesFile(variableDictionary))
+            using (var variablesFile = CreateVariablesFile(variableDictionary ))
             {
                 var calamariCommand = Calamari();
                 buildCommand(calamariCommand);
                 calamariCommand.VariablesFileArguments(variablesFile.FilePath, variablesFile.EncryptionKey);
-
+                
                 return Invoke(calamariCommand);
             }
         }
@@ -700,8 +700,8 @@ namespace Calamari.Tests.Fixtures.PowerShell
             public VariableFile(IVariables variables)
             {
                 FilePath = Path.GetTempFileName();
-                EncryptionKey = AesEncryption.RandomString(10);
-
+                EncryptionKey =  AesEncryption.RandomString(10);
+                
                 variables.SaveAsEncryptedExecutionVariables(FilePath, EncryptionKey);
                 tempFile = new TemporaryFile(FilePath);
             }
@@ -724,7 +724,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
         string GetPowerShellEditionVariable()
         {
-            switch (PowerShellEdition)
+            switch(PowerShellEdition)
             {
                 case PowerShellEdition.Desktop:
                     return "Desktop";

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
@@ -406,7 +406,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
         {
             var (output, _) = RunPowerShellScript("CanSetEnvironmentUrl.ps1");
             output.AssertSuccess();
-            output.AssertOutput("##octopus[set-environmentstate key='TXlFbnZpcm9ubWVudA==' value='aHR0cHM6Ly9teS1lbnZpcm9ubWVudC5leGFtcGxlLmNvbQ==' type='dXJs']");
+            output.AssertOutput("##octopus[set-environmentstate key='TXlFbnZpcm9ubWVudA==' value='aHR0cHM6Ly9teS1lbnZpcm9ubWVudC5leGFtcGxlLmNvbQ==' type='VXJs']");
             AssertPowerShellEdition(output);
         }
 

--- a/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
+++ b/source/Calamari.Tests/Fixtures/PowerShell/PowerShellFixtureBase.cs
@@ -58,7 +58,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
             var output = InvokeCalamariForPowerShell(calamari => calamari
                 .Action("run-script")
-                .Argument("script", GetFixtureResource("Scripts", ProfileScript)), 
+                .Argument("script", GetFixtureResource("Scripts", ProfileScript)),
                 variables);
 
             output.AssertSuccess();
@@ -146,7 +146,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
                 new CalamariExecutionVariable("Octopus.Action[PreviousStep].Output.FirstName", "Steve", false),
                 new CalamariExecutionVariable("Octopus.Action[PreviousStep].Output.LastName", "Not Jobs", true)
             };
-            
+
             var serialized = variables.ToJsonString();
             var bytes = ProtectedData.Protect(Encoding.UTF8.GetBytes(serialized), Convert.FromBase64String("5XETGOgqYR2bRhlfhDruEg=="), DataProtectionScope.CurrentUser);
             var encoded = Convert.ToBase64String(bytes);
@@ -205,7 +205,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
         public void ShouldWriteServiceMessageForArtifacts()
         {
             var artifactPath = IsRunningOnUnixLikeEnvironment ? @"\tmp\calamari\File.txt" : @"C:\Path\File.txt";
-            var (output, _) = RunPowerShellScript("CanCreateArtifact.ps1", new Dictionary<string, string> {{"ArtifactPath", artifactPath}});
+            var (output, _) = RunPowerShellScript("CanCreateArtifact.ps1", new Dictionary<string, string> { { "ArtifactPath", artifactPath } });
             output.AssertSuccess();
             var expectedArtifactServiceMessage = IsRunningOnUnixLikeEnvironment
                 ? "##octopus[createArtifact path='L3RtcC9jYWxhbWFyaS9GaWxlLnR4dA==' name='XHRtcFxjYWxhbWFyaVxGaWxlLnR4dA==' length='MA==']"
@@ -245,7 +245,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
             try
             {
-                var (output, _) = RunPowerShellScript("CanCreateArtifactPiped.ps1", new Dictionary<string, string> {{"TempDirectory", tempPath}});
+                var (output, _) = RunPowerShellScript("CanCreateArtifactPiped.ps1", new Dictionary<string, string> { { "TempDirectory", tempPath } });
                 output.AssertSuccess();
                 foreach (var artifact in artifacts)
                 {
@@ -276,7 +276,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
             output.AssertOutput("##octopus[k8s-manifest-applied manifest='ImFwaVZlcnNpb24iOiAidjEiDQoia2luZCI6ICJOYW1lc3BhY2UiDQoibWV0YWRhdGEiOg0KICAibmFtZSI6ICJkaWZmcyINCiJsYWJlbHMiOg0KICAgICJuYW1lIjogImRpZmZzIg0K' ns='bXk=']");
             AssertPowerShellEdition(output);
         }
-        
+
         [Test]
         public void ShouldWriteServiceMessageForKubernetesManifestFile()
         {
@@ -300,7 +300,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
             try
             {
-                var (output, _) = RunPowerShellScript("ReportKubernetesManifestFile.ps1", new Dictionary<string, string> {{"ManifestFilePath", filePath}});
+                var (output, _) = RunPowerShellScript("ReportKubernetesManifestFile.ps1", new Dictionary<string, string> { { "ManifestFilePath", filePath } });
                 output.AssertSuccess();
                 output.AssertOutput("##octopus[k8s-manifest-applied manifest='ImFwaVZlcnNpb24iOiAidjEiDQoia2luZCI6ICJOYW1lc3BhY2UiDQoibWV0YWRhdGEiOg0KICAibmFtZSI6ICJleGFtcGxlIg0KImxhYmVscyI6DQogICAgIm5hbWUiOiAiZXhhbXBsZSINCg==']");
                 output.AssertOutput("##octopus[k8s-manifest-applied manifest='ImFwaVZlcnNpb24iOiAidjEiDQoia2luZCI6ICJOYW1lc3BhY2UiDQoibWV0YWRhdGEiOg0KICAibmFtZSI6ICJkaWZmcyINCiJsYWJlbHMiOg0KICAgICJuYW1lIjogImRpZmZzIg==']");
@@ -341,7 +341,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
             var nonExistantArtifactPath = IsRunningOnUnixLikeEnvironment
                 ? @"\tmp\NonExistantPath\NonExistantFile.txt"
                 : @"C:\NonExistantPath\NonExistantFile.txt";
-            var (output, _) = RunPowerShellScript("WarningForMissingArtifact.ps1", new Dictionary<string, string> {{"ArtifactPath", nonExistantArtifactPath}});
+            var (output, _) = RunPowerShellScript("WarningForMissingArtifact.ps1", new Dictionary<string, string> { { "ArtifactPath", nonExistantArtifactPath } });
             output.AssertSuccess();
             output.AssertOutput($@"There is no file at '{nonExistantArtifactPath}' right now. Writing the service message just in case the file is available when the artifacts are collected at a later point in time.");
             var expectedArtifactServiceMessage = IsRunningOnUnixLikeEnvironment
@@ -398,6 +398,15 @@ namespace Calamari.Tests.Fixtures.PowerShell
             var (output, _) = RunPowerShellScript("CanSetEnvironmentState.ps1");
             output.AssertSuccess();
             output.AssertOutput("##octopus[set-environmentstate key='U2VjcmV0S2V5' value='U2VjcmV0IFZhbHVl' sensitive='VHJ1ZQ==' type='U3RhdGU=']");
+            AssertPowerShellEdition(output);
+        }
+
+        [Test]
+        public void ShouldWriteServiceMessageForEnvironmentUrl()
+        {
+            var (output, _) = RunPowerShellScript("CanSetEnvironmentUrl.ps1");
+            output.AssertSuccess();
+            output.AssertOutput("##octopus[set-environmentstate key='TXlFbnZpcm9ubWVudA==' value='aHR0cHM6Ly9teS1lbnZpcm9ubWVudC5leGFtcGxlLmNvbQ==' type='dXJs']");
             AssertPowerShellEdition(output);
         }
 
@@ -667,12 +676,12 @@ namespace Calamari.Tests.Fixtures.PowerShell
             var variableDictionary = variables ?? new CalamariVariables();
             variableDictionary.Add(PowerShellVariables.Edition, GetPowerShellEditionVariable());
 
-            using (var variablesFile = CreateVariablesFile(variableDictionary ))
+            using (var variablesFile = CreateVariablesFile(variableDictionary))
             {
                 var calamariCommand = Calamari();
                 buildCommand(calamariCommand);
                 calamariCommand.VariablesFileArguments(variablesFile.FilePath, variablesFile.EncryptionKey);
-                
+
                 return Invoke(calamariCommand);
             }
         }
@@ -691,8 +700,8 @@ namespace Calamari.Tests.Fixtures.PowerShell
             public VariableFile(IVariables variables)
             {
                 FilePath = Path.GetTempFileName();
-                EncryptionKey =  AesEncryption.RandomString(10);
-                
+                EncryptionKey = AesEncryption.RandomString(10);
+
                 variables.SaveAsEncryptedExecutionVariables(FilePath, EncryptionKey);
                 tempFile = new TemporaryFile(FilePath);
             }
@@ -715,7 +724,7 @@ namespace Calamari.Tests.Fixtures.PowerShell
 
         string GetPowerShellEditionVariable()
         {
-            switch(PowerShellEdition)
+            switch (PowerShellEdition)
             {
                 case PowerShellEdition.Desktop:
                     return "Desktop";

--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/CanSetEnvironmentUrl.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/CanSetEnvironmentUrl.ps1
@@ -1,0 +1,2 @@
+
+Set-EnvironmentUrl -Name "MyEnvironment" -Url "https://my-environment.example.com"

--- a/source/Calamari.Tests/Fixtures/PowerShell/Scripts/CanSetEnvironmentUrl.ps1
+++ b/source/Calamari.Tests/Fixtures/PowerShell/Scripts/CanSetEnvironmentUrl.ps1
@@ -1,2 +1,2 @@
 
-Set-EnvironmentUrl -Name "MyEnvironment" -Url "https://my-environment.example.com"
+Set-EnvironmentUrl -Key "MyEnvironment" -Url "https://my-environment.example.com"


### PR DESCRIPTION
## Context

We are adding support for setting environment state within a deployment/runbook run. State will be persisted across deployments for the project/environment/(tenant) and will primarily be used across provisioning, deployment and deprovisioning of ephemeral environments.

State will be set using a new service message in the format `set-environmentstate -key "{key}" -value "{value}" -sensitive "{sensitive}" -type "{type}".

Different types of state will be supported: 
- `State`: General state to be persisted. https://github.com/OctopusDeploy/Calamari/pull/2104
- `Url`: Url to be associated and shown with the environment. <-- This PR

## Changes

Adds helper functions to PowerShell and Bash for setting environment urls, mirroring the functions for setting output variables.

- PowerShell: `Set-EnvironmentUrl -Key {key} -Url {url}`.
- Bash: `set_environmenturl {key} {url}`.

## Reviewing and testing

Automated tests have been added, we'll need to pair and test this with the work in Octopus Server to handle service messages.