### PR TITLE
Run gzip directly in BuildDockerImages instead of through pwsh

### DIFF
--- a/build/Build.Docker.cs
+++ b/build/Build.Docker.cs
@@ -1,12 +1,15 @@
 ﻿using Calamari.Build.Utilities;
 using JetBrains.Annotations;
+using Nuke.Common.Tooling;
 using Nuke.Common.Tools.Docker;
-using Nuke.Common.Tools.PowerShell;
 
 namespace Calamari.Build;
 
 public partial class Build
 {
+    //Resolved from PATH so a missing gzip fails by name, rather than as a mystery exit code
+    static Tool Gzip => ToolResolver.GetPathTool("gzip");
+
     [PublicAPI]
     Target BuildDockerImages =>
         d =>
@@ -82,10 +85,10 @@ public partial class Build
                                                                                               return settings;
                                                                                           });
 
-                                                            //compress with gzip
-                                                            PowerShellTasks.PowerShell(_ => _
-                                                                                            .EnableNoProfile()
-                                                                                            .SetCommand($"gzip -k -9 -f '{outputFile}'"));
+                                                            //compress with gzip. Invoked directly rather than via pwsh, which only
+                                                            //added a dependency on whatever .NET runtime the agent's `pwsh` global tool
+                                                            //was built against - not the SDK this build pins.
+                                                            Gzip($"-k -9 -f \"{outputFile}\"");
 
                                                             //gzip always uses the .gz suffix
                                                             var compressedZipPath = $"{outputFile}.gz";


### PR DESCRIPTION
[Build: Docker images](https://build.octopushq.com/buildConfiguration/TeamModernDeployments_Calamari_VNext_Build_BuildDockerImages/24122436) failing... but why now...

`BuildDockerImages` launched `pwsh` for one thing — running `gzip` on the OCI tar. The agent's `pwsh` is a dotnet global tool needing .NET 10, while `build.sh` bootstraps a .NET 8-only SDK into `.nuke/temp/dotnet-unix` and puts it on `PATH`:

```
App: /root/.dotnet/tools/pwsh
Framework: 'Microsoft.NETCore.App', version '10.0.0' (x64)
.NET location: .../.nuke/temp/dotnet-unix
The following frameworks were found:
  8.0.30
```

**Why it started failing on 2026-09-07:** the `nautilus-linux` agent image changed between the last green build (24081109, Sep 3) and the first red one (24122436, Sep 7) — bash 5.1.4 -> 5.2.21, and the system SDK it reports went 6.0.428 -> 10.0.400. Both logs show the same `./build.sh BuildDockerImages` and the same net8 SDK bootstrap, `BuildDockerImages.xml` is untouched in the settings diff between the two builds, and no Calamari commit landed in that window. The agent's `pwsh` is the only variable that moved.

So: call `gzip` directly. This was the build's only use of `PowerShellTasks`.

Also stops a silent failure — `pwsh -Command` exits 0 regardless of the native exit code, so a failed gzip used to surface later as a missing artifact in `PublishArtifacts`. A Nuke `Tool` asserts a zero exit code.

Verified locally `/usr/bin/gzip` from `PATH`, `-k` still keeps the `.tar` next to the `.gz`, and a forced failure throws `ProcessException: Process 'gzip' exited with code 1`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
