### PR TITLE
Improved azure error logging

### DIFF
--- a/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupOperatorFixture.cs
+++ b/source/Calamari.AzureResourceGroup.Tests/AzureResourceGroupOperatorFixture.cs
@@ -1,0 +1,96 @@
+using System;
+using Azure;
+using Azure.Core;
+using Azure.ResourceManager.Resources.Models;
+using NUnit.Framework;
+
+namespace Calamari.AzureResourceGroup.Tests;
+
+[TestFixture]
+public class AzureResourceGroupOperatorFixture
+{
+    [Test]
+    public void ExtractAzureErrorInfo_CompilesErrorMessage()
+    {
+        var statusMessage = StatusMessageWith("StorageAccountAlreadyTaken", "The storage account named testsa is already taken.");
+
+        var result = AzureResourceGroupOperator.ExtractAzureErrorInfo(statusMessage);
+
+        Assert.That(result, Is.EqualTo("[StorageAccountAlreadyTaken] The storage account named testsa is already taken."));
+    }
+
+    [Test]
+    public void ExtractAzureErrorInfo_NoError_IsEmpty()
+    {
+        var statusMessage = ArmResourcesModelFactory.StatusMessage("Failed", null);
+
+        var result = AzureResourceGroupOperator.ExtractAzureErrorInfo(statusMessage);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [TestCase("Failed", "[FAILED]")]
+    [TestCase("Canceled", "[CANCELED]")]
+    [TestCase("failed", "[FAILED]")]
+    public void FormatFailedOperation_UsesUppercasedProvisioningStateAsTag(string provisioningState, string expectedTag)
+    {
+        var properties = OperationProperties(provisioningState,
+            TargetResource("Microsoft.Storage/storageAccounts", "testsa"));
+
+        var result = AzureResourceGroupOperator.FormatFailedOperation(properties);
+
+        Assert.That(result, Does.Contain($"{expectedTag} Microsoft.Storage/storageAccounts 'testsa'"));
+    }
+
+    [Test]
+    public void FormatFailedOperation_NoProvisioningState_FallsBackToFailedTag()
+    {
+        var properties = OperationProperties(null, TargetResource("Microsoft.Storage/storageAccounts", "testsa"));
+
+        var result = AzureResourceGroupOperator.FormatFailedOperation(properties);
+
+        Assert.That(result, Does.Contain("[FAILED]"));
+    }
+
+    [Test]
+    public void FormatFailedOperation_NoTargetResource_UsesUnknownPlaceholders()
+    {
+        var properties = OperationProperties("Failed", targetResource: null);
+
+        var result = AzureResourceGroupOperator.FormatFailedOperation(properties);
+
+        Assert.That(result, Does.Contain("Unknown Type 'Unknown Resource'"));
+    }
+
+    [Test]
+    public void FormatFailedOperation_TargetResourceWithoutResourceType_UsesUnknownTypePlaceholder()
+    {
+        var targetResource = ArmResourcesModelFactory.TargetResource(id: null, resourceName: "testsa", resourceType: null);
+        var properties = OperationProperties("Failed", targetResource);
+
+        var result = AzureResourceGroupOperator.FormatFailedOperation(properties);
+
+        Assert.That(result, Does.Contain("Unknown Type 'testsa'"));
+    }
+
+    static StatusMessage StatusMessageWith(string code, string message)
+        => ArmResourcesModelFactory.StatusMessage("Failed", new ResponseError(code, message));
+
+    static TargetResource TargetResource(string resourceType, string resourceName)
+        => ArmResourcesModelFactory.TargetResource(id: null, resourceName: resourceName, resourceType: new ResourceType(resourceType));
+
+    static ArmDeploymentOperationProperties OperationProperties(string provisioningState,
+                                                                TargetResource targetResource,
+                                                                StatusMessage statusMessage = null,
+                                                                DateTimeOffset? timestamp = null)
+        => ArmResourcesModelFactory.ArmDeploymentOperationProperties(provisioningOperation: null,
+            provisioningState: provisioningState,
+            timestamp: timestamp,
+            duration: null,
+            serviceRequestId: null,
+            statusCode: null,
+            statusMessage: statusMessage,
+            targetResource: targetResource,
+            requestContent: null,
+            responseContent: null);
+}

--- a/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
+++ b/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
@@ -10,6 +10,7 @@ using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
 using Calamari.Azure;
 using Calamari.CloudAccounts;
+using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Newtonsoft.Json;
@@ -143,8 +144,7 @@ class AzureResourceGroupOperator(ILog log) : IAzureResourceGroupOperator
         }
         catch (Exception ex)
         {
-            log.Error(await BuildDeploymentFailureMessage(resourceGroupResource, deploymentName, ex));
-            throw;
+            throw new CommandException(await BuildDeploymentFailureMessage(resourceGroupResource, deploymentName, ex), ex);
         }
     }
 

