### PR TITLE
Guard the DI container's orderings and shape

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -42,6 +42,7 @@
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Fixtures\PowerShell\Scripts\HelloWithVariable.ps1"/>
+        <EmbeddedResource Include="Fixtures\Util\ContainerSnapshot.expected.txt"/>
         <None Include="Fixtures\ConfigurationVariables\Samples\**">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/source/Calamari.Tests/Fixtures/Util/ContainerOrderingFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/ContainerOrderingFixture.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using Calamari.Common.Features.Discovery;
+using Calamari.Common.Features.Scripting;
+using Calamari.Common.Features.Scripts;
+using Calamari.Common.Features.StructuredVariables;
+using Calamari.Common.Plumbing.Extensions;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Testing;
+using FluentAssertions;
+using NUnit.Framework;
+using KubernetesSpecialVariables = Calamari.Kubernetes.SpecialVariables;
+using DeploymentSpecialVariables = Calamari.Deployment.SpecialVariables;
+
+namespace Calamari.Tests.Fixtures.Util
+{
+    /// <summary>
+    /// Guards the orderings that the DI container is responsible for producing.
+    ///
+    /// Script wrappers form an execution chain and file-format replacers are tried in sequence,
+    /// so a change in order is a change in deployment behaviour — but every wrapper still
+    /// constructs and every command still resolves, so nothing else in the suite would notice.
+    /// </summary>
+    [TestFixture]
+    public class ContainerOrderingFixture
+    {
+        IContainer container;
+
+        [SetUp]
+        public void SetUp()
+        {
+            container = TestableSyncProgram.For<Calamari.Program>().BuildTestContainer();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            container?.Dispose();
+        }
+
+        /// <summary>
+        /// This is the invariant that makes the wrapper chain independent of the DI container.
+        ///
+        /// ScriptEngine orders wrappers with OrderByDescending(Priority), which is a *stable* sort,
+        /// so any two wrappers sharing a priority fall back to the order the container happened to
+        /// return them in. While every priority is distinct the chain is fully determined by
+        /// ScriptWrapperPriorities; introduce a tie and it silently becomes container-dependent.
+        /// </summary>
+        [Test]
+        [Category("PlatformAgnostic")]
+        public void ScriptWrapperPrioritiesAreUnique()
+        {
+            var wrappers = container.Resolve<IEnumerable<IScriptWrapper>>().ToList();
+
+            wrappers.Should().NotBeEmpty("the flavour is expected to register script wrappers");
+
+            var duplicates = wrappers.GroupBy(w => w.Priority)
+                                     .Where(g => g.Count() > 1)
+                                     .Select(g => $"priority {g.Key}: {string.Join(", ", g.Select(w => w.GetType().Name))}")
+                                     .ToList();
+
+            duplicates.Should()
+                      .BeEmpty("wrappers sharing a priority make the execution chain depend on the DI container's "
+                               + "collection ordering rather than on ScriptWrapperPriorities");
+        }
+
+        /// <summary>
+        /// Pins the full chain for a representative step that enables every wrapper at once:
+        /// a Kubernetes deployment, authenticated with an AWS account, running PowerShell,
+        /// with resource status checking on.
+        /// </summary>
+        [Test]
+        [Category("PlatformAgnostic")]
+        public void ScriptWrapperChain_ForKubernetesAwsPowerShellStep_IsOrderedByDescendingPriority()
+        {
+            var variables = container.Resolve<IVariables>();
+
+            // Kubernetes step: enables KubernetesContextScriptWrapper and ManifestReportScriptWrapper
+            variables.Set(KubernetesSpecialVariables.ClusterUrl, "https://cluster.example");
+            // ...and ResourceStatusReportScriptWrapper, provided it is not a blue/green or wait deployment
+            variables.Set(KubernetesSpecialVariables.ResourceStatusCheck, "True");
+            // AWS authentication: enables AwsScriptWrapper
+            variables.Set(DeploymentSpecialVariables.Account.AccountType, "AmazonWebServicesAccount");
+            // Script function registration: enables FunctionAppenderScriptWrapper for supported syntaxes.
+            // Literal because ScriptFunctionsVariables is internal to Calamari.Common.
+            variables.Set("Octopus.Sashimi.ScriptFunctions.Registration", "SomeRegistration");
+
+            var chain = ResolveChain(ScriptSyntax.PowerShell);
+
+            chain.Should()
+                 .Equal(new[]
+                        {
+                            nameof(Calamari.Kubernetes.ResourceStatus.ResourceStatusReportScriptWrapper), // 1003
+                            nameof(Calamari.Kubernetes.ManifestReportScriptWrapper),                      // 1002
+                            nameof(Calamari.Kubernetes.KubernetesContextScriptWrapper),                   // 1001
+                            nameof(Calamari.Aws.Integration.AwsScriptWrapper),                            // 1000
+                            nameof(Calamari.Common.Features.FunctionScriptContributions.FunctionAppenderScriptWrapper) // 100
+                        },
+                        "the wrapper chain determines the order authentication and tooling are applied around a script");
+        }
+
+        /// <summary>
+        /// With no variables set no wrapper should opt in, so a plain script runs unwrapped.
+        /// </summary>
+        [Test]
+        [Category("PlatformAgnostic")]
+        public void ScriptWrapperChain_ForAPlainScript_IsEmpty()
+        {
+            ResolveChain(ScriptSyntax.PowerShell).Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Structured configuration variables try each replacer in turn, so this order decides
+        /// which format wins for a file that more than one replacer would accept.
+        /// </summary>
+        [Test]
+        [Category("PlatformAgnostic")]
+        public void FileFormatVariableReplacers_ResolveInDeclaredPriorityOrder()
+        {
+            using var scope = container.BeginLifetimeScope();
+
+            var replacers = scope.Resolve<PrioritisedList<IFileFormatVariableReplacer>>()
+                                 .Select(r => r.GetType().Name);
+
+            replacers.Should()
+                     .Equal(nameof(JsonFormatVariableReplacer),
+                            nameof(XmlFormatVariableReplacer),
+                            nameof(YamlFormatVariableReplacer),
+                            nameof(PropertiesFormatVariableReplacer));
+        }
+
+        /// <summary>
+        /// KubernetesDiscovererFactory builds a dictionary keyed on Type, so a duplicate key
+        /// throws at construction and a reordering would change which discoverer wins.
+        /// </summary>
+        [Test]
+        [Category("PlatformAgnostic")]
+        public void KubernetesDiscoverers_HaveDistinctTypeKeys()
+        {
+            var discoverers = container.Resolve<IEnumerable<IKubernetesDiscoverer>>().ToList();
+
+            discoverers.Should().NotBeEmpty();
+            discoverers.Select(d => d.Type).Should().OnlyHaveUniqueItems();
+        }
+
+        /// <summary>
+        /// Mirrors the enabled-and-ordered selection ScriptEngine.BuildWrapperChain performs
+        /// before folding the wrappers into a linked list.
+        /// </summary>
+        List<string> ResolveChain(ScriptSyntax syntax)
+            => container.Resolve<IEnumerable<IScriptWrapper>>()
+                        .Where(w => w.IsEnabled(syntax))
+                        .OrderByDescending(w => w.Priority)
+                        .Select(w => w.GetType().Name)
+                        .ToList();
+    }
+}

--- a/source/Calamari.Tests/Fixtures/Util/ContainerSnapshot.expected.txt
+++ b/source/Calamari.Tests/Fixtures/Util/ContainerSnapshot.expected.txt
@@ -1,0 +1,198 @@
+## AUTOFAC
+9.3.1.0
+
+## REGISTRATIONS
+ApiResourceScopeLookup :: Calamari.Kubernetes.IApiResourceScopeLookup :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+ApplyCloudFormationChangesetCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Apply an existing AWS CloudFormation changeset,Name=apply-aws-cloudformation-changeset,TypeId=RuntimeType]
+ApplyDeltaCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Applies a delta file to a package to create a new version of the package,Name=apply-delta,TypeId=RuntimeType]
+ArgoCDFilesUpdatedReporter :: Calamari.ArgoCD.IArgoCDFilesUpdatedReporter :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ArgoCDManifestsFileMatcher :: Calamari.ArgoCD.Conventions.IArgoCDManifestsFileMatcher :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+AssemblyEmbeddedResources :: Calamari.Common.Features.EmbeddedResources.ICalamariEmbeddedResources :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+AwsKubernetesDiscoverer :: Calamari.Common.Features.Discovery.IKubernetesDiscoverer :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+AwsScriptWrapper :: Calamari.Common.Features.Scripting.IScriptWrapper :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+AwsTargetDiscoveryContextResolver :: Calamari.Aws.Discovery.IAwsTargetDiscoveryContextResolver :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+AzureDevOpsPullRequestClientFactory :: Calamari.ArgoCD.Git.PullRequests.IGitVendorPullRequestClientFactory :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+AzureKubernetesDiscoverer :: Calamari.Common.Features.Discovery.IKubernetesDiscoverer :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+BitBucketPullRequestClientFactory :: Calamari.ArgoCD.Git.PullRequests.IGitVendorPullRequestClientFactory :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+CalamariCertificateStore :: Calamari.Integration.Certificates.ICertificateStore :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+CalamariExecutor :: Calamari.LaunchTools.ILaunchTool :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Tool=Calamari,TypeId=RuntimeType]
+ClaudeSettingsWriter :: Calamari.AiAgent.ClaudeCodeBehaviour.ClaudeSettingsWriter :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+CleanCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Removes packages and files according to the configured retention policy,Name=clean,TypeId=RuntimeType]
+CleanPackagesCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Apply retention to the package cache,Name=clean-packages,TypeId=RuntimeType]
+CodeGenFunctionsRegistry :: Calamari.Common.Features.FunctionScriptContributions.CodeGenFunctionsRegistry :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+CombinedPackageExtractor :: Calamari.Common.Features.Packages.ICombinedPackageExtractor :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+CommandLineRunner :: Calamari.Common.Features.Processes.ICommandLineRunner :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+CommitToGitCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Update a Git repository with selected package content, then transform with optional script,Name=commit-to-git,TypeId=RuntimeType]
+CommitToGitConfigFactory :: Calamari.CommitToGit.CommitToGitConfigFactory :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+CommonOptions :: AutoActivate+Calamari.Common.Plumbing.Commands.CommonOptions :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: [__AutoActivated=True]
+CommonOptions :: AutoActivate+Calamari.Common.Plumbing.Commands.CommonOptions :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: [__AutoActivated=True]
+ConfigurationTransformer :: Calamari.Common.Features.ConfigurationTransforms.IConfigurationTransformer :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ConfigurationTransformsBehaviour :: Calamari.Common.Features.Behaviours.ConfigurationTransformsBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ConfigurationVariablesBehaviour :: Calamari.Common.Features.Behaviours.ConfigurationVariablesBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ConfigurationVariablesReplacer :: Calamari.Common.Features.ConfigurationVariables.IConfigurationVariablesReplacer :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ConfiguredScriptBehaviour :: Calamari.Common.Features.Behaviours.ConfiguredScriptBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ConsoleLog :: AutoActivate+Calamari.Common.Plumbing.Logging.ILog :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: [__AutoActivated=True]
+CreateAwsS3Command :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Creates an AWS S3 bucket,Name=create-aws-s3,TypeId=RuntimeType]
+DefaultPathResolutionService :: Calamari.Common.Features.Processes.ScriptIsolation.IPathResolutionService :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+DeleteCloudFormationCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Destroy an existing AWS CloudFormation stack,Name=delete-aws-cloudformation,TypeId=RuntimeType]
+DeployCloudFormationCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Creates a new AWS CloudFormation deployment,Name=deploy-aws-cloudformation,TypeId=RuntimeType]
+DeployConfiguredScriptBehaviour :: Calamari.Common.Features.Behaviours.DeployConfiguredScriptBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+DeployEcsServiceCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Deploys a service to an Amazon ECS cluster,Name=deploy-aws-ecs-service,TypeId=RuntimeType]
+DeployJavaArchiveCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Deploys a Java archive (.jar, .war, .ear),Name=deploy-java-archive,TypeId=RuntimeType]
+DeployPackageCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Extracts and installs a deployment package,Name=deploy-package,TypeId=RuntimeType]
+DeployPackagedScriptBehaviour :: Calamari.Common.Features.Behaviours.DeployPackagedScriptBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+DeploymentConfigFactory :: Calamari.ArgoCD.Conventions.DeploymentConfigFactory :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+DeploymentJournalWriter :: Calamari.Common.Plumbing.Deployment.Journal.IDeploymentJournalWriter :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+DownloadAndRegisterPackageCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Downloads a package and atomically registers its use in the package journal,Name=download-and-register-package,TypeId=RuntimeType]
+DownloadPackageCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Downloads a NuGet package from a NuGet feed,Name=download-package,TypeId=RuntimeType]
+EcsClientFactory :: Calamari.Aws.Integration.Ecs.IEcsClientFactory :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+EcsClusterDiscoveryBehaviour :: Calamari.Aws.Behaviours.EcsClusterDiscoveryBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+EcsClusterDiscoveryWriter :: Calamari.Aws.Integration.Ecs.IEcsClusterDiscoveryWriter :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+EcsClusterTargetDiscoveryCommand :: aws-ecs-cluster-target-discovery (Calamari.Common.Plumbing.Pipeline.PipelineCommand) :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Discover AWS ECS Clusters,Name=aws-ecs-cluster-target-discovery,TypeId=RuntimeType]
+EcsDiscoverer :: Calamari.Aws.Integration.Ecs.IEcsDiscoverer :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+EcsImageNameResolver :: Calamari.Aws.Inputs.Ecs.IEcsImageNameResolver :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+EcsStackNameGenerator :: Calamari.Aws.Integration.Ecs.IEcsStackNameGenerator :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+ExecuteManifestCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=null,Name=execute-manifest,TypeId=RuntimeType]
+ExtractBehaviour :: Calamari.Common.Features.Behaviours.ExtractBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ExtractPackage :: Calamari.Common.Features.Packages.IExtractPackage :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ExtractPackageCommand :: Calamari.Commands.ICommandWithInputs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=null,Name=extract-package,TypeId=RuntimeType]
+FileSubstituter :: Calamari.Common.Features.Substitutions.IFileSubstituter :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+FindAndRegisterPackageCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Finds a package and atomically registers its use in the package journal,Name=find-and-register-package,TypeId=RuntimeType]
+FindPackageCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Finds the package that matches the specified ID and version. If no exact match is found, it returns a list of the nearest packages that matches the ID,Name=find-package,TypeId=RuntimeType]
+FreeSpaceChecker :: Calamari.Common.Plumbing.FileSystem.IFreeSpaceChecker :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+FunctionAppenderScriptWrapper :: Calamari.Common.Features.Scripting.IScriptWrapper :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+GatherAndApplyRawYamlExecutor :: Calamari.Kubernetes.Commands.Executors.IRawYamlKubernetesApplyExecutor :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+GitHubPullRequestClientFactory :: Calamari.ArgoCD.Git.PullRequests.IGitVendorPullRequestClientFactory :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+GitLabPullRequestClientFactory :: Calamari.ArgoCD.Git.PullRequests.IGitVendorPullRequestClientFactory :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+GitVendorPullRequestClientResolver :: Calamari.ArgoCD.Git.PullRequests.IGitVendorPullRequestClientResolver :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+GlobSubstituteFileMatcher :: Calamari.Common.Features.Substitutions.ISubstituteFileMatcher :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+HealthCheckCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Run a health check on an AWS ECS Cluster,Name=aws-ecs-health-check,TypeId=RuntimeType]
+HelmTemplateValueSourcesParser :: Calamari.Kubernetes.Helm.HelmTemplateValueSourcesParser :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+HelmUpgradeCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Performs Helm Upgrade with Chart while performing variable replacement,Name=helm-upgrade,TypeId=RuntimeType]
+IFileLockService :: Calamari.Common.Features.Processes.ScriptIsolation.IFileLockService :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+INonSensitiveVariables :: Calamari.Common.Plumbing.Variables.INonSensitiveVariables :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+IVariables :: Calamari.Common.Plumbing.Variables.IVariables :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+ImportCertificateCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Imports a X.509 certificate into a Windows certificate store,Name=import-certificate,TypeId=RuntimeType]
+InvokeClaudeCodeBehaviour :: Calamari.AiAgent.ClaudeCodeBehaviour.InvokeClaudeCodeBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+JavaLibraryCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Invokes the Octopus java library,Name=java-library,TypeId=RuntimeType]
+JsonFormatVariableReplacer :: Calamari.Common.Features.StructuredVariables.IFileFormatVariableReplacer :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [RegistrationPriority=1]
+JsonJournalRepository :: Calamari.Deployment.PackageRetention.Repositories.IJournalRepository :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+Kubectl :: Calamari.Kubernetes.Integration.IKubectl+Calamari.Kubernetes.Integration.Kubectl :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+KubectlGet :: Calamari.Kubernetes.ResourceStatus.IKubectlGet :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+KubernetesApplyRawYamlCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Apply Raw Yaml to Kubernetes Cluster,Name=kubernetes-apply-raw-yaml,TypeId=RuntimeType]
+KubernetesAuthenticationCommand :: Calamari.Commands.ICommandWithInputs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=null,Name=authenticate-to-kubernetes,TypeId=RuntimeType]
+KubernetesContextScriptWrapper :: Calamari.Common.Features.Scripting.IScriptWrapper :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+KubernetesDiscovererFactory :: Calamari.Kubernetes.Commands.Discovery.IKubernetesDiscovererFactory :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+KubernetesDiscoveryCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Discover Kubernetes cluster targets,Name=kubernetes-target-discovery,TypeId=RuntimeType]
+KubernetesKustomizeCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Apply Kubernetes manifests with Kustomize,Name=kubernetes-kustomize,TypeId=RuntimeType]
+KubernetesManifestNamespaceResolver :: Calamari.Kubernetes.IKubernetesManifestNamespaceResolver :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+KubernetesVerifyResourcesCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Verifies that resources applied by a Kubernetes deploy step have reached their desired state,Name=kubernetes-verify-resources,TypeId=RuntimeType]
+KustomizeExecutor :: Calamari.Kubernetes.Commands.Executors.IKustomizeKubernetesApplyExecutor :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+LeastFrequentlyUsedWithAgingSort :: Calamari.Deployment.PackageRetention.Caching.ISortJournalEntries :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+LifetimeScope :: Autofac.IComponentContext+Autofac.ILifetimeScope :: Shared/CurrentScopeLifetime/ExternallyOwned :: []
+LockDirectoryFactory :: Calamari.Common.Features.Processes.ScriptIsolation.ILockDirectoryFactory :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+LockOptionsResolver :: Calamari.Common.Features.Processes.ScriptIsolation.LockOptionsResolver :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ManifestReportScriptWrapper :: Calamari.Common.Features.Scripting.IScriptWrapper :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+ManifestReporter :: Calamari.Kubernetes.IManifestReporter :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+ManifestRetriever :: Calamari.Kubernetes.IManifestRetriever :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+MemoryCache :: Microsoft.Extensions.Caching.Memory.IMemoryCache :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+<PhysicalFileSystem> :: AutoActivate+Calamari.Common.Plumbing.FileSystem.ICalamariFileSystem :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: [__AutoActivated=True]
+NoOp<WindowsX509CertificateStore> :: Calamari.Integration.Certificates.I<WindowsX509CertificateStore> :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+NodeExecutor :: Calamari.LaunchTools.ILaunchTool :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Tool=Node,TypeId=RuntimeType]
+NonSensitiveFileSubstituter :: Calamari.Common.Features.Substitutions.INonSensitiveFileSubstituter :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+NonSensitiveSubstituteInFiles :: Calamari.Common.Features.Substitutions.INonSensitiveSubstituteInFiles :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+NonSensitiveSubstituteInFilesBehaviour :: Calamari.Common.Features.Behaviours.NonSensitiveSubstituteInFilesBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+PackageJournal :: Calamari.Common.Plumbing.Deployment.PackageRetention.IManagePackageCache :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+PackageQuantityPackageCacheCleaner :: Calamari.Deployment.PackageRetention.Caching.IRetentionAlgorithm :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+PackageStore :: Calamari.Integration.FileSystem.IPackageStore :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+PercentFreeDiskSpacePackageCacheCleaner :: Calamari.Deployment.PackageRetention.Caching.IRetentionAlgorithm :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+PostDeployConfiguredScriptBehaviour :: Calamari.Common.Features.Behaviours.PostDeployConfiguredScriptBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+PostDeployPackagedScriptBehaviour :: Calamari.Common.Features.Behaviours.PostDeployPackagedScriptBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+PowerShellLanguage :: Calamari.Common.Features.FunctionScriptContributions.ICodeGenFunctions :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+PreDeployConfiguredScriptBehaviour :: Calamari.Common.Features.Behaviours.PreDeployConfiguredScriptBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+PreDeployPackagedScriptBehaviour :: Calamari.Common.Features.Behaviours.PreDeployPackagedScriptBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+PrioritisedList<IFileFormatVariableReplacer> :: Calamari.Common.Plumbing.Extensions.PrioritisedList`1[[Calamari.Common.Features.StructuredVariables.IFileFormatVariableReplacer, Calamari.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]] :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+PropertiesFormatVariableReplacer :: Calamari.Common.Features.StructuredVariables.IFileFormatVariableReplacer :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [RegistrationPriority=4]
+RegisterPackageUseCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Register the use of a package in the package journal,Name=register-package,TypeId=RuntimeType]
+ReleasePackageLockCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Releases a given package lock for a specific task ID.,Name=release-package-lock,TypeId=RuntimeType]
+RequestedLockOptionsFactory :: Calamari.Common.Features.Processes.ScriptIsolation.RequestedLockOptionsFactory :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ResourceFinder :: Calamari.Kubernetes.ResourceStatus.IResourceFinder :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+ResourceRetriever :: Calamari.Kubernetes.ResourceStatus.IResourceRetriever :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+ResourceStatusCheckTask :: Calamari.Kubernetes.ResourceStatus.ResourceStatusCheckTask :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ResourceStatusReportExecutor :: Calamari.Kubernetes.ResourceStatus.IResourceStatusReportExecutor :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ResourceStatusReportScriptWrapper :: Calamari.Common.Features.Scripting.IScriptWrapper :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+ResourceUpdateReporter :: Calamari.Kubernetes.ResourceStatus.IResourceUpdateReporter :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+RollbackScriptBehaviour :: Calamari.Common.Features.Behaviours.RollbackScriptBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+RunAgentCommand :: run-claude-code (Calamari.Common.Plumbing.Pipeline.PipelineCommand) :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Invokes an Claude Code CLI,Name=run-claude-code,TypeId=RuntimeType]
+RunScriptCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Invokes a script,Name=run-script,TypeId=RuntimeType]
+RunningResourceStatusCheck :: Calamari.Kubernetes.ResourceStatus.IRunningResourceStatusCheck :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+ScriptEngine :: Calamari.Common.Features.Scripting.IScriptEngine :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+ScriptIsolationEnforcer :: Calamari.Common.Features.Processes.ScriptIsolation.IScriptIsolationEnforcer :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+SelfHostedGitLabInspector :: Calamari.ArgoCD.Git.PullRequests.Vendors.GitLab.SelfHostedGitLabInspector :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+StructuredConfigVariablesCommand :: Calamari.Commands.ICommandWithInputs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=null,Name=structured-config-variables,TypeId=RuntimeType]
+StructuredConfigVariablesService :: Calamari.Common.Features.StructuredVariables.IStructuredConfigVariablesService :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+StructuredConfigurationVariablesBehaviour :: Calamari.Common.Features.Behaviours.StructuredConfigurationVariablesBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+SubstituteInFiles :: Calamari.Common.Features.Substitutions.ISubstituteInFiles :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+SubstituteInFilesBehaviour :: Calamari.Common.Features.Behaviours.SubstituteInFilesBehaviour :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+SubstituteInFilesCommand :: Calamari.Commands.ICommandWithInputs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=null,Name=substitute-in-files,TypeId=RuntimeType]
+SubstituteVariablesInFilesCommand :: Calamari.Commands.ICommandWithInputs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=null,Name=substitute-variables-in-files,TypeId=RuntimeType]
+SystemMountedDrivesProvider :: Calamari.Common.Features.Processes.ScriptIsolation.IMountedDrivesProvider :: Shared/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+SystemSemaphoreManager :: AutoActivate+Calamari.Common.Features.Processes.Semaphores.ISemaphoreFactory :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: [__AutoActivated=True]
+TemporaryDirectoryFallbackProvider :: Calamari.Common.Features.Processes.ScriptIsolation.ITemporaryDirectoryFallbackProvider :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+Timer :: Calamari.Kubernetes.ResourceStatus.ITimer :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+TransferPackageCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Copies a deployment package to a specific directory,Name=transfer-package,TypeId=RuntimeType]
+TransformFileLocator :: Calamari.Common.Features.ConfigurationTransforms.ITransformFileLocator :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+UpdateArgoCDAppImagesCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Update container image versions for one or more Argo CD Applications, persisting them in a Git repository,Name=update-argo-cd-app-images,TypeId=RuntimeType]
+UpdateArgoCDAppManifestsCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Update Kubernetes manifests from a package for one or more Argo CD Applications, persisting them in a Git repository,Name=update-argo-cd-app-manifests,TypeId=RuntimeType]
+UpdateEcsServiceCommand :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Updates an ECS service to a new task definition revision,Name=update-aws-ecs-service,TypeId=RuntimeType]
+UploadAwsS3Command :: Calamari.Commands.Support.ICommandWithArgs :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [Description=Uploads a package or package file(s) to an AWS s3 bucket,Name=upload-aws-s3,TypeId=RuntimeType]
+VariableJsonJournalPathProvider :: Calamari.Deployment.PackageRetention.Repositories.IJsonJournalPathProvider :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+VariableLogger :: Calamari.Common.Plumbing.Logging.VariableLogger :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: []
+VariablesFactory :: Calamari.Common.Plumbing.Variables.VariablesFactory :: Shared/RootScopeLifetime/OwnedByLifetimeScope :: []
+XmlFormatVariableReplacer :: Calamari.Common.Features.StructuredVariables.IFileFormatVariableReplacer :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [RegistrationPriority=2]
+YamlFormatVariableReplacer :: Calamari.Common.Features.StructuredVariables.IFileFormatVariableReplacer :: None/CurrentScopeLifetime/OwnedByLifetimeScope :: [RegistrationPriority=3]
+
+## COLLECTION RESOLUTION ORDER
+IScriptWrapper: KubernetesContextScriptWrapper, ManifestReportScriptWrapper, ResourceStatusReportScriptWrapper, FunctionAppenderScriptWrapper, AwsScriptWrapper
+ICodeGenFunctions: PowerShellLanguage
+IKubernetesDiscoverer: AwsKubernetesDiscoverer, AzureKubernetesDiscoverer
+IFileFormatVariableReplacer: JsonFormatVariableReplacer, XmlFormatVariableReplacer, YamlFormatVariableReplacer, PropertiesFormatVariableReplacer
+ICommandWithArgs: HelmUpgradeCommand, KubernetesApplyRawYamlCommand, KubernetesDiscoveryCommand, KubernetesKustomizeCommand, KubernetesVerifyResourcesCommand, CleanCommand, CleanPackagesCommand, CommitToGitCommand, DeployPackageCommand, DownloadAndRegisterPackageCommand, DownloadPackageCommand, ExecuteManifestCommand, FindAndRegisterPackageCommand, FindPackageCommand, ImportCertificateCommand, RegisterPackageUseCommand, ReleasePackageLockCommand, RunScriptCommand, TransferPackageCommand, DeployJavaArchiveCommand, JavaLibraryCommand, UpdateArgoCDAppImagesCommand, UpdateArgoCDAppManifestsCommand, ApplyDeltaCommand, ApplyCloudFormationChangesetCommand, CreateAwsS3Command, DeleteCloudFormationCommand, DeployCloudFormationCommand, DeployEcsServiceCommand, HealthCheckCommand, UpdateEcsServiceCommand, UploadAwsS3Command
+
+## COMMANDS: metadata + injected concrete types
+apply-aws-cloudformation-changeset => ApplyCloudFormationChangesetCommand { log:ConsoleLog, packageFile:null, variables:CalamariVariables[KeyValuePair<String,String>], waitForComplete:False }
+apply-delta => ApplyDeltaCommand { basisFileName:null, commandLineRunner:CommandLineRunner, deltaFileName:null, fileHash:null, fileSystem:<PhysicalFileSystem>, log:ConsoleLog, newFileName:null, showProgress:False, skipVerification:False }
+aws-ecs-health-check => HealthCheckCommand { <log>P:ConsoleLog, <variables>P:CalamariVariables[KeyValuePair<String,String>] }
+clean => CleanCommand { days:0, fileSystem:<PhysicalFileSystem>, log:ConsoleLog, releases:0, retentionPolicySet:null, variables:CalamariVariables[KeyValuePair<String,String>] }
+clean-packages => CleanPackagesCommand { journal:PackageJournal }
+commit-to-git => CommitToGitCommand { commandLineRunner:CommandLineRunner, configFactory:CommitToGitConfigFactory, customPropertiesFile:null, customPropertiesPassword:null, deploymentJournalWriter:DeploymentJournalWriter, fileSystem:<PhysicalFileSystem>, gitVendorPullRequestClientResolver:GitVendorPullRequestClientResolver, log:ConsoleLog, nonSensitiveSubstituteInFiles:NonSensitiveSubstituteInFiles, pathToPackage:null, scriptEngine:ScriptEngine, scriptFileArg:null, scriptParametersArg:null, substituteInFiles:SubstituteInFiles, variables:CalamariVariables[KeyValuePair<String,String>] }
+create-aws-s3 => CreateAwsS3Command { <log>P:ConsoleLog, <variables>P:CalamariVariables[KeyValuePair<String,String>] }
+delete-aws-cloudformation => DeleteCloudFormationCommand { log:ConsoleLog, packageFile:null, variables:CalamariVariables[KeyValuePair<String,String>], waitForComplete:False }
+deploy-aws-cloudformation => DeployCloudFormationCommand { disableRollback:False, extractPackage:ExtractPackage, fileSystem:<PhysicalFileSystem>, log:ConsoleLog, pathToPackage:null, stackName:null, structuredConfigVariablesService:StructuredConfigVariablesService, templateFile:null, templateParameterFile:null, templateParameterS3Url:null, templateS3Url:null, variables:CalamariVariables[KeyValuePair<String,String>], waitForComplete:False }
+deploy-aws-ecs-service => DeployEcsServiceCommand { <ecsImageNameResolver>P:EcsImageNameResolver, <log>P:ConsoleLog, <stackNameGenerator>P:EcsStackNameGenerator, <variables>P:CalamariVariables[KeyValuePair<String,String>] }
+deploy-java-archive => DeployJavaArchiveCommand { archiveFile:null, commandLineRunner:CommandLineRunner, deploymentJournalWriter:DeploymentJournalWriter, extractPackage:ExtractPackage, fileSystem:<PhysicalFileSystem>, log:ConsoleLog, scriptEngine:ScriptEngine, structuredConfigVariablesService:StructuredConfigVariablesService, substituteInFiles:SubstituteInFiles, variables:CalamariVariables[KeyValuePair<String,String>] }
+deploy-package => DeployPackageCommand { commandLineRunner:CommandLineRunner, deploymentJournalWriter:DeploymentJournalWriter, extractPackage:ExtractPackage, fileSystem:<PhysicalFileSystem>, log:ConsoleLog, pathToPackage:null, scriptEngine:ScriptEngine, structuredConfigVariablesService:StructuredConfigVariablesService, substituteInFiles:SubstituteInFiles, variables:CalamariVariables[KeyValuePair<String,String>], windowsX509CertificateStore:NoOp<WindowsX509CertificateStore> }
+download-and-register-package => DownloadAndRegisterPackageCommand { downloadService:PackageDownloadService, journal:PackageJournal, log:ConsoleLog, options:PackageDownloadAndRegisterOptions }
+download-package => DownloadPackageCommand { downloadService:PackageDownloadService, log:ConsoleLog, options:PackageDownloadOptions }
+execute-manifest => ExecuteManifestCommand { commandLineRunner:CommandLineRunner, executionTools:Meta`2[][Meta<ILaunchTool,LaunchToolMeta>], fileSystem:<PhysicalFileSystem>, log:ConsoleLog, variables:CalamariVariables[KeyValuePair<String,String>] }
+find-and-register-package => FindAndRegisterPackageCommand { fileSystem:<PhysicalFileSystem>, findService:PackageFindService, journal:PackageJournal, log:ConsoleLog, options:PackageFindRegistrationOptions }
+find-package => FindPackageCommand { findService:PackageFindService, options:PackageFindOptions }
+helm-upgrade => HelmUpgradeCommand { commandLineRunner:CommandLineRunner, extractPackage:ExtractPackage, fileSystem:<PhysicalFileSystem>, kubectl:Kubectl, log:ConsoleLog, manifestReporter:ManifestReporter, namespaceResolver:KubernetesManifestNamespaceResolver, pathToPackage:null, scriptEngine:ScriptEngine, statusExecutor:ResourceStatusReportExecutor, substituteInFiles:SubstituteInFiles, templateValueSourcesParser:HelmTemplateValueSourcesParser, variables:CalamariVariables[KeyValuePair<String,String>] }
+import-certificate => ImportCertificateCommand { log:ConsoleLog, variables:CalamariVariables[KeyValuePair<String,String>], windowsX509CertificateStore:NoOp<WindowsX509CertificateStore> }
+java-library => JavaLibraryCommand { actionType:null, commandLineRunner:CommandLineRunner, fileSystem:<PhysicalFileSystem>, log:ConsoleLog, scriptEngine:ScriptEngine, variables:CalamariVariables[KeyValuePair<String,String>] }
+kubernetes-apply-raw-yaml => KubernetesApplyRawYamlCommand { kubernetesApplyExecutor:GatherAndApplyRawYamlExecutor, statusReporter:ResourceStatusReportExecutor, variables:CalamariVariables[KeyValuePair<String,String>] }
+kubernetes-kustomize => KubernetesKustomizeCommand { kubernetesApplyExecutor:KustomizeExecutor, log:ConsoleLog, statusReporter:ResourceStatusReportExecutor, variables:CalamariVariables[KeyValuePair<String,String>] }
+kubernetes-target-discovery => KubernetesDiscoveryCommand { discovererFactory:KubernetesDiscovererFactory, log:ConsoleLog, variables:CalamariVariables[KeyValuePair<String,String>] }
+kubernetes-verify-resources => KubernetesVerifyResourcesCommand { commandLineRunner:CommandLineRunner, fileSystem:<PhysicalFileSystem>, kubectl:Kubectl, log:ConsoleLog, statusReporter:ResourceStatusReportExecutor, variables:CalamariVariables[KeyValuePair<String,String>] }
+register-package => RegisterPackageUseCommand { fileSystem:<PhysicalFileSystem>, journal:PackageJournal, log:ConsoleLog, packageId:null, packagePath:null, packageVersion:null, rawVersionString:null, taskId:null, versionFormat:Semver }
+release-package-lock => ReleasePackageLockCommand { defaultTimeBeforeLockExpiration:TimeSpan, journal:PackageJournal, log:ConsoleLog, taskId:null, variables:CalamariVariables[KeyValuePair<String,String>] }
+run-script => RunScriptCommand { commandLineRunner:CommandLineRunner, deploymentJournalWriter:DeploymentJournalWriter, fileSystem:<PhysicalFileSystem>, log:ConsoleLog, packageFile:null, scriptEngine:ScriptEngine, scriptFileArg:null, scriptParametersArg:null, structuredConfigVariablesService:StructuredConfigVariablesService, substituteInFiles:SubstituteInFiles, variables:CalamariVariables[KeyValuePair<String,String>] }
+transfer-package => TransferPackageCommand { deploymentJournalWriter:DeploymentJournalWriter, fileSystem:<PhysicalFileSystem>, log:ConsoleLog, variables:CalamariVariables[KeyValuePair<String,String>] }
+update-argo-cd-app-images => UpdateArgoCDAppImagesCommand { configFactory:DeploymentConfigFactory, customPropertiesFile:null, customPropertiesPassword:null, fileSystem:<PhysicalFileSystem>, gitVendorPullRequestClientResolver:GitVendorPullRequestClientResolver, log:ConsoleLog, variables:CalamariVariables[KeyValuePair<String,String>] }
+update-argo-cd-app-manifests => UpdateArgoCDAppManifestsCommand { argoCDManifestsFileMatcher:ArgoCDManifestsFileMatcher, configFactory:DeploymentConfigFactory, customPropertiesFile:null, customPropertiesPassword:null, extractPackage:ExtractPackage, fileSystem:<PhysicalFileSystem>, gitVendorPullRequestClientResolver:GitVendorPullRequestClientResolver, log:ConsoleLog, nonSensitiveVariables:NonSensitiveCalamariVariables[KeyValuePair<String,String>], pathToPackage:null, substituteInFiles:NonSensitiveSubstituteInFiles, variables:CalamariVariables[KeyValuePair<String,String>] }
+update-aws-ecs-service => UpdateEcsServiceCommand { log:ConsoleLog, variables:CalamariVariables[KeyValuePair<String,String>] }
+upload-aws-s3 => UploadAwsS3Command { bucket:null, extractPackage:ExtractPackage, fileSystem:<PhysicalFileSystem>, log:ConsoleLog, pathToPackage:null, s3OutputVariablesStrategy:AllFiles, structuredConfigVariablesService:StructuredConfigVariablesService, substituteInFiles:SubstituteInFiles, targetMode:null, variables:CalamariVariables[KeyValuePair<String,String>] }
+
+## PIPELINE COMMANDS (named registrations)
+aws-ecs-cluster-target-discovery
+run-claude-code

