### PR TITLE
Install the .NET 10 SDK alongside 8.0 on the EKS test EC2 instance

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/Terraform/EC2/test.sh
+++ b/source/Calamari.Tests/KubernetesFixtures/Terraform/EC2/test.sh
@@ -5,7 +5,7 @@ rm packages-microsoft-prod.deb
 sudo apt-get update
 sudo apt-get install -y apt-transport-https zip
 sudo apt-get update
-sudo apt-get install -y dotnet-sdk-8.0
+sudo apt-get install -y dotnet-sdk-8.0 dotnet-sdk-10.0
 
 export AWS_CLUSTER_URL=${endpoint}
 export AWS_CLUSTER_NAME=${cluster_name}


### PR DESCRIPTION
`test.sh` for the EKS live test installs only `dotnet-sdk-8.0`, so the EC2 instance can't run net10 assemblies. Adds 10.0 beside it.

Additive and net8-safe — raised separately so the existing chain can confirm it changes nothing before #2091 lands.