--- a/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
+++ b/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,6 +21,10 @@ namespace Calamari.AzureResourceGroup;
 
 class AzureResourceGroupOperator(ILog log) : IAzureResourceGroupOperator
 {
+    static readonly TimeSpan FailureLoggingTimeout = TimeSpan.FromMinutes(2);
+    static readonly string[] FailedStates = { "Failed", "Canceled" };
+    const int MaxReportedFailures = 10;
+
     // Used by the ARM-template deploy behaviour: creates the ArmClient and runs the full submit/poll/finalise flow.
     public async Task Deploy(IAzureAccount account,
                              string subscriptionId,
@@ -36,7 +41,7 @@ class AzureResourceGroupOperator(ILog log) : IAzureResourceGroupOperator
         log.Info($"Deploying Resource Group {resourceGroupName} in subscription {subscriptionId}.\nDeployment name: {deploymentName}\nDeployment mode: {deploymentMode}");
 
         var deploymentOperation = await CreateDeployment(resourceGroupResource, deploymentName, deploymentMode, template, parameters);
-        await PollForCompletionWithTimeout(deploymentOperation, variables);
+        await PollForCompletionWithTimeout(deploymentOperation, resourceGroupResource, deploymentName, variables);
         await FinalizeDeployment(deploymentOperation, variables);
     }
 
@@ -55,7 +60,7 @@ class AzureResourceGroupOperator(ILog log) : IAzureResourceGroupOperator
         var resourceGroupResource = await GetOrCreateResourceGroup(armClient, subscriptionId, resourceGroupName, resourceGroupLocation);
 
         var deploymentOperation = await CreateDeployment(resourceGroupResource, deploymentName, deploymentMode, template, parameters);
-        await PollForCompletion(deploymentOperation);
+        await PollForCompletion(deploymentOperation, resourceGroupResource, deploymentName);
         await FinalizeDeployment(deploymentOperation, variables);
     }
 
@@ -107,19 +112,27 @@ class AzureResourceGroupOperator(ILog log) : IAzureResourceGroupOperator
         }
     }
 
-    async Task PollForCompletionWithTimeout(ArmOperation<ArmDeploymentResource> deploymentOperation, IVariables variables)
+    async Task PollForCompletionWithTimeout(ArmOperation<ArmDeploymentResource> deploymentOperation,
+                                            ResourceGroupResource resourceGroupResource,
+                                            string deploymentName,
+                                            IVariables variables)
     {
         var pollingTimeout = GetPollingTimeout(variables);
         var asyncResourceGroupPollingTimeoutPolicy = Policy.TimeoutAsync(pollingTimeout, TimeoutStrategy.Optimistic);
-        await asyncResourceGroupPollingTimeoutPolicy.ExecuteAsync(ct => Poll(deploymentOperation, ct), CancellationToken.None);
+        await asyncResourceGroupPollingTimeoutPolicy.ExecuteAsync(ct => Poll(deploymentOperation, resourceGroupResource, deploymentName, ct), CancellationToken.None);
     }
 
-    async Task PollForCompletion(ArmOperation<ArmDeploymentResource> deploymentOperation)
+    async Task PollForCompletion(ArmOperation<ArmDeploymentResource> deploymentOperation,
+                                 ResourceGroupResource resourceGroupResource,
+                                 string deploymentName)
     {
-        await Poll(deploymentOperation, CancellationToken.None);
+        await Poll(deploymentOperation, resourceGroupResource, deploymentName, CancellationToken.None);
     }
 
-    async Task Poll(ArmOperation<ArmDeploymentResource> deploymentOperation, CancellationToken cancellationToken)
+    async Task Poll(ArmOperation<ArmDeploymentResource> deploymentOperation,
+                    ResourceGroupResource resourceGroupResource,
+                    string deploymentName,
+                    CancellationToken cancellationToken)
     {
         log.Info("Polling for deployment completion...");
         try
@@ -128,10 +141,45 @@ class AzureResourceGroupOperator(ILog log) : IAzureResourceGroupOperator
             var response = await deploymentOperation.WaitForCompletionAsync(delayStrategy, cancellationToken);
             log.Info($"Deployment completed with status: {response.Value?.Data.Properties?.ProvisioningState}");
         }