--- a/source/Calamari.Tests/Fixtures/Util/ContainerSnapshotFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Util/ContainerSnapshotFixture.cs
@@ -1,0 +1,239 @@
+#nullable enable
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Autofac;
+using Autofac.Core;
+using Autofac.Features.Metadata;
+using Calamari.Commands;
+using Calamari.Commands.Support;
+using Calamari.Common.Plumbing.Pipeline;
+using Calamari.Testing;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Fixtures.Util
+{
+    /// <summary>
+    /// Compares a rendering of the whole production container against an approved snapshot.
+    ///
+    /// Targeted assertions only catch what someone thought to assert. This catches anything
+    /// observable that moves — a registration appearing or vanishing, a lifetime changing, a
+    /// different implementation being injected — which is what makes it useful across a
+    /// dependency upgrade, where you cannot predict in advance what will shift.
+    ///
+    /// To re-approve after an intended change, run with CALAMARI_APPROVE_CONTAINER_SNAPSHOT=1
+    /// and review the resulting diff.
+    /// </summary>
+    [TestFixture]
+    public class ContainerSnapshotFixture
+    {
+        // Deliberately not named *.approved.* — .gitattributes marks that pattern binary,
+        // which would hide the diff this test exists to surface in review.
+        const string ExpectedFileName = "ContainerSnapshot.expected.txt";
+        const string ApprovalEnvironmentVariable = "CALAMARI_APPROVE_CONTAINER_SNAPSHOT";
+
+        /// <summary>
+        /// Implementations chosen by the host OS rather than by the container. Collapsed to a
+        /// placeholder so one approved file serves every platform the tests run on.
+        /// </summary>
+        static readonly (string Concrete, string Placeholder)[] PlatformSpecificTypes =
+        {
+            ("NixCalamariPhysicalFileSystem", "<PhysicalFileSystem>"),
+            ("WindowsPhysicalFileSystem", "<PhysicalFileSystem>"),
+            ("KubernetesFileSystem", "<PhysicalFileSystem>"),
+            ("WindowsX509CertificateStore", "<WindowsX509CertificateStore>"),
+            ("NoOpWindowsX509CertificateStore", "<WindowsX509CertificateStore>")
+        };
+
+        [Test]
+        [Category("PlatformAgnostic")]
+        public void ContainerMatchesApprovedSnapshot()
+        {
+            var actual = Normalise(CaptureSnapshot());
+
+            if (Environment.GetEnvironmentVariable(ApprovalEnvironmentVariable) == "1")
+            {
+                File.WriteAllText(ExpectedFileSourcePath(), actual);
+                Assert.Inconclusive($"Snapshot re-approved. Review the diff in {ExpectedFileName} before committing.");
+            }
+
+            var expected = ReadExpected();
+
+            if (actual == expected)
+                return;
+
+            var actualPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "ContainerSnapshot.actual.txt");
+            File.WriteAllText(actualPath, actual);
+
+            actual.Should()
+                  .Be(expected,
+                      $"the container should match {ExpectedFileName}. Actual written to {actualPath}. "
+                      + $"If the change is intended, re-run with {ApprovalEnvironmentVariable}=1 and review the diff.");
+        }
+
+        static string CaptureSnapshot()
+        {
+            var sb = new StringBuilder();
+            using var container = TestableSyncProgram.For<Calamari.Program>().BuildTestContainer();
+
+            sb.AppendLine("## AUTOFAC");
+            sb.AppendLine(typeof(ContainerBuilder).Assembly.GetName().Version!.ToString());
+            sb.AppendLine();
+
+            sb.AppendLine("## REGISTRATIONS");
+            foreach (var line in container.ComponentRegistry.Registrations.Select(DescribeRegistration).OrderBy(l => l, StringComparer.Ordinal))
+                sb.AppendLine(line);
+            sb.AppendLine();
+
+            sb.AppendLine("## COLLECTION RESOLUTION ORDER");
+            DumpCollection<Calamari.Common.Features.Scripting.IScriptWrapper>(container, sb);
+            DumpCollection<Calamari.Common.Features.FunctionScriptContributions.ICodeGenFunctions>(container, sb);
+            DumpCollection<Calamari.Common.Features.Discovery.IKubernetesDiscoverer>(container, sb);
+            DumpCollection<Calamari.Common.Features.StructuredVariables.IFileFormatVariableReplacer>(container, sb);
+            DumpCollection<ICommandWithArgs>(container, sb);
+            sb.AppendLine();
+
+            sb.AppendLine("## COMMANDS: metadata + injected concrete types");
+            var commands = container.Resolve<IEnumerable<Meta<Lazy<ICommandWithArgs>, CommandMeta>>>()
+                                    .OrderBy(c => c.Metadata.Name, StringComparer.Ordinal);
+            foreach (var command in commands)
+            {
+                string line;
+                try
+                {
+                    var instance = command.Value.Value;
+                    line = $"{command.Metadata.Name} => {Name(instance.GetType())} {{ {DescribeFields(instance)} }}";
+                }
+                catch (Exception ex)
+                {
+                    line = $"{command.Metadata.Name} => THREW {ex.GetType().Name}";
+                }
+
+                sb.AppendLine(line);
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("## PIPELINE COMMANDS (named registrations)");
+            foreach (var name in container.ComponentRegistry.Registrations
+                                          .SelectMany(r => r.Services)
+                                          .OfType<KeyedService>()
+                                          .Where(k => k.ServiceType == typeof(PipelineCommand))
+                                          .Select(k => k.ServiceKey.ToString())
+                                          .OrderBy(n => n, StringComparer.Ordinal))
+                sb.AppendLine(name);
+
+            return sb.ToString();
+        }
+
+        static string DescribeRegistration(IComponentRegistration registration)
+        {
+            var services = string.Join("+", registration.Services.Select(s => s.Description).OrderBy(s => s, StringComparer.Ordinal));
+
+            // __RegistrationOrder is an Autofac-internal tick counter and differs on every run.
+            var metadata = string.Join(",",
+                                       registration.Metadata
+                                                   .Where(kv => kv.Key != "__RegistrationOrder")
+                                                   .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                                                   .Select(kv => $"{kv.Key}={Describe(kv.Value)}"));
+
+            return $"{Name(registration.Activator.LimitType)} :: {services} :: "
+                   + $"{registration.Sharing}/{registration.Lifetime.GetType().Name}/{registration.Ownership} :: [{metadata}]";
+        }
+
+        static void DumpCollection<T>(IComponentContext container, StringBuilder sb)
+        {
+            try
+            {
+                var items = container.Resolve<IEnumerable<T>>().Select(x => Name(x!.GetType()));
+                sb.AppendLine($"{typeof(T).Name}: {string.Join(", ", items)}");
+            }
+            catch (Exception ex)
+            {
+                sb.AppendLine($"{typeof(T).Name}: THREW {ex.GetType().Name}");
+            }
+        }
+
+        static string DescribeFields(object instance)
+        {
+            var fields = instance.GetType()
+                                 .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                                 .Where(f => !f.IsLiteral)
+                                 .OrderBy(f => f.Name, StringComparer.Ordinal);
+
+            var parts = new List<string>();
+            foreach (var field in fields)
+            {
+                object? value;
+                try
+                {
+                    value = field.GetValue(instance);
+                }
+                catch
+                {
+                    value = "<unreadable>";
+                }
+
+                parts.Add($"{field.Name}:{Describe(value)}");
+            }
+
+            return string.Join(", ", parts);
+        }
+
+        static string Describe(object? value)
+        {
+            switch (value)
+            {
+                case null:
+                    return "null";
+                case string s:
+                    return s;
+                case Enum e:
+                    return e.ToString();
+            }
+
+            if (value is IEnumerable enumerable)
+            {
+                // Distinct element types only. Element counts vary with the ambient environment
+                // (IVariables carries environment variables) and would swamp the diff.
+                var elementTypes = enumerable.Cast<object?>()
+                                             .Select(x => x is null ? "null" : Name(x.GetType()))
+                                             .Distinct()
+                                             .OrderBy(n => n, StringComparer.Ordinal);
+                return $"{Name(value.GetType())}[{string.Join("|", elementTypes)}]";
+            }
+
+            return value.GetType().IsPrimitive ? value.ToString()! : Name(value.GetType());
+        }
+
+        static string Name(Type type)
+            => type.IsGenericType
+                ? $"{type.Name.Split('`')[0]}<{string.Join(",", type.GetGenericArguments().Select(Name))}>"
+                : type.Name;
+
+        static string Normalise(string snapshot)
+            => PlatformSpecificTypes.Aggregate(snapshot.Replace("\r\n", "\n"),
+                                               (current, mapping) => current.Replace(mapping.Concrete, mapping.Placeholder));
+
+        static string ReadExpected()
+        {
+            var assembly = typeof(ContainerSnapshotFixture).Assembly;
+            var resourceName = assembly.GetManifestResourceNames()
+                                       .SingleOrDefault(n => n.EndsWith(ExpectedFileName, StringComparison.Ordinal));
+
+            resourceName.Should().NotBeNull($"{ExpectedFileName} should be embedded in {assembly.GetName().Name}");
+
+            using var stream = assembly.GetManifestResourceStream(resourceName!)!;
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd().Replace("\r\n", "\n");
+        }
+
+        static string ExpectedFileSourcePath([CallerFilePath] string callerFilePath = "")
+            => Path.Combine(Path.GetDirectoryName(callerFilePath)!, ExpectedFileName);
+    }
+}


