### PR TITLE
Fix memory growth

### DIFF
--- a/source/Calamari/Kubernetes/Integration/CaptureCommandOutput.cs
+++ b/source/Calamari/Kubernetes/Integration/CaptureCommandOutput.cs
@@ -14,39 +14,21 @@ namespace Calamari.Kubernetes.Integration
 
     public class CaptureCommandOutput : ICommandInvocationOutputSink, ICommandOutput
     {
-        readonly List<Message> messages = new List<Message>();
-        Message[] snapshot;
+        private readonly List<Message> messages = new List<Message>();
+        public Message[] Messages => messages.ToArray();
 
-        public Message[] Messages => snapshot ??= messages.ToArray();
-
-        public IEnumerable<string> InfoLogs
-        {
-            get
-            {
-                foreach (var message in Messages)
-                {
-                    if (message.Level == Level.Info)
-                        yield return message.Text;
-                }
-            }
-        }
+        public IEnumerable<string> InfoLogs => Messages.Where(m => m.Level == Level.Info).Select(m => m.Text).ToArray();
 
         public string MergeInfoLogs() => string.Join(Environment.NewLine, InfoLogs);
 
         public void WriteInfo(string line)
         {
-            Add(new Message(Level.Info, line));
+            messages.Add(new Message(Level.Info, line));
         }
 
         public void WriteError(string line)
         {
-            Add(new Message(Level.Error, line));
-        }
-
-        void Add(Message message)
-        {
-            messages.Add(message);
-            snapshot = null;
+            messages.Add(new Message(Level.Error, line));
         }
     }
 

--- a/source/Calamari/Kubernetes/Integration/CaptureCommandOutput.cs
+++ b/source/Calamari/Kubernetes/Integration/CaptureCommandOutput.cs
@@ -14,21 +14,39 @@ namespace Calamari.Kubernetes.Integration
 
     public class CaptureCommandOutput : ICommandInvocationOutputSink, ICommandOutput
     {
-        private readonly List<Message> messages = new List<Message>();
-        public Message[] Messages => messages.ToArray();
+        readonly List<Message> messages = new List<Message>();
+        Message[] snapshot;
 
-        public IEnumerable<string> InfoLogs => Messages.Where(m => m.Level == Level.Info).Select(m => m.Text).ToArray();
+        public Message[] Messages => snapshot ??= messages.ToArray();
+
+        public IEnumerable<string> InfoLogs
+        {
+            get
+            {
+                foreach (var message in Messages)
+                {
+                    if (message.Level == Level.Info)
+                        yield return message.Text;
+                }
+            }
+        }
 
         public string MergeInfoLogs() => string.Join(Environment.NewLine, InfoLogs);
 
         public void WriteInfo(string line)
         {
-            messages.Add(new Message(Level.Info, line));
+            Add(new Message(Level.Info, line));
         }
 
         public void WriteError(string line)
         {
-            messages.Add(new Message(Level.Error, line));
+            Add(new Message(Level.Error, line));
+        }
+
+        void Add(Message message)
+        {
+            messages.Add(message);
+            snapshot = null;
         }
     }
 

--- a/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/KubectlGet.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Calamari.Common.Plumbing.Extensions;
+using System.Text;
 using Calamari.Kubernetes.Integration;
 using Calamari.Kubernetes.ResourceStatus.Resources;
 
