### PR TITLE
Always send modelUsage on the claude-code-usage service message

### DIFF
--- a/source/Calamari.Tests/AiAgent/ClaudeCodeBehaviour/ClaudeCodeUsageReporterFixture.cs
+++ b/source/Calamari.Tests/AiAgent/ClaudeCodeBehaviour/ClaudeCodeUsageReporterFixture.cs
@@ -107,6 +107,22 @@ public class ClaudeCodeUsageReporterFixture
         msg.GetValue(ClaudeCodeServiceMessages.Usage.ModelUsageAttribute).Should().NotBeNull();
     }
 
+    [Test]
+    public void RunSummaryWithoutModelUsage_StillCarriesAnEmptyModelUsageAttribute()
+    {
+        // The server requires the attribute; a run that fails before any model round-trip has none
+        reporter.SetRunSummary(new ClaudeCodeRunSummary
+        {
+            TotalCostUsd = 0,
+            DurationMs = 1234,
+            NumTurns = 0,
+        });
+
+        reporter.WriteServiceMessage(log);
+
+        DeserializeModelUsage().Should().BeEmpty();
+    }
+
     ClaudeCodeModelUsage[] DeserializeModelUsage()
     {
         var msg = log.ServiceMessages.Single(m => m.Name == ClaudeCodeServiceMessages.Usage.Name);

--- a/source/Calamari/AiAgent/ClaudeCodeBehaviour/ClaudeCodeUsageReporter.cs
+++ b/source/Calamari/AiAgent/ClaudeCodeBehaviour/ClaudeCodeUsageReporter.cs
@@ -44,14 +44,13 @@ public class ClaudeCodeUsageReporter
     {
         if (modelUsage.Count == 0 && summaryProperties.Count == 0)
             return;
+        
+        if (modelUsage.Count == 0)
+            log.Verbose("Claude Code reported no per-model usage for this run.");
 
         var properties = new Dictionary<string, string>(summaryProperties);
-
-        if (modelUsage.Count > 0)
-        {
-            var usageList = new List<ClaudeCodeModelUsage>(modelUsage.Values);
-            properties[ClaudeCodeServiceMessages.Usage.ModelUsageAttribute] = JsonSerializer.Serialize(usageList);
-        }
+        var usageList = new List<ClaudeCodeModelUsage>(modelUsage.Values);
+        properties[ClaudeCodeServiceMessages.Usage.ModelUsageAttribute] = JsonSerializer.Serialize(usageList);
 
         log.WriteServiceMessage(new ServiceMessage(ClaudeCodeServiceMessages.Usage.Name, properties));
     }


### PR DESCRIPTION
Fixes [SF-3393](https://linear.app/octopus/issue/SF-3393/add-missing-property-to-claude-code-usage-service-message)

`claude-code-usage` only carried `modelUsage` when there was per-model usage to report, but the server treats that property as required. A run that ends before any model round-trip (auth failure, cancellation, injection check disabled) sends summary-only and the server-side mapper throws, dropping the whole service message batch — including the transcript.

Now always sends the attribute, empty list included, so the run summary still gets through. Logs a verbose line when there's no per-model usage.

:warning: Does this change require a corresponding Server Change?

No — the server already requires `modelUsage`; this makes Calamari always send it. A separate server-side change to stop the mapper throwing on old agents is worth doing, tracked by LEV-1350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)