### PR TITLE
Honour a feature toggle to ignore AzureWebApp PreservePaths

### DIFF
--- a/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
+++ b/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
@@ -13,7 +13,9 @@ using Azure.ResourceManager.Resources;
 using Calamari.Azure;
 using Calamari.Azure.AppServices;
 using Calamari.CloudAccounts;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing;
 using Calamari.Testing.Azure;
 using Calamari.Testing.Helpers;
@@ -324,6 +326,47 @@ namespace Calamari.AzureWebApp.Tests
             await AssertContent(webSiteResource.Data.DefaultHostName, actualText, "newfile.html");
 
             var response = await client.GetAsync($"https://{webSiteResource.Data.DefaultHostName}/NotKeep", cancellationToken);
+            response.IsSuccessStatusCode.Should().BeFalse();
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+
+        [Test]
+        public async Task Deploy_WebApp_Ignore_Preserve_Paths_Flag_Overrides_Preserve_Paths()
+        {
+            using var tempPath = TemporaryDirectory.Create();
+            const string actualText = "Hello World";
+
+            Directory.CreateDirectory(Path.Combine(tempPath.DirectoryPath, "Keep"));
+            File.WriteAllText(Path.Combine(tempPath.DirectoryPath, "Keep", "index.html"), actualText);
+
+            await CommandTestBuilder.CreateAsync<DeployAzureWebCommand, Program>()
+                                    .WithArrange(context =>
+                                                 {
+                                                     AddDefaults(context);
+
+                                                     context.WithFilesToCopy(tempPath.DirectoryPath);
+                                                 })
+                                    .Execute();
+
+            using var tempPath2 = TemporaryDirectory.Create();
+
+            File.WriteAllText(Path.Combine(tempPath2.DirectoryPath, "newfile.html"), actualText);
+
+            await CommandTestBuilder.CreateAsync<DeployAzureWebCommand, Program>()
+                                    .WithArrange(context =>
+                                                 {
+                                                     AddDefaults(context);
+                                                     context.Variables.Add(SpecialVariables.Action.Azure.RemoveAdditionalFiles, bool.TrueString);
+                                                     context.Variables.Add(SpecialVariables.Action.Azure.PreservePaths, @"\\Keep;\\Keep\\index.html");
+                                                     context.Variables.Add(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.AzureWebAppIgnorePreservePathsFeatureToggle);
+
+                                                     context.WithFilesToCopy(tempPath2.DirectoryPath);
+                                                 })
+                                    .Execute();
+
+            await AssertContent(webSiteResource.Data.DefaultHostName, actualText, "newfile.html");
+
+            var response = await client.GetAsync($"https://{webSiteResource.Data.DefaultHostName}/Keep", cancellationToken);
             response.IsSuccessStatusCode.Should().BeFalse();
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }

--- a/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
+++ b/source/Calamari.AzureWebApp.Tests/DeployAzureWebCommandFixture.cs
@@ -13,9 +13,7 @@ using Azure.ResourceManager.Resources;
 using Calamari.Azure;
 using Calamari.Azure.AppServices;
 using Calamari.CloudAccounts;
-using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.FileSystem;
-using Calamari.Common.Plumbing.Variables;
 using Calamari.Testing;
 using Calamari.Testing.Azure;
 using Calamari.Testing.Helpers;
@@ -326,47 +324,6 @@ namespace Calamari.AzureWebApp.Tests
             await AssertContent(webSiteResource.Data.DefaultHostName, actualText, "newfile.html");
 
             var response = await client.GetAsync($"https://{webSiteResource.Data.DefaultHostName}/NotKeep", cancellationToken);
