### PR TITLE
Add archive extraction benchmarks and adversarial-input tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ source/Calamari.Tests/Some sample text
 # Claude Code: per-developer files
 CLAUDE.local.md
 .claude/settings.local.json
+
+# BenchmarkDotNet output (source/Calamari.Benchmarks)
+BenchmarkDotNet.Artifacts/

--- a/source/Calamari.Benchmarks/Calamari.Benchmarks.csproj
+++ b/source/Calamari.Benchmarks/Calamari.Benchmarks.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <RootNamespace>Calamari.Benchmarks</RootNamespace>
+        <AssemblyName>Calamari.Benchmarks</AssemblyName>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <!-- BenchmarkDotNet refuses to run against a non-optimised build, so this is only meaningful in Release. -->
+        <IsBenchmarkProject>true</IsBenchmarkProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!--
+            Deliberately no direct SharpCompress PackageReference. The extraction benchmarks are here to
+            detect whether a SharpCompress version change moves extraction cost, so this project must track
+            whatever version Calamari.Common resolves rather than pinning its own.
+        -->
+        <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
+        <ProjectReference Include="..\Calamari.ConsolidateCalamariPackages\Calamari.ConsolidateCalamariPackages.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/source/Calamari.Benchmarks/ConsolidatedPackageBenchmarks.cs
+++ b/source/Calamari.Benchmarks/ConsolidatedPackageBenchmarks.cs
@@ -1,0 +1,140 @@
+using System;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Calamari.Benchmarks.Support;
+using Octopus.Calamari.ConsolidatedPackage;
+using Octopus.Calamari.ConsolidatedPackage.Api;
+
+namespace Calamari.Benchmarks
+{
+    /// <summary>
+    /// Measures reading a consolidated Calamari package — the path Octopus Server takes when it unpacks a
+    /// flavour for a deployment target.
+    ///
+    /// Motivation: an observation that extracting from the ConsolidatedPackage took roughly 6 seconds where
+    /// roughly 500ms was expected. That was never confirmed or dismissed, because there was no benchmark to
+    /// measure it against. These benchmarks are that measurement.
+    ///
+    /// Note that this path uses <see cref="System.IO.Compression.ZipArchive"/> from the BCL, NOT SharpCompress.
+    /// A SharpCompress version change cannot move these numbers. See <see cref="PackageExtractionBenchmarks"/>
+    /// for the SharpCompress-backed extractors.
+    ///
+    /// To measure against a real consolidated package instead of a synthetic one, set
+    /// <c>CALAMARI_BENCHMARK_CONSOLIDATED_PACKAGE</c> to its path. The <c>FilesPerPlatform</c> and
+    /// <c>PayloadBytes</c> parameters are then ignored.
+    /// </summary>
+    [MemoryDiagnoser]
+    [SimpleJob(RunStrategy.Monitoring, warmupCount: 1, iterationCount: 10, invocationCount: 1)]
+    public class ConsolidatedPackageBenchmarks
+    {
+        public const string RealPackageEnvironmentVariable = "CALAMARI_BENCHMARK_CONSOLIDATED_PACKAGE";
+
+        string packagePath = null!;
+        string? temporaryDirectory;
+        IConsolidatedPackageStreamProvider streamProvider = null!;
+        IConsolidatedPackage package = null!;
+        (string flavour, string platform)[] allFlavourPlatforms = null!;
+
+        /// <summary>Files per flavour per platform. A real self-contained Calamari flavour is in the low hundreds.</summary>
+        [Params(50, 200)]
+        public int FilesPerPlatform { get; set; }
+
+        /// <summary>
+        /// Bytes per file. Kept small by default so the harness stays usable; raise it to trade setup time
+        /// for a payload closer to real assembly sizes.
+        /// </summary>
+        [Params(4096)]
+        public int PayloadBytes { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var realPackage = Environment.GetEnvironmentVariable(RealPackageEnvironmentVariable);
+            if (!string.IsNullOrWhiteSpace(realPackage))
+            {
+                if (!File.Exists(realPackage))
+                    throw new FileNotFoundException($"{RealPackageEnvironmentVariable} is set but no file exists at that path.", realPackage);
+
+                packagePath = realPackage;
+                Console.WriteLine($"Using real consolidated package: {packagePath} ({new FileInfo(packagePath).Length / (1024 * 1024)} MB)");
+            }
+            else
+            {
+                temporaryDirectory = Path.Combine(Path.GetTempPath(), "Calamari.Benchmarks", Guid.NewGuid().ToString("n"));
+                packagePath = Path.Combine(temporaryDirectory, "Calamari.Consolidated.zip");
+
+                var built = SyntheticConsolidatedPackage.Build(packagePath, FilesPerPlatform, PayloadBytes);
+                Console.WriteLine($"Synthetic consolidated package: {built.ArchiveEntryCount} archive entries, "
+                                  + $"{built.IndexEntryCount} index entries, {built.SizeOnDiskBytes / (1024 * 1024)} MB on disk.");
+            }
+
+            streamProvider = new FileBasedStreamProvider(packagePath);
+            package = new ConsolidatedPackageFactory().LoadFrom(streamProvider);
+
+            allFlavourPlatforms = package.Index.GetAvailablePackages()
+                                         .SelectMany(p => package.Index.GetPackage(p.package)
+                                                                 .PlatformFiles.Keys
+                                                                 .Select(platform => (p.package, platform)))
+                                         .ToArray();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            if (temporaryDirectory != null && Directory.Exists(temporaryDirectory))
+                Directory.Delete(temporaryDirectory, recursive: true);
+        }
+
+        /// <summary>
+        /// Reading index.json alone. Establishes the floor: whatever a full extract costs, this much of it is
+        /// just opening the archive and deserialising the index.
+        /// </summary>
+        [Benchmark]
+        public int LoadIndex()
+            => new ConsolidatedPackageFactory().LoadFrom(streamProvider).Index.GetAvailablePackages().Count();
+
+        /// <summary>
+        /// One flavour, one platform — the single unit of work Server actually asks for.
+        /// </summary>
+        [Benchmark]
+        public long ExtractSingleFlavourPlatform()
+        {
+            var (flavour, platform) = allFlavourPlatforms[0];
+            return Drain(package.ExtractCalamariPackage(flavour, platform));
+        }
+
+        /// <summary>
+        /// Every flavour and platform in sequence. This is the shape that surfaces the per-call cost of
+        /// re-opening the archive and rebuilding the full entry lookup, which is where a surprising
+        /// multi-second total would come from.
+        /// </summary>
+        [Benchmark]
+        public long ExtractAllFlavourPlatforms()
+        {
+            long total = 0;
+            foreach (var (flavour, platform) in allFlavourPlatforms)
+                total += Drain(package.ExtractCalamariPackage(flavour, platform));
+
+            return total;
+        }
+
+        /// <summary>
+        /// ExtractCalamariPackage yields streams that are disposed as the enumerator advances, so each one has
+        /// to be consumed before MoveNext. Copying to <see cref="Stream.Null"/> measures decompression without
+        /// also measuring the write side of the filesystem.
+        /// </summary>
+        static long Drain(System.Collections.Generic.IEnumerable<(string entryName, long size, Stream sourceStream)> entries)
+        {
+            long bytes = 0;
+            foreach (var (_, size, sourceStream) in entries)
+            {
+                sourceStream.CopyTo(Stream.Null);
+                bytes += size;
+            }
+
+            return bytes;
+        }
+    }
+}

