### PR TITLE
[DO NOT MERGE] CI vehicle for #2095 — .NET 10 experiment chain

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
         <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
-        <PackageReference Include="Autofac" Version="4.8.0" />
+        <PackageReference Include="Autofac" Version="9.3.1" />
         <PackageReference Include="Octopus.Globfish" Version="1.0.8" />
         <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
         <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />

--- a/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
+++ b/source/Calamari.Common/Features/Scripting/DotnetScript/DotnetScriptExecutor.cs
@@ -11,6 +11,8 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
 {
     public class DotnetScriptExecutor : ScriptExecutor
     {
+        const string DotnetRollForwardVariableName = "DOTNET_ROLL_FORWARD";
+
         readonly ICommandLineRunner commandLineRunner;
 
         public DotnetScriptExecutor(ICommandLineRunner commandLineRunner, ILog log): base(log)
@@ -37,13 +39,37 @@ namespace Calamari.Common.Features.Scripting.DotnetScript
             bool.TryParse(variables.Get("Octopus.Action.Script.CSharp.BypassIsolation", "false"), out var bypassDotnetScriptIsolation);
 
             var cli = CreateCommandLineInvocation(executable, arguments, !string.IsNullOrWhiteSpace(localDotnetScriptPath));
-            cli.EnvironmentVars = environmentVars;
+            cli.EnvironmentVars = WithDotnetRollForward(environmentVars);
             cli.WorkingDirectory = workingDirectory;
             cli.Isolate = !bypassDotnetScriptIsolation;
 
             yield return new ScriptExecution(cli, otherTemporaryFiles.Concat(new[] { bootstrapFile, configurationFile }));
         }
         
+        /// <summary>
+        /// dotnet-script is a framework-dependent application - the bundled copy targets
+        /// Microsoft.NETCore.App 8.0.0. By default a framework-dependent app will not roll forward
+        /// across a major version, so on a machine that only has a newer runtime installed it fails
+        /// to launch with "You must install or update .NET to run this application".
+        ///
+        /// Calamari itself is published self-contained and carries no such requirement; this affects
+        /// only the separate dotnet-script process. Setting DOTNET_ROLL_FORWARD=Major lets it run on
+        /// whatever newer runtime is present, so C# script steps don't additionally require the exact
+        /// runtime dotnet-script was built against.
+        /// </summary>
+        static Dictionary<string, string> WithDotnetRollForward(Dictionary<string, string>? environmentVars)
+        {
+            var vars = environmentVars == null
+                ? new Dictionary<string, string>()
+                : new Dictionary<string, string>(environmentVars);
+
+            // Don't override an explicit value - the surrounding environment may have set one deliberately.
+            if (!vars.ContainsKey(DotnetRollForwardVariableName))
+                vars[DotnetRollForwardVariableName] = "Major";
+
+            return vars;
+        }
+
         private string GetExecutable(string? localDotnetScriptPath, string bundledExecutable)
         {
             return string.IsNullOrWhiteSpace(localDotnetScriptPath)

--- a/source/Calamari.Testing/Calamari.Testing.csproj
+++ b/source/Calamari.Testing/Calamari.Testing.csproj
@@ -14,6 +14,9 @@
         <PackageReference Include="NUnit" Version="3.14.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="Octopus.1Password.Sdk" Version="0.0.127"/>
+        <!-- Pinned to remediate the vulnerable RestSharp 110.2.0 pulled in transitively via
+             Octopus.1Password.Sdk (GHSA-4rr6-2v9v-wcpc). -->
+        <PackageReference Include="RestSharp" Version="112.1.0" />
         <PackageReference Include="Serilog" Version="4.4.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
         <PackageReference Include="System.Text.Json" Version="9.0.16" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -20,10 +20,10 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.7.0"/>
+        <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.10"/>
         <PackageReference Include="System.Text.Json" Version="9.0.16" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.41"/>
-        <PackageReference Include="WireMock.Net" Version="1.6.9"/>
+        <PackageReference Include="WireMock.Net" Version="2.13.0"/>
         <PackageReference Include="XPath2" Version="1.1.5"/>
         <ProjectReference Include="..\Calamari.Testing\Calamari.Testing.csproj"/>
         <ProjectReference Include="..\Calamari\Calamari.csproj"/>

--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/EC2/test.sh
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/EC2/test.sh
@@ -5,7 +5,7 @@ rm packages-microsoft-prod.deb
 sudo apt-get update
 sudo apt-get install -y apt-transport-https zip
 sudo apt-get update
-sudo apt-get install -y dotnet-sdk-8.0
+sudo apt-get install -y dotnet-sdk-8.0 dotnet-sdk-10.0
 
 export AWS_CLUSTER_URL=${endpoint}
 export AWS_CLUSTER_NAME=${cluster_name}

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="SharpCompress" Version="0.49.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.16" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
-    <PackageReference Include="Autofac" Version="4.8.0" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="KubernetesClient" Version="17.0.14" />
     <PackageReference Include="Octopus.LibGit2Sharp" Version="0.31.1-octopus.3" />
   </ItemGroup>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -31,10 +31,6 @@
     <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
     <ProjectReference Include="..\Calamari.Contracts\Calamari.Contracts.csproj" />
     <ProjectReference Include="..\Calamari.Shared\Calamari.Shared.csproj" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Octokit" Version="14.0.0" />


### PR DESCRIPTION
**Do not merge. Do not review.** This PR exists only so TeamCity can build the contents of #2095.

## Why this exists

#2095 targets `nj/deps-cve-test-tooling` (it is stacked on #2094). The `.NET 10` experiment chain's
`pullRequests` build feature filters on `filterTargetBranch = %VCSRoot.DefaultBranch%`, so TeamCity
never creates a `pull/2095` logical branch — which is why `+:pull/2095` was already in the ChainFull
branch filter and still matched nothing.

This PR targets `main`, so it gets a real `pull/<this number>` branch that can be wired into the
trigger filter.

## What to wire up

- **`.NET 10` experiment** — `TeamModernDeployments_Calamari_Experiments_Dotnet10_Chains_ChainFull`,
  trigger `TRIGGER_155`: add `+:pull/<this number>`
- **Calamari vNext** — `..._VNext_Chains_ChainFull`: add `-:pull/<this number>` so this does **not**
  also run the live 58-build chain. Without this, every push doubles agent load. Same treatment
  #2110 documents.

## Contents

Identical to `nj/net10-prep-deps-v2` at `c349943b6` — i.e. #2094 + #2095 combined, since #2095 is
stacked on #2094. Deliberately **not** rebased onto current `main`, so CI tests exactly what is in
#2095 rather than a different tree.

| Commit | From |
|---|---|
| Upgrade test dependencies carrying known vulnerabilities | #2094 |
| Remove framework-provided package references | #2095 |
| Upgrade Autofac 4.8.0 -> 9.3.1 | #2095 |
| Align remaining dependency versions | #2095 |
| Let dotnet-script roll forward to a newer .NET runtime | #2095 |
| Align Serilog versions with Microsoft.Extensions.Logging 10.0.10 | #2095 |

## Re-syncing after new commits on #2095

```
git push origin +nj/net10-prep-deps-v2:nj/net10-prep-deps-v2-ci
```

## Caveat on what a green run here proves

Product code on this branch is still **net8**. A green chain proves the dependency bumps hold; it
does **not** validate the dotnet-script change. `DOTNET_ROLL_FORWARD=Major` is a no-op whenever an
8.x runtime is present, so on any agent that has .NET 8 the roll-forward path is never taken.
Exercising it needs an environment with .NET 10 and no 8.x runtime. See
`research/dotnet-script-net10.md` in the migration notes.

Close this once #2094 lands and #2095 retargets to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)