### PR TITLE
Report Kubernetes object ownership on the k8s-status service message

### DIFF
--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceUpdateReporterTests.cs
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/ResourceUpdateReporterTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Calamari.Common.Plumbing.ServiceMessages;
 using Calamari.Common.Plumbing.Variables;
 using Calamari.Kubernetes;
 using Calamari.Kubernetes.ResourceStatus;
@@ -154,6 +155,53 @@ namespace Calamari.Tests.KubernetesFixtures.ResourceStatus
                 new KeyValuePair<string, string>("kind", "Namespace"),
                 new KeyValuePair<string, string>("namespace", null),
             }).Count() == 6);
+        }
+
+        [Test]
+        public void ReportsTheUidOfTheControllingOwnerReference()
+        {
+            var serviceMessage = ReportSingleResourceFrom("one-replicaset-with-controlling-owner.json");
+
+            serviceMessage.Properties.Should().Contain("ownerUuid", "42c67fbc-486c-4091-a4df-3827d32b23c7");
+        }
+
+        [Test]
+        public void OmitsOwnerUuidWhenNoOwnerReferenceIsTheController()
+        {
+            var serviceMessage = ReportSingleResourceFrom("one-replicaset-with-non-controlling-owners.json");
+
+            serviceMessage.Properties.Should().NotContainKey("ownerUuid");
+        }
+
+        [Test]
+        public void OmitsOwnerUuidWhenThereAreNoOwnerReferences()
+        {
+            var serviceMessage = ReportSingleResourceFrom("one-deployment.json");
+
+            serviceMessage.Properties.Should().NotContainKey("ownerUuid");
+        }
+
+        [Test]
+        public void ReportsTheFirstControllingOwnerWhenMoreThanOneIsMarkedAsController()
+        {
+            var serviceMessage = ReportSingleResourceFrom("one-replicaset-with-multiple-controlling-owners.json");
+
+            serviceMessage.Properties.Should().Contain("ownerUuid", "42c67fbc-486c-4091-a4df-3827d32b23c7");
+        }
+
+        static ServiceMessage ReportSingleResourceFrom(string assetFileName)
+        {
+            var log = new InMemoryLog();
+            var reporter = new ResourceUpdateReporter(new CalamariVariables(), log);
+
+            var newStatuses = ResourceFactory
+                .FromListJson(TestFileLoader.Load(assetFileName), new Options())
+                .ToDictionary(resource => resource.Uid, resource => resource);
+
+            reporter.ReportUpdatedResources(new Dictionary<string, Resource>(), newStatuses, 1);
+
+            return log.ServiceMessages
+                .Single(message => message.Name == SpecialVariables.ServiceMessages.ResourceStatus.Name);
         }
     }
 }

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/one-replicaset-with-controlling-owner.json
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/one-replicaset-with-controlling-owner.json
@@ -1,0 +1,43 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "ReplicaSet",
+      "metadata": {
+        "creationTimestamp": "2023-03-06T06:23:16Z",
+        "generation": 1,
+        "labels": {
+          "app": "nginx"
+        },
+        "name": "nginx-748c667d99",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "name": "nginx",
+            "uid": "42c67fbc-486c-4091-a4df-3827d32b23c7",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ],
+        "resourceVersion": "1052117",
+        "uid": "8dd1bd54-2c4e-4f1a-9b7f-6e63f0d0a1c2"
+      },
+      "spec": {
+        "replicas": 1
+      },
+      "status": {
+        "availableReplicas": 1,
+        "observedGeneration": 1,
+        "readyReplicas": 1,
+        "replicas": 1
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": ""
+  }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/one-replicaset-with-multiple-controlling-owners.json
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/one-replicaset-with-multiple-controlling-owners.json
@@ -1,0 +1,51 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "ReplicaSet",
+      "metadata": {
+        "creationTimestamp": "2023-03-06T06:23:16Z",
+        "generation": 1,
+        "labels": {
+          "app": "nginx"
+        },
+        "name": "nginx-748c667d99",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "name": "nginx",
+            "uid": "42c67fbc-486c-4091-a4df-3827d32b23c7",
+            "controller": true,
+            "blockOwnerDeletion": true
+          },
+          {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "name": "nginx-other",
+            "uid": "badc0de0-486c-4091-a4df-3827d32b23c7",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ],
+        "resourceVersion": "1052117",
+        "uid": "8dd1bd54-2c4e-4f1a-9b7f-6e63f0d0a1c2"
+      },
+      "spec": {
+        "replicas": 1
+      },
+      "status": {
+        "availableReplicas": 1,
+        "observedGeneration": 1,
+        "readyReplicas": 1,
+        "replicas": 1
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": ""
+  }
+}