--- a/source/Calamari.Benchmarks/PackageExtractionBenchmarks.cs
+++ b/source/Calamari.Benchmarks/PackageExtractionBenchmarks.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Calamari.Benchmarks.Support;
+using Calamari.Common.Features.Packages;
+using Calamari.Common.Plumbing.Logging;
+
+namespace Calamari.Benchmarks
+{
+    /// <summary>
+    /// Measures Calamari's own package extractors, which are backed by SharpCompress.
+    ///
+    /// This is the half of extraction cost that a SharpCompress version bump can actually move. Run it before
+    /// and after a bump and compare — that is the question left open by SF-1864, where a jump of thirteen
+    /// minor versions went in with no throughput measurement on either side.
+    ///
+    /// Extraction writes to disk, so these are wall-clock measurements taken one invocation at a time rather
+    /// than BenchmarkDotNet's usual tight loop. Expect them to be noisier than in-memory benchmarks, and
+    /// compare runs on the same machine.
+    /// </summary>
+    [MemoryDiagnoser]
+    [SimpleJob(RunStrategy.Monitoring, warmupCount: 1, iterationCount: 10, invocationCount: 1)]
+    public class PackageExtractionBenchmarks
+    {
+        string workingDirectory = null!;
+        string packagePath = null!;
+        string extractionDirectory = null!;
+        IPackageExtractor extractor = null!;
+
+        [Params("zip", "tar", "tar.gz", "tar.bz2")]
+        public string Format { get; set; } = "zip";
+
+        [Params(200, 2000)]
+        public int FileCount { get; set; }
+
+        [Params(4096)]
+        public int PayloadBytes { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            workingDirectory = Path.Combine(Path.GetTempPath(), "Calamari.Benchmarks", Guid.NewGuid().ToString("n"));
+            packagePath = SyntheticArchive.Build(Path.Combine(workingDirectory, "packages"), Format, FileCount, PayloadBytes);
+            extractor = CreateExtractor(Format);
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            if (Directory.Exists(workingDirectory))
+                Directory.Delete(workingDirectory, recursive: true);
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            // A fresh target per iteration: extracting over an existing tree measures overwrite, not extraction.
+            extractionDirectory = Path.Combine(workingDirectory, "extracted", Guid.NewGuid().ToString("n"));
+            Directory.CreateDirectory(extractionDirectory);
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            if (Directory.Exists(extractionDirectory))
+                Directory.Delete(extractionDirectory, recursive: true);
+        }
+
+        [Benchmark]
+        public int Extract() => extractor.Extract(packagePath, extractionDirectory);
+
+        static IPackageExtractor CreateExtractor(string format)
+            => format switch
+               {
+                   "zip" => new ZipPackageExtractor(ConsoleLog.Instance),
+                   "tar" => new TarPackageExtractor(ConsoleLog.Instance),
+                   "tar.gz" => new TarGzipPackageExtractor(ConsoleLog.Instance),
+                   "tar.bz2" => new TarBzipPackageExtractor(ConsoleLog.Instance),
+                   _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unknown archive format.")
+               };
+    }
+}

--- a/source/Calamari.Benchmarks/Program.cs
+++ b/source/Calamari.Benchmarks/Program.cs
@@ -1,0 +1,11 @@
+using System;
+using BenchmarkDotNet.Running;
+
+namespace Calamari.Benchmarks
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+            => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/source/Calamari.Benchmarks/README.md
+++ b/source/Calamari.Benchmarks/README.md
@@ -1,7 +1,12 @@
 # Calamari.Benchmarks
 
-Wall-clock and allocation measurements for archive handling. Nothing here runs in CI — it is a tool you run
-by hand when you need a number.
+Wall-clock and allocation measurements for archive handling. It is a tool you run by hand when you need a
+number; CI compiles this project as part of the solution build but never executes the benchmarks.
+
+That is deliberate. These are wall-clock, disk-touching measurements taken on shared build agents across
+several platforms, so any regression threshold would be either too loose to catch anything or flaky enough
+that people mute it. There is also no stored baseline to compare against, so a CI run would print numbers
+into a build log that nobody diffs. See "Keeping this from rotting" below for what is guarded instead.
 
 It exists because the repo had no benchmark of any kind, which left two questions unanswerable:
 