### PR DESCRIPTION
Adds two DI guards to `Calamari.Tests`. No production code changes.

## Why

Script wrappers form an execution chain; file-format replacers are tried in sequence. A reordering changes deployment behaviour, but every wrapper still constructs and every command still resolves — so the existing suite stays green. Nothing currently detects it.

## What

**`ContainerOrderingFixture`** — asserts the orderings directly. The load-bearing test is `ScriptWrapperPrioritiesAreUnique`: `ScriptEngine` sorts with `OrderByDescending`, which is stable, so two wrappers sharing a priority silently hand the tie-break to the container's collection ordering.

Priorities are distinct today (1003/1002/1001/1000/100) — but `AwsScriptWrapper`, `AzureContextScriptWrapper`, `GoogleCloudContextScriptWrapper` and `AzureServiceFabricPowerShellContext` all sit on `CloudAuthenticationPriority` in their separate flavours. A second cloud wrapper in any one flavour would make that chain container-dependent. Asserting the invariant is a better guard than pinning a sequence.

The rest pin the wrapper chain for a Kubernetes/AWS/PowerShell step, the file-format replacer order, and discoverer key uniqueness.

**`ContainerSnapshotFixture`** — compares a rendering of the whole container against `ContainerSnapshot.expected.txt`: registrations, lifetimes, collection order, and the concrete types injected into every command. Targeted assertions only catch what someone thought of; this catches anything observable that moves. Re-approve with `CALAMARI_APPROVE_CONTAINER_SNAPSHOT=1`.

