### PR TITLE
Increase AWS retry to 5

### DIFF
--- a/source/Calamari.Aws/Util/ClientExtensions.cs
+++ b/source/Calamari.Aws/Util/ClientExtensions.cs
@@ -10,6 +10,9 @@ namespace Calamari.Aws.Util;
 
 public static class ClientExtensions
 {
+    //The SDK's Standard retry mode allows only 2 retries, which is not enough to ride out AWS throttling
+    const int MaxErrorRetry = 5;
+
     public static TConfig AsClientConfig<TConfig>(this AwsEnvironmentGeneration environment)
         where TConfig : ClientConfig, new()
     {
@@ -17,6 +20,7 @@ public static class ClientExtensions
                                  {
                                      x.RegionEndpoint = environment.AwsRegion;
                                      x.AllowAutoRedirect = true;
+                                     x.MaxErrorRetry = MaxErrorRetry;
                                  });
     }}
 


### PR DESCRIPTION
No server change required.

# Background

CloudFormation steps intermittently fail with `AmazonCloudFormationException: Rate exceeded`, surfaced by `CloudFormationTests.ShouldDeployChangeset` in Server CI ([Chain: Full #2026.3.13729](https://build.octopushq.com/buildConfiguration/OctopusDeploy_OctopusServer_TeamCorePlatform_ChainFull/23912210)).

The SDK's `RetryHandler` is in the stack trace, so it had already retried. AWS SDK v4 (`AWSSDK.Core` 4.0.100.9) defaults to `Standard` retry mode, which does treat throttling as retryable — but `MaxErrorRetry` is only **2**. `AsClientConfig` left that default in place.

# Results

All AWS clients (CloudFormation, S3, IAM, STS) get 5 retries instead of 2, so a transient throttle costs backoff rather than a failed deployment.

# How to review this PR

AWS doesn't publish per-operation request rate quotas for CloudFormation — the [quotas page](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html) documents no request rates at all — so `5` can't be derived from a documented limit. The real measure is the throttle rate afterwards.

Two things worth challenging: it applies to all AWS clients rather than just CloudFormation, and under *sustained* throttling a deployment now takes longer to fail. Adaptive retry mode would add client-side rate limiting and is arguably the better shape, but the SDK calls it "experimental", which felt wrong for the deployment hot path.

#2149 fixes how the failure is reported once retries are exhausted.