@@ -38,26 +38,46 @@ namespace Calamari.Kubernetes.ResourceStatus
 
         static KubectlGetResult ProcessResult(CommandResultWithOutput commandResult)
         {
-            return new KubectlGetResult(
-                commandResult.Output.InfoLogs.Join(string.Empty),
-                commandResult.Output.Messages.Select(msg => $"{msg.Level}: {msg.Text}").ToList(),
-                commandResult.Result.ExitCode);
+            // these payloads are a whole namespace of one kind, so we avoid copying them
+            var messages = commandResult.Output.Messages;
+
+            var resourceJson = new StringBuilder();
+            foreach (var message in messages)
+            {
+                if (message.Level == Level.Info)
+                    resourceJson.Append(message.Text);
+            }
+
+            return new KubectlGetResult(resourceJson.ToString(), messages, commandResult.Result.ExitCode);
         }
     }
 
     public class KubectlGetResult
     {
+        readonly Message[] messages;
+        readonly IList<string> formattedOutput;
+
         public KubectlGetResult(string resourceJson, IList<string> rawOutput, int exitCode)
         {
             ResourceJson = resourceJson;
-            RawOutput = rawOutput;
+            formattedOutput = rawOutput;
+            ExitCode = exitCode;
+        }
+
+        public KubectlGetResult(string resourceJson, Message[] messages, int exitCode)
+        {
+            ResourceJson = resourceJson;
+            this.messages = messages;
             ExitCode = exitCode;
         }
 
         public string ResourceJson { get; }
 
-        public IList<string> RawOutput { get; }
-
         public int ExitCode { get; }
+
+        public bool HasOutput => messages?.Length > 0 || formattedOutput?.Count > 0;
+
+        public IEnumerable<string> RawOutput
+            => formattedOutput ?? messages?.Select(msg => $"{msg.Level}: {msg.Text}") ?? Enumerable.Empty<string>();
     }
 }

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceRetriever.cs
@@ -50,7 +50,7 @@ namespace Calamari.Kubernetes.ResourceStatus
         /// <inheritdoc />
         public IEnumerable<ResourceRetrieverResult> GetAllOwnedResources(IEnumerable<ResourceIdentifier> resourceIdentifiers, IKubectl kubectl, Options options)
         {
-            var childResourceCache = new Dictionary<(ResourceGroupVersionKind, string), KubectlGetResult>();
+            var childResourceCache = new Dictionary<(ResourceGroupVersionKind, string), ChildResourceLookup>();
 
             var results = resourceIdentifiers
                           .Select(identifier => GetResource(identifier, kubectl, options))
@@ -70,7 +70,7 @@ namespace Calamari.Kubernetes.ResourceStatus
             var result = kubectlGet.Resource(resourceIdentifier, kubectl);
             LogKubectlErrorIfFailed(result, options, log);
 
-            if (result.RawOutput.IsNullOrEmpty())
+            if (!result.HasOutput)
                 return ResourceRetrieverResult.Failure($"Failed to get resource {resourceIdentifier.Name} in namespace {resourceIdentifier.Namespace}");
 
             var parseResult = TryParse(ResourceFactory.FromJson, result, options);
@@ -78,52 +78,63 @@ namespace Calamari.Kubernetes.ResourceStatus
         }
 
         IEnumerable<Resource> GetChildrenResources(Resource parentResource, IKubectl kubectl, Options options,
-            Dictionary<(ResourceGroupVersionKind, string), KubectlGetResult> childResourceCache)
+            Dictionary<(ResourceGroupVersionKind, string), ChildResourceLookup> childResourceCache)
         {
             var childGvk = parentResource.ChildGroupVersionKind;
             if (childGvk is null) return Enumerable.Empty<Resource>();
 
-            var result = GetAllResourcesCached(childGvk, parentResource.Namespace, kubectl, options, childResourceCache);
+            var lookup = GetChildResourceLookupCached(childGvk, parentResource.Namespace, kubectl, options, childResourceCache);
+            var children = lookup.ForOwner(parentResource.Uid);
 
-            if (result.RawOutput.IsNullOrEmpty())
+            foreach (var child in children)
+            {
+                // the lookup is shared between parents, so resolve each child's children once
+                if (child.Children == null)
+                {
+                    child.UpdateChildren(GetChildrenResources(child, kubectl, options, childResourceCache));
+                }
+            }
+
+            return children;
+        }
+
+        // only cache the parsed results, or you'll cause bankruptcy given post-ai memory costs
+        ChildResourceLookup GetChildResourceLookupCached(ResourceGroupVersionKind groupVersionKind, string @namespace, IKubectl kubectl, Options options,
+            Dictionary<(ResourceGroupVersionKind, string), ChildResourceLookup> childResourceCache)
+        {
+            var cacheKey = (groupVersionKind, @namespace);
+            if (childResourceCache.TryGetValue(cacheKey, out var cached))
+            {
+                return cached;
+            }
+
+            var lookup = BuildChildResourceLookup(groupVersionKind, @namespace, kubectl, options);
+            childResourceCache[cacheKey] = lookup;
+            return lookup;
+        }
+
+        ChildResourceLookup BuildChildResourceLookup(ResourceGroupVersionKind groupVersionKind, string @namespace, IKubectl kubectl, Options options)
+        {
+            var result = kubectlGet.AllResources(groupVersionKind, @namespace, kubectl);
+            LogKubectlErrorIfFailed(result, options, log);
+
+            if (!result.HasOutput)
             {
                 // Child resources are ignored for determining deployment success.
-                log.Verbose($"Failed to get child resources for {parentResource.Name} in namespace {parentResource.Namespace}");
-                return Enumerable.Empty<Resource>();
+                log.Verbose($"Failed to get child resources of type {groupVersionKind.Kind} in namespace {@namespace}");
+                return ChildResourceLookup.Empty;
             }
 
             var parseResult = TryParse(ResourceFactory.FromListJson, result, options);
             if (!parseResult.IsSuccess)
             {
                 // Child resources are ignored for determining deployment success.
-                log.Verbose($"Failed to parse child resources for {parentResource.Name} in namespace {parentResource.Namespace}");
+                log.Verbose($"Failed to parse child resources of type {groupVersionKind.Kind} in namespace {@namespace}");
                 log.Verbose(parseResult.ErrorMessage);
-                return Enumerable.Empty<Resource>();
+                return ChildResourceLookup.Empty;
             }
 
-            var resources = parseResult.Value;
-            return resources.Where(resource => resource.OwnerUids.Contains(parentResource.Uid))
-                            .Select(child =>
-                                    {
-                                        child.UpdateChildren(GetChildrenResources(child, kubectl, options, childResourceCache));
-                                        return child;
-                                    })
-                            .ToList();
-        }
-
-        KubectlGetResult GetAllResourcesCached(ResourceGroupVersionKind groupVersionKind, string @namespace, IKubectl kubectl, Options options,
-            Dictionary<(ResourceGroupVersionKind, string), KubectlGetResult> childResourceCache)
-        {
-            var cacheKey = (groupVersionKind, @namespace);
-            if (childResourceCache.TryGetValue(cacheKey, out var cachedResult))
-            {
-                return cachedResult;
-            }
-
-            var result = kubectlGet.AllResources(groupVersionKind, @namespace, kubectl);
-            LogKubectlErrorIfFailed(result, options, log);
-            childResourceCache[cacheKey] = result;
-            return result;
+            return ChildResourceLookup.From(parseResult.Value);
         }
 
         static ParseResult<T> TryParse<T>(Func<string, Options, T> function, KubectlGetResult getResult, Options options) where T : class