Both are `PlatformAgnostic`. The snapshot is normalised so one file serves every platform — OS-chosen filesystem and certificate-store implementations collapse to placeholders, Autofac's `__RegistrationOrder` tick counter is dropped, collection fields render distinct element types rather than counts.

The expected file is deliberately **not** named `*.approved.*` — `.gitattributes` marks that pattern `binary -text` (protecting ~207 existing approved files from line-ending normalisation), which would hide the diff this test exists to surface.

## Rebased onto main — what that showed

Originally baselined at Autofac 4.8.0 so the upgrade would land as a reviewed diff. **That upgrade has since merged via #2131**, so this is now baselined at **9.3.1** to match main.

Rebasing across it reproduced exactly the predicted diff and nothing else — the recorded version line plus five `RegisterInstance` registrations gaining `AutoActivate`, with all five ordering tests still passing:

```
2c2
< 4.8.0.0
---
> 9.3.1.0
27,28c27,28 · 34c34 · 99c99 · 140c140
- CommonOptions ×2, ConsoleLog, <PhysicalFileSystem>, SystemSemaphoreManager
+ ... :: AutoActivate+... :: ... :: [__AutoActivated=True]
```

Those five are inert: none of the instances is `IDisposable`, and the codebase has no `OnActivating`/`OnActivated` handlers. Autofac 9 simply attaches already-constructed instances at container-build time rather than at first resolve.

The rebase crossed **eight commits of main** — Octostache 3.9.3 and the new date filters, the unconditional docker credential helper, a new feature toggle, removal of the net462 reference assemblies. **Nothing outside those six lines moved.** For a golden file that's the evidence that matters: it is stable enough not to cry wolf.

## Verification

14 tests green locally (these 6, plus `CommandResolutionTests` and `PrioritisedRegistrationFixture`).

The golden was captured on macOS. The normalisation should make it OS-invariant, but CI running it on Windows is the actual proof — if the platform mapping missed something it surfaces there as a clear diff rather than a mystery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)