### PR TITLE
Upgrade Autofac and remove the dead net462 reference assemblies

### DIFF
--- a/source/Calamari.Common/Calamari.Common.csproj
+++ b/source/Calamari.Common/Calamari.Common.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
         <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
-        <PackageReference Include="Autofac" Version="4.8.0" />
+        <PackageReference Include="Autofac" Version="9.3.1" />
         <PackageReference Include="Octopus.Globfish" Version="1.0.8" />
         <PackageReference Include="JavaPropertiesParser" Version="0.2.1" />
         <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="SharpCompress" Version="0.49.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.16" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
-    <PackageReference Include="Autofac" Version="4.8.0" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="KubernetesClient" Version="17.0.14" />
     <PackageReference Include="Octopus.LibGit2Sharp" Version="0.31.1-octopus.3" />
   </ItemGroup>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -31,10 +31,6 @@
     <ProjectReference Include="..\Calamari.Common\Calamari.Common.csproj" />
     <ProjectReference Include="..\Calamari.Contracts\Calamari.Contracts.csproj" />
     <ProjectReference Include="..\Calamari.Shared\Calamari.Shared.csproj" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Octokit" Version="14.0.0" />


### PR DESCRIPTION
| Commit | What |
|---|---|
| Remove the dead .NET Framework reference assemblies | `Microsoft.NETFramework.ReferenceAssemblies.net462`, unused |
| Upgrade Autofac 4.8.0 → 9.3.1 | No code changes needed |

`ContainerBuilder.Update()` is the headline Autofac 5 removal and was never used here.

**Neither change is required for .NET 10.** Autofac 4.8.0 builds with no warnings and resolves correctly on `net10.0` — measured. This is hygiene: 4.8.0 is from 2018 and only ships `net45` and `netstandard1.1` assets. Doing it while Calamari still targets net8 means a green net8 build proves the bump in isolation, ahead of the target-framework flip.


-one new warning is `CS8714` at `Calamari.Common/Plumbing/Pipeline/Resolver.cs:17` — Autofac 9's `Resolve<TService>` carries a `notnull` constraint that `TBehaviour` doesn't satisfy. `Calamari.Common` doesn't treat warnings as errors, so it builds.

Yes server will reference this when shipped.
