### PR TITLE
WIP: Support the date add filters in file substitution

### DIFF
--- a/source/Calamari.Tests/Fixtures/Substitutions/Approved/SubstitutionsFixture.ShouldApplyFiltersDuringSubstitution.approved.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Approved/SubstitutionsFixture.ShouldApplyFiltersDuringSubstitution.approved.txt
@@ -13,3 +13,14 @@ PropertiesKeyEscape: \=\:'"\\\r\n\t\ <>\uffe6
 PropertiesValueEscape: =:'"\\\r\n\t <>\uffe6
 UriEscape: =:'%22%5C%0D%0A%09%20%3C%3E%EF%BF%A6
 UriDataEscape: %3D%3A%27%22%5C%0D%0A%09%20%3C%3E%EF%BF%A6
+AddSeconds: 2030-05-22T09:05:30.0000000
+AddMinutes: 2030-05-22T09:07:00.0000000
+AddHours: 2030-05-22T11:05:00.0000000
+AddHoursNegative: 2030-05-22T07:05:00.0000000
+AddHoursFortyEight: 2030-05-24T09:05:00.0000000
+AddDays: 2030-05-23T09:05:00.0000000
+AddWeeks: 2030-05-29T09:05:00.0000000
+AddMonths: 2030-06-22T09:05:00.0000000
+AddTimeSpanTwoAndAHalfDays: 2030-05-24T21:05:00.0000000
+AddTimeSpanLeadingFieldIsDaysOver23: 2030-07-09T09:05:00.0000000
+AddHoursFormatted: 2030-05-22 11:05:00

--- a/source/Calamari.Tests/Fixtures/Substitutions/Samples/Filters.txt
+++ b/source/Calamari.Tests/Fixtures/Substitutions/Samples/Filters.txt
@@ -8,3 +8,14 @@ PropertiesKeyEscape: #{var | PropertiesKeyEscape}
 PropertiesValueEscape: #{var | PropertiesValueEscape}
 UriEscape: #{var | UriEscape}
 UriDataEscape: #{var | UriDataEscape}
+AddSeconds: #{dateVar | AddSeconds 30}
+AddMinutes: #{dateVar | AddMinutes 2}
+AddHours: #{dateVar | AddHours 2}
+AddHoursNegative: #{dateVar | AddHours -2}
+AddHoursFortyEight: #{dateVar | AddHours 48}
+AddDays: #{dateVar | AddDays 1}
+AddWeeks: #{dateVar | AddWeeks 1}
+AddMonths: #{dateVar | AddMonths 1}
+AddTimeSpanTwoAndAHalfDays: #{dateVar | AddTimeSpan "2.12:00:00"}
+AddTimeSpanLeadingFieldIsDaysOver23: #{dateVar | AddTimeSpan 48:00:00}
+AddHoursFormatted: #{dateVar | AddHours 2 | Format "yyyy-MM-dd HH:mm:ss"}

--- a/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
+++ b/source/Calamari.Tests/Fixtures/Substitutions/SubstitutionsFixture.cs
@@ -48,7 +48,8 @@ namespace Calamari.Tests.Fixtures.Substitutions
         {
             var variables = new CalamariVariables
             {
-                ["var"] = "=:'\"\\\r\n\t <>\uFFE6"
+                ["var"] = "=:'\"\\\r\n\t <>\uFFE6",
+                ["dateVar"] = "2030-05-22 09:05:00"
             };
 
             var textAfterReplacement = PerformTest(GetFixtureResource("Samples", "Filters.txt"), variables).text;


### PR DESCRIPTION
> [!WARNING]
> **WIP — do not merge, and CI is expected to be red.** This encodes the desired end state; it cannot pass until the Octostache pin is bumped.

Variant of #2124 and #2128, for the full filter set in OctopusDeploy/Octostache#126.

## Why

Calamari does variable substitution in files at deploy time using **its own pinned Octostache**. These filters won't work inside substituted config files until that pin moves — even after Octopus Server ships them. A filter that resolves in a project variable but echoes unreplaced in a `web.config` is unpleasant to diagnose.

## What

Eleven cases added to `ShouldApplyFiltersDuringSubstitution`, with a fixed `dateVar` so output stays deterministic:

| Expression | Output |
|---|---|
| `AddSeconds 30` | `2030-05-22T09:05:30.0000000` |
| `AddMinutes 2` | `2030-05-22T09:07:00.0000000` |
| `AddHours 2` | `2030-05-22T11:05:00.0000000` |
| `AddHours -2` | `2030-05-22T07:05:00.0000000` |
| `AddHours 48` | `2030-05-24T09:05:00.0000000` |
| `AddDays 1` | `2030-05-23T09:05:00.0000000` |
| `AddWeeks 1` | `2030-05-29T09:05:00.0000000` |
| `AddMonths 1` | `2030-06-22T09:05:00.0000000` |
| `AddTimeSpan "2.12:00:00"` | `2030-05-24T21:05:00.0000000` |
| `AddTimeSpan 48:00:00` | `2030-07-09T09:05:00.0000000` |
| `AddHours 2 \| Format "yyyy-MM-dd HH:mm:ss"` | `2030-05-22 11:05:00` |

Values were produced by running the expressions against the Octostache branch, not hand-written.

Note the last two `AddTimeSpan` rows sit directly against `AddHours 48`: the same "48" reaches **24 May** via `AddHours` and **9 July** via `AddTimeSpan 48:00:00`, because the .NET TimeSpan format re-reads the leading field as days above 23. Pinned here so the difference is visible in the deployment path, not just in Octostache's own tests.

## To finish

- [ ] OctopusDeploy/Octostache#126 approved and merged, package published
- [ ] Bump `Octostache` from `3.9.2` in `Calamari.Shared.csproj:38` and `Calamari.Common.csproj:30`
- [ ] Confirm the approval test goes green, then mark ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)