-        catch
+        catch (Exception ex)
         {
-            log.Error("Error polling for deployment completion");
+            log.Error(await BuildDeploymentFailureMessage(resourceGroupResource, deploymentName, ex));
             throw;
+        }
+    }
+
+    async Task<string> BuildDeploymentFailureMessage(ResourceGroupResource resourceGroupResource,
+                                                     string deploymentName,
+                                                     Exception originalException)
+    {
+        var baseMessage = $"Error polling for deployment completion: {originalException.Message}";
+        try
+        {
+            using var errorLoggingCancellation = new CancellationTokenSource(FailureLoggingTimeout);
+
+            var deploymentResponse = await resourceGroupResource.GetArmDeploymentAsync(deploymentName, errorLoggingCancellation.Token);
+            if (!deploymentResponse.HasValue)
+                return baseMessage;
+
+            var report = await CollectFailedOperations(deploymentResponse.Value, errorLoggingCancellation.Token);
+
+            if (report.FailureCount == 0)
+                return baseMessage;
+
+            var sb = new StringBuilder(baseMessage);
+            sb.Append($"\n\nFailed Azure resources ({report.FailureCount} of {report.TotalCount} operations failed or were canceled):");
+            sb.Append(report.Details);
+            if (report.OmittedCount > 0)
+                sb.Append($"\n  ... and {report.OmittedCount} more. See the Azure Portal for the full list.");
+            sb.Append("\n\nFor full details check Azure Portal > Resource Groups > Deployments, ");
+            sb.Append("or see https://aka.ms/arm-deployment-operations for troubleshooting guidance.");
+
+            return sb.ToString();
+        }
+        catch (Exception ex)
+        {
+            log.Verbose($"Could not retrieve detailed deployment error information: {ex.Message}");
+            return baseMessage;
         }
     }
 
@@ -163,6 +211,61 @@ class AzureResourceGroupOperator(ILog log) : IAzureResourceGroupOperator
 
         log.Info(sb.ToString());
     }
