### PR TITLE
Support AddHours and AddDays date filters in file substitution

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Octopus.Versioning" Version="5.1.884" />
         <PackageReference Include="Octopus.TinyTypes" Version="2.2.1156" />
         <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
-        <PackageReference Include="Octostache" Version="3.9.2" />
+        <PackageReference Include="Octostache" Version="3.9.3" />
         <PackageReference Include="Polly" Version="8.3.1" />
         <PackageReference Include="SharpCompress" Version="0.49.1" />
         <PackageReference Include="XPath2" Version="1.1.5" />

--- a/source/Calamari.Shared/Calamari.Shared.csproj
+++ b/source/Calamari.Shared/Calamari.Shared.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Octopus.Octodiff" Version="2.0.547" />
     <PackageReference Include="Octopus.Versioning" Version="5.1.884" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.449" />
-    <PackageReference Include="Octostache" Version="3.9.2" />
+    <PackageReference Include="Octostache" Version="3.9.3" />
     <PackageReference Include="SharpCompress" Version="0.49.1" />
     <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />

--- a/source/Calamari.Tests/Fixtures/Substitutions/Approved/SubstitutionsFixture.ShouldApplyFiltersDuringSubstitution.approved.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Approved/SubstitutionsFixture.ShouldApplyFiltersDuringSubstitution.approved.txt
@@ -13,3 +13,7 @@ PropertiesKeyEscape: \=\:'"\\\r\n\t\ <>\uffe6
 PropertiesValueEscape: =:'"\\\r\n\t <>\uffe6
 UriEscape: =:'%22%5C%0D%0A%09%20%3C%3E%EF%BF%A6
 UriDataEscape: %3D%3A%27%22%5C%0D%0A%09%20%3C%3E%EF%BF%A6
+AddHours: 2030-05-22T11:05:00.0000000
+AddHoursNegative: 2030-05-22T07:05:00.0000000
+AddDays: 2030-05-23T09:05:00.0000000
+AddHoursFormatted: 2030-05-22 11:05:00

--- a/source/Calamari.Tests/Fixtures/Substitutions/Samples/Filters.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Samples/Filters.txt
@@ -8,3 +8,7 @@ PropertiesKeyEscape: #{var | PropertiesKeyEscape}
 PropertiesValueEscape: #{var | PropertiesValueEscape}
 UriEscape: #{var | UriEscape}
 UriDataEscape: #{var | UriDataEscape}
+AddHours: #{dateVar | AddHours 2}
+AddHoursNegative: #{dateVar | AddHours -2}
+AddDays: #{dateVar | AddDays 1}
+AddHoursFormatted: #{dateVar | AddHours 2 | Format "yyyy-MM-dd HH:mm:ss"}

--- a/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
@@ -48,7 +48,8 @@ namespace Calamari.Tests.Fixtures.Substitutions
         {
             var variables = new CalamariVariables
             {
-                ["var"] = "=:'\"\\\r\n\t <>\uFFE6"
+                ["var"] = "=:'\"\\\r\n\t <>\uFFE6",
+                ["dateVar"] = "2030-05-22 09:05:00"
             };
 
             var textAfterReplacement = PerformTest(GetFixtureResource("Samples", "Filters.txt"), variables).text;


### PR DESCRIPTION
## Why

Calamari performs variable substitution in files at deploy time using **its own pinned copy of Octostache**, independent of the server's. The new `AddHours`/`AddDays` filters (OctopusDeploy/Octostache#124) therefore won't work inside substituted config files until Calamari's pin moves, even after Octopus Server ships them.

That split is the failure mode worth avoiding: a filter that resolves in a project variable but silently echoes unreplaced inside a `web.config` is unpleasant to diagnose. Found by tracing how previous filters (`NowDateUtc`, `PropertiesKeyEscape`, `YamlSingleQuoteEscape`) landed across the org — Calamari was the one consumer we'd missed.

## What

Adds four cases to the existing `ShouldApplyFiltersDuringSubstitution` approval test, using a new fixed `dateVar` so the output stays deterministic (no `NowDate`):

```
AddHours: #{dateVar | AddHours 2}
AddHoursNegative: #{dateVar | AddHours -2}
AddDays: #{dateVar | AddDays 1}
AddHoursFormatted: #{dateVar | AddHours 2 | Format "yyyy-MM-dd HH:mm:ss"}
```

Approved values were verified by running the expressions against the Octostache branch, not hand-written:

| Expression | Output |
|---|---|
| `#{dateVar \| AddHours 2}` | `2030-05-22T11:05:00.0000000` |
| `#{dateVar \| AddHours -2}` | `2030-05-22T07:05:00.0000000` |
| `#{dateVar \| AddDays 1}` | `2030-05-23T09:05:00.0000000` |
| `#{dateVar \| AddHours 2 \| Format "yyyy-MM-dd HH:mm:ss"}` | `2030-05-22 11:05:00` |

The existing escaping-filter rows are untouched.

## To finish this PR

- [ ] OctopusDeploy/Octostache#124 approved and merged
- [ ] Octostache package published
- [ ] Bump `Octostache` from `3.9.2` to the new version in:
  - `source/Calamari.Shared/Calamari.Shared.csproj:38`
  - `source/Calamari.Common/Calamari.Common.csproj:30`
- [ ] Confirm this approval test goes green, then mark ready for review

The same bump is needed in OctopusDeploy/OctopusDeploy (`Octopus.Variables`, `Sashimi.Server.Contracts`, `Octopus.Core`), tracked on OctopusDeploy/OctopusDeploy#46148.


🤖 Generated with [Claude Code](https://claude.com/claude-code)