### PR TITLE
Add native Tomcat Manager HTTP client and connector configurator

### DIFF
--- a/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
+++ b/source/Calamari.Common/FeatureToggles/OctopusFeatureToggle.cs
@@ -13,6 +13,7 @@ namespace Calamari.Common.FeatureToggles
             public const string AzureWebAppIgnorePreservePathsFeatureToggle = "azure-web-app-ignore-preserve-paths";
             public const string AzureWebAppIgnoreChecksumFeatureToggle = "azure-web-app-ignore-checksum";
             public const string JavaKeystoreNativeBouncyCastle = "java-keystore-native-bouncycastle";
+            public const string TomcatNativeIntegration = "tomcat-native-integration";
         };
 
         public static readonly OctopusFeatureToggle KustomizePatchImageUpdatesFeatureToggle = new(KnownSlugs.KustomizePatchImageUpdatesFeatureToggle);
@@ -22,6 +23,7 @@ namespace Calamari.Common.FeatureToggles
         public static readonly OctopusFeatureToggle AzureWebAppIgnorePreservePathsFeatureToggle = new(KnownSlugs.AzureWebAppIgnorePreservePathsFeatureToggle);
         public static readonly OctopusFeatureToggle AzureWebAppIgnoreChecksumFeatureToggle = new(KnownSlugs.AzureWebAppIgnoreChecksumFeatureToggle);
         public static readonly OctopusFeatureToggle JavaKeystoreNativeBouncyCastleFeatureToggle = new(KnownSlugs.JavaKeystoreNativeBouncyCastle);
