### PR TITLE
WIP: Support AddTimeSpan in file substitution

### DIFF
--- a/source/Calamari.Tests/Fixtures/Substitutions/Approved/SubstitutionsFixture.ShouldApplyFiltersDuringSubstitution.approved.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Approved/SubstitutionsFixture.ShouldApplyFiltersDuringSubstitution.approved.txt
@@ -13,3 +13,9 @@ PropertiesKeyEscape: \=\:'"\\\r\n\t\ <>\uffe6
 PropertiesValueEscape: =:'"\\\r\n\t <>\uffe6
 UriEscape: =:'%22%5C%0D%0A%09%20%3C%3E%EF%BF%A6
 UriDataEscape: %3D%3A%27%22%5C%0D%0A%09%20%3C%3E%EF%BF%A6
+AddTimeSpanHours: 2030-05-22T11:05:00.0000000
+AddTimeSpanNegative: 2030-05-22T07:05:00.0000000
+AddTimeSpanDays: 2030-05-24T09:05:00.0000000
+AddTimeSpanTwoAndAHalfDays: 2030-05-24T21:05:00.0000000
+AddTimeSpanLeadingFieldIsDaysOver23: 2030-07-09T09:05:00.0000000
+AddTimeSpanFormatted: 2030-05-22 11:05:00

--- a/source/Calamari.Tests/Fixtures/Substitutions/Samples/Filters.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Samples/Filters.txt
@@ -8,3 +8,9 @@ PropertiesKeyEscape: #{var | PropertiesKeyEscape}
 PropertiesValueEscape: #{var | PropertiesValueEscape}
 UriEscape: #{var | UriEscape}
 UriDataEscape: #{var | UriDataEscape}
+AddTimeSpanHours: #{dateVar | AddTimeSpan 02:00:00}
+AddTimeSpanNegative: #{dateVar | AddTimeSpan -02:00:00}
+AddTimeSpanDays: #{dateVar | AddTimeSpan "2.00:00:00"}
+AddTimeSpanTwoAndAHalfDays: #{dateVar | AddTimeSpan "2.12:00:00"}
+AddTimeSpanLeadingFieldIsDaysOver23: #{dateVar | AddTimeSpan 48:00:00}
+AddTimeSpanFormatted: #{dateVar | AddTimeSpan 02:00:00 | Format "yyyy-MM-dd HH:mm:ss"}

--- a/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
@@ -48,7 +48,8 @@ namespace Calamari.Tests.Fixtures.Substitutions
         {
             var variables = new CalamariVariables
             {
-                ["var"] = "=:'\"\\\r\n\t <>\uFFE6"
+                ["var"] = "=:'\"\\\r\n\t <>\uFFE6",
+                ["dateVar"] = "2030-05-22 09:05:00"
             };
 
             var textAfterReplacement = PerformTest(GetFixtureResource("Samples", "Filters.txt"), variables).text;


### PR DESCRIPTION
> [!WARNING]
> **WIP — do not merge, and CI is expected to be red.** This encodes the desired end state; it cannot pass until the Octostache pin is bumped.

Variant of #2124, for the single-filter shape in OctopusDeploy/Octostache#125.

## Why

Calamari does variable substitution in files at deploy time using **its own pinned Octostache**. `AddTimeSpan` won't work inside substituted config files until that pin moves — even after Octopus Server ships it. A filter that resolves in a project variable but echoes unreplaced in a `web.config` is unpleasant to diagnose.

## What

Six cases added to `ShouldApplyFiltersDuringSubstitution`, with a fixed `dateVar` so output stays deterministic:

| Expression | Output |
|---|---|
| `#{dateVar \| AddTimeSpan 02:00:00}` | `2030-05-22T11:05:00.0000000` |
| `#{dateVar \| AddTimeSpan -02:00:00}` | `2030-05-22T07:05:00.0000000` |
| `#{dateVar \| AddTimeSpan "2.00:00:00"}` | `2030-05-24T09:05:00.0000000` |
| `#{dateVar \| AddTimeSpan "2.12:00:00"}` | `2030-05-24T21:05:00.0000000` |
| `#{dateVar \| AddTimeSpan 48:00:00}` | `2030-07-09T09:05:00.0000000` |
| `#{dateVar \| AddTimeSpan 02:00:00 \| Format "yyyy-MM-dd HH:mm:ss"}` | `2030-05-22 11:05:00` |

Values were produced by running the expressions against the Octostache branch, not hand-written.

Note the fifth row: `48:00:00` moves the date from 22 May to **9 July** — 48 days, not 48 hours. That's the .NET TimeSpan format re-reading the leading field as days once it exceeds 23. It's pinned here deliberately so the behaviour is visible in the deployment path, not just in Octostache's own tests.

## To finish

- [ ] OctopusDeploy/Octostache#125 approved and merged, package published
- [ ] Bump `Octostache` from `3.9.2` in `Calamari.Shared.csproj:38` and `Calamari.Common.csproj:30`
- [ ] Confirm the approval test goes green, then mark ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)