### PR TITLE
Honour a feature toggle to ignore AzureWebApp UseChecksum

### DIFF
--- a/source/Calamari.AzureWebApp/NetCoreWebDeploymentExecutor.cs
+++ b/source/Calamari.AzureWebApp/NetCoreWebDeploymentExecutor.cs
@@ -37,6 +37,13 @@ namespace Calamari.AzureWebApp
                 throw new CommandException("Cannot execute on non-Windows operating systems as there is a required dependency on the Web Deploy tooling (msdeploy.exe).");
             }
 
+            if (variables.GetFlag(SpecialVariables.Action.Azure.UseChecksum))
+            {
+                log.Warn("The `Use checksum to compare files` option is deprecated and will be removed in a future release.\r\n" +
+                         "Checksum-based comparison has no equivalent in the modern Azure deployment APIs; deployments will fall back to timestamp-based comparison.\r\n" +
+                         $"Remove the `{SpecialVariables.Action.Azure.UseChecksum}` variable from this step, or migrate to the `Deploy an Azure App Service` step.");
+            }
+
             var netCoreShimExeFolder = GetNetCoreShimExeFolder();
             var netCoreShimExePath = Path.Combine(netCoreShimExeFolder, ToolName);
 

--- a/source/Calamari.AzureWebApp/NetCoreWebDeploymentExecutor.cs
+++ b/source/Calamari.AzureWebApp/NetCoreWebDeploymentExecutor.cs
@@ -209,7 +209,7 @@ namespace Calamari.AzureWebApp
         {
             var args = new List<string>();
 
-            if (variables.GetFlag(SpecialVariables.Action.Azure.UseChecksum))
+            if (!OctopusFeatureToggles.AzureWebAppIgnoreChecksumFeatureToggle.IsEnabled(variables) && variables.GetFlag(SpecialVariables.Action.Azure.UseChecksum))
             {
                 args.Add("--useChecksum");
             }

--- a/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
@@ -12,6 +12,7 @@ namespace Calamari.Common.FeatureToggles
             public const string GitDependenciesForScriptsFeatureToggle = "git-dependencies-for-scripts";
             public const string EnableLegacyKubernetesResourceChecks = "enable-legacy-kubernetes-resource-checks";
             public const string AzureWebAppIgnorePreservePathsFeatureToggle = "azure-web-app-ignore-preserve-paths";
+            public const string AzureWebAppIgnoreChecksumFeatureToggle = "azure-web-app-ignore-checksum";
         };
 
         public static readonly OctopusFeatureToggle KustomizePatchImageUpdatesFeatureToggle = new(KnownSlugs.KustomizePatchImageUpdatesFeatureToggle);
@@ -20,6 +21,7 @@ namespace Calamari.Common.FeatureToggles
         public static readonly OctopusFeatureToggle GitDependenciesForScriptsFeatureToggle = new(KnownSlugs.GitDependenciesForScriptsFeatureToggle);
         public static readonly OctopusFeatureToggle EnableLegacyKubernetesResourceChecksFeatureToggle = new(KnownSlugs.EnableLegacyKubernetesResourceChecks);
         public static readonly OctopusFeatureToggle AzureWebAppIgnorePreservePathsFeatureToggle = new(KnownSlugs.AzureWebAppIgnorePreservePathsFeatureToggle);
+        public static readonly OctopusFeatureToggle AzureWebAppIgnoreChecksumFeatureToggle = new(KnownSlugs.AzureWebAppIgnoreChecksumFeatureToggle);
 
         public class OctopusFeatureToggle
         {


### PR DESCRIPTION
Adds `AzureWebAppIgnoreChecksumFeatureToggle` to the known slugs. Guards the `--useChecksum` MSDeploy shim argument with it in `NetCoreWebDeploymentExecutor`. Mirrors the existing `AzureWebAppIgnorePreservePathsFeatureToggle` pattern (#2121).

Also logs a deployment-time warning whenever `UseChecksum` is set, regardless of the toggle. Checksum-based sync has no equivalent in the modern Azure deployment APIs. Customers should see this warning before we remove the option.

Companion Server change: OctopusDeploy/OctopusDeploy#46123