+
+    static async Task<FailedOperationsReport> CollectFailedOperations(ArmDeploymentResource deploymentResource,
+                                                                     CancellationToken cancellationToken)
+    {
+        var sb = new StringBuilder();
+        var failureCount = 0;
+        var totalCount = 0;
+
+        await foreach (var op in deploymentResource.GetDeploymentOperationsAsync(cancellationToken: cancellationToken))
+        {
+            totalCount++;
+
+            var properties = op.Properties;
+            if (properties == null || !FailedStates.Contains(properties.ProvisioningState ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+                continue;
+
+            failureCount++;
+
+            if (failureCount <= MaxReportedFailures)
+                sb.Append(FormatFailedOperation(properties));
+        }
+
+        return new FailedOperationsReport(sb.ToString(), failureCount, totalCount, Math.Max(0, failureCount - MaxReportedFailures));
+    }
+
+    internal static string FormatFailedOperation(ArmDeploymentOperationProperties properties)
+    {
+        var state = properties.ProvisioningState?.ToUpperInvariant() ?? "FAILED";
+        var resourceType = properties.TargetResource?.ResourceType?.ToString();
+        var sb = new StringBuilder($"\n  [{state}] {(string.IsNullOrEmpty(resourceType) ? "Unknown Type" : resourceType)} " +
+                                   $"'{properties.TargetResource?.ResourceName ?? "Unknown Resource"}'");
+
+        var errorInfo = properties.StatusMessage != null ? ExtractAzureErrorInfo(properties.StatusMessage) : string.Empty;
+        if (!string.IsNullOrWhiteSpace(errorInfo))
+            sb.Append($"\n     Error: {errorInfo}");
+
+        if (properties.Timestamp.HasValue)
+            sb.Append($"\n     Failed at: {properties.Timestamp.Value.UtcDateTime:yyyy-MM-dd HH:mm:ss} UTC");
+
+        return sb.ToString();
+    }
+
+    internal static string ExtractAzureErrorInfo(StatusMessage statusMessage)
+    {
+        var error = statusMessage.Error;
+        if (error == null)
+            return string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(error.Code) && !string.IsNullOrWhiteSpace(error.Message))
+            return $"[{error.Code}] {error.Message}";
+
+        return !string.IsNullOrWhiteSpace(error.Message) ? error.Message : error.Code ?? string.Empty;
+    }
+
+    record FailedOperationsReport(string Details, int FailureCount, int TotalCount, int OmittedCount);
 
     void CaptureOutputs(string? outputsJson, IVariables variables)
     {

--- a/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
+++ b/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
@@ -144,6 +144,7 @@ class AzureResourceGroupOperator(ILog log) : IAzureResourceGroupOperator
         // This Azure exception is thrown for failed deployments. It is handled here to provide specific failure details
         catch (RequestFailedException)
         {
+            log.Error("Error completing deployment");
             var failureDetail = await BuildDeploymentFailureMessage(resourceGroupResource, deploymentName);
             if (failureDetail != null)
                 log.Error(failureDetail);

--- a/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
+++ b/source/Calamari.AzureResourceGroup/AzureResourceGroupOperator.cs
@@ -10,7 +10,6 @@ using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
 using Calamari.Azure;
 using Calamari.CloudAccounts;
-using Calamari.Common.Commands;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
 using Newtonsoft.Json;
@@ -142,32 +141,42 @@ class AzureResourceGroupOperator(ILog log) : IAzureResourceGroupOperator
             var response = await deploymentOperation.WaitForCompletionAsync(delayStrategy, cancellationToken);
             log.Info($"Deployment completed with status: {response.Value?.Data.Properties?.ProvisioningState}");
         }
-        catch (Exception ex)
+        // This Azure exception is thrown for failed deployments. It is handled here to provide specific failure details
+        catch (RequestFailedException)
         {
-            throw new CommandException(await BuildDeploymentFailureMessage(resourceGroupResource, deploymentName, ex), ex);
+            var failureDetail = await BuildDeploymentFailureMessage(resourceGroupResource, deploymentName);
+            if (failureDetail != null)
+                log.Error(failureDetail);
+
+            throw;
+        }
+        catch
+        {
+            log.Error("Error polling for deployment completion");
+            throw;
         }
     }
 
-    async Task<string> BuildDeploymentFailureMessage(ResourceGroupResource resourceGroupResource,
-                                                     string deploymentName,
-                                                     Exception originalException)
+    async Task<string?> BuildDeploymentFailureMessage(ResourceGroupResource resourceGroupResource,
+                                                     string deploymentName)
     {
-        var baseMessage = $"Error polling for deployment completion: {originalException.Message}";
         try
         {
             using var errorLoggingCancellation = new CancellationTokenSource(FailureLoggingTimeout);
 
             var deploymentResponse = await resourceGroupResource.GetArmDeploymentAsync(deploymentName, errorLoggingCancellation.Token);
             if (!deploymentResponse.HasValue)
-                return baseMessage;
+            {
+                log.Warn($"Could not retrieve deployment '{deploymentName}' from Azure, so the resources that failed cannot be listed.");
+                return null;
+            }
 
             var report = await CollectFailedOperations(deploymentResponse.Value, errorLoggingCancellation.Token);
 
             if (report.FailureCount == 0)
-                return baseMessage;
+                return null;
 
-            var sb = new StringBuilder(baseMessage);
-            sb.Append($"\n\nFailed Azure resources ({report.FailureCount} of {report.TotalCount} operations failed or were canceled):");
+            var sb = new StringBuilder($"Failed Azure resources ({report.FailureCount} of {report.TotalCount} operations failed or were canceled):");
             sb.Append(report.Details);
             if (report.OmittedCount > 0)
                 sb.Append($"\n  ... and {report.OmittedCount} more. See the Azure Portal for the full list.");
@@ -178,8 +187,8 @@ class AzureResourceGroupOperator(ILog log) : IAzureResourceGroupOperator
         }
         catch (Exception ex)
         {
-            log.Verbose($"Could not retrieve detailed deployment error information: {ex.Message}");
-            return baseMessage;
+            log.Warn($"Could not retrieve details of the failed Azure resources: {ex.Message}");
+            return null;
         }
     }
 


### PR DESCRIPTION
# Description
Fixes: HPY-1405

When an Azure deployment fails, Calamari currently logs Azure's `DeploymentFailed` status, but this does not provide users with any useful information about what went wrong and how the issue might be resolved. This PR improves error logging by retrieving the deployment operation results from Azure and providing detailed logging when more specific error messages are available.

# Results
## Single resource failure
<img width="1315" height="500" alt="image" src="https://github.com/user-attachments/assets/2f7acfb3-f120-4ed9-a449-2ef129b0c0d7" />

## Multiple resource failures
<img width="1315" height="587" alt="image" src="https://github.com/user-attachments/assets/a0c2cded-dc17-4749-b77e-666b8106f240" />

## Successful deployment (unchanged)
<img width="2542" height="1780" alt="image" src="https://github.com/user-attachments/assets/f91fd555-5cd5-4878-b4e7-82a201d671a0" />
