### PR TITLE
Report CloudFormation throttling as a rate limit, not an unknown error

### DIFF
--- a/source/Calamari.Aws/Deployment/Conventions/DescribeCloudFormationChangeSetConvention.cs
+++ b/source/Calamari.Aws/Deployment/Conventions/DescribeCloudFormationChangeSetConvention.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
@@ -36,6 +37,27 @@ public class DescribeCloudFormationChangeSetConvention(
                                                  );
     }
         
+    //Repeated from the SDK, where this set is only exposed as an instance property on Amazon.Runtime.RetryPolicy
+    static readonly HashSet<string> ThrottlingErrorCodes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Throttling",
+        "ThrottlingException",
+        "ThrottledException",
+        "RequestThrottled",
+        "RequestThrottledException",
+        "TooManyRequestsException",
+        "ProvisionedThroughputExceededException",
+        "RequestLimitExceeded",
+        "BandwidthLimitExceeded",
+        "SlowDown",
+        "PriorRequestNotComplete",
+        "EC2ThrottledException"
+    };
+
+    static bool IsThrottling(AmazonCloudFormationException ex)
+        => (ex.ErrorCode != null && ThrottlingErrorCodes.Contains(ex.ErrorCode))
+           || ex.StatusCode == HttpStatusCode.TooManyRequests;
+
     public async Task DescribeChangeset(StackArn stack, ChangeSetArn changeSet, IVariables variables)
     {
         Guard.NotNull(stack, "The provided stack identifier or name may not be null");
@@ -55,6 +77,12 @@ public class DescribeCloudFormationChangeSetConvention(
                                           "The AWS account used to perform the operation does not have the required permissions to describe the change set.\n" +
                                           "Please ensure the current account has permission to perform action 'cloudformation:DescribeChangeSet'." +
                                           ex.Message + "\n");
+        }
+        catch (AmazonCloudFormationException ex) when (IsThrottling(ex))
+        {
+            throw new RateExceededException(
+                                            "AWS throttled the request to describe the CloudFormation change set. This is usually transient - try the deployment again.\n" +
+                                            ex.Message + "\n");
         }
         catch (AmazonCloudFormationException ex)
         {

--- a/source/Calamari.Aws/Exceptions/RateExceededException.cs
+++ b/source/Calamari.Aws/Exceptions/RateExceededException.cs
@@ -1,0 +1,21 @@
+using System;
+using Calamari.Common.Commands;
+
+namespace Calamari.Aws.Exceptions
+{
+    /// <summary>
+    /// Represents an AWS API call rejected because the request rate limit was exceeded
+    /// </summary>
+    public class RateExceededException : CommandException
+    {
+        public RateExceededException(string message)
+            : base(message)
+        {
+        }
+
+        public RateExceededException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}


### PR DESCRIPTION
No server change required.

# Background

`DescribeCloudFormationChangeSetConvention` only special-cases `AccessDenied`; everything else falls through to `UnknownException`. So AWS throttling reports as:

```
Error: Calamari.Aws.Exceptions.UnknownException: An unrecognized exception was thrown
       while describing the CloudFormation change set.
Error:  ---> Amazon.CloudFormation.AmazonCloudFormationException: Rate exceeded
       ... ~60 more lines of SDK stack trace ...
```

Throttling isn't unrecognized — it's documented, usually transient, and has a clear user action. `UnknownException` also derives from plain `Exception` rather than `CommandException`, which is why the log gets the stack dump.

# Results

Throttling now throws `RateExceededException` (deriving from `CommandException`, matching `PermissionException`) with a one-line explanation instead of a stack trace.

# How to review this PR

**The duplicated error-code list.** The SDK has this exact set as `RetryPolicy.ThrottlingErrorCodes`, but it's an *instance* property — using it doesn't compile (`CS0120`), and `IsThrottlingError` is likewise an instance method. Hence the local copy, with HTTP 429 as a backstop. 

**Scope.** Only the describe-changeset path. The same `UnknownException` catch-all exists in other CloudFormation conventions.

Adds no retries; PR #2148 raises the SDK retry budget, which is what should reduce how often this happens