@@ -165,15 +176,53 @@ namespace Calamari.Kubernetes.ResourceStatus
             log.Verbose($"kubectl failed with exit code: {getResult.ExitCode}");
             log.Verbose("---------------------------");
 
-            if (getResult.RawOutput != null && getResult.RawOutput.Any())
+            foreach (var line in getResult.RawOutput)
             {
-                foreach (var line in getResult.RawOutput)
-                {
-                    log.Verbose(line);
-                }
+                log.Verbose(line);
             }
 
             log.Verbose("---------------------------");
+        }
+
+        class ChildResourceLookup
+        {
+            public static readonly ChildResourceLookup Empty = new ChildResourceLookup(new Dictionary<string, List<Resource>>());
+
+            readonly Dictionary<string, List<Resource>> byOwnerUid;
+
+            ChildResourceLookup(Dictionary<string, List<Resource>> byOwnerUid)
+            {
+                this.byOwnerUid = byOwnerUid;
+            }
+
+            public static ChildResourceLookup From(IEnumerable<Resource> resources)
+            {
+                var byOwnerUid = new Dictionary<string, List<Resource>>();
+
+                foreach (var resource in resources)
+                {
+                    foreach (var ownerUid in resource.OwnerUids ?? Enumerable.Empty<string>())
+                    {
+                        if (ownerUid.IsNullOrEmpty())
+                            continue;
+
+                        if (!byOwnerUid.TryGetValue(ownerUid, out var owned))
+                        {
+                            owned = new List<Resource>();
+                            byOwnerUid[ownerUid] = owned;
+                        }
+
+                        owned.Add(resource);
+                    }
+                }
+
+                return new ChildResourceLookup(byOwnerUid);
+            }
+
+            public IReadOnlyList<Resource> ForOwner(string ownerUid)
+                => !ownerUid.IsNullOrEmpty() && byOwnerUid.TryGetValue(ownerUid, out var owned)
+                    ? owned
+                    : Array.Empty<Resource>();
         }
 
         class ParseResult<T> where T : class

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ConfigMap.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ConfigMap.cs
@@ -9,7 +9,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         
         public ConfigMap(JObject json, Options options) : base(json, options)
         {
-            Data = (data.SelectToken("$.data")
+            Data = (json.SelectToken("$.data")
                 ?.ToObject<Dictionary<string, string>>() ?? new Dictionary<string, string>())
                 .Count;
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/CronJob.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/CronJob.cs
@@ -9,8 +9,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public CronJob(JObject json, Options options) : base(json, options)
         {
-            Schedule = Field("$.spec.schedule");
-            Suspend = FieldOrDefault("$.spec.suspend", false);
+            Schedule = Field(json, "$.spec.schedule");
+            Suspend = FieldOrDefault(json, "$.spec.suspend", false);
         }
 
         public override bool HasUpdate(Resource lastStatus)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/DaemonSet.cs
@@ -17,18 +17,18 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public DaemonSet(JObject json, Options options) : base(json, options)
         {
-            Desired = FieldOrDefault("$.status.desiredNumberScheduled", 0);
-            Current = FieldOrDefault("$.status.currentNumberScheduled", 0);
-            Ready = FieldOrDefault("$.status.numberReady", 0);
-            UpToDate = FieldOrDefault("$.status.updatedNumberScheduled", 0);
-            Available = FieldOrDefault("$.status.numberAvailable", 0);
-            var selectors = data.SelectToken("$.spec.template.spec.nodeSelector")
+            Desired = FieldOrDefault(json, "$.status.desiredNumberScheduled", 0);
+            Current = FieldOrDefault(json, "$.status.currentNumberScheduled", 0);
+            Ready = FieldOrDefault(json, "$.status.numberReady", 0);
+            UpToDate = FieldOrDefault(json, "$.status.updatedNumberScheduled", 0);
+            Available = FieldOrDefault(json, "$.status.numberAvailable", 0);
+            var selectors = json.SelectToken("$.spec.template.spec.nodeSelector")
                 ?.ToObject<Dictionary<string, string>>() ?? new Dictionary<string, string>();
             NodeSelector = FormatNodeSelectors(selectors);
 
             ResourceStatus = options.EnableLegacyResourceStatusChecks
                 ? GetLegacyResourceStatus()
-                : GetResourceStatus();
+                : GetResourceStatus(json);
         }
 
         ResourceStatus GetLegacyResourceStatus()
@@ -37,16 +37,16 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                 : ResourceStatus.InProgress;
 
         // Aligns with gitops-engine getDaemonSetHealth.
-        ResourceStatus GetResourceStatus()
+        ResourceStatus GetResourceStatus(JObject json)
         {
-            var generation = FieldOrDefault("$.metadata.generation", 0);
-            var observedGeneration = FieldOrDefault("$.status.observedGeneration", 0);
+            var generation = FieldOrDefault(json, "$.metadata.generation", 0);
+            var observedGeneration = FieldOrDefault(json, "$.status.observedGeneration", 0);
             if (generation > observedGeneration)
             {
                 return ResourceStatus.InProgress;
             }
 
-            if (Field("$.spec.updateStrategy.type") == "OnDelete")
+            if (Field(json, "$.spec.updateStrategy.type") == "OnDelete")
             {
                 return ResourceStatus.Successful;
             }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Deployment.cs
@@ -26,12 +26,12 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         {
             enableLegacyResourceStatusChecks = options.EnableLegacyResourceStatusChecks;
 
-            ReadyReplicas = FieldOrDefault("$.status.readyReplicas", 0);
-            Desired = FieldOrDefault("$.spec.replicas", 0);
-            TotalReplicas = FieldOrDefault("$.status.replicas", 0);
+            ReadyReplicas = FieldOrDefault(json, "$.status.readyReplicas", 0);
+            Desired = FieldOrDefault(json, "$.spec.replicas", 0);
+            TotalReplicas = FieldOrDefault(json, "$.status.replicas", 0);
             Ready = $"{ReadyReplicas}/{Desired}";
-            Available = FieldOrDefault("$.status.availableReplicas", 0);
-            UpToDate = FieldOrDefault("$.status.updatedReplicas", 0);
+            Available = FieldOrDefault(json, "$.status.availableReplicas", 0);
+            UpToDate = FieldOrDefault(json, "$.status.updatedReplicas", 0);
 
             ResourceStatus = GetResourceStatus(json);
         }
@@ -40,13 +40,13 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         ResourceStatus GetResourceStatus(JObject json)
         {
             // gitops-engine treats a paused deployment as suspended rather than blocking on it.
-            if (!enableLegacyResourceStatusChecks && FieldOrDefault("$.spec.paused", false))
+            if (!enableLegacyResourceStatusChecks && FieldOrDefault(json, "$.spec.paused", false))
             {
                 return ResourceStatus.Successful;
             }
 
-            var generation = FieldOrDefault("$.metadata.generation", 0);
-            var observedGeneration = FieldOrDefault("$.status.observedGeneration", 0);
+            var generation = FieldOrDefault(json, "$.metadata.generation", 0);
+            var observedGeneration = FieldOrDefault(json, "$.status.observedGeneration", 0);
 
             if (generation > observedGeneration)
             {

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointSlice.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/EndpointSlice.cs
@@ -12,13 +12,13 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public EndpointSlice(JObject json, Options options) : base(json, options)
         {
-            AddressType = Field("$.addressType");
+            AddressType = Field(json, "$.addressType");
             
-            var ports = data.SelectToken("$.ports")
+            var ports = json.SelectToken("$.ports")
                 ?.ToObject<ServicePort[]>() ?? new ServicePort[] { };
             Ports = ports.Select(port => port.Port.ToString());
 
-            var endpoints = data.SelectToken("$.endpoints")
+            var endpoints = json.SelectToken("$.endpoints")
                 ?.ToObject<Endpoint[]>() ?? new Endpoint[] { };
             Endpoints = FormatEndpoints(endpoints);
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Ingress.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Ingress.cs
@@ -12,13 +12,13 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public Ingress(JObject json, Options options) : base(json, options)
         {
-            Class = Field("$.spec.ingressClassName");
+            Class = Field(json, "$.spec.ingressClassName");
 
-            var rules = data.SelectToken("$.spec.rules")
+            var rules = json.SelectToken("$.spec.rules")
                 ?.ToObject<IngressRule[]>() ?? new IngressRule[] { };
             Hosts = FormatHosts(rules);            
 
-            var loadBalancerIngresses = data.SelectToken("$.status.loadBalancer.ingress")
+            var loadBalancerIngresses = json.SelectToken("$.status.loadBalancer.ingress")
                 ?.ToObject<LoadBalancerIngress[]>() ?? new LoadBalancerIngress[] { };
             
             Address = FormatAddress(loadBalancerIngresses);

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Job.cs
@@ -10,13 +10,13 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public Job(JObject json, Options options) : base(json, options)
         {
-            var succeeded = FieldOrDefault("$.status.succeeded", 0);
-            var desired = FieldOrDefault("$.spec.completions", 0);
+            var succeeded = FieldOrDefault(json, "$.status.succeeded", 0);
+            var desired = FieldOrDefault(json, "$.spec.completions", 0);
             Completions = $"{succeeded}/{desired}";
 
             var defaultTime = DateTime.UtcNow;
-            var completionTime = FieldOrDefault("$.status.completionTime", defaultTime);
-            var startTime = FieldOrDefault("$.status.startTime", defaultTime);
+            var completionTime = FieldOrDefault(json, "$.status.completionTime", defaultTime);
+            var startTime = FieldOrDefault(json, "$.status.startTime", defaultTime);
 
             Duration = $"{completionTime - startTime:c}";
 
@@ -27,16 +27,16 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
             }
 
             ResourceStatus = options.EnableLegacyResourceStatusChecks
-                ? GetLegacyResourceStatus(succeeded, desired)
+                ? GetLegacyResourceStatus(json, succeeded, desired)
                 : GetResourceStatus(json);
         }
 
-        ResourceStatus GetLegacyResourceStatus(int succeeded, int desired)
+        static ResourceStatus GetLegacyResourceStatus(JObject json, int succeeded, int desired)
         {
-            var backoffLimit = FieldOrDefault("$.spec.backoffLimit", 0);
+            var backoffLimit = FieldOrDefault(json, "$.spec.backoffLimit", 0);
 
             // Using a default value of -1 rather than 0 as a job can be created with a backoffLimit of 0 and we don't want to immediately mark the job as failed
-            var failed = FieldOrDefault("$.status.failed", -1);
+            var failed = FieldOrDefault(json, "$.status.failed", -1);
 
             if (failed >= backoffLimit)
             {

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/PersistentVolume.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/PersistentVolume.cs
@@ -12,9 +12,9 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public PersistentVolume(JObject json, Options options) : base(json, options)
         {
-            Status = Field("$.status.phase");
-            ReclaimPolicy = Field("$.spec.persistentVolumeReclaimPolicy");
-            Capacity = Field("$.spec.capacity.storage");
+            Status = Field(json, "$.status.phase");
+            ReclaimPolicy = Field(json, "$.spec.persistentVolumeReclaimPolicy");
+            Capacity = Field(json, "$.spec.capacity.storage");
         }
 
         public override bool HasUpdate(Resource lastStatus)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/PersistentVolumeClaim.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/PersistentVolumeClaim.cs
@@ -14,11 +14,11 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         
         public PersistentVolumeClaim(JObject json, Options options) : base(json, options)
         {
-            Status = Field("$.status.phase");
-            Volume = Field("$.spec.volumeName");
-            Capacity = Field("$.status.capacity.storage");
-            AccessModes = data.SelectToken("$.status.accessModes")?.Values<string>() ?? new string[] { };
-            StorageClass = Field("$.spec.storageClassName");
+            Status = Field(json, "$.status.phase");
+            Volume = Field(json, "$.spec.volumeName");
+            Capacity = Field(json, "$.status.capacity.storage");
+            AccessModes = json.SelectToken("$.status.accessModes")?.Values<string>().ToList() ?? new List<string>();
+            StorageClass = Field(json, "$.spec.storageClassName");
         }
 
         public override bool HasUpdate(Resource lastStatus)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Pod.cs
@@ -11,20 +11,20 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public Pod(JObject json, Options options) : base(json, options)
         {
-            var phase = Field("$.status.phase");
-            var initContainerStatuses = data
+            var phase = Field(json, "$.status.phase");
+            var initContainerStatuses = json
                 .SelectToken("$.status.initContainerStatuses")
                 ?.ToObject<ContainerStatus[]>() ?? new ContainerStatus[] { };
-            var containerStatuses = data
+            var containerStatuses = json
                 .SelectToken("$.status.containerStatuses")
                 ?.ToObject<ContainerStatus[]>() ?? new ContainerStatus[] { };
-            var ready = data
+            var ready = json
                 .SelectToken("$.status.conditions[?(@.type == 'Ready')].status")
                 ?.Value<string>() ?? string.Empty;
             
             Status = GetStatus(phase, initContainerStatuses, containerStatuses);
 
-            var restartPolicy = FieldOrDefault("$.spec.restartPolicy", "Always");
+            var restartPolicy = FieldOrDefault(json, "$.spec.restartPolicy", "Always");
             ResourceStatus = options.EnableLegacyResourceStatusChecks
                 ? GetLegacyResourceStatus(phase, ready)
                 : GetResourceStatus(phase, containerStatuses, ready, restartPolicy);

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ReplicaSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ReplicaSet.cs
@@ -13,9 +13,9 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public ReplicaSet(JObject json, Options options) : base(json, options)
         {
-            Desired = FieldOrDefault("$.status.replicas", 0);
-            Current = FieldOrDefault($".status.availableReplicas", 0);
-            Ready = FieldOrDefault("$.status.readyReplicas", 0);
+            Desired = FieldOrDefault(json, "$.status.replicas", 0);
+            Current = FieldOrDefault(json, $".status.availableReplicas", 0);
+            Ready = FieldOrDefault(json, "$.status.readyReplicas", 0);
 
             ResourceStatus = options.EnableLegacyResourceStatusChecks
                 ? GetLegacyResourceStatus()
@@ -28,8 +28,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         // Aligns with gitops-engine getReplicaSetHealth.
         ResourceStatus GetResourceStatus(JObject json)
         {
-            var generation = FieldOrDefault("$.metadata.generation", 0);
-            var observedGeneration = FieldOrDefault("$.status.observedGeneration", 0);
+            var generation = FieldOrDefault(json, "$.metadata.generation", 0);
+            var observedGeneration = FieldOrDefault(json, "$.status.observedGeneration", 0);
             if (generation > observedGeneration)
             {
                 return ResourceStatus.InProgress;
@@ -42,7 +42,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                 return ResourceStatus.Failed;
             }
 
-            var specReplicas = FieldOrDefault<int?>("$.spec.replicas", null);
+            var specReplicas = FieldOrDefault<int?>(json, "$.spec.replicas", null);
             if (specReplicas.HasValue && Current < specReplicas.Value)
             {
                 return ResourceStatus.InProgress;

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -10,18 +11,16 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     /// </summary>
     public class Resource : IResourceIdentity
     {
-        [JsonIgnore] protected JObject data;
-
         [JsonIgnore] public IEnumerable<string> OwnerUids { get; }
 
         [JsonIgnore] public string Uid { get; protected set; }
-        
+
         [JsonIgnore] public ResourceGroupVersionKind GroupVersionKind { get; protected set; }
         [JsonIgnore] public string Name { get; }
         [JsonIgnore] public string Namespace { get; }
 
         [JsonIgnore] public virtual ResourceStatus ResourceStatus { get; set; } = ResourceStatus.Successful;
-        
+
         [JsonIgnore]
         public virtual ResourceGroupVersionKind ChildGroupVersionKind => default;
 
@@ -30,24 +29,25 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         internal Resource() { }
 
+        // json stays a parameter - retaining it pinned the whole parsed document via JToken.Parent
         public Resource(JObject json, Options options)
         {
-            data = json;
-            OwnerUids = data.SelectTokens("$.metadata.ownerReferences[*].uid").Values<string>();
-            Uid = Field("$.metadata.uid");
-            GroupVersionKind  = json.ToResourceGroupVersionKind();
-            Name = Field("$.metadata.name");
+            // force enumeration to prevent memory growth
+            OwnerUids = json.SelectTokens("$.metadata.ownerReferences[*].uid").Values<string>().ToList();
+            Uid = Field(json, "$.metadata.uid");
+            GroupVersionKind = json.ToResourceGroupVersionKind();
+            Name = Field(json, "$.metadata.name");
             //we explicitly want null if there is no namespace
-            Namespace = FieldOrDefault<string>("$.metadata.namespace", null);
+            Namespace = FieldOrDefault<string>(json, "$.metadata.namespace", null);
         }
 
         public virtual bool HasUpdate(Resource lastStatus) => false;
 
         public virtual void UpdateChildren(IEnumerable<Resource> children) => Children = children;
 
-        protected string Field(string jsonPath) => FieldOrDefault(jsonPath, "");
+        protected static string Field(JObject data, string jsonPath) => FieldOrDefault(data, jsonPath, "");
 
-        protected T FieldOrDefault<T>(string jsonPath, T defaultValue)
+        protected static T FieldOrDefault<T>(JObject data, string jsonPath, T defaultValue)
         {
             var result = data.SelectToken(jsonPath);
             if (result == null)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/ResourceFactory.cs
@@ -32,7 +32,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         public static IEnumerable<Resource> FromListJson(string json, Options options)
         {
             var listResponse = JObject.Parse(json);
-            return listResponse.SelectTokens("$.items[*]").Select(item => FromJObject((JObject)item, options));
+            return listResponse.SelectTokens("$.items[*]").Select(item => FromJObject((JObject)item, options)).ToList();
         }
 
         public static Resource FromJObject(JObject data, Options options)

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Secret.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Secret.cs
@@ -10,8 +10,8 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         
         public Secret(JObject json, Options options) : base(json, options)
         {
-            Type = Field("$.type");
-            Data = (data.SelectToken("$.data")
+            Type = Field(json, "$.type");
+            Data = (json.SelectToken("$.data")
                 ?.ToObject<Dictionary<string, string>>() ?? new Dictionary<string, string>())
                 .Count;
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Service.cs
@@ -15,14 +15,14 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public Service(JObject json, Options options) : base(json, options)
         {
-            Type = Field("$.spec.type");
-            ClusterIp = Field("$.spec.clusterIP");
+            Type = Field(json, "$.spec.type");
+            ClusterIp = Field(json, "$.spec.clusterIP");
 
-            var ports = data.SelectToken("$.spec.ports")
+            var ports = json.SelectToken("$.spec.ports")
                 ?.ToObject<ServicePort[]>() ?? new ServicePort[] { };
             Ports = FormatPorts(ports);
 
-            var loadBalancerIngresses = data.SelectToken("$.status.loadBalancer.ingress")
+            var loadBalancerIngresses = json.SelectToken("$.status.loadBalancer.ingress")
                 ?.ToObject<LoadBalancerIngress[]>() ?? new LoadBalancerIngress[] { };
 
             ExternalIp = FormatExternalIp(loadBalancerIngresses);

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/StatefulSet.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/StatefulSet.cs
@@ -10,39 +10,39 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
 
         public StatefulSet(JObject json, Options options) : base(json, options)
         {
-            var readyReplicas = FieldOrDefault("$.status.readyReplicas", 0);
-            var replicas = FieldOrDefault("$.status.replicas", 0);
+            var readyReplicas = FieldOrDefault(json, "$.status.readyReplicas", 0);
+            var replicas = FieldOrDefault(json, "$.status.replicas", 0);
             Ready = $"{readyReplicas}/{replicas}";
 
             ResourceStatus = options.EnableLegacyResourceStatusChecks
                 ? GetLegacyResourceStatus(readyReplicas, replicas)
-                : GetResourceStatus(readyReplicas);
+                : GetResourceStatus(json, readyReplicas);
         }
 
         static ResourceStatus GetLegacyResourceStatus(int readyReplicas, int replicas)
             => readyReplicas == replicas ? ResourceStatus.Successful : ResourceStatus.InProgress;
 
         // Aligns with gitops-engine getStatefulSetHealth.
-        ResourceStatus GetResourceStatus(int readyReplicas)
+        static ResourceStatus GetResourceStatus(JObject json, int readyReplicas)
         {
-            var generation = FieldOrDefault("$.metadata.generation", 0);
-            var observedGeneration = FieldOrDefault("$.status.observedGeneration", 0);
+            var generation = FieldOrDefault(json, "$.metadata.generation", 0);
+            var observedGeneration = FieldOrDefault(json, "$.status.observedGeneration", 0);
             if (observedGeneration == 0 || generation > observedGeneration)
             {
                 return ResourceStatus.InProgress;
             }
 
-            var specReplicas = FieldOrDefault<int?>("$.spec.replicas", null);
+            var specReplicas = FieldOrDefault<int?>(json, "$.spec.replicas", null);
             if (specReplicas.HasValue && readyReplicas < specReplicas.Value)
             {
                 return ResourceStatus.InProgress;
             }
 
-            var updateStrategy = Field("$.spec.updateStrategy.type");
-            if (updateStrategy == "RollingUpdate" && data.SelectToken("$.spec.updateStrategy.rollingUpdate") != null)
+            var updateStrategy = Field(json, "$.spec.updateStrategy.type");
+            if (updateStrategy == "RollingUpdate" && json.SelectToken("$.spec.updateStrategy.rollingUpdate") != null)
             {
-                var partition = FieldOrDefault<int?>("$.spec.updateStrategy.rollingUpdate.partition", null);
-                var updatedReplicas = FieldOrDefault("$.status.updatedReplicas", 0);
+                var partition = FieldOrDefault<int?>(json, "$.spec.updateStrategy.rollingUpdate.partition", null);
+                var updatedReplicas = FieldOrDefault(json, "$.status.updatedReplicas", 0);
                 if (specReplicas.HasValue && partition.HasValue && updatedReplicas < specReplicas.Value - partition.Value)
                 {
                     return ResourceStatus.InProgress;
@@ -55,7 +55,7 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
                 return ResourceStatus.Successful;
             }
 
-            if (Field("$.status.updateRevision") != Field("$.status.currentRevision"))
+            if (Field(json, "$.status.updateRevision") != Field(json, "$.status.currentRevision"))
             {
                 return ResourceStatus.InProgress;
             }


### PR DESCRIPTION
This PR fixes the 2 main reasons we were seeing memory growth when running resource monitoring in environments with many resources:
1. We stopped caching the raw JSON and started caching the parse. This way, we aren't copying and retaining as much data.
2. All of the resources we made held its JObject in a field, and that JObject was still a node inside the list it came from, so we were retaining a bunch (I'm pretty sure because of `JToken.Parent`). The json is now a constructor parameter rather than a field, so once the objects are made we can let go of the list properly.