--- a/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/one-replicaset-with-non-controlling-owners.json
+++ b/source/Calamari.Tests/KubernetesFixtures/ResourceStatus/assets/one-replicaset-with-non-controlling-owners.json
@@ -1,0 +1,49 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "ReplicaSet",
+      "metadata": {
+        "creationTimestamp": "2023-03-06T06:23:16Z",
+        "generation": 1,
+        "labels": {
+          "app": "nginx"
+        },
+        "name": "nginx-748c667d99",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "name": "nginx",
+            "uid": "42c67fbc-486c-4091-a4df-3827d32b23c7",
+            "controller": false,
+            "blockOwnerDeletion": true
+          },
+          {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "name": "nginx-config",
+            "uid": "c0ffee00-486c-4091-a4df-3827d32b23c7"
+          }
+        ],
+        "resourceVersion": "1052117",
+        "uid": "8dd1bd54-2c4e-4f1a-9b7f-6e63f0d0a1c2"
+      },
+      "spec": {
+        "replicas": 1
+      },
+      "status": {
+        "availableReplicas": 1,
+        "observedGeneration": 1,
+        "readyReplicas": 1,
+        "replicas": 1
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": ""
+  }
+}

--- a/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/ResourceUpdateReporter.cs
@@ -97,6 +97,12 @@ namespace Calamari.Kubernetes.ResourceStatus
                 {ResourceStatusAttributes.CheckCount, checkCount.ToString()}
             };
 
+            // Absent rather than empty: the server reads this optionally, and a blank value would read as an owner with no uid.
+            if (!string.IsNullOrEmpty(resource.ControllerOwnerUid))
+            {
+                parameters.Add(ResourceStatusAttributes.OwnerUuid, resource.ControllerOwnerUid);
+            }
+
             var message = new ServiceMessage(SpecialVariables.ServiceMessages.ResourceStatus.Name, parameters);
             log.WriteServiceMessage(message);
         }

--- a/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
+++ b/source/Calamari/Kubernetes/ResourceStatus/Resources/Resource.cs
@@ -13,6 +13,10 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
     {
         [JsonIgnore] public IEnumerable<string> OwnerUids { get; }
 
+        // Kubernetes permits at most one owner reference with controller: true, so this is the single parent
+        // an object hangs off in an ownership tree. Null for objects Octopus applies directly, which are roots.
+        [JsonIgnore] public string ControllerOwnerUid { get; }
+
         [JsonIgnore] public string Uid { get; protected set; }
 
         [JsonIgnore] public ResourceGroupVersionKind GroupVersionKind { get; protected set; }
@@ -34,6 +38,9 @@ namespace Calamari.Kubernetes.ResourceStatus.Resources
         {
             // force enumeration to prevent memory growth
             OwnerUids = json.SelectTokens("$.metadata.ownerReferences[*].uid").Values<string>().ToList();
+            ControllerOwnerUid = json.SelectTokens("$.metadata.ownerReferences[*]")
+                                     .FirstOrDefault(owner => owner["controller"]?.Value<bool?>() == true)
+                                     ?["uid"]?.Value<string>();
             Uid = Field(json, "$.metadata.uid");
             GroupVersionKind = json.ToResourceGroupVersionKind();
             Name = Field(json, "$.metadata.name");

--- a/source/Calamari/Kubernetes/SpecialVariables.cs
+++ b/source/Calamari/Kubernetes/SpecialVariables.cs
@@ -158,6 +158,7 @@ namespace Calamari.Kubernetes
                     public const string TargetName = "targetName";
                     public const string SpaceId = "spaceId";
                     public const string Uuid = "uuid";
+                    public const string OwnerUuid = "ownerUuid";
                     public const string Group = "group";
                     public const string Version = "version";
                     public const string Kind = "kind";


### PR DESCRIPTION
Adds an optional ownerUuid property carrying the uid of the owner reference marked controller: true, so Server can render a deployment's objects as an ownership tree. The property is omitted entirely when an object has no controlling owner, which is the case for objects Octopus applies directly.

Older servers ignore the new property: the service message parser dumps every attribute into a plain dictionary and the k8s-status mapper reads known keys by name, so no capability gate is needed.

:warning: Does this change require a corresponding Server Change?
:warning: If so - please add a "Requires Server Change" label to this PR!