-            response.IsSuccessStatusCode.Should().BeFalse();
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        }
-
-        [Test]
-        public async Task Deploy_WebApp_Ignore_Preserve_Paths_Flag_Overrides_Preserve_Paths()
-        {
-            using var tempPath = TemporaryDirectory.Create();
-            const string actualText = "Hello World";
-
-            Directory.CreateDirectory(Path.Combine(tempPath.DirectoryPath, "Keep"));
-            File.WriteAllText(Path.Combine(tempPath.DirectoryPath, "Keep", "index.html"), actualText);
-
-            await CommandTestBuilder.CreateAsync<DeployAzureWebCommand, Program>()
-                                    .WithArrange(context =>
-                                                 {
-                                                     AddDefaults(context);
-
-                                                     context.WithFilesToCopy(tempPath.DirectoryPath);
-                                                 })
-                                    .Execute();
-
-            using var tempPath2 = TemporaryDirectory.Create();
-
-            File.WriteAllText(Path.Combine(tempPath2.DirectoryPath, "newfile.html"), actualText);
-
-            await CommandTestBuilder.CreateAsync<DeployAzureWebCommand, Program>()
-                                    .WithArrange(context =>
-                                                 {
-                                                     AddDefaults(context);
-                                                     context.Variables.Add(SpecialVariables.Action.Azure.RemoveAdditionalFiles, bool.TrueString);
-                                                     context.Variables.Add(SpecialVariables.Action.Azure.PreservePaths, @"\\Keep;\\Keep\\index.html");
-                                                     context.Variables.Add(KnownVariables.EnabledFeatureToggles, OctopusFeatureToggles.KnownSlugs.AzureWebAppIgnorePreservePathsFeatureToggle);
-
-                                                     context.WithFilesToCopy(tempPath2.DirectoryPath);
-                                                 })
-                                    .Execute();
-
-            await AssertContent(webSiteResource.Data.DefaultHostName, actualText, "newfile.html");
-
-            var response = await client.GetAsync($"https://{webSiteResource.Data.DefaultHostName}/Keep", cancellationToken);
             response.IsSuccessStatusCode.Should().BeFalse();
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }

--- a/source/Calamari.AzureWebApp/NetCoreWebDeploymentExecutor.cs
+++ b/source/Calamari.AzureWebApp/NetCoreWebDeploymentExecutor.cs
@@ -7,6 +7,7 @@ using Calamari.Azure.AppServices;
 using Calamari.AzureWebApp.Integration.Websites.Publishing;
 using Calamari.AzureWebApp.Util;
 using Calamari.Common.Commands;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
@@ -224,10 +225,13 @@ namespace Calamari.AzureWebApp
                 args.Add("--useAppOffline");
             }
 
-            var preservePaths = variables.GetStrings(SpecialVariables.Action.Azure.PreservePaths, ';');
-            if (preservePaths.Count > 0)
+            if (!OctopusFeatureToggles.AzureWebAppIgnorePreservePathsFeatureToggle.IsEnabled(variables))
             {
-                args.Add($"--preservePaths={string.Join("|",preservePaths.Select(s => $"\"{s}\""))}");
+                var preservePaths = variables.GetStrings(SpecialVariables.Action.Azure.PreservePaths, ';');
+                if (preservePaths.Count > 0)
+                {
+                    args.Add($"--preservePaths={string.Join("|",preservePaths.Select(s => $"\"{s}\""))}");
+                }
             }
 
             // ReSharper disable once InvertIf

--- a/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
@@ -11,6 +11,7 @@ namespace Calamari.Common.FeatureToggles
             public const string UseDockerCredentialHelper = "calamari-use-docker-credential-helper";
             public const string GitDependenciesForScriptsFeatureToggle = "git-dependencies-for-scripts";
             public const string EnableLegacyKubernetesResourceChecks = "enable-legacy-kubernetes-resource-checks";
+            public const string AzureWebAppIgnorePreservePathsFeatureToggle = "azure-web-app-ignore-preserve-paths";
         };
 
         public static readonly OctopusFeatureToggle KustomizePatchImageUpdatesFeatureToggle = new(KnownSlugs.KustomizePatchImageUpdatesFeatureToggle);
@@ -18,6 +19,7 @@ namespace Calamari.Common.FeatureToggles
         public static readonly OctopusFeatureToggle UseDockerCredentialHelperFeatureToggle = new(KnownSlugs.UseDockerCredentialHelper);
         public static readonly OctopusFeatureToggle GitDependenciesForScriptsFeatureToggle = new(KnownSlugs.GitDependenciesForScriptsFeatureToggle);
         public static readonly OctopusFeatureToggle EnableLegacyKubernetesResourceChecksFeatureToggle = new(KnownSlugs.EnableLegacyKubernetesResourceChecks);
+        public static readonly OctopusFeatureToggle AzureWebAppIgnorePreservePathsFeatureToggle = new(KnownSlugs.AzureWebAppIgnorePreservePathsFeatureToggle);
 
         public class OctopusFeatureToggle
         {


### PR DESCRIPTION
Adds AzureWebAppIgnorePreservePathsFeatureToggle to the OctopusFeatureToggles known slugs, and guards the `--preservePaths` MSDeploy shim argument with it in NetCoreWebDeploymentExecutor. Lets Octopus Server remotely suppress the undocumented Octopus.Action.Azure.PreservePaths variable to help gauge how many customers rely on it.