+        public static readonly OctopusFeatureToggle TomcatNativeIntegrationFeatureToggle = new(KnownSlugs.TomcatNativeIntegration);
 
         public class OctopusFeatureToggle
         {

--- a/source/Calamari.Shared/Integration/Certificates/Java/Tomcat/TomcatCertificateOptions.cs
+++ b/source/Calamari.Shared/Integration/Certificates/Java/Tomcat/TomcatCertificateOptions.cs
@@ -1,0 +1,95 @@
+using System.IO;
+using Calamari.Common.Commands;
+
+namespace Calamari.Integration.Certificates.Java.Tomcat
+{
+    /// <summary>
+    /// Matches com.octopus.calamari.tomcathttps.TomcatHttpsOptions (Octopus.Dependencies.Java).
+    /// </summary>
+    public class TomcatCertificateOptions
+    {
+        public const string DefaultHostName = "_default_";
+
+        public string CatalinaBase { get; }
+        public string Service { get; }
+        public string Port { get; }
+        public TomcatHttpsImplementation Implementation { get; }
+        public TomcatVersion Version { get; }
+        public bool IsDefault { get; }
+        public string HostName { get; }
+
+        public string PrivateKeyPem { get; }
+        public string CertificatePem { get; }
+        public string KeystorePassword { get; }
+        public string KeystoreAlias { get; }
+        public string KeystoreFilename { get; }
+        public string PrivateKeyFilename { get; }
+        public string PublicKeyFilename { get; }
+
+        public TomcatCertificateOptions(
+            string catalinaBase,
+            string service,
+            string port,
+            TomcatHttpsImplementation implementation,
+            TomcatVersion version,
+            bool isDefault,
+            string hostName,
+            string privateKeyPem,
+            string certificatePem,
+            string keystorePassword,
+            string keystoreAlias,
+            string keystoreFilename,
+            string privateKeyFilename,
+            string publicKeyFilename)
+        {
+            CatalinaBase = catalinaBase;
+            Service = service;
+            Port = string.IsNullOrWhiteSpace(port) ? "8443" : port;
+            Implementation = implementation;
+            Version = version;
+            IsDefault = isDefault;
+            HostName = string.IsNullOrWhiteSpace(hostName) ? DefaultHostName : hostName;
+            PrivateKeyPem = privateKeyPem;
+            CertificatePem = certificatePem;
+            KeystorePassword = keystorePassword;
+            KeystoreAlias = keystoreAlias;
+            KeystoreFilename = keystoreFilename;
+            PrivateKeyFilename = privateKeyFilename;
+            PublicKeyFilename = publicKeyFilename;
+        }
+
+        public bool IsDefaultHostName => HostName == DefaultHostName;
+
+        public string ServerXmlPath => Path.Combine(CatalinaBase, "conf", "server.xml");
+
+        public void Validate()
+        {
+            if (Version.Major < 7 || Version.Major > 9)
+                throw new CommandException($"Only Tomcat 7 to 9 are supported (found {Version.Major}.{Version.Minor}).");
+
+            if (!IsDefaultHostName && !Version.UsesSslHostConfig)
+                throw new CommandException("Configuring a certificate for a specific hostname (SNI) requires Tomcat 8.5 or above.");
+
+            Implementation.ValidateVersion(Version);
+        }
+
+        /// <summary>
+        /// Resolves the absolute path a keystore/key/cert file should be written to, and the value that
+        /// should be written into server.xml for it - Tomcat resolves paths relative to
+        /// ${catalina.base} at runtime, so an absolute path under CatalinaBase is rewritten to that
+        /// portable form (matching TomcatHttpsOptions.convertPathToTomcatVariable).
+        /// </summary>
+        public (string AbsolutePath, string ConfigValue) ResolvePath(string configuredFilename, string defaultFileName)
+        {
+            var absolutePath = string.IsNullOrWhiteSpace(configuredFilename)
+                ? Path.Combine(CatalinaBase, "conf", defaultFileName)
+                : configuredFilename;
+
+            var configValue = absolutePath.StartsWith(CatalinaBase)
+                ? "${catalina.base}" + absolutePath.Substring(CatalinaBase.Length).Replace('\\', '/')
+                : absolutePath;
+
+            return (absolutePath, configValue);
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/Certificates/Java/Tomcat/TomcatConnectorAttributes.cs
+++ b/source/Calamari.Shared/Integration/Certificates/Java/Tomcat/TomcatConnectorAttributes.cs
@@ -1,0 +1,43 @@
+namespace Calamari.Integration.Certificates.Java.Tomcat
+{
+    /// <summary>
+    /// Matches com.octopus.calamari.tomcathttps.AttributeDatabase (Octopus.Dependencies.Java) - the
+    /// certificate/keystore-related Connector attribute names that must be stripped before writing new
+    /// certificate configuration, so a previous APR-style config doesn't linger alongside a new
+    /// keystore-style one (or vice versa).
+    /// </summary>
+    public static class TomcatConnectorAttributes
+    {
+        public const string DefaultSslHostConfigName = "defaultSSLHostConfigName";
+
+        public static readonly string[] ConflictingAttributes =
+        {
+            "certificateKeyFile",
+            "certificateFile",
+            "certificateKeyAlias",
+            "certificateKeyPassword",
+            "certificateKeystoreFile",
+            "certificateKeystorePassword",
+            "certificateKeystoreProvider",
+            "certificateKeystoreType",
+            "SSLCertificateFile",
+            "SSLCertificateKeyFile",
+            "SSLPassword",
+            "keyAlias",
+            "keyPass",
+            "keystoreFile",
+            "keystorePass",
+            "keystoreProvider",
+            "keystoreType"
+        };
+
+        public static void RemoveConflictingAttributes(System.Xml.XmlElement element)
+        {
+            foreach (var attribute in ConflictingAttributes)
+            {
+                if (element.HasAttribute(attribute))
+                    element.RemoveAttribute(attribute);
+            }
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/Certificates/Java/Tomcat/TomcatConnectorConfigurator.cs
+++ b/source/Calamari.Shared/Integration/Certificates/Java/Tomcat/TomcatConnectorConfigurator.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Logging;
+
+namespace Calamari.Integration.Certificates.Java.Tomcat
+{
+    /// <summary>
+    /// Configures a Tomcat HTTPS connector by editing server.xml directly, replacing
+    /// com.octopus.calamari.tomcathttps.TomcatHttpsConfig/ConfigureConnector/ConfigureTomcat7Connector/
+    /// ConfigureTomcat85Connector (Octopus.Dependencies.Java). No JVM is required - this is plain XML
+    /// manipulation, and the keystore itself is built with <see cref="JavaKeystoreBuilder"/> rather
+    /// than a JVM's own KeyStore API.
+    /// </summary>
+    public class TomcatConnectorConfigurator
+    {
+        readonly JavaKeystoreBuilder keystoreBuilder;
+        readonly ILog log;
+
+        public TomcatConnectorConfigurator(ILog log)
+        {
+            this.log = log;
+            keystoreBuilder = new JavaKeystoreBuilder(log);
+        }
+
+        public void ConfigureHttps(TomcatCertificateOptions options)
+        {
+            options.Validate();
+
+            if (!File.Exists(options.ServerXmlPath))
+                throw new CommandException($"Could not find the Tomcat configuration file at \"{options.ServerXmlPath}\".");
+
+            var document = new XmlDocument();
+            document.Load(options.ServerXmlPath);
+
+            var serviceNode = FindElement(document.DocumentElement!, "Service", new Dictionary<string, string> { { "name", options.Service } })
+                              ?? throw new CommandException($"Could not find a <Service name=\"{options.Service}\"> element in \"{options.ServerXmlPath}\".");
+
+            var connectorNode = FindElement(serviceNode, "Connector", new Dictionary<string, string> { { "port", options.Port } })
+                                ?? CreateElement(document, serviceNode, "Connector", new Dictionary<string, string> { { "port", options.Port } });
+
+            if (options.Version.UsesSslHostConfig)
+                ConfigureTomcat85Connector(document, connectorNode, options);
+            else
+                ConfigureTomcat7Connector(document, connectorNode, options);
+
+            BackupServerXml(options);
+            document.Save(options.ServerXmlPath);
+
+            log.Info($"Successfully configured HTTPS on the \"{options.Service}\" service's connector on port {options.Port}.");
+        }
+
+        // ----- Tomcat 7.0/8.0: certificate attributes go directly on <Connector> -----
+
+        void ConfigureTomcat7Connector(XmlDocument document, XmlElement connector, TomcatCertificateOptions options)
+        {
+            if (options.Implementation == TomcatHttpsImplementation.Nio2)
+                throw new CommandException("Tomcat 7.0/8.0 does not support the Non-Blocking IO 2 Connector.");
+
+            ValidateProtocolSwap(connector, options);
+            TomcatConnectorAttributes.RemoveConflictingAttributes(connector);
+
+            connector.SetAttribute("protocol", options.Implementation.ProtocolClassName());
+            connector.SetAttribute("SSLEnabled", "true");
+            connector.SetAttribute("scheme", "https");
+            connector.SetAttribute("secure", "true");
+
+            if (options.Implementation == TomcatHttpsImplementation.Apr)
+            {
+                var (_, keyConfigValue) = WritePrivateKeyPem(options);
+                var (_, certConfigValue) = WritePublicCertificatePem(options);
+                connector.SetAttribute("SSLCertificateKeyFile", keyConfigValue);
+                connector.SetAttribute("SSLCertificateFile", certConfigValue);
+            }
+            else
+            {
+                var (_, keystoreConfigValue) = WriteKeystore(options);
+                connector.SetAttribute("keystoreFile", keystoreConfigValue);
+                connector.SetAttribute("keystorePass", options.KeystorePassword);
+                connector.SetAttribute("keyAlias", options.KeystoreAlias);
+            }
+        }
+
+        // ----- Tomcat 8.5/9.0: certificate attributes go on a <SSLHostConfig><Certificate> child -----
+
+        void ConfigureTomcat85Connector(XmlDocument document, XmlElement connector, TomcatCertificateOptions options)
+        {
+            ValidateProtocolSwap(connector, options);
+
+            connector.SetAttribute("protocol", options.Implementation.ProtocolClassName());
+            connector.SetAttribute("SSLEnabled", "true");
+
+            if (DefaultHostIsAlreadyOnConnector(connector, options))
+            {
+                // The existing default certificate is expressed the old way (attributes directly on
+                // <Connector>, with no matching <SSLHostConfig>) - keep mutating it there, rather than
+                // introducing a second, conflicting way of expressing the same default host.
+                TomcatConnectorAttributes.RemoveConflictingAttributes(connector);
+
+                if (options.Implementation == TomcatHttpsImplementation.Apr)
+                {
+                    var (_, keyConfigValue) = WritePrivateKeyPem(options);
+                    var (_, certConfigValue) = WritePublicCertificatePem(options);
+                    connector.SetAttribute("SSLCertificateKeyFile", keyConfigValue);
+                    connector.SetAttribute("SSLCertificateFile", certConfigValue);
+                }
+                else
+                {
+                    var (_, keystoreConfigValue) = WriteKeystore(options);
+                    connector.SetAttribute("keystoreFile", keystoreConfigValue);
+                    connector.SetAttribute("keystorePass", options.KeystorePassword);
+                    connector.SetAttribute("keyAlias", options.KeystoreAlias);
+                }
+
+                return;
+            }
+
+            SetDefaultHostNameIfRequired(connector, options);
+
+            var hostConfigAttrs = options.IsDefaultHostName
+                ? new Dictionary<string, string>()
+                : new Dictionary<string, string> { { "hostName", options.HostName } };
+
+            var sslHostConfig = FindElement(connector, "SSLHostConfig", hostConfigAttrs, allowMissingAttributes: options.IsDefaultHostName)
+                                 ?? CreateElement(document, connector, "SSLHostConfig", hostConfigAttrs);
+
+            var certificateType = MapKeyAlgorithmToCertificateType(options);
+            var certificateAttrs = new Dictionary<string, string> { { "type", certificateType } };
+            var certificate = FindElement(sslHostConfig, "Certificate", certificateAttrs, allowMissingAttributes: true)
+                              ?? CreateElement(document, sslHostConfig, "Certificate", certificateAttrs);
+
+            TomcatConnectorAttributes.RemoveConflictingAttributes(certificate);
+
+            if (options.Implementation == TomcatHttpsImplementation.Apr)
+            {
+                var (_, keyConfigValue) = WritePrivateKeyPem(options);
+                var (_, certConfigValue) = WritePublicCertificatePem(options);
+                certificate.SetAttribute("certificateKeyFile", keyConfigValue);
+                certificate.SetAttribute("certificateFile", certConfigValue);
+            }
+            else
+            {
+                var (_, keystoreConfigValue) = WriteKeystore(options);
+                certificate.SetAttribute("certificateKeystoreFile", keystoreConfigValue);
+                certificate.SetAttribute("certificateKeystorePassword", options.KeystorePassword);
+                certificate.SetAttribute("certificateKeyAlias", options.KeystoreAlias);
+            }
+        }
+
+        // ----- Shared helpers -----
+
+        static void ValidateProtocolSwap(XmlElement connector, TomcatCertificateOptions options)
+        {
+            if (ConnectorIsEmpty(connector))
+                return;
+
+            var currentProtocol = connector.GetAttribute("protocol");
+            var newProtocol = options.Implementation.ProtocolClassName();
+            if (!string.IsNullOrEmpty(currentProtocol) && currentProtocol != newProtocol)
+                throw new CommandException($"The connector on port {options.Port} already has certificate configuration using a different implementation ({currentProtocol}). Remove the existing configuration before switching to {newProtocol}.");
+        }
+
+        /// <summary>
+        /// Approximates com.octopus.calamari.tomcathttps.ConfigureConnector.connectorIsEmpty: true when
+        /// the connector carries none of the certificate/keystore attributes this class manages, and
+        /// has no SSLHostConfig children - i.e. it's a fresh connector this class hasn't touched yet.
+        /// </summary>
+        static bool ConnectorIsEmpty(XmlElement connector)
+        {
+            if (TomcatConnectorAttributes.ConflictingAttributes.Any(connector.HasAttribute))
+                return false;
+
+            return !connector.ChildNodes.OfType<XmlElement>().Any(e => e.Name == "SSLHostConfig");
+        }
+
+        bool DefaultHostIsAlreadyOnConnector(XmlElement connector, TomcatCertificateOptions options)
+        {
+            if (!options.IsDefaultHostName)
+                return false;
+
+            var currentDefaultHost = connector.HasAttribute(TomcatConnectorAttributes.DefaultSslHostConfigName)
+                ? connector.GetAttribute(TomcatConnectorAttributes.DefaultSslHostConfigName)
+                : TomcatCertificateOptions.DefaultHostName;
+
+            if (currentDefaultHost != options.HostName)
+                return false;
+
+            var hasMatchingSslHostConfig = connector.ChildNodes.OfType<XmlElement>()
+                                                     .Any(e => e.Name == "SSLHostConfig" && (!e.HasAttribute("hostName") || e.GetAttribute("hostName") == options.HostName));
+
+            return !hasMatchingSslHostConfig && !ConnectorIsEmpty(connector);
+        }
+
+        static void SetDefaultHostNameIfRequired(XmlElement connector, TomcatCertificateOptions options)
+        {
+            if (!options.IsDefault && !ConnectorIsEmpty(connector))
+                return;
+
+            if (options.IsDefaultHostName)
+                connector.RemoveAttribute(TomcatConnectorAttributes.DefaultSslHostConfigName);
+            else
+                connector.SetAttribute(TomcatConnectorAttributes.DefaultSslHostConfigName, options.HostName);
+        }
+
+        static string MapKeyAlgorithmToCertificateType(TomcatCertificateOptions options)
+        {
+            var algorithm = JavaKeystoreBuilder.GetPrivateKeyAlgorithm(options.PrivateKeyPem);
+            switch (algorithm)
+            {
+                case "RSA":
+                    return "RSA";
+                case "DSA":
+                    return "DSA";
+                case "EC":
+                case "ECDSA":
+                    return "EC";
+                default:
+                    throw new CommandException($"Unrecognised private key algorithm \"{algorithm}\" - expected RSA, DSA or EC. See https://tomcat.apache.org/tomcat-8.5-doc/config/http.html#SSL_Support_-_Certificate");
+            }
+        }
+
+        (string AbsolutePath, string ConfigValue) WriteKeystore(TomcatCertificateOptions options)
+        {
+            var (absolutePath, configValue) = options.ResolvePath(options.KeystoreFilename, "octopus.p12");
+            keystoreBuilder.SaveKeystoreToFile(options.KeystoreAlias, options.PrivateKeyPem, options.CertificatePem, options.KeystorePassword, absolutePath);
+            return (absolutePath, configValue);
+        }
+
+        (string AbsolutePath, string ConfigValue) WritePrivateKeyPem(TomcatCertificateOptions options)
+        {
+            var (absolutePath, configValue) = options.ResolvePath(options.PrivateKeyFilename, "octopus.key");
+            File.WriteAllText(absolutePath, options.PrivateKeyPem);
+            return (absolutePath, configValue);
+        }
+
+        (string AbsolutePath, string ConfigValue) WritePublicCertificatePem(TomcatCertificateOptions options)
+        {
+            var (absolutePath, configValue) = options.ResolvePath(options.PublicKeyFilename, "octopus.crt");
+            File.WriteAllText(absolutePath, options.CertificatePem);
+            return (absolutePath, configValue);
+        }
+
+        static void BackupServerXml(TomcatCertificateOptions options)
+        {
+            var backupZipPath = Path.Combine(options.CatalinaBase, "conf", "octopus_backup.zip");
+            var entryName = DateTime.UtcNow.ToString("yyyy.MM.dd-HH.mm.ss.fff");
+
+            var mode = File.Exists(backupZipPath) ? ZipArchiveMode.Update : ZipArchiveMode.Create;
+            using (var fileStream = new FileStream(backupZipPath, mode == ZipArchiveMode.Create ? FileMode.CreateNew : FileMode.Open))
+            using (var archive = new ZipArchive(fileStream, mode))
+            {
+                var entry = archive.CreateEntry($"server.xml.{entryName}");
+                using (var entryStream = entry.Open())
+                using (var serverXmlStream = File.OpenRead(options.ServerXmlPath))
+                {
+                    serverXmlStream.CopyTo(entryStream);
+                }
+            }
+        }
+
+        static XmlElement? FindElement(XmlElement parent, string tagName, Dictionary<string, string> requiredAttributes, bool allowMissingAttributes = false)
+        {
+            foreach (var child in parent.ChildNodes.OfType<XmlElement>().Where(e => e.Name == tagName))
+            {
+                var matches = requiredAttributes.All(attr =>
+                                                          allowMissingAttributes
+                                                              ? !child.HasAttribute(attr.Key) || child.GetAttribute(attr.Key) == attr.Value
+                                                              : child.GetAttribute(attr.Key) == attr.Value);
+                if (matches)
+                    return child;
+            }
+
+            return null;
+        }
+
+        static XmlElement CreateElement(XmlDocument document, XmlElement parent, string tagName, Dictionary<string, string> attributes)
+        {
+            var element = document.CreateElement(tagName);
+            foreach (var attribute in attributes)
+                element.SetAttribute(attribute.Key, attribute.Value);
+
+            parent.AppendChild(element);
+            return element;
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/Certificates/Java/Tomcat/TomcatHttpsImplementation.cs
+++ b/source/Calamari.Shared/Integration/Certificates/Java/Tomcat/TomcatHttpsImplementation.cs
@@ -1,0 +1,74 @@
+namespace Calamari.Integration.Certificates.Java.Tomcat
+{
+    /// <summary>
+    /// Matches com.octopus.calamari.tomcathttps.TomcatHttpsImplementation (Octopus.Dependencies.Java).
+    /// NIO2 requires Tomcat 8.0+; BIO was removed in Tomcat 8.5. BIO/NIO/NIO2 all configure identically
+    /// (a keystore file) - only the protocol class name and version bounds differ. APR is the odd one
+    /// out: it configures raw PEM certificate/key files directly, with no keystore involved at all.
+    /// </summary>
+    public enum TomcatHttpsImplementation
+    {
+        Nio,
+        Nio2,
+        Bio,
+        Apr
+    }
+
+    public static class TomcatHttpsImplementationExtensions
+    {
+        public static string ProtocolClassName(this TomcatHttpsImplementation implementation)
+        {
+            switch (implementation)
+            {
+                case TomcatHttpsImplementation.Apr:
+                    return "org.apache.coyote.http11.Http11AprProtocol";
+                case TomcatHttpsImplementation.Nio:
+                    return "org.apache.coyote.http11.Http11NioProtocol";
+                case TomcatHttpsImplementation.Nio2:
+                    return "org.apache.coyote.http11.Http11Nio2Protocol";
+                case TomcatHttpsImplementation.Bio:
+                    return "org.apache.coyote.http11.Http11Protocol";
+                default:
+                    throw new System.ArgumentOutOfRangeException(nameof(implementation));
+            }
+        }
+
+        public static bool IsKeystoreBased(this TomcatHttpsImplementation implementation) => implementation != TomcatHttpsImplementation.Apr;
+
+        public static void ValidateVersion(this TomcatHttpsImplementation implementation, TomcatVersion version)
+        {
+            if (implementation == TomcatHttpsImplementation.Nio2 && version.Major < 8)
+                throw new Calamari.Common.Commands.CommandException("Tomcat versions before 8.0 do not support the Non-Blocking IO 2 Connector.");
+
+            if (implementation == TomcatHttpsImplementation.Bio && (version.Major > 8 || (version.Major == 8 && version.Minor >= 5)))
+                throw new Calamari.Common.Commands.CommandException("Tomcat 8.5 and above do not support the Blocking IO Connector.");
+        }
+    }
+
+    public struct TomcatVersion
+    {
+        public int Major { get; }
+        public int Minor { get; }
+
+        public TomcatVersion(int major, int minor)
+        {
+            Major = major;
+            Minor = minor;
+        }
+
+        /// <summary>
+        /// True for Tomcat 8.5 and above (the version at which the SSLHostConfig/Certificate element
+        /// style replaced setting certificate attributes directly on the Connector).
+        /// </summary>
+        public bool UsesSslHostConfig => Major > 8 || (Major == 8 && Minor >= 5);
+
+        public static TomcatVersion Parse(string serverInfoOutput)
+        {
+            var match = System.Text.RegularExpressions.Regex.Match(serverInfoOutput, @"Server number:\s+(?<major>\d+)\.(?<minor>\d+)");
+            if (!match.Success)
+                throw new Calamari.Common.Commands.CommandException($"Could not determine the Tomcat version from: {serverInfoOutput}");
+
+            return new TomcatVersion(int.Parse(match.Groups["major"].Value), int.Parse(match.Groups["minor"].Value));
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/Tomcat/TomcatManagerClient.cs
+++ b/source/Calamari.Shared/Integration/Tomcat/TomcatManagerClient.cs
@@ -1,0 +1,204 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using Calamari.Common.Commands;
+using Calamari.Common.Plumbing.Logging;
+using Polly;
+using Polly.Retry;
+
+namespace Calamari.Integration.Tomcat
+{
+    /// <summary>
+    /// A client for Tomcat's Manager "/text/..." HTTP API, replacing the Java-based
+    /// com.octopus.calamari.tomcat.TomcatDeploy/TomcatState (Octopus.Dependencies.Java) with a plain
+    /// HttpClient. No JVM or Octopus.Dependencies.Java tool package is required to talk to Tomcat's
+    /// Manager app - it's just an authenticated HTTP call.
+    /// </summary>
+    public class TomcatManagerClient
+    {
+        // Matches Constants.CONNECTION_TIMEOUT (300 seconds) used by the existing deploy/redeploy calls.
+        static readonly TimeSpan DeployTimeout = TimeSpan.FromMinutes(5);
+
+        readonly ILog log;
+        readonly HttpClient httpClient;
+
+        public TomcatManagerClient(ILog log, HttpClient? httpClient = null)
+        {
+            this.log = log;
+            this.httpClient = httpClient ?? new HttpClient();
+        }
+
+        public void Deploy(TomcatManagerOptions options, string applicationPath)
+        {
+            ExecuteWithRetry(() =>
+            {
+                using (var request = new HttpRequestMessage(HttpMethod.Put, options.DeployUrl))
+                {
+                    AddAuth(request, options);
+                    using (var fileStream = File.OpenRead(applicationPath))
+                    {
+                        request.Content = new StreamContent(fileStream);
+                        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                        Send(request, DeployTimeout);
+                    }
+                }
+            });
+        }
+
+        public void Redeploy(TomcatManagerOptions options)
+        {
+            ExecuteWithRetry(() => SendGet(options.RedeployUrl, options, DeployTimeout));
+        }
+
+        public void Undeploy(TomcatManagerOptions options)
+        {
+            ExecuteWithRetry(() => SendGet(options.UndeployUrl, options));
+        }
+
+        public void Start(TomcatManagerOptions options)
+        {
+            ExecuteWithRetry(() => SendGet(options.StartUrl, options));
+        }
+
+        public void Stop(TomcatManagerOptions options)
+        {
+            ExecuteWithRetry(() => SendGet(options.StopUrl, options));
+        }
+
+        public string List(TomcatManagerOptions options)
+        {
+            string? result = null;
+            ExecuteWithRetry(() => { result = SendGet(options.ListUrl, options); });
+            return result!;
+        }
+
+        /// <summary>
+        /// Confirms the application is in the expected running/stopped state (and, if a version was
+        /// specified, that the expected version is the one currently deployed) by parsing Tomcat
+        /// Manager's plain-text "list" response. Matches com.octopus.calamari.tomcat.TomcatState's
+        /// verification logic, including its notable leniency: if no matching line is found, this is
+        /// logged as a warning rather than treated as a failure, because Tomcat's Manager API doesn't
+        /// return an error in that case either.
+        /// </summary>
+        public bool VerifyState(TomcatManagerOptions options, bool expectRunning)
+        {
+            var listBody = List(options);
+            var expectedPath = "/" + (options.UrlPath ?? "");
+            var expectedState = expectRunning ? "running" : "stopped";
+
+            foreach (var line in listBody.Split('\n'))
+            {
+                var tokens = line.Split(':').Select(t => t.Trim()).Where(t => t.Length > 0).ToArray();
+                if (tokens.Length != 4)
+                    continue;
+
+                var path = tokens[0];
+                var state = tokens[1];
+                var displayName = tokens[3];
+
+                if (path != expectedPath || state != expectedState)
+                    continue;
+
+                if (!string.IsNullOrWhiteSpace(options.Version))
+                {
+                    var displayNameParts = displayName.Split(new[] { "##" }, StringSplitOptions.None);
+                    if (displayNameParts.Length < 2 || displayNameParts[^1] != options.Version)
+                        continue;
+                }
+                else if (displayName.Contains("##"))
+                {
+                    continue;
+                }
+
+                return true;
+            }
+
+            log.Warn($"Could not confirm that \"{expectedPath}\" is {expectedState} - Tomcat's Manager API did not report an error, so this is not treated as a failure.");
+            return false;
+        }
+
+        void SendGet(string url, TomcatManagerOptions options, TimeSpan? timeout = null)
+        {
+            using (var request = new HttpRequestMessage(HttpMethod.Get, url))
+            {
+                AddAuth(request, options);
+                Send(request, timeout);
+            }
+        }
+
+        string SendGet(string url, TomcatManagerOptions options)
+        {
+            using (var request = new HttpRequestMessage(HttpMethod.Get, url))
+            {
+                AddAuth(request, options);
+                return Send(request, null);
+            }
+        }
+
+        static void AddAuth(HttpRequestMessage request, TomcatManagerOptions options)
+        {
+            request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationHeaderValue);
+        }
+
+        string Send(HttpRequestMessage request, TimeSpan? timeout)
+        {
+            using (var cts = timeout.HasValue ? new CancellationTokenSource(timeout.Value) : null)
+            {
+                var response = httpClient.Send(request, cts?.Token ?? CancellationToken.None);
+                using (var reader = new StreamReader(response.Content.ReadAsStream()))
+                {
+                    var body = reader.ReadToEnd();
+                    ValidateResponse((int)response.StatusCode, body);
+                    return body;
+                }
+            }
+        }
+
+        static void ValidateResponse(int statusCode, string body)
+        {
+            switch (statusCode)
+            {
+                case 401:
+                    throw new TomcatAuthenticationException("Tomcat Manager returned 401 Unauthorized. Check the username and password supplied to the step.");
+                case 403:
+                    throw new TomcatAuthenticationException("Tomcat Manager returned 403 Forbidden. Make sure the user is part of the manager-script role in tomcat-users.xml.");
+                default:
+                    if (statusCode < 100 || statusCode > 399)
+                        throw new CommandException($"Tomcat Manager response code {statusCode} indicated failure: {body}");
+                    break;
+            }
+        }
+
+        static void ExecuteWithRetry(Action action)
+        {
+            CreateRetryPipeline().Execute(action);
+        }
+
+        static ResiliencePipeline CreateRetryPipeline()
+        {
+            return new ResiliencePipelineBuilder()
+                   .AddRetry(new RetryStrategyOptions
+                   {
+                       // Bad credentials will fail exactly the same way on every attempt, so retrying
+                       // them wastes 75 seconds for no benefit. Only genuinely-could-be-transient
+                       // failures (connection issues, unexpected response codes that might clear up on
+                       // their own) are retried.
+                       ShouldHandle = new PredicateBuilder().Handle<Exception>(ex => ex is not TomcatAuthenticationException),
+                       MaxRetryAttempts = 4,
+                       Delay = TimeSpan.FromSeconds(5),
+                       BackoffType = DelayBackoffType.Exponential
+                   })
+                   .Build();
+        }
+    }
+
+    public class TomcatAuthenticationException : CommandException
+    {
+        public TomcatAuthenticationException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/source/Calamari.Shared/Integration/Tomcat/TomcatManagerOptions.cs
+++ b/source/Calamari.Shared/Integration/Tomcat/TomcatManagerOptions.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Text;
+
+namespace Calamari.Integration.Tomcat
+{
+    /// <summary>
+    /// The parameters needed to talk to a Tomcat Manager instance and build its "/text/..." API URLs,
+    /// matching the URL-building logic in the existing com.octopus.calamari.tomcat.TomcatOptions
+    /// (Octopus.Dependencies.Java).
+    /// </summary>
+    public class TomcatManagerOptions
+    {
+        public string Controller { get; }
+        public string User { get; }
+        public string Password { get; }
+        public string Application { get; }
+        public string Name { get; }
+        public string Tag { get; }
+        public string Version { get; }
+
+        public TomcatManagerOptions(string controller, string user, string password, string application, string name, string tag, string version)
+        {
+            Controller = string.IsNullOrWhiteSpace(controller) ? "http://localhost:8080" : controller.Trim();
+            User = user ?? "";
+            Password = password ?? "";
+            Application = (application ?? "").Trim();
+            Name = (name ?? "").Trim();
+            Tag = (tag ?? "").Trim();
+            Version = (version ?? "").Trim();
+        }
+
+        /// <summary>
+        /// The path Tomcat's Manager app should deploy the application under. Derived from the
+        /// application filename's "context##version" naming convention when no explicit name is set.
+        /// </summary>
+        public string? UrlPath
+        {
+            get
+            {
+                if (Name == "/")
+                    return "";
+
+                if (!string.IsNullOrWhiteSpace(Name))
+                    return Name.TrimStart('/');
+
+                if (!string.IsNullOrWhiteSpace(Application))
+                {
+                    var baseName = System.IO.Path.GetFileNameWithoutExtension(Application);
+                    return baseName.Split(new[] { "##" }, StringSplitOptions.None)[0].Replace("#", "/");
+                }
+
+                return null;
+            }
+        }
+
+        string? UrlVersion
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(Version))
+                    return Version;
+
+                if (Application.Contains("##"))
+                {
+                    var baseName = System.IO.Path.GetFileNameWithoutExtension(Application);
+                    var parts = baseName.Split(new[] { "##" }, StringSplitOptions.None);
+                    return parts.Length > 1 ? parts[1] : null;
+                }
+
+                return null;
+            }
+        }
+
+        public string BuildUrl(string action, bool includeUpdateFlag = false)
+        {
+            var builder = new StringBuilder($"{Controller}/text/{action}?");
+
+            if (includeUpdateFlag)
+                builder.Append("update=true&");
+
+            var version = UrlVersion;
+            if (!string.IsNullOrWhiteSpace(version))
+                builder.Append($"version={Uri.EscapeDataString(version)}&");
+
+            var path = UrlPath;
+            if (path != null)
+                builder.Append($"path=/{Uri.EscapeDataString(path)}&");
+
+            if (!string.IsNullOrWhiteSpace(Tag))
+                builder.Append($"tag={Uri.EscapeDataString(Tag)}");
+
+            return builder.ToString().TrimEnd('&', '?');
+        }
+
+        public string DeployUrl => BuildUrl("deploy", includeUpdateFlag: true);
+        public string RedeployUrl => BuildUrl("deploy");
+        public string UndeployUrl => BuildUrl("undeploy");
+        public string StartUrl => BuildUrl("start");
+        public string StopUrl => BuildUrl("stop");
+        public string ListUrl => $"{Controller}/text/list";
+
+        public string AuthorizationHeaderValue => "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{User}:{Password}"));
+    }
+}

--- a/source/Calamari.Tests/Java/Fixtures/TomcatConnectorConfiguratorFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/TomcatConnectorConfiguratorFixture.cs
@@ -1,0 +1,256 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Xml;
+using Calamari.Common.Commands;
+using Calamari.Integration.Certificates.Java.Tomcat;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.OpenSsl;
+using Org.BouncyCastle.Security;
+
+namespace Calamari.Tests.Java.Fixtures
+{
+    [TestFixture]
+    public class TomcatConnectorConfiguratorFixture
+    {
+        InMemoryLog log;
+        string catalinaBase;
+        string serverXmlPath;
+        string privateKeyPem;
+        string certificatePem;
+
+        [SetUp]
+        public void SetUp()
+        {
+            log = new InMemoryLog();
+            catalinaBase = Path.Combine(Path.GetTempPath(), "TomcatConnectorConfiguratorFixture-" + Guid.NewGuid());
+            Directory.CreateDirectory(Path.Combine(catalinaBase, "conf"));
+            serverXmlPath = Path.Combine(catalinaBase, "conf", "server.xml");
+
+            (privateKeyPem, certificatePem) = CreateSelfSignedRsaCertificate();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(catalinaBase))
+                Directory.Delete(catalinaBase, true);
+        }
+
+        void WriteServerXml(string serviceXml)
+        {
+            File.WriteAllText(serverXmlPath, $"<Server><Service name=\"Catalina\">{serviceXml}</Service></Server>");
+        }
+
+        TomcatCertificateOptions BuildOptions(TomcatHttpsImplementation implementation, TomcatVersion version, bool isDefault = true, string hostName = "")
+        {
+            return new TomcatCertificateOptions(
+                                                 catalinaBase,
+                                                 "Catalina",
+                                                 "8443",
+                                                 implementation,
+                                                 version,
+                                                 isDefault,
+                                                 hostName,
+                                                 privateKeyPem,
+                                                 certificatePem,
+                                                 "sekret",
+                                                 "myalias",
+                                                 "",
+                                                 "",
+                                                 "");
+        }
+
+        [Test]
+        public void ConfigureHttps_OnTomcat9WithNio_CreatesSslHostConfigWithKeystoreCertificate()
+        {
+            WriteServerXml("<Connector port=\"8443\" />");
+            var options = BuildOptions(TomcatHttpsImplementation.Nio, new TomcatVersion(9, 0));
+
+            new TomcatConnectorConfigurator(log).ConfigureHttps(options);
+
+            var document = new XmlDocument();
+            document.Load(serverXmlPath);
+            var connector = (XmlElement)document.SelectSingleNode("//Connector[@port='8443']")!;
+
+            connector.GetAttribute("protocol").Should().Be("org.apache.coyote.http11.Http11NioProtocol");
+            connector.GetAttribute("SSLEnabled").Should().Be("true");
+
+            var certificate = (XmlElement)connector.SelectSingleNode("SSLHostConfig/Certificate")!;
+            certificate.GetAttribute("type").Should().Be("RSA");
+            certificate.GetAttribute("certificateKeystorePassword").Should().Be("sekret");
+            certificate.GetAttribute("certificateKeyAlias").Should().Be("myalias");
+            certificate.GetAttribute("certificateKeystoreFile").Should().StartWith("${catalina.base}");
+
+            var keystorePath = certificate.GetAttribute("certificateKeystoreFile").Replace("${catalina.base}", catalinaBase);
+            File.Exists(keystorePath).Should().BeTrue();
+        }
+
+        [Test]
+        public void ConfigureHttps_OnTomcat7WithNio_SetsAttributesDirectlyOnConnector()
+        {
+            WriteServerXml("<Connector port=\"8443\" />");
+            var options = BuildOptions(TomcatHttpsImplementation.Nio, new TomcatVersion(7, 0));
+
+            new TomcatConnectorConfigurator(log).ConfigureHttps(options);
+
+            var document = new XmlDocument();
+            document.Load(serverXmlPath);
+            var connector = (XmlElement)document.SelectSingleNode("//Connector[@port='8443']")!;
+
+            connector.GetAttribute("protocol").Should().Be("org.apache.coyote.http11.Http11NioProtocol");
+            connector.GetAttribute("keystorePass").Should().Be("sekret");
+            connector.GetAttribute("keyAlias").Should().Be("myalias");
+            connector.SelectSingleNode("SSLHostConfig").Should().BeNull("Tomcat 7 has no SSLHostConfig concept");
+        }
+
+        [Test]
+        public void ConfigureHttps_WithApr_WritesRawPemFilesInsteadOfAKeystore()
+        {
+            WriteServerXml("<Connector port=\"8443\" />");
+            var options = BuildOptions(TomcatHttpsImplementation.Apr, new TomcatVersion(9, 0));
+
+            new TomcatConnectorConfigurator(log).ConfigureHttps(options);
+
+            var document = new XmlDocument();
+            document.Load(serverXmlPath);
+            var connector = (XmlElement)document.SelectSingleNode("//Connector[@port='8443']")!;
+            var certificate = (XmlElement)connector.SelectSingleNode("SSLHostConfig/Certificate")!;
+
+            certificate.HasAttribute("certificateKeystoreFile").Should().BeFalse();
+            certificate.GetAttribute("certificateKeyFile").Should().StartWith("${catalina.base}");
+            certificate.GetAttribute("certificateFile").Should().StartWith("${catalina.base}");
+
+            var keyPath = certificate.GetAttribute("certificateKeyFile").Replace("${catalina.base}", catalinaBase);
+            File.ReadAllText(keyPath).Should().Be(privateKeyPem);
+        }
+
+        [Test]
+        public void ConfigureHttps_WithNonDefaultHostname_SetsHostNameOnSslHostConfig()
+        {
+            WriteServerXml("<Connector port=\"8443\" />");
+            // Configure the connector's default certificate first (establishing
+            // defaultSSLHostConfigName), then add a second, SNI-specific certificate for a different
+            // hostname - the second call must not disturb the first one's default host marker.
+            var defaultOptions = BuildOptions(TomcatHttpsImplementation.Nio, new TomcatVersion(9, 0), isDefault: true, hostName: "");
+            new TomcatConnectorConfigurator(log).ConfigureHttps(defaultOptions);
+
+            var sniOptions = BuildOptions(TomcatHttpsImplementation.Nio, new TomcatVersion(9, 0), isDefault: false, hostName: "www.example.com");
+            new TomcatConnectorConfigurator(log).ConfigureHttps(sniOptions);
+
+            var document = new XmlDocument();
+            document.Load(serverXmlPath);
+            var connector = (XmlElement)document.SelectSingleNode("//Connector[@port='8443']")!;
+
+            connector.HasAttribute(TomcatConnectorAttributes.DefaultSslHostConfigName).Should().BeFalse("the default host was never renamed away from _default_, so no explicit marker is needed");
+            var sniHostConfig = (XmlElement)connector.SelectSingleNode("SSLHostConfig[@hostName='www.example.com']")!;
+            sniHostConfig.GetAttribute("hostName").Should().Be("www.example.com");
+            connector.SelectNodes("SSLHostConfig")!.Count.Should().Be(2, "the default host's SSLHostConfig and the SNI one should coexist");
+        }
+
+        [Test]
+        public void ConfigureHttps_WhenServiceIsMissing_ThrowsCommandException()
+        {
+            File.WriteAllText(serverXmlPath, "<Server></Server>");
+            var options = BuildOptions(TomcatHttpsImplementation.Nio, new TomcatVersion(9, 0));
+
+            Action act = () => new TomcatConnectorConfigurator(log).ConfigureHttps(options);
+
+            act.Should().Throw<CommandException>().WithMessage("*Catalina*");
+        }
+
+        [Test]
+        public void ConfigureHttps_WhenConnectorDoesNotExist_CreatesOne()
+        {
+            WriteServerXml("");
+            var options = BuildOptions(TomcatHttpsImplementation.Nio, new TomcatVersion(9, 0));
+
+            new TomcatConnectorConfigurator(log).ConfigureHttps(options);
+
+            var document = new XmlDocument();
+            document.Load(serverXmlPath);
+            document.SelectSingleNode("//Connector[@port='8443']").Should().NotBeNull();
+        }
+
+        [Test]
+        public void ConfigureHttps_WithNio2OnTomcat7_ThrowsCommandException()
+        {
+            WriteServerXml("<Connector port=\"8443\" />");
+            var options = BuildOptions(TomcatHttpsImplementation.Nio2, new TomcatVersion(7, 0));
+
+            Action act = () => new TomcatConnectorConfigurator(log).ConfigureHttps(options);
+
+            act.Should().Throw<CommandException>().WithMessage("*Non-Blocking IO 2*");
+        }
+
+        [Test]
+        public void ConfigureHttps_WithBioOnTomcat9_ThrowsCommandException()
+        {
+            WriteServerXml("<Connector port=\"8443\" />");
+            var options = BuildOptions(TomcatHttpsImplementation.Bio, new TomcatVersion(9, 0));
+
+            Action act = () => new TomcatConnectorConfigurator(log).ConfigureHttps(options);
+
+            act.Should().Throw<CommandException>().WithMessage("*Blocking IO*");
+        }
+
+        [Test]
+        public void ConfigureHttps_BacksUpTheOriginalServerXmlIntoAZip()
+        {
+            WriteServerXml("<Connector port=\"8443\" />");
+            var originalContent = File.ReadAllText(serverXmlPath);
+            var options = BuildOptions(TomcatHttpsImplementation.Nio, new TomcatVersion(9, 0));
+
+            new TomcatConnectorConfigurator(log).ConfigureHttps(options);
+
+            var backupZipPath = Path.Combine(catalinaBase, "conf", "octopus_backup.zip");
+            File.Exists(backupZipPath).Should().BeTrue();
+
+            using (var archive = ZipFile.OpenRead(backupZipPath))
+            {
+                archive.Entries.Should().HaveCount(1);
+                using (var reader = new StreamReader(archive.Entries[0].Open()))
+                {
+                    reader.ReadToEnd().Should().Be(originalContent);
+                }
+            }
+        }
+
+        static (string PrivateKeyPem, string CertificatePem) CreateSelfSignedRsaCertificate()
+        {
+            var keyGenerator = new RsaKeyPairGenerator();
+            keyGenerator.Init(new KeyGenerationParameters(new SecureRandom(), 2048));
+            var keyPair = keyGenerator.GenerateKeyPair();
+
+            var generator = new Org.BouncyCastle.X509.X509V3CertificateGenerator();
+            var subject = new Org.BouncyCastle.Asn1.X509.X509Name("CN=octopus-tomcat-test");
+            generator.SetSerialNumber(Org.BouncyCastle.Math.BigInteger.ValueOf(DateTime.UtcNow.Ticks));
+            generator.SetIssuerDN(subject);
+            generator.SetSubjectDN(subject);
+            generator.SetNotBefore(DateTime.UtcNow.AddDays(-1));
+            generator.SetNotAfter(DateTime.UtcNow.AddYears(1));
+            generator.SetPublicKey(keyPair.Public);
+            var certificate = generator.Generate(new Org.BouncyCastle.Crypto.Operators.Asn1SignatureFactory("SHA256WITHRSA", keyPair.Private));
+
+            string privateKeyPem;
+            using (var writer = new StringWriter())
+            {
+                new PemWriter(writer).WriteObject(keyPair.Private);
+                privateKeyPem = writer.ToString();
+            }
+
+            string certificatePem;
+            using (var writer = new StringWriter())
+            {
+                new PemWriter(writer).WriteObject(certificate);
+                certificatePem = writer.ToString();
+            }
+
+            return (privateKeyPem, certificatePem);
+        }
+    }
+}

--- a/source/Calamari.Tests/Java/Fixtures/TomcatManagerClientFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/TomcatManagerClientFixture.cs
@@ -1,0 +1,193 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using Calamari.Common.Commands;
+using Calamari.Integration.Tomcat;
+using Calamari.Testing.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Java.Fixtures
+{
+    /// <summary>
+    /// Exercises TomcatManagerClient against a real local HTTP server that mimics Tomcat Manager's
+    /// "/text/..." plain-text API, rather than mocking HttpClient - this is closer to what actually
+    /// happens on the wire (headers, status codes, body encoding) than a mocked handler would be.
+    /// </summary>
+    [TestFixture]
+    public class TomcatManagerClientFixture
+    {
+        HttpListener listener;
+        string baseUrl;
+        InMemoryLog log;
+        string workingDirectory;
+
+        string lastMethod;
+        string lastPath;
+        string lastAuthHeader;
+        string lastRequestBody;
+        int nextResponseStatusCode;
+        string nextResponseBody;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // NUnit reuses one fixture instance across every [Test] in this class, so these have to be
+            // reset here rather than via field initializers - otherwise a status code set by one test
+            // leaks into whichever test happens to run next.
+            nextResponseStatusCode = 200;
+            nextResponseBody = "OK - Deployed application";
+
+            log = new InMemoryLog();
+            workingDirectory = Path.Combine(Path.GetTempPath(), "TomcatManagerClientFixture-" + Guid.NewGuid());
+            Directory.CreateDirectory(workingDirectory);
+
+            var port = GetFreeTcpPort();
+            baseUrl = $"http://localhost:{port}/manager";
+
+            listener = new HttpListener();
+            listener.Prefixes.Add($"http://localhost:{port}/");
+            listener.Start();
+            listener.BeginGetContext(OnRequest, null);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            listener.Stop();
+            listener.Close();
+            if (Directory.Exists(workingDirectory))
+                Directory.Delete(workingDirectory, true);
+        }
+
+        void OnRequest(IAsyncResult result)
+        {
+            HttpListenerContext context;
+            try
+            {
+                context = listener.EndGetContext(result);
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+
+            listener.BeginGetContext(OnRequest, null);
+
+            lastMethod = context.Request.HttpMethod;
+            lastPath = context.Request.Url?.PathAndQuery;
+            lastAuthHeader = context.Request.Headers["Authorization"];
+
+            using (var reader = new StreamReader(context.Request.InputStream))
+            {
+                lastRequestBody = reader.ReadToEnd();
+            }
+
+            context.Response.StatusCode = nextResponseStatusCode;
+            var bytes = Encoding.UTF8.GetBytes(nextResponseBody);
+            context.Response.ContentLength64 = bytes.Length;
+            context.Response.OutputStream.Write(bytes, 0, bytes.Length);
+            context.Response.OutputStream.Close();
+        }
+
+        static int GetFreeTcpPort()
+        {
+            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        [Test]
+        public void Deploy_SendsAPutWithTheFileContentsAndBasicAuth()
+        {
+            var applicationPath = Path.Combine(workingDirectory, "myapp.war");
+            File.WriteAllText(applicationPath, "war file contents");
+
+            var options = new TomcatManagerOptions(baseUrl, "admin", "sekret", "", "myapp", "", "");
+            var client = new TomcatManagerClient(log);
+
+            client.Deploy(options, applicationPath);
+
+            lastMethod.Should().Be("PUT");
+            lastPath.Should().Be("/manager/text/deploy?update=true&path=/myapp");
+            lastAuthHeader.Should().Be("Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes("admin:sekret")));
+            lastRequestBody.Should().Be("war file contents");
+        }
+
+        [Test]
+        public void Start_SendsAGetToTheStartEndpoint()
+        {
+            var options = new TomcatManagerOptions(baseUrl, "admin", "sekret", "", "myapp", "", "");
+            var client = new TomcatManagerClient(log);
+
+            client.Start(options);
+
+            lastMethod.Should().Be("GET");
+            lastPath.Should().Be("/manager/text/start?path=/myapp");
+        }
+
+        [Test]
+        public void VerifyState_WhenListContainsAMatchingRunningLine_ReturnsTrue()
+        {
+            nextResponseBody = "OK - Listed applications for virtual host localhost\n/myapp:running:0:myapp\n/:running:0:ROOT\n";
+
+            var options = new TomcatManagerOptions(baseUrl, "admin", "sekret", "", "myapp", "", "");
+            var client = new TomcatManagerClient(log);
+
+            client.VerifyState(options, expectRunning: true).Should().BeTrue();
+        }
+
+        [Test]
+        public void VerifyState_WhenNoLineMatches_ReturnsFalseWithoutThrowing()
+        {
+            nextResponseBody = "OK - Listed applications for virtual host localhost\n/other:running:0:other\n";
+
+            var options = new TomcatManagerOptions(baseUrl, "admin", "sekret", "", "myapp", "", "");
+            var client = new TomcatManagerClient(log);
+
+            client.VerifyState(options, expectRunning: true).Should().BeFalse();
+        }
+
+        [Test]
+        public void VerifyState_WithAVersionedDeployment_OnlyMatchesTheExpectedVersion()
+        {
+            nextResponseBody = "OK - Listed applications for virtual host localhost\n/myapp:running:0:myapp##2.0\n/myapp:running:0:myapp##1.0\n";
+
+            var options = new TomcatManagerOptions(baseUrl, "admin", "sekret", "", "myapp", "", "2.0");
+            var client = new TomcatManagerClient(log);
+
+            client.VerifyState(options, expectRunning: true).Should().BeTrue();
+        }
+
+        [Test]
+        public void Start_WhenServerReturns401_ThrowsCommandExceptionMentioningUnauthorized()
+        {
+            nextResponseStatusCode = 401;
+            nextResponseBody = "";
+
+            var options = new TomcatManagerOptions(baseUrl, "admin", "wrong-password", "", "myapp", "", "");
+            var client = new TomcatManagerClient(log);
+
+            Action act = () => client.Start(options);
+
+            act.Should().Throw<CommandException>().WithMessage("*401*");
+        }
+
+        [Test]
+        public void Start_WhenServerReturns403_ThrowsCommandExceptionMentioningManagerScriptRole()
+        {
+            nextResponseStatusCode = 403;
+            nextResponseBody = "";
+
+            var options = new TomcatManagerOptions(baseUrl, "admin", "sekret", "", "myapp", "", "");
+            var client = new TomcatManagerClient(log);
+
+            Action act = () => client.Start(options);
+
+            act.Should().Throw<CommandException>().WithMessage("*manager-script*");
+        }
+    }
+}

--- a/source/Calamari.Tests/Java/Fixtures/TomcatManagerOptionsFixture.cs
+++ b/source/Calamari.Tests/Java/Fixtures/TomcatManagerOptionsFixture.cs
@@ -1,0 +1,90 @@
+using Calamari.Integration.Tomcat;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Calamari.Tests.Java.Fixtures
+{
+    [TestFixture]
+    public class TomcatManagerOptionsFixture
+    {
+        [Test]
+        public void DeployUrl_WithNameAndVersion_IncludesUpdateFlagPathAndVersion()
+        {
+            var options = new TomcatManagerOptions("http://localhost:8080/manager", "admin", "pw", "", "myapp", "", "1.0");
+
+            options.DeployUrl.Should().Be("http://localhost:8080/manager/text/deploy?update=true&version=1.0&path=/myapp");
+        }
+
+        [Test]
+        public void RedeployUrl_DoesNotIncludeUpdateFlag()
+        {
+            var options = new TomcatManagerOptions("http://localhost:8080/manager", "admin", "pw", "", "myapp", "sometag", "");
+
+            options.RedeployUrl.Should().Be("http://localhost:8080/manager/text/deploy?path=/myapp&tag=sometag");
+        }
+
+        [Test]
+        public void UrlPath_WhenNameIsRootSlash_IsEmpty()
+        {
+            var options = new TomcatManagerOptions("http://localhost:8080/manager", "admin", "pw", "", "/", "", "");
+
+            options.UrlPath.Should().Be("");
+        }
+
+        [Test]
+        public void UrlPath_WhenNameHasLeadingSlashes_StripsThem()
+        {
+            var options = new TomcatManagerOptions("http://localhost:8080/manager", "admin", "pw", "", "///myapp", "", "");
+
+            options.UrlPath.Should().Be("myapp");
+        }
+
+        [Test]
+        public void UrlPath_WhenNameIsBlank_DerivesFromApplicationFilename()
+        {
+            var options = new TomcatManagerOptions("http://localhost:8080/manager", "admin", "pw", "/tmp/staging/myapp#sub##2.0.war", "", "", "");
+
+            options.UrlPath.Should().Be("myapp/sub");
+        }
+
+        [Test]
+        public void UrlPath_WhenNeitherNameNorApplicationIsSet_IsNull()
+        {
+            var options = new TomcatManagerOptions("http://localhost:8080/manager", "admin", "pw", "", "", "", "");
+
+            options.UrlPath.Should().BeNull();
+        }
+
+        [Test]
+        public void StopUrl_WithNoNameOrVersion_HasNoPathOrVersionParam()
+        {
+            var options = new TomcatManagerOptions("http://localhost:8080/manager", "admin", "pw", "", "", "", "");
+
+            options.StopUrl.Should().Be("http://localhost:8080/manager/text/stop");
+        }
+
+        [Test]
+        public void ListUrl_IsAlwaysJustTheListEndpoint()
+        {
+            var options = new TomcatManagerOptions("http://localhost:8080/manager", "admin", "pw", "", "myapp", "", "1.0");
+
+            options.ListUrl.Should().Be("http://localhost:8080/manager/text/list");
+        }
+
+        [Test]
+        public void Controller_WhenBlank_DefaultsToLocalhost8080()
+        {
+            var options = new TomcatManagerOptions("", "admin", "pw", "", "", "", "");
+
+            options.Controller.Should().Be("http://localhost:8080");
+        }
+
+        [Test]
+        public void AuthorizationHeaderValue_IsBasicBase64OfUserColonPassword()
+        {
+            var options = new TomcatManagerOptions("http://localhost:8080/manager", "admin", "pw", "", "", "", "");
+
+            options.AuthorizationHeaderValue.Should().Be("Basic YWRtaW46cHc=");
+        }
+    }
+}

--- a/source/Calamari/Deployment/Features/Java/Actions/TomcatDeployCertificateAction.cs
+++ b/source/Calamari/Deployment/Features/Java/Actions/TomcatDeployCertificateAction.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Calamari.Common.Commands;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Features.Packages.Java;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.Integration.Certificates.Java.Tomcat;
 
 namespace Calamari.Deployment.Features.Java.Actions
 {
@@ -24,16 +26,23 @@ namespace Calamari.Deployment.Features.Java.Actions
             var variables = deployment.Variables;
             var tomcatVersion = GetTomcatVersion(variables);
             log.Info("Deploying certificate to Tomcat");
+
+            if (OctopusFeatureToggles.TomcatNativeIntegrationFeatureToggle.IsEnabled(variables))
+            {
+                ExecuteNative(variables, tomcatVersion);
+                return;
+            }
+
             runner.Run("com.octopus.calamari.tomcathttps.TomcatHttpsConfig", new Dictionary<string, string>()
             {
-                {"OctopusEnvironment_Java_Certificate_Variable", variables.Get(SpecialVariables.Action.Java.JavaKeystore.Variable)},                
-                {"OctopusEnvironment_Java_Certificate_Password", variables.Get(SpecialVariables.Action.Java.JavaKeystore.Password)},                               
+                {"OctopusEnvironment_Java_Certificate_Variable", variables.Get(SpecialVariables.Action.Java.JavaKeystore.Variable)},
+                {"OctopusEnvironment_Java_Certificate_Password", variables.Get(SpecialVariables.Action.Java.JavaKeystore.Password)},
                 {"OctopusEnvironment_Java_Certificate_KeystoreFilename", variables.Get(SpecialVariables.Action.Java.JavaKeystore.KeystoreFilename)},
                 {"OctopusEnvironment_Java_Certificate_KeystoreAlias", variables.Get(SpecialVariables.Action.Java.JavaKeystore.KeystoreAlias)},
                 {"OctopusEnvironment_Java_Certificate_Private_Key", variables.Get(variables.Get(SpecialVariables.Action.Java.JavaKeystore.Variable) + ".PrivateKeyPem")},
                 {"OctopusEnvironment_Java_Certificate_Public_Key", variables.Get(variables.Get(SpecialVariables.Action.Java.JavaKeystore.Variable) + ".CertificatePem")},
                 {"OctopusEnvironment_Java_Certificate_Public_Key_Subject", variables.Get(variables.Get(SpecialVariables.Action.Java.JavaKeystore.Variable) + ".Subject")},
-                
+
                 {"OctopusEnvironment_Tomcat_Certificate_Version", tomcatVersion},
                 {"OctopusEnvironment_Tomcat_Certificate_Default", variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.Default)},
                 {"OctopusEnvironment_Tomcat_Certificate_Hostname", variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.Hostname)},
@@ -46,7 +55,49 @@ namespace Calamari.Deployment.Features.Java.Actions
                 {"OctopusEnvironment_Tomcat_Certificate_PublicKeyFilename", variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.PublicKeyFilename)},
             });
         }
-        
+
+        void ExecuteNative(IVariables variables, string tomcatVersionOutput)
+        {
+            var certificateId = variables.Get(SpecialVariables.Action.Java.JavaKeystore.Variable);
+
+            var catalinaBase = variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.CatalinaBase);
+            if (string.IsNullOrWhiteSpace(catalinaBase))
+                catalinaBase = variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.CatalinaHome);
+
+            var options = new TomcatCertificateOptions(
+                                                        catalinaBase,
+                                                        variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.Service),
+                                                        variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.Port),
+                                                        ParseImplementation(variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.Implementation)),
+                                                        TomcatVersion.Parse(tomcatVersionOutput),
+                                                        variables.GetFlag(SpecialVariables.Action.Java.TomcatDeployCertificate.Default, true),
+                                                        variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.Hostname),
+                                                        variables.Get(certificateId + ".PrivateKeyPem"),
+                                                        variables.Get(certificateId + ".CertificatePem"),
+                                                        variables.Get(SpecialVariables.Action.Java.JavaKeystore.Password),
+                                                        variables.Get(SpecialVariables.Action.Java.JavaKeystore.KeystoreAlias),
+                                                        variables.Get(SpecialVariables.Action.Java.JavaKeystore.KeystoreFilename),
+                                                        variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.PrivateKeyFilename),
+                                                        variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.PublicKeyFilename));
+
+            new TomcatConnectorConfigurator(log).ConfigureHttps(options);
+        }
+
+        static TomcatHttpsImplementation ParseImplementation(string value)
+        {
+            switch ((value ?? "NIO").Trim().ToUpperInvariant())
+            {
+                case "APR":
+                    return TomcatHttpsImplementation.Apr;
+                case "NIO2":
+                    return TomcatHttpsImplementation.Nio2;
+                case "BIO":
+                    return TomcatHttpsImplementation.Bio;
+                default:
+                    return TomcatHttpsImplementation.Nio;
+            }
+        }
+
         string GetTomcatVersion(IVariables variables)
         {
             var catalinaHome = variables.Get(SpecialVariables.Action.Java.TomcatDeployCertificate.CatalinaHome) ??
@@ -62,7 +113,7 @@ namespace Calamari.Deployment.Features.Java.Actions
 
             var version = new StringBuilder();
             var versionCheck = SilentProcessRunner.ExecuteCommand(JavaRuntime.CmdPath,
-                $"-cp \"{catalinaPath}\" org.apache.catalina.util.ServerInfo", ".", 
+                $"-cp \"{catalinaPath}\" org.apache.catalina.util.ServerInfo", ".",
                 (stdOut) =>
                 {
                     log.Verbose(stdOut);

--- a/source/Calamari/Deployment/Features/Java/Actions/TomcatStateAction.cs
+++ b/source/Calamari/Deployment/Features/Java/Actions/TomcatStateAction.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using Calamari.Common.Commands;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Plumbing.Logging;
+using Calamari.Integration.Tomcat;
 
 namespace Calamari.Deployment.Features.Java.Actions
 {
@@ -18,6 +20,29 @@ namespace Calamari.Deployment.Features.Java.Actions
         {
             var variables = deployment.Variables;
             log.Info("Updating Tomcat state");
+
+            if (OctopusFeatureToggles.TomcatNativeIntegrationFeatureToggle.IsEnabled(variables))
+            {
+                var options = new TomcatManagerOptions(
+                                                        variables.Get(SpecialVariables.Action.Java.Tomcat.Controller),
+                                                        variables.Get(SpecialVariables.Action.Java.Tomcat.User),
+                                                        variables.Get(SpecialVariables.Action.Java.Tomcat.Password),
+                                                        "",
+                                                        variables.Get(SpecialVariables.Action.Java.Tomcat.DeployName),
+                                                        "",
+                                                        variables.Get(SpecialVariables.Action.Java.Tomcat.Version));
+
+                var enabled = variables.GetFlag(SpecialVariables.Action.Java.Tomcat.Enabled, true);
+                var client = new TomcatManagerClient(log);
+                if (enabled)
+                    client.Start(options);
+                else
+                    client.Stop(options);
+
+                client.VerifyState(options, enabled);
+                return;
+            }
+
             runner.Run("com.octopus.calamari.tomcat.TomcatState", new Dictionary<string, string>()
             {
                 {"OctopusEnvironment_Tomcat_Deploy_Name", variables.Get(SpecialVariables.Action.Java.Tomcat.DeployName)},

--- a/source/Calamari/Deployment/Features/Java/TomcatFeature.cs
+++ b/source/Calamari/Deployment/Features/Java/TomcatFeature.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Calamari.Common.Commands;
+using Calamari.Common.FeatureToggles;
 using Calamari.Common.Features.Deployment;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
+using Calamari.Integration.Tomcat;
 
 namespace Calamari.Deployment.Features.Java
 {
@@ -31,6 +33,12 @@ namespace Calamari.Deployment.Features.Java
                   (variables.Get(KnownVariables.Package.EnabledFeatures) ?? "").Contains(SpecialVariables.Action.Java.Tomcat.Feature)))
                 return;
 
+            if (OctopusFeatureToggles.TomcatNativeIntegrationFeatureToggle.IsEnabled(variables))
+            {
+                ExecuteNative(deployment);
+                return;
+            }
+
             // Environment variables are used to pass parameters to the Java library
             log.Verbose("Invoking java to perform Tomcat integration");
             javaRunner.Run("com.octopus.calamari.tomcat.TomcatDeploy", new Dictionary<string, string>()
@@ -43,6 +51,33 @@ namespace Calamari.Deployment.Features.Java
                 {"OctopusEnvironment_Tomcat_Deploy_Enabled", variables.Get(SpecialVariables.Action.Java.Tomcat.Enabled)},
                 {"OctopusEnvironment_Tomcat_Deploy_Version", variables.Get(SpecialVariables.Action.Java.Tomcat.Version)},
             });
+        }
+
+        void ExecuteNative(RunningDeployment deployment)
+        {
+            var variables = deployment.Variables;
+            var applicationPath = variables.Get(PackageVariables.Output.InstallationPackagePath, deployment.PackageFilePath);
+
+            var options = new TomcatManagerOptions(
+                                                    variables.Get(SpecialVariables.Action.Java.Tomcat.Controller),
+                                                    variables.Get(SpecialVariables.Action.Java.Tomcat.User),
+                                                    variables.Get(SpecialVariables.Action.Java.Tomcat.Password),
+                                                    applicationPath,
+                                                    variables.Get(SpecialVariables.Action.Java.Tomcat.DeployName),
+                                                    "",
+                                                    variables.Get(SpecialVariables.Action.Java.Tomcat.Version));
+
+            log.Verbose("Deploying application to Tomcat");
+            var client = new TomcatManagerClient(log);
+            client.Deploy(options, applicationPath);
+
+            var enabled = variables.GetFlag(SpecialVariables.Action.Java.Tomcat.Enabled, true);
+            if (enabled)
+                client.Start(options);
+            else
+                client.Stop(options);
+
+            client.VerifyState(options, enabled);
         }
     }
 }


### PR DESCRIPTION
⚠️ **Does this change require a corresponding Server Change?** Yes — same reason as #2140, the `tomcat-native-integration` toggle needs its own Server-side `OctopusFeatureToggle` definition. Adding the `Requires Server Change` label.

Stacked on #2140 (`feature/java-keystore-bouncycastle`) — please merge that one first.

## Background
Continues the effort started in #2140 to drop the `Octopus.Dependencies.Java` dependency from Calamari. This PR covers the 3 Tomcat steps: Deploy, State, and Deploy a Certificate to Tomcat, all of which currently shell out to Java processes in that package.

## Results
- `TomcatManagerClient`/`TomcatManagerOptions` (`Calamari.Shared/Integration/Tomcat/`): talks to Tomcat's Manager `/text/...` HTTP API directly — it was always just an authenticated HTTP call, no JVM needed. Covers deploy/redeploy/undeploy/start/stop/list, matching the original's URL-building and retry policy, except 401/403 responses now throw a distinct `TomcatAuthenticationException` that's excluded from retry (same "don't retry deterministic failures" fix as #2140).
- `TomcatConnectorConfigurator` (`.../Certificates/Java/Tomcat/`): edits `server.xml` directly via `XmlDocument`/XPath (matching the existing convention in `XmlFormatVariableReplacer`) for the Deploy Certificate step. Covers Tomcat 7/8.0 (attributes on `<Connector>`) and 8.5+ (`<SSLHostConfig><Certificate>`), both keystore-based (BIO/NIO/NIO2, reusing `JavaKeystoreBuilder` from #2140) and APR (raw PEM files), plus version guards (NIO2 needs ≥8.0, BIO forbidden ≥8.5).
- All three actions (`TomcatFeature`, `TomcatStateAction`, `TomcatDeployCertificateAction`) branch on the single `tomcat-native-integration` toggle; default off, existing path unchanged.

## Caveats
`ConnectorIsEmpty` approximates the original's large version-accumulated attribute whitelist by checking for absence of certificate-specific attributes instead — simpler, sufficient for the default-host-detection heuristic it backs, but not a byte-for-byte port. Flagged for review.

## Testing
22 new NUnit tests across 3 fixtures: URL-building unit tests, a real local `HttpListener` exercising the HTTP client end-to-end (auth headers, 401/403), and 9 tests driving `TomcatConnectorConfigurator` against real generated certs and real `server.xml` files (Tomcat 7 vs 9, NIO vs APR, missing `<Service>`, version guards, backup zip). Same 4 pre-existing unrelated `DeployJavaArchiveFixture` JVM-dependent failures as #2140.

Beyond the committed suite, this was also manually verified end-to-end against a **real Tomcat 9 container** (Docker, manager app enabled, Tomcat Native/APR loaded), using temporary `[Explicit]` fixtures that were not committed:
- `TomcatManagerClient`: full deploy (WAR upload) → list → `VerifyState` → stop → start → undeploy lifecycle against the real Manager API, plus a wrong-credentials case confirming the fail-fast (no retry) behaviour.
- `TomcatConnectorConfigurator`: generated real certs, ran the configurator against a copy of the container's actual `server.xml` for both the NIO (keystore) and APR (raw PEM) implementations, pushed the result back into the container, and confirmed via `openssl s_client`/`curl` that Tomcat started the HTTPS connector and served the exact certificate configured in each case.

## How to review
`TomcatConnectorConfigurator.cs` is the core and riskiest piece — the version/implementation branching is where subtle bugs would hide. `TomcatManagerClient.cs` is comparatively straightforward HTTP wiring. The diff shown here is scoped to Tomcat-only changes since the base is #2140's branch, not `main`.