### PR TITLE
chore: Repo-level Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,109 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard"
+  ],
+  "timezone": "Australia/Brisbane",
+  "schedule": [
+    "before 6am on monday"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "minimumReleaseAge": "3 days",
+  "ignorePaths": [
+    "source/Calamari.Tests/Fixtures/**",
+    "publish/**",
+    "**/bin/**",
+    "**/obj/**"
+  ],
+  "vulnerabilityAlerts": {
+    "description": "Advisories jump the weekly queue and carry their own label",
+    "enabled": true,
+    "labels": [
+      "dependencies",
+      "security"
+    ],
+    "schedule": [
+      "at any time"
+    ],
+    "minimumReleaseAge": null
+  },
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "description": "Majors wait for a tick on the dependency dashboard",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "One PR for the AWS SDK, which versions its packages in lockstep",
+      "matchPackageNames": [
+        "AWSSDK.**"
+      ],
+      "groupName": "AWS SDK"
+    },
+    {
+      "description": "One PR for the Azure SDK and the identity library it depends on",
+      "matchPackageNames": [
+        "Azure.**",
+        "Microsoft.Identity.Client"
+      ],
+      "groupName": "Azure SDK"
+    },
+    {
+      "description": "One PR for the NuGet client libraries",
+      "matchPackageNames": [
+        "NuGet.**"
+      ],
+      "groupName": "NuGet client"
+    },
+    {
+      "description": "One PR for test-only dependencies",
+      "matchPackageNames": [
+        "Assent",
+        "FluentAssertions",
+        "Microsoft.Extensions.TimeProvider.Testing",
+        "Microsoft.NET.Test.Sdk",
+        "NSubstitute",
+        "NUnit",
+        "NUnit3TestAdapter",
+        "TeamCity.VSTest.TestAdapter",
+        "TestStack.BDDfy",
+        "WireMock.Net",
+        "nunit"
+      ],
+      "groupName": "test dependencies"
+    },
+    {
+      "description": "One PR for Serilog and its sinks",
+      "matchPackageNames": [
+        "Serilog",
+        "Serilog.**"
+      ],
+      "groupName": "Serilog"
+    },
+    {
+      "description": "One PR for Octopus packages. Most resolve from feedz.io, so they stay quiet until the runner has credentials for that feed",
+      "matchPackageNames": [
+        "Octopus.**",
+        "Octostache"
+      ],
+      "groupName": "Octopus packages"
+    },
+    {
+      "description": "Workflow actions move slowly and are pinned by digest to match the existing pin on renovatebot/github-action",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "GitHub Actions",
+      "pinDigests": true,
+      "schedule": [
+        "before 6am on the first day of the month"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Background

Renovate has been installed since January with no configuration. `renovate.json` holds only a schema reference. The schedule in `renovate-dependencies.yml` stays commented out. Every dependency bump in the history was written by hand, including the ones that closed advisories.

This PR adds the configuration. Turning the schedule on is a separate decision.

## Results

- Weekly run. Advisories run on their own schedule with a `security` label.
- `osvVulnerabilityAlerts` adds the OSV database on top of GitHub's alerts.
- The AWS SDK, the Azure SDK, the NuGet client, Serilog, and the test dependencies each land as one PR.
- Majors queue on the dependency dashboard for approval.
- Workflow actions update monthly and pin by digest.
- Test fixtures and the `publish` output are ignored. No automerge.

Validated with `renovate-config-validator`.

## How to review this PR

General quality. The grouping is the one judgment call: fewer PRs, coarser review granularity.

## Reducing risk

- Nothing runs from this PR. The scheduled trigger stays commented out.
- Confirm `RENOVATE_GITHUB_TOKEN` belongs to an org member before turning the schedule on. TeamCity filters PR builds to `MEMBER`. The 12 Dependabot PRs have never built for that reason.
- The Octopus group stays quiet until the runner has feedz.io credentials.
- `global.json` and the release branches are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