@@ -55,6 +60,26 @@ CALAMARI_BENCHMARK_CONSOLIDATED_PACKAGE=/path/to/Calamari.<hash>.zip \
 ```
 
 The `FilesPerPlatform` and `PayloadBytes` parameters are ignored when that variable is set.
+
+## Keeping this from rotting
+
+The solution build catches compile breakage, but nothing here is executed in CI, so the risk is that the
+harness quietly stops working and we only find out during the next upgrade — exactly when nobody wants to be
+debugging a benchmark.
+
+The fragile part is `Support/`, which builds the fixtures the benchmarks measure. Those classes are covered
+by ordinary tests in the existing suite:
+
+- `Calamari.Tests` → `SyntheticArchiveFixture` — every format it produces is extractable by the matching
+  Calamari extractor, entries are spread over a directory tree, and payloads don't compress away to nothing.
+- `Calamari.ConsolidateCalamariPackages.Tests` → `SyntheticConsolidatedPackageTests` — the generated package
+  is readable by the real `ConsolidatedPackageFactory`, every flavour and platform resolves its files, and
+  shared files really are stored once and referenced many times.
+
+Those projects **source-link** the `Support/` files with a `<Compile Include>` rather than taking a
+ProjectReference on this project, so BenchmarkDotNet does not become a dependency of packages that ship to
+test agents. That only works while `Support/` stays free of BenchmarkDotNet types — keep benchmark
+attributes in the benchmark classes, not in the builders.
 
 ## Reading the results
 

--- a/source/Calamari.Benchmarks/README.md
+++ b/source/Calamari.Benchmarks/README.md
@@ -1,0 +1,68 @@
+# Calamari.Benchmarks
+
+Wall-clock and allocation measurements for archive handling. Nothing here runs in CI — it is a tool you run
+by hand when you need a number.
+
+It exists because the repo had no benchmark of any kind, which left two questions unanswerable:
+
+1. An observation that extracting from the ConsolidatedPackage took roughly **6 seconds** where roughly
+   **500ms** was expected. There was nothing to measure it against, so it was never confirmed or dismissed.
+2. Whether a SharpCompress version change moves extraction cost. SF-1864 moved SharpCompress thirteen minor
+   versions (0.37.2 → 0.49.1) with no throughput measurement on either side of the bump.
+
+## Running
+
+```bash
+# everything (slow — the tar.bz2 cases dominate)
+dotnet run -c Release --project source/Calamari.Benchmarks
+
+# one suite
+dotnet run -c Release --project source/Calamari.Benchmarks -- --filter '*ConsolidatedPackageBenchmarks*'
+dotnet run -c Release --project source/Calamari.Benchmarks -- --filter '*PackageExtractionBenchmarks*'
+
+# smoke test that the harness still works, without waiting for real measurements
+dotnet run -c Release --project source/Calamari.Benchmarks -- --filter '*' --job Dry
+```
+
+Release configuration is required; BenchmarkDotNet refuses to run against an unoptimised build.
+
+## The two suites measure different things
+
+**`ConsolidatedPackageBenchmarks`** covers `ConsolidatedPackage.ExtractCalamariPackage` — the path Octopus
+Server takes when unpacking a flavour.
+
+This path uses `System.IO.Compression.ZipArchive` from the BCL. **It does not use SharpCompress**, so a
+SharpCompress bump cannot move these numbers. If you are evaluating an upgrade, this suite is the control,
+not the experiment.
+
+**`PackageExtractionBenchmarks`** covers Calamari's own extractors (`ZipPackageExtractor`,
+`TarGzipPackageExtractor`, `TarBzipPackageExtractor`, `TarPackageExtractor`), which *are* SharpCompress-backed.
+This is the suite to run before and after a version change.
+
+## Measuring against a real consolidated package
+
+By default the consolidated-package suite generates a synthetic archive: same shape as the real one
+(content-addressed entries, an `index.json`, most files shared across platforms), but with small
+pseudo-random payloads rather than real assemblies. That makes it repeatable and quick, and it is enough to
+compare runs against each other — but the absolute numbers are lower than production, because production
+payloads are much larger.
+
+To measure the real thing, point it at an actual consolidated package:
+
+```bash
+CALAMARI_BENCHMARK_CONSOLIDATED_PACKAGE=/path/to/Calamari.<hash>.zip \
+  dotnet run -c Release --project source/Calamari.Benchmarks -- --filter '*ConsolidatedPackageBenchmarks*'
+```
+
+The `FilesPerPlatform` and `PayloadBytes` parameters are ignored when that variable is set.
+
+## Reading the results
+
+These write to disk, so they run one invocation per iteration under `RunStrategy.Monitoring` rather than
+BenchmarkDotNet's usual tight loop. Expect more variance than an in-memory benchmark, and only compare runs
+taken on the same machine — cross-machine and CI-vs-laptop comparisons are not meaningful.
+
+`ExtractAllFlavourPlatforms` is the one to watch for the 6-second question. It walks every flavour and
+platform in the index, which is the shape that exposes per-call cost: `ExtractCalamariPackage` re-opens the
+archive and rebuilds a dictionary over *every* entry on each call, so cost scales with total archive size
+rather than with the number of files that call actually wants.

--- a/source/Calamari.Benchmarks/Support/SyntheticArchive.cs
+++ b/source/Calamari.Benchmarks/Support/SyntheticArchive.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using SharpCompress.Common;
+using SharpCompress.Writers;
+
+namespace Calamari.Benchmarks.Support
+{
+    /// <summary>
+    /// Writes package-shaped archives for the extraction benchmarks: a mix of nested directories and files,
+    /// with incompressible payloads so inflate cost is not optimised away.
+    /// </summary>
+    public static class SyntheticArchive
+    {
+        public static readonly IReadOnlyDictionary<string, (ArchiveType Archive, CompressionType Compression)> Formats =
+            new Dictionary<string, (ArchiveType, CompressionType)>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["zip"] = (ArchiveType.Zip, CompressionType.Deflate),
+                ["tar"] = (ArchiveType.Tar, CompressionType.None),
+                ["tar.gz"] = (ArchiveType.Tar, CompressionType.GZip),
+                ["tar.bz2"] = (ArchiveType.Tar, CompressionType.BZip2)
+            };
+
+        public static string Build(string directory, string format, int fileCount, int payloadBytes)
+        {
+            if (!Formats.TryGetValue(format, out var archiveFormat))
+                throw new ArgumentOutOfRangeException(nameof(format), format, $"Unknown archive format. Known: {string.Join(", ", Formats.Keys)}");
+
+            Directory.CreateDirectory(directory);
+            var path = Path.Combine(directory, $"Benchmark.Package.1.0.0.{format}");
+            if (File.Exists(path))
+                File.Delete(path);
+
+            using (var stream = File.OpenWrite(path))
+            using (var writer = WriterFactory.Open(stream,
+                                                   archiveFormat.Archive,
+                                                   new WriterOptions(archiveFormat.Compression)
+                                                   {
+                                                       ArchiveEncoding = new ArchiveEncoding { Default = Encoding.UTF8 }
+                                                   }))
+            {
+                for (var i = 0; i < fileCount; i++)
+                {
+                    // Spread files over a directory tree rather than a flat root, so the benchmark includes
+                    // the directory-creation work that real package layouts force.
+                    var entryName = $"content/group{i % 16:d2}/nested/file{i:d6}.bin";
+                    writer.Write(entryName, new MemoryStream(Payload(entryName, payloadBytes)));
+                }
+            }
+
+            return path;
+        }
+
+        static byte[] Payload(string seed, int payloadBytes)
+        {
+            var buffer = new byte[payloadBytes];
+            new Random(seed.GetHashCode()).NextBytes(buffer);
+            return buffer;
+        }
+    }
+}

--- a/source/Calamari.Benchmarks/Support/SyntheticArchive.cs
+++ b/source/Calamari.Benchmarks/Support/SyntheticArchive.cs
@@ -33,7 +33,7 @@ namespace Calamari.Benchmarks.Support
                 File.Delete(path);
 
             using (var stream = File.OpenWrite(path))
-            using (var writer = WriterFactory.Open(stream,
+            using (var writer = WriterFactory.OpenWriter(stream,
                                                    archiveFormat.Archive,
                                                    new WriterOptions(archiveFormat.Compression)
                                                    {

--- a/source/Calamari.Benchmarks/Support/SyntheticConsolidatedPackage.cs
+++ b/source/Calamari.Benchmarks/Support/SyntheticConsolidatedPackage.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using Octopus.Calamari.ConsolidatedPackage;
+using Octopus.Calamari.ConsolidatedPackage.Api;
+
+namespace Calamari.Benchmarks.Support
+{
+    /// <summary>
+    /// Builds a zip shaped like a real consolidated Calamari package: content-addressed entries
+    /// (<c>&lt;hash&gt;/&lt;filename&gt;</c>) plus an <c>index.json</c> mapping each flavour and platform
+    /// onto those entries.
+    ///
+    /// The shape matters more than the bytes. Two properties of the real package drive extraction cost and
+    /// are reproduced here:
+    /// <list type="bullet">
+    /// <item>Most files are byte-identical across platforms of a flavour, so consolidation stores one entry
+    /// and the index points many platforms at it. That is what makes the archive entry count much smaller
+    /// than the index entry count.</item>
+    /// <item>Every <c>ExtractCalamariPackage</c> call re-opens the archive and rebuilds a lookup over
+    /// <em>all</em> entries, so cost per call scales with total archive size, not with the number of files
+    /// that call actually wants.</item>
+    /// </list>
+    /// </summary>
+    public static class SyntheticConsolidatedPackage
+    {
+        /// <summary>Flavours in a real consolidated package, as of the build at time of writing.</summary>
+        public static readonly string[] Flavours =
+        {
+            "Calamari",
+            "Calamari.AzureAppService",
+            "Calamari.AzureResourceGroup",
+            "Calamari.AzureScripting",
+            "Calamari.AzureServiceFabric",
+            "Calamari.AzureWebApp",
+            "Calamari.GoogleCloudScripting",
+            "Calamari.Scripting",
+            "Calamari.Terraform"
+        };
+
+        public static readonly string[] Platforms =
+        {
+            "win-x64",
+            "linux-x64",
+            "linux-arm",
+            "linux-arm64",
+            "osx-x64",
+            "osx-arm64"
+        };
+
+        /// <summary>
+        /// Fraction of a flavour's files that are byte-identical across every platform, and therefore
+        /// stored once. The remainder are platform-specific (native binaries, the RID-stamped nuspec).
+        /// </summary>
+        const double SharedFileFraction = 0.7;
+
+        public static BuiltPackage Build(string destinationPath, int filesPerPlatform, int payloadBytes)
+        {
+            var entryContents = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+            var packages = new Dictionary<string, IConsolidatedPackageIndex.Package>(StringComparer.OrdinalIgnoreCase);
+
+            var sharedCount = (int)(filesPerPlatform * SharedFileFraction);
+            var platformSpecificCount = filesPerPlatform - sharedCount;
+
+            foreach (var flavour in Flavours)
+            {
+                var platformFiles = new Dictionary<string, IConsolidatedPackageIndex.FileTransfer[]>(StringComparer.Ordinal);
+
+                // Shared entries are created once per flavour and referenced by every platform, mirroring
+                // how consolidation dedupes binary-identical managed assemblies.
+                var sharedEntries = Enumerable.Range(0, sharedCount)
+                                              .Select(i =>
+                                                      {
+                                                          var destination = $"{flavour}.Shared{i}.dll";
+                                                          var source = ContentAddressedEntryName(flavour, "shared", i, destination);
+                                                          entryContents[source] = Payload(source, payloadBytes);
+                                                          return new IConsolidatedPackageIndex.FileTransfer(source, destination);
+                                                      })
+                                              .ToArray();
+
+                foreach (var platform in Platforms)
+                {
+                    var platformSpecific = Enumerable.Range(0, platformSpecificCount)
+                                                     .Select(i =>
+                                                             {
+                                                                 var destination = i == 0
+                                                                     ? $"Octopus.{flavour}.{platform}.nuspec"
+                                                                     : $"{flavour}.Native{i}.dll";
+                                                                 var source = ContentAddressedEntryName(flavour, platform, i, destination);
+                                                                 entryContents[source] = Payload(source, payloadBytes);
+                                                                 return new IConsolidatedPackageIndex.FileTransfer(source, destination);
+                                                             });
+
+                    platformFiles[platform] = platformSpecific.Concat(sharedEntries).ToArray();
+                }
+
+                packages[flavour] = new IConsolidatedPackageIndex.Package(flavour, "2026.2.1", IsNupkg: true, platformFiles);
+            }
+
+            var index = new ConsolidatedPackageIndex(packages);
+            WriteZip(destinationPath, entryContents, index);
+
+            var indexEntryCount = packages.Values.Sum(p => p.PlatformFiles.Values.Sum(f => f.Length));
+            return new BuiltPackage(destinationPath, entryContents.Count, indexEntryCount, new FileInfo(destinationPath).Length);
+        }
+
+        static void WriteZip(string destinationPath, Dictionary<string, byte[]> entryContents, ConsolidatedPackageIndex index)
+        {
+            var directory = Path.GetDirectoryName(destinationPath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            if (File.Exists(destinationPath))
+                File.Delete(destinationPath);
+
+            using var zip = ZipFile.Open(destinationPath, ZipArchiveMode.Create);
+
+            foreach (var (entryName, content) in entryContents)
+            {
+                // CompressionLevel.Fastest matches what ConsolidatedPackageCreator uses.
+                var entry = zip.CreateEntry(entryName, CompressionLevel.Fastest);
+                using var entryStream = entry.Open();
+                entryStream.Write(content, 0, content.Length);
+            }
+
+            var indexEntry = zip.CreateEntry("index.json", CompressionLevel.Fastest);
+            using (var indexStream = indexEntry.Open())
+            {
+                var bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(index, Formatting.Indented));
+                indexStream.Write(bytes, 0, bytes.Length);
+            }
+        }
+
+        static string ContentAddressedEntryName(string flavour, string scope, int index, string fileName)
+        {
+            // Real entries are prefixed with an MD5 of the file content. Any stable, unique, hash-shaped
+            // prefix reproduces the entry-name length and cardinality that the lookup has to cope with.
+            var seed = $"{flavour}|{scope}|{index}";
+            var hash = ((uint)seed.GetHashCode()).ToString("x8");
+            return $"{hash}{hash.GetHashCode():x8}{index:x8}{scope.Length:x8}/{fileName}";
+        }
+
+        static byte[] Payload(string seed, int payloadBytes)
+        {
+            // Pseudo-random but deterministic, and deliberately not compressible to a constant: real
+            // assemblies do not deflate to nothing, and an all-zero payload would understate inflate cost.
+            var buffer = new byte[payloadBytes];
+            var random = new Random(seed.GetHashCode());
+            random.NextBytes(buffer);
+            return buffer;
+        }
+
+        public sealed record BuiltPackage(string Path, int ArchiveEntryCount, int IndexEntryCount, long SizeOnDiskBytes);
+    }
+}

--- a/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
+++ b/source/Calamari.ConsolidateCalamariPackages.Tests/Calamari.ConsolidateCalamariPackages.Tests.csproj
@@ -21,4 +21,13 @@
     <ItemGroup>
       <ProjectReference Include="..\Calamari.ConsolidateCalamariPackages\Calamari.ConsolidateCalamariPackages.csproj" />
     </ItemGroup>
+    <ItemGroup>
+        <!--
+            Source-linked rather than referenced, so BenchmarkDotNet does not become a dependency of this
+            test project. Keeping Calamari.Benchmarks/Support free of BenchmarkDotNet types is what makes
+            this work.
+        -->
+        <Compile Include="..\Calamari.Benchmarks\Support\SyntheticConsolidatedPackage.cs"
+                 Link="BenchmarkSupport\SyntheticConsolidatedPackage.cs"/>
+    </ItemGroup>
 </Project>

--- a/source/Calamari.ConsolidateCalamariPackages.Tests/SyntheticConsolidatedPackageTests.cs
+++ b/source/Calamari.ConsolidateCalamariPackages.Tests/SyntheticConsolidatedPackageTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using System.Linq;
+using Calamari.Benchmarks.Support;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Calamari.ConsolidatedPackage;
+
+namespace Calamari.ConsolidateCalamariPackages.Tests;
+
+/// <summary>
+/// Guards the consolidated-package builder used by Calamari.Benchmarks against rot.
+///
+/// The benchmark project is compiled by the solution build but never executed in CI, so nothing else proves
+/// this builder still produces a package the real loader can read. A benchmark whose fixture no longer
+/// resembles production would quietly report meaningless numbers.
+///
+/// The class is source-linked into this project rather than referenced; see the Compile item in the csproj.
+/// </summary>
+[TestFixture]
+public class SyntheticConsolidatedPackageTests
+{
+    const int FilesPerPlatform = 10;
+    const int PayloadBytes = 128;
+
+    string temporaryDirectory = null!;
+    SyntheticConsolidatedPackage.BuiltPackage built = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        temporaryDirectory = Path.Combine(Path.GetTempPath(), "Calamari.Benchmarks.Tests", Guid.NewGuid().ToString("n"));
+        built = SyntheticConsolidatedPackage.Build(Path.Combine(temporaryDirectory, "Calamari.Consolidated.zip"), FilesPerPlatform, PayloadBytes);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(temporaryDirectory))
+            Directory.Delete(temporaryDirectory, recursive: true);
+    }
+
+    [Test]
+    public void IsReadableByTheRealLoader()
+    {
+        var package = new ConsolidatedPackageFactory().LoadFrom(new FileBasedStreamProvider(built.Path));
+
+        var availableFlavours = package.Index.GetAvailablePackages().Select(p => p.package).ToArray();
+
+        availableFlavours.Should().BeEquivalentTo(SyntheticConsolidatedPackage.Flavours);
+    }
+
+    [Test]
+    public void EveryFlavourAndPlatformExtractsTheExpectedFiles()
+    {
+        var package = new ConsolidatedPackageFactory().LoadFrom(new FileBasedStreamProvider(built.Path));
+
+        foreach (var flavour in SyntheticConsolidatedPackage.Flavours)
+        foreach (var platform in SyntheticConsolidatedPackage.Platforms)
+        {
+            var entries = Drain(package, flavour, platform);
+
+            entries.Should().HaveCount(FilesPerPlatform, $"{flavour}/{platform} should resolve every indexed file");
+            entries.Should().OnlyContain(e => e.bytesRead == PayloadBytes, "every payload should be readable in full");
+            entries.Select(e => e.entryName).Should().OnlyHaveUniqueItems();
+        }
+    }
+
+    [Test]
+    public void SharedFilesAreStoredOnceAndReferencedByEveryPlatform()
+    {
+        // This is the property that makes the fixture resemble a real consolidated package: the archive holds
+        // far fewer entries than the index references, because consolidation dedupes binary-identical files
+        // across platforms. Lose it and the benchmark measures an archive several times too large.
+        built.ArchiveEntryCount.Should()
+             .BeLessThan(built.IndexEntryCount,
+                         "shared files should be stored once and pointed at by every platform");
+
+        var expectedIndexEntries = SyntheticConsolidatedPackage.Flavours.Length
+                                   * SyntheticConsolidatedPackage.Platforms.Length
+                                   * FilesPerPlatform;
+        built.IndexEntryCount.Should().Be(expectedIndexEntries);
+    }
+
+    [Test]
+    public void ProducesAnArchiveOnDisk()
+    {
+        File.Exists(built.Path).Should().BeTrue();
+        built.SizeOnDiskBytes.Should().Be(new FileInfo(built.Path).Length);
+        built.SizeOnDiskBytes.Should().BeGreaterThan(0);
+    }
+
+    /// <summary>
+    /// ExtractCalamariPackage disposes each stream as the enumerator advances, so every payload has to be
+    /// read before MoveNext. Materialising the sequence first would close them all.
+    /// </summary>
+    static (string entryName, long bytesRead)[] Drain(Octopus.Calamari.ConsolidatedPackage.Api.IConsolidatedPackage package, string flavour, string platform)
+    {
+        var results = new System.Collections.Generic.List<(string, long)>();
+        foreach (var (entryName, _, sourceStream) in package.ExtractCalamariPackage(flavour, platform))
+        {
+            using var buffer = new MemoryStream();
+            sourceStream.CopyTo(buffer);
+            results.Add((entryName, buffer.Length));
+        }
+
+        return results.ToArray();
+    }
+}

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -42,6 +42,15 @@
         <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.3.0"/>
     </ItemGroup>
     <ItemGroup>
+        <!--
+            Source-linked rather than referenced. A ProjectReference to Calamari.Benchmarks would drag
+            BenchmarkDotNet and its dependencies into this test package, which ships to every test agent.
+            Keeping Calamari.Benchmarks/Support free of BenchmarkDotNet types is what makes this work.
+        -->
+        <Compile Include="..\Calamari.Benchmarks\Support\SyntheticArchive.cs"
+                 Link="Fixtures\Integration\Packages\BenchmarkSupport\SyntheticArchive.cs"/>
+    </ItemGroup>
+    <ItemGroup>
         <EmbeddedResource Include="Fixtures\PowerShell\Scripts\HelloWithVariable.ps1"/>
         <None Include="Fixtures\ConfigurationVariables\Samples\**">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/ArchiveRobustnessFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/ArchiveRobustnessFixture.cs
@@ -181,10 +181,11 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         [TestCase(typeof(ZipPackageExtractor), "zip", ArchiveType.Zip, CompressionType.Deflate)]
         public void CorruptedPayloadInCompressedArchiveThrows(Type extractorType, string extension, ArchiveType archiveType, CompressionType compressionType)
         {
-            // Each compressed format detects the damage, though not uniformly: zip and gzip surface a
-            // ZlibException, while bzip2 currently surfaces an IndexOutOfRangeException from inside the
-            // decoder. The exact type is an implementation detail of the archive library and is deliberately
-            // not asserted; that it fails rather than writing garbage is the property that matters.
+            // Every compressed format detects the damage. Zip and gzip surface a ZlibException; bzip2
+            // surfaces an InvalidFormatException on SharpCompress 0.49.1, where 0.37.2 leaked an
+            // IndexOutOfRangeException from inside the decoder — the upgrade turned an implementation
+            // artifact into a domain exception. The exact type is still an archive-library detail and is
+            // deliberately not asserted; that it fails rather than writing garbage is what matters.
             using var tempFolder = TemporaryDirectory.Create();
             var packageFile = Path.Combine(tempFolder.DirectoryPath, $"corrupt.{extension}");
             var extractionDir = CreateExtractionDirectory(tempFolder);
@@ -253,7 +254,7 @@ namespace Calamari.Tests.Fixtures.Integration.Packages
         static void WriteArchive(string packageFile, ArchiveType archiveType, CompressionType compressionType, Action<IWriter> write)
         {
             using var stream = File.OpenWrite(packageFile);
-            using var writer = WriterFactory.Open(stream,
+            using var writer = WriterFactory.OpenWriter(stream,
                                                   archiveType,
                                                   new WriterOptions(compressionType)
                                                   {

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/ArchiveRobustnessFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/ArchiveRobustnessFixture.cs
@@ -1,0 +1,287 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Calamari.Common.Features.Packages;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using FluentAssertions;
+using NUnit.Framework;
+using SharpCompress.Common;
+using SharpCompress.Writers;
+
+namespace Calamari.Tests.Fixtures.Integration.Packages
+{
+    /// <summary>
+    /// Characterises how the package extractors behave on archives that are large or damaged, rather than on
+    /// the small well-formed samples the rest of the suite uses.
+    ///
+    /// These are not regression tests for a known defect. They pin down behaviour that was previously
+    /// unmeasured, so a future archive-library change that alters it shows up as a failing test rather than
+    /// as a deployment failure. The vectors are the ones identified as uncovered during the SharpCompress
+    /// 0.49.1 upgrade (SF-1864): entry counts far above the samples, deep directory nesting, long entry
+    /// names, and archives that are truncated or corrupt rather than merely "not an archive at all".
+    ///
+    /// Two of these tests assert behaviour that is arguably wrong. They are written to the behaviour that
+    /// exists today, and say so — see <see cref="TruncatedTarArchiveIsSilentlyExtractedInPart"/> and
+    /// <see cref="CorruptedPayloadInUncompressedTarIsNotDetected"/>.
+    /// </summary>
+    [TestFixture]
+    public class ArchiveRobustnessFixture
+    {
+        const int TruncationEntryCount = 50;
+        const string EntryContent = "0123456789abcdef";
+
+        [Test]
+        [TestCase(typeof(TarGzipPackageExtractor), "tar.gz", ArchiveType.Tar, CompressionType.GZip)]
+        [TestCase(typeof(TarPackageExtractor), "tar", ArchiveType.Tar, CompressionType.None)]
+        [TestCase(typeof(TarBzipPackageExtractor), "tar.bz2", ArchiveType.Tar, CompressionType.BZip2)]
+        [TestCase(typeof(ZipPackageExtractor), "zip", ArchiveType.Zip, CompressionType.Deflate)]
+        public void ExtractHandlesHighEntryCount(Type extractorType, string extension, ArchiveType archiveType, CompressionType compressionType)
+        {
+            // The sample packages have single-digit entry counts. A real deployment package routinely has
+            // thousands, so this checks nothing degrades or truncates in between.
+            const int entryCount = 1000;
+
+            using var tempFolder = TemporaryDirectory.Create();
+            var packageFile = Path.Combine(tempFolder.DirectoryPath, $"many-entries.{extension}");
+            var extractionDir = CreateExtractionDirectory(tempFolder);
+
+            WriteArchive(packageFile,
+                         archiveType,
+                         compressionType,
+                         writer =>
+                         {
+                             for (var i = 0; i < entryCount; i++)
+                                 writer.Write($"content/group{i % 16:d2}/file{i:d5}.txt", PayloadStream($"entry {i}"));
+                         });
+
+            var extractor = CreateExtractor(extractorType);
+
+            var filesExtracted = extractor.Extract(packageFile, extractionDir);
+
+            filesExtracted.Should().Be(entryCount);
+            Directory.GetFiles(extractionDir, "*.txt", SearchOption.AllDirectories).Should().HaveCount(entryCount);
+            File.ReadAllText(Path.Combine(extractionDir, "content", "group00", "file00000.txt")).Should().Be("entry 0");
+        }
+
+        [Test]
+        [TestCase(typeof(TarGzipPackageExtractor), "tar.gz", ArchiveType.Tar, CompressionType.GZip)]
+        [TestCase(typeof(TarPackageExtractor), "tar", ArchiveType.Tar, CompressionType.None)]
+        [TestCase(typeof(TarBzipPackageExtractor), "tar.bz2", ArchiveType.Tar, CompressionType.BZip2)]
+        [TestCase(typeof(ZipPackageExtractor), "zip", ArchiveType.Zip, CompressionType.Deflate)]
+        public void ExtractHandlesDeeplyNestedPaths(Type extractorType, string extension, ArchiveType archiveType, CompressionType compressionType)
+        {
+            // 40 single-character segments keeps the deepest path inside Windows' 260-character limit once the
+            // temporary root is prepended, so this stays portable. It is still far deeper than any sample package.
+            const int depth = 40;
+            var nestedPath = string.Join("/", Enumerable.Repeat("d", depth));
+
+            using var tempFolder = TemporaryDirectory.Create();
+            var packageFile = Path.Combine(tempFolder.DirectoryPath, $"deep.{extension}");
+            var extractionDir = CreateExtractionDirectory(tempFolder);
+
+            WriteArchive(packageFile,
+                         archiveType,
+                         compressionType,
+                         writer => writer.Write($"{nestedPath}/deep.txt", PayloadStream("deeply nested")));
+
+            var extractor = CreateExtractor(extractorType);
+
+            var filesExtracted = extractor.Extract(packageFile, extractionDir);
+
+            filesExtracted.Should().Be(1);
+            var expected = Path.Combine(new[] { extractionDir }.Concat(Enumerable.Repeat("d", depth)).Append("deep.txt").ToArray());
+            File.Exists(expected).Should().BeTrue("the full nesting depth should be recreated on disk");
+            File.ReadAllText(expected).Should().Be("deeply nested");
+        }
+
+        [Test]
+        [TestCase(typeof(TarGzipPackageExtractor), "tar.gz", ArchiveType.Tar, CompressionType.GZip)]
+        [TestCase(typeof(TarPackageExtractor), "tar", ArchiveType.Tar, CompressionType.None)]
+        [TestCase(typeof(TarBzipPackageExtractor), "tar.bz2", ArchiveType.Tar, CompressionType.BZip2)]
+        [TestCase(typeof(ZipPackageExtractor), "zip", ArchiveType.Zip, CompressionType.Deflate)]
+        public void ExtractHandlesLongEntryNames(Type extractorType, string extension, ArchiveType archiveType, CompressionType compressionType)
+        {
+            // 150 characters is longer than any real package entry while still leaving room for the temporary
+            // root inside Windows' 260-character path limit. Behaviour *beyond* that limit is OS-divergent and
+            // deliberately not asserted here; characterising it needs a Windows agent first.
+            var longName = new string('a', 150) + ".txt";
+
+            using var tempFolder = TemporaryDirectory.Create();
+            var packageFile = Path.Combine(tempFolder.DirectoryPath, $"long-names.{extension}");
+            var extractionDir = CreateExtractionDirectory(tempFolder);
+
+            WriteArchive(packageFile, archiveType, compressionType, writer => writer.Write(longName, PayloadStream("long name")));
+
+            var extractor = CreateExtractor(extractorType);
+
+            var filesExtracted = extractor.Extract(packageFile, extractionDir);
+
+            filesExtracted.Should().Be(1);
+            File.ReadAllText(Path.Combine(extractionDir, longName)).Should().Be("long name");
+        }
+
+        [Test]
+        [TestCase(typeof(TarBzipPackageExtractor), "tar.bz2", ArchiveType.Tar, CompressionType.BZip2)]
+        [TestCase(typeof(ZipPackageExtractor), "zip", ArchiveType.Zip, CompressionType.Deflate)]
+        public void TruncatedArchiveThrows(Type extractorType, string extension, ArchiveType archiveType, CompressionType compressionType)
+        {
+            // Zip fails because truncation removes the central directory; bzip2 fails on its block checksums.
+            using var tempFolder = TemporaryDirectory.Create();
+            var packageFile = Path.Combine(tempFolder.DirectoryPath, $"truncated.{extension}");
+            var extractionDir = CreateExtractionDirectory(tempFolder);
+
+            WriteTruncatableArchive(packageFile, archiveType, compressionType);
+            Truncate(packageFile);
+
+            var extractor = CreateExtractor(extractorType);
+
+            Assert.That(() => extractor.Extract(packageFile, extractionDir), Throws.Exception);
+        }
+
+        /// <summary>
+        /// A truncated tar or tar.gz extracts whatever entries it can read and returns normally, reporting a
+        /// file count lower than the archive actually contained.
+        ///
+        /// Neither format has a trailing index or whole-archive checksum, so the reader cannot tell a
+        /// truncated archive from one that simply ended. The consequence is that a package which arrives
+        /// incomplete deploys as a partial package with no error raised — Calamari has no independent record
+        /// of how many entries it should have seen. Worth a fix, but that is a behaviour change beyond the
+        /// scope of characterising it; this test exists so the change is visible when it happens.
+        /// </summary>
+        [Test]
+        [TestCase(typeof(TarGzipPackageExtractor), "tar.gz", ArchiveType.Tar, CompressionType.GZip)]
+        [TestCase(typeof(TarPackageExtractor), "tar", ArchiveType.Tar, CompressionType.None)]
+        public void TruncatedTarArchiveIsSilentlyExtractedInPart(Type extractorType, string extension, ArchiveType archiveType, CompressionType compressionType)
+        {
+            using var tempFolder = TemporaryDirectory.Create();
+            var packageFile = Path.Combine(tempFolder.DirectoryPath, $"truncated.{extension}");
+            var extractionDir = CreateExtractionDirectory(tempFolder);
+
+            WriteTruncatableArchive(packageFile, archiveType, compressionType);
+            Truncate(packageFile);
+
+            var extractor = CreateExtractor(extractorType);
+
+            var filesExtracted = extractor.Extract(packageFile, extractionDir);
+
+            filesExtracted.Should()
+                          .BeGreaterThan(0)
+                          .And.BeLessThan(TruncationEntryCount,
+                                          "the archive was cut in half, so only some entries are readable");
+            Directory.GetFiles(extractionDir, "*", SearchOption.AllDirectories)
+                     .Should()
+                     .HaveCount(filesExtracted, "the reported count should match what actually landed on disk");
+        }
+
+        [Test]
+        [TestCase(typeof(TarGzipPackageExtractor), "tar.gz", ArchiveType.Tar, CompressionType.GZip)]
+        [TestCase(typeof(TarBzipPackageExtractor), "tar.bz2", ArchiveType.Tar, CompressionType.BZip2)]
+        [TestCase(typeof(ZipPackageExtractor), "zip", ArchiveType.Zip, CompressionType.Deflate)]
+        public void CorruptedPayloadInCompressedArchiveThrows(Type extractorType, string extension, ArchiveType archiveType, CompressionType compressionType)
+        {
+            // Each compressed format detects the damage, though not uniformly: zip and gzip surface a
+            // ZlibException, while bzip2 currently surfaces an IndexOutOfRangeException from inside the
+            // decoder. The exact type is an implementation detail of the archive library and is deliberately
+            // not asserted; that it fails rather than writing garbage is the property that matters.
+            using var tempFolder = TemporaryDirectory.Create();
+            var packageFile = Path.Combine(tempFolder.DirectoryPath, $"corrupt.{extension}");
+            var extractionDir = CreateExtractionDirectory(tempFolder);
+
+            WriteSingleLargeEntryArchive(packageFile, archiveType, compressionType);
+            CorruptEntryPayload(packageFile);
+
+            var extractor = CreateExtractor(extractorType);
+
+            Assert.That(() => extractor.Extract(packageFile, extractionDir), Throws.Exception);
+        }
+
+        /// <summary>
+        /// An uncompressed tar carries no checksum over entry data, so a corrupted payload is written to disk
+        /// verbatim and extraction reports success.
+        ///
+        /// This is inherent to the format rather than a defect in the extractor — there is nothing in a tar to
+        /// check the bytes against. It is recorded here so the exposure is explicit: of the formats Calamari
+        /// accepts, plain <c>.tar</c> is the one where silent content corruption is possible.
+        /// </summary>
+        [Test]
+        public void CorruptedPayloadInUncompressedTarIsNotDetected()
+        {
+            using var tempFolder = TemporaryDirectory.Create();
+            var packageFile = Path.Combine(tempFolder.DirectoryPath, "corrupt.tar");
+            var extractionDir = CreateExtractionDirectory(tempFolder);
+
+            WriteSingleLargeEntryArchive(packageFile, ArchiveType.Tar, CompressionType.None);
+            CorruptEntryPayload(packageFile);
+
+            var extractor = new TarPackageExtractor(ConsoleLog.Instance);
+
+            var filesExtracted = extractor.Extract(packageFile, extractionDir);
+
+            filesExtracted.Should().Be(1);
+            File.ReadAllText(Path.Combine(extractionDir, "big.txt"))
+                .Should()
+                .NotBe(LargeEntryContent, "the corrupted bytes are written through without detection");
+        }
+
+        static string LargeEntryContent => new string(Enumerable.Range(0, 4096).Select(i => (char)('a' + i % 26)).ToArray());
+
+        static IPackageExtractor CreateExtractor(Type extractorType)
+            => (IPackageExtractor)Activator.CreateInstance(extractorType, ConsoleLog.Instance);
+
+        static string CreateExtractionDirectory(TemporaryDirectory tempFolder)
+        {
+            var extractionDir = Path.Combine(tempFolder.DirectoryPath, "extraction");
+            Directory.CreateDirectory(extractionDir);
+            return extractionDir;
+        }
+
+        static void WriteTruncatableArchive(string packageFile, ArchiveType archiveType, CompressionType compressionType)
+            => WriteArchive(packageFile,
+                            archiveType,
+                            compressionType,
+                            writer =>
+                            {
+                                for (var i = 0; i < TruncationEntryCount; i++)
+                                    writer.Write($"file{i:d3}.txt", PayloadStream(EntryContent));
+                            });
+
+        static void WriteSingleLargeEntryArchive(string packageFile, ArchiveType archiveType, CompressionType compressionType)
+            => WriteArchive(packageFile, archiveType, compressionType, writer => writer.Write("big.txt", PayloadStream(LargeEntryContent)));
+
+        static void WriteArchive(string packageFile, ArchiveType archiveType, CompressionType compressionType, Action<IWriter> write)
+        {
+            using var stream = File.OpenWrite(packageFile);
+            using var writer = WriterFactory.Open(stream,
+                                                  archiveType,
+                                                  new WriterOptions(compressionType)
+                                                  {
+                                                      ArchiveEncoding = new ArchiveEncoding { Default = Encoding.UTF8 }
+                                                  });
+            write(writer);
+        }
+
+        static MemoryStream PayloadStream(string content) => new MemoryStream(Encoding.UTF8.GetBytes(content));
+
+        static void Truncate(string path)
+        {
+            var bytes = File.ReadAllBytes(path);
+            File.WriteAllBytes(path, bytes.Take(bytes.Length / 2).ToArray());
+        }
+
+        static void CorruptEntryPayload(string path)
+        {
+            var bytes = File.ReadAllBytes(path);
+
+            // A 32-byte window a quarter of the way in. The archives this runs against hold a single large
+            // entry, so that window is inside the entry payload: past the header, well before any trailer or
+            // central directory. Damaging those instead would test archive structure, not content integrity.
+            var start = bytes.Length / 4;
+            for (var i = start; i < start + 32 && i < bytes.Length; i++)
+                bytes[i] ^= 0xFF;
+
+            File.WriteAllBytes(path, bytes);
+        }
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Integration/Packages/SyntheticArchiveFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Integration/Packages/SyntheticArchiveFixture.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using Calamari.Benchmarks.Support;
+using Calamari.Common.Features.Packages;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Integration.Packages
+{
+    /// <summary>
+    /// Guards the archive builder used by Calamari.Benchmarks against rot.
+    ///
+    /// The benchmark project is compiled by the solution build but never executed in CI, so nothing else
+    /// proves this builder still produces archives the extractors can actually read. Without that, a broken
+    /// builder would only surface the next time someone needed a measurement — which is during an upgrade,
+    /// when they are least inclined to debug the harness.
+    ///
+    /// The class is source-linked into this project rather than referenced; see the Compile item in
+    /// Calamari.Tests.csproj for why.
+    /// </summary>
+    [TestFixture]
+    public class SyntheticArchiveFixture
+    {
+        [Test]
+        [TestCase("zip", typeof(ZipPackageExtractor))]
+        [TestCase("tar", typeof(TarPackageExtractor))]
+        [TestCase("tar.gz", typeof(TarGzipPackageExtractor))]
+        [TestCase("tar.bz2", typeof(TarBzipPackageExtractor))]
+        public void BuiltArchiveIsExtractableByTheMatchingExtractor(string format, Type extractorType)
+        {
+            const int fileCount = 20;
+            const int payloadBytes = 256;
+
+            using var tempFolder = TemporaryDirectory.Create();
+            var packagePath = SyntheticArchive.Build(Path.Combine(tempFolder.DirectoryPath, "packages"), format, fileCount, payloadBytes);
+            var extractionDir = Path.Combine(tempFolder.DirectoryPath, "extraction");
+            Directory.CreateDirectory(extractionDir);
+
+            new FileInfo(packagePath).Length.Should().BeGreaterThan(0);
+
+            var extractor = (IPackageExtractor)Activator.CreateInstance(extractorType, ConsoleLog.Instance);
+
+            var filesExtracted = extractor.Extract(packagePath, extractionDir);
+
+            filesExtracted.Should()
+                          .Be(fileCount, "the benchmark would otherwise be measuring a smaller archive than it reports");
+            Directory.GetFiles(extractionDir, "*.bin", SearchOption.AllDirectories).Should().HaveCount(fileCount);
+        }
+
+        [Test]
+        public void BuiltArchiveSpreadsEntriesAcrossDirectories()
+        {
+            // The benchmark is meant to include directory-creation cost, which only happens if entries are
+            // actually nested rather than sitting in the archive root.
+            using var tempFolder = TemporaryDirectory.Create();
+            var packagePath = SyntheticArchive.Build(Path.Combine(tempFolder.DirectoryPath, "packages"), "zip", 32, 128);
+            var extractionDir = Path.Combine(tempFolder.DirectoryPath, "extraction");
+            Directory.CreateDirectory(extractionDir);
+
+            new ZipPackageExtractor(ConsoleLog.Instance).Extract(packagePath, extractionDir);
+
+            Directory.GetDirectories(extractionDir, "*", SearchOption.AllDirectories)
+                     .Should()
+                     .HaveCountGreaterThan(1, "entries should be spread over a directory tree, not flat");
+        }
+
+        [Test]
+        public void PayloadsAreIncompressibleEnoughToBeWorthMeasuring()
+        {
+            // An all-zero or highly repetitive payload would deflate to almost nothing, and the benchmark
+            // would measure bookkeeping rather than decompression. This is the property that keeps the
+            // numbers meaningful, so it is worth pinning.
+            const int fileCount = 20;
+            const int payloadBytes = 4096;
+
+            using var tempFolder = TemporaryDirectory.Create();
+            var packagePath = SyntheticArchive.Build(Path.Combine(tempFolder.DirectoryPath, "packages"), "zip", fileCount, payloadBytes);
+
+            var uncompressedTotal = (long)fileCount * payloadBytes;
+            new FileInfo(packagePath).Length
+                                     .Should()
+                                     .BeGreaterThan((long)(uncompressedTotal * 0.5),
+                                                    "random payloads should not compress away to nothing");
+        }
+
+        [Test]
+        public void UnknownFormatIsRejected()
+        {
+            using var tempFolder = TemporaryDirectory.Create();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => SyntheticArchive.Build(tempFolder.DirectoryPath, "rar", 1, 16));
+        }
+    }
+}

--- a/source/Calamari.sln
+++ b/source/Calamari.sln
@@ -88,6 +88,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Calamari.Contracts", "Calam
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Calamari.DockerCredentialHelper", "Calamari.DockerCredentialHelper\Calamari.DockerCredentialHelper.csproj", "{B34DBEEC-7AC2-4BFE-ACDD-1788828925BD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Calamari.Benchmarks", "Calamari.Benchmarks\Calamari.Benchmarks.csproj", "{410019DF-659C-4B65-931E-EB6C8011CDC3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -232,6 +234,10 @@ Global
 		{B34DBEEC-7AC2-4BFE-ACDD-1788828925BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B34DBEEC-7AC2-4BFE-ACDD-1788828925BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B34DBEEC-7AC2-4BFE-ACDD-1788828925BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{410019DF-659C-4B65-931E-EB6C8011CDC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{410019DF-659C-4B65-931E-EB6C8011CDC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{410019DF-659C-4B65-931E-EB6C8011CDC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{410019DF-659C-4B65-931E-EB6C8011CDC3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Follow-up to the two items flagged as "worth a ticket" in [this review comment](https://github.com/OctopusDeploy/Calamari/pull/2087#issuecomment-5141077231) on #2087. Neither blocked that PR. Both were properties of the extraction code that were unmeasured before the SharpCompress bump and would have stayed unmeasured after it.

Rebased onto the merged #2087, so this measures the extractors as they now ship on SharpCompress 0.49.1. No production code changes.

## 1. Benchmarks (`source/Calamari.Benchmarks`, BenchmarkDotNet)

New project. Compiled by the solution build, but the benchmarks are **not executed** in CI — see "Why not run them in CI" below.

**`ConsolidatedPackageBenchmarks`** — the first measurement of `ExtractCalamariPackage`, so the ~6s-vs-~500ms observation from the [original thread](https://octopusdeploy.slack.com/archives/C03SG0LFJHX/p1777933912502139) can finally be confirmed or dismissed. Point it at a real package with `CALAMARI_BENCHMARK_CONSOLIDATED_PACKAGE=/path/to/Calamari.<hash>.zip`; otherwise it generates a synthetic one of the same shape.

**`PackageExtractionBenchmarks`** — the SharpCompress-backed extractors, so the *next* version bump can be measured rather than reasoned about.

**The two suites are not interchangeable.** `ExtractCalamariPackage` uses `System.IO.Compression.ZipArchive` from the BCL, *not* SharpCompress. A SharpCompress bump cannot move those numbers — that suite is the control, not the experiment. That means the ~6s observation and the SharpCompress upgrade were never actually related, which wasn't obvious to me before reading the code.

Indicative numbers, Apple M-series, synthetic package, 4KB payloads:

| Benchmark | 50 files/platform | 200 files/platform |
|---|---|---|
| `LoadIndex` | 8.0 ms | 32.1 ms |
| `ExtractSingleFlavourPlatform` | 1.8 ms | 7.4 ms |
| `ExtractAllFlavourPlatforms` (54 combos) | 98 ms / 54 MB alloc | 317 ms / 218 MB alloc |

Two things that fall out, neither addressed here:

- `ExtractCalamariPackage` re-opens the archive and rebuilds a `ToDictionary` over **every** entry on each call, so per-call cost scales with total archive size rather than with the files that call wants. Across 54 flavour/platform combinations that is 54 full scans.
- Real payloads are far larger than 4KB, so production numbers scale up from here. Nothing yet contradicts the ~6s report — this gives us the means to check it.

I've deliberately left the production code alone; optimising it is a separate change with its own risk.

## 2. `ArchiveRobustnessFixture`

Covers the adversarial vectors the suite didn't reach: high entry counts (1,000 vs the samples' single digits), 40-level nesting, 150-character entry names, and archives that are **truncated or corrupt** rather than merely "not an archive at all". 20 tests, ~3s.

These are characterisation tests. Where current behaviour is arguably wrong, they assert what happens today and say so, rather than asserting an aspiration and failing:

| Format | Truncated | Corrupt entry payload |
|---|---|---|
| `.zip` | throws | throws |
| `.tar.bz2` | throws | throws |
| `.tar.gz` | **silent partial extract** | throws |
| `.tar` | **silent partial extract** | **written through undetected** |

**A truncated `.tar` or `.tar.gz` extracts what it can, returns normally, and reports a file count lower than the archive held.** Neither format has a trailing index or whole-archive checksum, so the reader can't distinguish a truncated archive from one that simply ended. A package that arrives incomplete deploys as a partial package with no error raised — Calamari has no independent record of how many entries it should have seen.

**An uncompressed `.tar` writes corrupted payloads through undetected.** Inherent to the format — there's nothing to check the bytes against. Recorded so the exposure is explicit: of the formats Calamari accepts, plain `.tar` is the one where silent content corruption is possible.

Both are worth fixing, but fixing them is a behaviour change well beyond characterising them. The tests exist so that when someone does, or when an archive-library change alters it, it's visible.

I ran this table against both 0.37.2 and 0.49.1 and it is **identical**, with one improvement: bzip2 payload corruption surfaces `InvalidFormatException` on 0.49.1 where 0.37.2 leaked an `IndexOutOfRangeException` from inside the decoder. The tests assert only that it fails, not the type — that's a library implementation detail.

## Why not run the benchmarks in CI

Worth stating explicitly, since "manual tool" is usually a smell:

- These are wall-clock, disk-touching measurements on shared agents across Windows, Ubuntu and ARM64. A regression threshold would be either too loose to catch anything or flaky enough that people mute it, and a muted check is worse than none.
- There's no stored baseline to compare against, so a CI run would print numbers into a build log nobody diffs.
- Cost: `tar.bz2` at 2,000 files runs ~2.3s per iteration; the full suite is minutes, per build, for numbers nobody reads.

The real risk that leaves is **rot** — the solution build catches compile breakage, but nothing proved the harness still *runs*. So the fragile part, the fixture builders in `Support/`, is now covered by ordinary tests in the existing suite (`SyntheticArchiveFixture`, `SyntheticConsolidatedPackageTests`): every generated format is extractable by the matching extractor, and the generated consolidated package is readable by the real `ConsolidatedPackageFactory`.

Those test projects **source-link** the `Support/` files rather than taking a ProjectReference, so BenchmarkDotNet doesn't become a dependency of packages that ship to test agents. Verified: no BenchmarkDotNet assemblies in either test output.

## Verification

- Full solution builds clean (0 errors) on 0.49.1.
- 90/90 in `ArchiveRobustnessFixture` + `SyntheticArchiveFixture` + `PackageExtractorFixture`; 4/4 in `SyntheticConsolidatedPackageTests`.
- All 28 benchmarks execute end to end.
- Pre-existing failures confirmed against pristine `main`, not caused by this branch: `Calamari.ConsolidateCalamariPackages.Tests` 18/20 fail identically (needs a full Nuke build to have produced the packages), and 5 Docker/GitHub downloader tests fail identically (need credentials).

`.sln` is `merge=union`; `dotnet sln add` reindented two unrelated project blocks as a side effect and I reverted that, so the diff there is 6 purely additive lines.
